### PR TITLE
Constraint counter

### DIFF
--- a/models/src/gadgets/r1cs/constraint_counter.rs
+++ b/models/src/gadgets/r1cs/constraint_counter.rs
@@ -1,0 +1,81 @@
+use crate::{
+    curves::Field,
+    gadgets::r1cs::{ConstraintSystem, Index, LinearCombination, Variable},
+};
+use snarkos_errors::gadgets::SynthesisError;
+
+/// Constraint counter for testing purposes.
+pub struct ConstraintCounter {
+    pub num_inputs: usize,
+    pub num_aux: usize,
+    pub num_constraints: usize,
+}
+
+impl ConstraintCounter {
+    pub fn new() -> Self {
+        Self {
+            num_aux: 0,
+            num_inputs: 0,
+            num_constraints: 0,
+        }
+    }
+
+    pub fn num_constraints(&self) -> usize {
+        self.num_constraints
+    }
+}
+
+impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ConstraintCounter {
+    type Root = Self;
+
+    fn alloc<F, A, AR>(&mut self, _: A, _: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<ConstraintF, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        let var = Variable::new_unchecked(Index::Aux(self.num_aux));
+        self.num_aux += 1;
+        Ok(var)
+    }
+
+    fn alloc_input<F, A, AR>(&mut self, _: A, _: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<ConstraintF, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        let var = Variable::new_unchecked(Index::Input(self.num_inputs));
+        self.num_inputs += 1;
+
+        Ok(var)
+    }
+
+    fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, _: LA, _: LB, _: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
+        LB: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
+        LC: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
+    {
+        self.num_constraints += 1;
+    }
+
+    fn push_namespace<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+    }
+
+    fn pop_namespace(&mut self) {}
+
+    fn get_root(&mut self) -> &mut Self::Root {
+        self
+    }
+
+    fn num_constraints(&self) -> usize {
+        self.num_constraints
+    }
+}

--- a/models/src/gadgets/r1cs/mod.rs
+++ b/models/src/gadgets/r1cs/mod.rs
@@ -1,4 +1,5 @@
 mod assignment;
+mod constraint_counter;
 mod constraint_system;
 mod impl_constraint_var;
 mod impl_lc;
@@ -7,6 +8,7 @@ mod test_fr;
 
 pub use crate::curves::to_field_vec::ToConstraintField;
 pub use assignment::*;
+pub use constraint_counter::ConstraintCounter;
 pub use constraint_system::{ConstraintSynthesizer, ConstraintSystem, Namespace};
 pub use test_constraint_system::TestConstraintSystem;
 pub use test_fr::*;


### PR DESCRIPTION
Equivalent of: https://github.com/scipr-lab/zexe/pull/151

Useful to estimate the number of constraints required when running ceremonies.