### PR TITLE
Remove persistent storage for testing

### DIFF
--- a/algorithms/src/commitment/tests.rs
+++ b/algorithms/src/commitment/tests.rs
@@ -35,7 +35,7 @@ fn commitment_parameter_serialization() {
 #[test]
 fn commitment_parameter_storage() {
     let rng = &mut thread_rng();
-    let mut path = std::env::current_dir().unwrap();
+    let mut path = std::env::temp_dir();
     path.push(TEST_COMMITMENT_PARAMETERS_PATH);
 
     let commitment = TestCommitment::setup(rng);

--- a/algorithms/src/crh/tests.rs
+++ b/algorithms/src/crh/tests.rs
@@ -35,7 +35,7 @@ fn crh_parameter_serialization() {
 #[test]
 fn crh_parameter_storage() {
     let rng = &mut thread_rng();
-    let mut path = std::env::current_dir().unwrap();
+    let mut path = std::env::temp_dir();
     path.push(TEST_CRH_PARAMETERS_PATH);
 
     let crh = TestCRH::setup(rng);

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -71,7 +71,7 @@ fn schnorr_signature_parameter_serialization() {
 #[test]
 fn schnorr_signature_parameter_storage() {
     let rng = &mut thread_rng();
-    let mut path = std::env::current_dir().unwrap();
+    let mut path = std::env::temp_dir();
     path.push(TEST_SIGNATURE_PARAMETERS_PATH);
 
     let schnorr_signature = TestSignature::setup(rng).unwrap();

--- a/algorithms/src/snark/tests.rs
+++ b/algorithms/src/snark/tests.rs
@@ -201,7 +201,7 @@ mod serialization {
     #[test]
     fn parameter_storage() {
         let rng = &mut thread_rng();
-        let mut path = std::env::current_dir().unwrap();
+        let mut path = std::env::temp_dir();
         path.push(TEST_PARAMETERS_PATH);
 
         let parameters =

--- a/consensus/src/test_data/mod.rs
+++ b/consensus/src/test_data/mod.rs
@@ -13,7 +13,7 @@ pub const TEST_CONSENSUS: ConsensusParameters = ConsensusParameters {
     target_block_time: 2i64, //unix seconds
 };
 
-pub const TEST_DB_PATH: &str = "../test_db";
+pub const TEST_DB_PATH: &str = "./test_db";
 
 pub fn random_storage_path() -> String {
     let ptr = Box::into_raw(Box::new(123));
@@ -21,7 +21,7 @@ pub fn random_storage_path() -> String {
 }
 
 pub fn initialize_test_blockchain() -> (Arc<MerkleTreeLedger>, PathBuf) {
-    let mut path = std::env::current_dir().unwrap();
+    let mut path = std::env::temp_dir();
     path.push(random_storage_path());
 
     MerkleTreeLedger::destroy_storage(path.clone()).unwrap();

--- a/consensus/tests/consensus_dpc.rs
+++ b/consensus/tests/consensus_dpc.rs
@@ -18,7 +18,7 @@ mod consensus_dpc {
     use snarkos_storage::BlockStorage;
     use snarkos_utilities::{bytes::ToBytes, to_bytes};
 
-    use rand::thread_rng;
+    use rand::{thread_rng, Rng};
 
     #[test]
     fn base_dpc_multiple_transactions() {
@@ -33,13 +33,12 @@ mod consensus_dpc {
         // Generate addresses
         let [genesis_address, miner_address, recipient] = generate_test_addresses(&parameters, &mut rng);
 
-        let (ledger, genesis_pred_vk_bytes) = setup_ledger(
-            "test_multiple_transations_db".to_string(),
-            &parameters,
-            ledger_parameters,
-            &genesis_address,
-            &mut rng,
-        );
+        let mut path = std::env::temp_dir();
+        let random_storage_path: usize = rng.gen();
+        path.push(format!("test_multiple_transations_db{}", random_storage_path));
+
+        let (ledger, genesis_pred_vk_bytes) =
+            setup_ledger(&path, &parameters, ledger_parameters, &genesis_address, &mut rng);
 
         let miner = Miner::new(miner_address.public_key, consensus.clone());
 

--- a/dpc/src/test_data/mod.rs
+++ b/dpc/src/test_data/mod.rs
@@ -9,6 +9,7 @@ use snarkos_objects::ledger::Ledger;
 use snarkos_utilities::{bytes::ToBytes, to_bytes};
 
 use rand::Rng;
+use std::path::PathBuf;
 
 pub struct Wallet {
     pub secret_key: &'static str,
@@ -84,7 +85,7 @@ pub fn generate_test_addresses<R: Rng>(
 }
 
 pub fn setup_ledger<R: Rng>(
-    db_name: String,
+    path: &PathBuf,
     parameters: &<InstantiatedDPC as DPCScheme<MerkleTreeLedger>>::Parameters,
     ledger_parameters: <Components as BaseDPCComponents>::MerkleParameters,
     genesis_address: &AddressPair<Components>,
@@ -124,9 +125,6 @@ pub fn setup_ledger<R: Rng>(
     )
     .unwrap();
     let genesis_memo = [0u8; 32];
-
-    let mut path = std::env::current_dir().unwrap();
-    path.push(db_name);
 
     // Use genesis record, serial number, and memo to initialize the ledger.
     let ledger = MerkleTreeLedger::new(

--- a/dpc/tests/base_dpc.rs
+++ b/dpc/tests/base_dpc.rs
@@ -27,7 +27,7 @@ use snarkos_objects::{
 use snarkos_storage::BlockStorage;
 use snarkos_utilities::rand::UniformRand;
 
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -41,14 +41,13 @@ fn base_dpc_integration_test() {
     // Generate addresses
     let [genesis_address, recipient, _] = generate_test_addresses(&parameters, &mut rng);
 
+    let mut path = std::env::temp_dir();
+    let random_storage_path: usize = rng.gen();
+    path.push(format!("test_dpc_integration_db{}", random_storage_path));
+
     // Setup the ledger
-    let (ledger, genesis_pred_vk_bytes) = setup_ledger(
-        "test_dpc_integration_db".to_string(),
-        &parameters,
-        ledger_parameters,
-        &genesis_address,
-        &mut rng,
-    );
+    let (ledger, genesis_pred_vk_bytes) =
+        setup_ledger(&path, &parameters, ledger_parameters, &genesis_address, &mut rng);
 
     #[cfg(debug_assertions)]
     let pred_nizk_pvk: PreparedVerifyingKey<_> = parameters.predicate_snark_parameters.verification_key.clone().into();

--- a/gadgets/src/curves/tests_field.rs
+++ b/gadgets/src/curves/tests_field.rs
@@ -241,7 +241,6 @@ fn bls12_377_field_gadgets_test() {
     field_test(cs.ns(|| "test_fq12"), c, d);
     random_frobenius_tests::<Fq12, _, Fq12Gadget, _>(cs.ns(|| "test_frob_fq12"), 13);
     if !cs.is_satisfied() {
-        println!("Here!");
         println!("{:?}", cs.which_is_unsatisfied().unwrap());
     }
 

--- a/storage/tests/mod.rs
+++ b/storage/tests/mod.rs
@@ -16,7 +16,7 @@ use std::{
     sync::Arc,
 };
 
-pub const TEST_DB_PATH: &str = "../test_db";
+pub const TEST_DB_PATH: &str = "./test_db";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TestTx;
@@ -139,7 +139,7 @@ impl FromBytes for TestMerkleParams {
 type Store = BlockStorage<TestTx, TestMerkleParams>;
 
 pub fn initialize_test_blockchain() -> (Arc<Store>, PathBuf) {
-    let mut path = std::env::current_dir().unwrap();
+    let mut path = std::env::temp_dir();
     path.push(random_storage_path());
 
     Store::destroy_storage(path.clone()).unwrap();
@@ -169,12 +169,7 @@ mod tests {
 
     #[test]
     pub fn test_initialize_blockchain() {
-        let mut path = std::env::current_dir().unwrap();
-        path.push(random_storage_path());
-
-        Store::destroy_storage(path.clone()).unwrap();
-
-        let blockchain = Arc::new(BlockStorage::open_at_path(path.clone()).unwrap());
+        let (blockchain, path) = initialize_test_blockchain();
 
         assert_eq!(blockchain.get_latest_block_height(), 0);
 
@@ -185,10 +180,7 @@ mod tests {
 
     #[test]
     pub fn test_storage() {
-        let mut path = std::env::current_dir().unwrap();
-        path.push(random_storage_path());
-
-        let blockchain = Arc::new(Store::open_at_path(path.clone()).unwrap());
+        let (blockchain, path) = initialize_test_blockchain();
 
         blockchain.storage.storage.put(b"my key", b"my value").unwrap();
 
@@ -229,7 +221,7 @@ mod tests {
 
     #[test]
     pub fn test_destroy_storage() {
-        let mut path = std::env::current_dir().unwrap();
+        let mut path = std::env::temp_dir();
         path.push(random_storage_path());
 
         Store::destroy_storage(path).unwrap();
@@ -240,12 +232,7 @@ mod tests {
 
         #[test]
         pub fn test_invalid_block_addition() {
-            let mut path = std::env::current_dir().unwrap();
-            path.push(random_storage_path());
-
-            Store::destroy_storage(path.clone()).unwrap();
-
-            let blockchain = Arc::new(Store::open_at_path(path.clone()).unwrap());
+            let (blockchain, path) = initialize_test_blockchain();
 
             let latest_block = blockchain.get_latest_block().unwrap();
 
@@ -256,12 +243,7 @@ mod tests {
 
         #[test]
         pub fn test_invalid_block_removal() {
-            let mut path = std::env::current_dir().unwrap();
-            path.push(random_storage_path());
-
-            Store::destroy_storage(path.clone()).unwrap();
-
-            let blockchain = Arc::new(Store::open_at_path(path.clone()).unwrap());
+            let (blockchain, path) = initialize_test_blockchain();
 
             assert!(blockchain.remove_latest_block().is_err());
             assert!(blockchain.remove_latest_blocks(5).is_err());
@@ -271,12 +253,7 @@ mod tests {
 
         #[test]
         pub fn test_invalid_block_retrieval() {
-            let mut path = std::env::current_dir().unwrap();
-            path.push(random_storage_path());
-
-            Store::destroy_storage(path.clone()).unwrap();
-
-            let blockchain = Arc::new(Store::open_at_path(path.clone()).unwrap());
+            let (blockchain, path) = initialize_test_blockchain();
 
             assert!(blockchain.get_block_from_block_num(2).is_err());
             assert!(blockchain.get_block_from_block_num(10).is_err());


### PR DESCRIPTION
Old testing model would leave residual storage if the tests failed or panicked. New implementation now utilizes temporary directories provided by the OS's env::temp_dir, so that the objects are removed when out of scope