### PR TITLE
Fix Merkle Tree bug

### DIFF
--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -7,7 +7,7 @@ pub struct MerkleTree<P: MerkleParameters> {
     root: Option<<P::H as CRH>::Output>,
     tree: Vec<<P::H as CRH>::Output>,
     leaves_hashed: Vec<<P::H as CRH>::Output>,
-    padding_tree: Vec<(<P::H as CRH>::Output, <P::H as CRH>::Output)>,
+    padding_tree: Vec<(<P::H as CRH>::Output, <P::H as CRH>::Output)>, // For each level after a full tree has been built from the leaves, keeps both the roots the siblings that are used to get to the desired height.
     parameters: P,
 }
 


### PR DESCRIPTION
@kobigurk found that if the given tree height is equal to HEIGHT-1, then there would be 1 extra root calculated. this PR fixes this. This PR also exposes the hashed leaves of the tree, which will be needed for later use in the SNARK