### PR TITLE
Hotfix for RPC account reading

### DIFF
--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -13,11 +13,10 @@ use snarkos_utilities::{
     to_bytes,
 };
 
-use jsonrpc_http_server::jsonrpc_core::{IoDelegate, MetaIoHandler, Params, Value};
-
 use base64;
+use jsonrpc_http_server::jsonrpc_core::{IoDelegate, MetaIoHandler, Params, Value};
 use rand::thread_rng;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 type JsonrpcError = jsonrpc_core::Error;
 
@@ -136,8 +135,7 @@ impl ProtectedRpcFunctions for RpcImpl {
 
         let mut old_account_private_keys = vec![];
         for private_key_string in transaction_input.old_account_private_keys {
-            let private_key_bytes = hex::decode(private_key_string)?;
-            old_account_private_keys.push(AccountPrivateKey::<Components>::read(&private_key_bytes[..])?);
+            old_account_private_keys.push(AccountPrivateKey::<Components>::from_str(&private_key_string)?);
         }
 
         // Fill any unused old_record indices with dummy records
@@ -151,6 +149,7 @@ impl ProtectedRpcFunctions for RpcImpl {
             let private_key = old_account_private_keys[0].clone();
             let public_key = AccountPublicKey::<Components>::from(
                 &self.parameters.circuit_parameters.account_commitment,
+                &self.parameters.circuit_parameters.account_signature,
                 &private_key,
             )?;
 
@@ -178,8 +177,7 @@ impl ProtectedRpcFunctions for RpcImpl {
         let mut new_dummy_flags = vec![];
         let mut new_values = vec![];
         for recipient in transaction_input.recipients {
-            let public_key_bytes = hex::decode(recipient.address)?;
-            new_account_public_keys.push(AccountPublicKey::<Components>::read(&public_key_bytes[..])?);
+            new_account_public_keys.push(AccountPublicKey::<Components>::from_str(&recipient.address)?);
             new_dummy_flags.push(false);
             new_values.push(recipient.amount);
         }

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -168,7 +168,7 @@ mod protected_rpc_tests {
         let [sender, receiver, _] = &FIXTURE_VK.test_accounts;
 
         let old_records = vec![hex::encode(to_bytes![DATA.records_1[0]].unwrap())];
-        let old_account_private_keys = vec![hex::encode(to_bytes![sender.private_key].unwrap())];
+        let old_account_private_keys = vec![sender.private_key.to_string()];
 
         let recipients = vec![TransactionRecipient {
             address: hex::encode(to_bytes![receiver.public_key].unwrap()),


### PR DESCRIPTION
Since we turned off CI verification prior to merging PRs, we didn't detect an account interface change prior to the merge of #247 with #254 .