### PR TITLE
Add parameters to Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*inner_snark_pk.params filter=lfs diff=lfs merge=lfs -text
+*outer_snark_pk.params filter=lfs diff=lfs merge=lfs -text
+*posw_snark_pk.params filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/target
 **.DS_Store
 **storage_db
+**inner_snark_pk*.params
+**outer_snark_pk*.params
+**posw_snark_pk*.params

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 **/target
 **.DS_Store
 **storage_db
-**inner_snark_pk*.params
-**outer_snark_pk*.params
-**posw_snark_pk*.params

--- a/errors/src/parameters/parameters.rs
+++ b/errors/src/parameters/parameters.rs
@@ -11,6 +11,9 @@ pub enum ParametersError {
     #[error("{}", _0)]
     Message(String),
 
+    #[error("Missing parameters")]
+    MissingParameters,
+
     #[error("Remote fetch is disabled, enable compiler flag for feature")]
     RemoteFetchDisabled,
 }

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -44,18 +44,11 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     Ok((inner_snark_pk, inner_snark_vk))
 }
 
-fn versioned_filename(checksum: &str) -> String {
-    match checksum.get(0..7) {
-        Some(sum) => format!("inner_snark_pk-{}.params", sum),
-        _ => format!("inner_snark_pk.params"),
-    }
-}
-
 pub fn main() {
     let (inner_snark_pk, inner_snark_vk) = setup::<Components>().unwrap();
     let inner_snark_pk_checksum = hex::encode(sha256(&inner_snark_pk));
     store(
-        &PathBuf::from(&versioned_filename(&inner_snark_pk_checksum)),
+        &PathBuf::from("inner_snark_pk.params"),
         &PathBuf::from("inner_snark_pk.checksum"),
         &inner_snark_pk,
     )

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -81,18 +81,10 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     Ok((outer_snark_pk, outer_snark_vk))
 }
 
-fn versioned_filename(checksum: &str) -> String {
-    match checksum.get(0..7) {
-        Some(sum) => format!("outer_snark_pk-{}.params", sum),
-        _ => format!("outer_snark_pk.params"),
-    }
-}
-
 pub fn main() {
     let (outer_snark_pk, outer_snark_vk) = setup::<Components>().unwrap();
-    let outer_snark_pk_checksum = hex::encode(sha256(&outer_snark_pk));
     store(
-        &PathBuf::from(&versioned_filename(&outer_snark_pk_checksum)),
+        &PathBuf::from("outer_snark_pk.params"),
         &PathBuf::from("outer_snark_pk.checksum"),
         &outer_snark_pk,
     )

--- a/parameters/examples/posw_snark.rs
+++ b/parameters/examples/posw_snark.rs
@@ -38,9 +38,8 @@ fn versioned_filename(checksum: &str) -> String {
 
 pub fn main() {
     let (posw_snark_pk, posw_snark_vk, _srs) = setup().unwrap();
-    let posw_snark_pk_checksum = hex::encode(sha256(&posw_snark_pk));
     store(
-        &PathBuf::from(&versioned_filename(&posw_snark_pk_checksum)),
+        &PathBuf::from("posw_snark_pk.params"),
         &PathBuf::from("posw_snark_pk.checksum"),
         &posw_snark_pk,
     )

--- a/parameters/src/params/inner_snark_pk.params
+++ b/parameters/src/params/inner_snark_pk.params
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54e627e21fa9e33e87148763811e1026722b4366080cc04bf2e28d587cdc61e3
+size 250108401

--- a/parameters/src/params/outer_snark_pk.params
+++ b/parameters/src/params/outer_snark_pk.params
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71402d27a0c2b2dd09b7cfbae8e66922a9a7032cad6d5bfdae92490bc230b45
+size 464560481

--- a/parameters/src/params/posw_snark_pk.params
+++ b/parameters/src/params/posw_snark_pk.params
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0ef545ce1436ddd95e2a21a547f35253a39b19d239c090520ba42f054367564
+size 172512528


### PR DESCRIPTION
## Motivation

This PR is motivated by #341 

The `inner_snark_pk.params`, `outer_snark_pk.params`, and `posw_snark_pk.params` are now stored via Git LFS. When you git clone the repository or checkout a branch, it will fetch the large parameter files from LFS. 

This is currently a Draft PR because this requires a bit more testing and making sure that Git LFS works well with the already existing `pre-push` git hook. Additionally, the logic for remote parameter fetching from S3 has not been removed.

The CI tests fails because running the tests currently does not fetch the parameters from LFS (need to add a command to properly fetch the files). Alternatively, we may need to use the remote logic as a failsafe/backup.  
