### PR TITLE
Compiler flag guard sw6

### DIFF
--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -22,7 +22,8 @@ serde = { version = "1.0.114", default-features = false, features = ["derive"] }
 rand_xorshift = { version = "0.2", default-features = false }
 
 [features]
-default = [ "snarkos-errors/default", "snarkos-models/default", "snarkos-utilities/default", ]
+default = ["snarkos-errors/default", "snarkos-models/default", "snarkos-utilities/default"]
+sw6 = []
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/curves/src/edwards_sw6/fq.rs
+++ b/curves/src/edwards_sw6/fq.rs
@@ -1,1 +1,1 @@
-pub use crate::sw6::fr::{Fr as Fq, FrParameters as FqParameters};
+pub use crate::bw6_761::fr::{Fr as Fq, FrParameters as FqParameters};

--- a/curves/src/lib.rs
+++ b/curves/src/lib.rs
@@ -31,6 +31,7 @@ pub mod bls12_377;
 pub mod bw6_761;
 pub mod edwards_bls12;
 pub mod edwards_sw6;
+#[cfg(feature = "sw6")]
 #[deprecated(since = "0.8.0", note = "Please use the `bw6_761` module instead")]
 pub mod sw6;
 pub mod templates;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Guards SW6, which is deprecated, behind a compiler flag.
