### PR TITLE
Adds from_y_coordinate for edwards

### DIFF
--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -48,7 +48,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             let r = input;
 
             // Let u = D.
-            // TODO (howardwu): change to 5.
+            // TODO (howardwu): change to 11.
             let u = Self::D;
 
             // Let ur2 = u * r^2;
@@ -195,7 +195,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
 
         let x = u_reconstructed;
 
-        // TODO (howardwu): change to 5.
+        // TODO (howardwu): change to 11.
         // Let u = D.
         let u = Self::D;
 

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -133,6 +133,15 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
         })
     }
 
+    /// Attempts to construct an affine point given a y-coordinate. The
+    /// point is not guaranteed to be in the prime order subgroup.
+    ///
+    /// If and only if `greatest` is set will the lexicographically
+    /// largest y-coordinate be selected.
+    fn from_y_coordinate(y: Self::BaseField, greatest: bool) -> Option<Self> {
+        unimplemented!()
+    }
+
     fn add(self, _other: &Self) -> Self {
         unimplemented!()
     }

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -131,6 +131,15 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
         })
     }
 
+    /// Attempts to construct an affine point given a y-coordinate. The
+    /// point is not guaranteed to be in the prime order subgroup.
+    ///
+    /// If and only if `greatest` is set will the lexicographically
+    /// largest y-coordinate be selected.
+    fn from_y_coordinate(y: Self::BaseField, greatest: bool) -> Option<Self> {
+        unimplemented!()
+    }
+
     fn add(self, _other: &Self) -> Self {
         unimplemented!()
     }

--- a/curves/src/templates/twisted_edwards_extended/tests.rs
+++ b/curves/src/templates/twisted_edwards_extended/tests.rs
@@ -42,6 +42,7 @@ where
 {
     edwards_curve_serialization_test::<P>();
     edwards_from_random_bytes::<P>();
+    edwards_from_x_and_y_coordinates::<P>();
 }
 
 pub fn edwards_curve_serialization_test<P: TEModelParameters>() {
@@ -139,5 +140,33 @@ where
             g = GroupAffine::<P>::from_random_bytes(&bytes);
         }
         let _g = g.unwrap();
+    }
+}
+
+pub fn edwards_from_x_and_y_coordinates<P: TEModelParameters>()
+where
+    P::BaseField: PrimeField,
+{
+    let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+    for _ in 0..ITERATIONS {
+        let a = GroupProjective::<P>::rand(&mut rng);
+        let a = a.into_affine();
+        {
+            let x = a.x;
+
+            let a1 = GroupAffine::<P>::from_x_coordinate(x, true).unwrap();
+            let a2 = GroupAffine::<P>::from_x_coordinate(x, false).unwrap();
+
+            assert!(a == a1 || a == a2);
+        }
+        {
+            let y = a.y;
+
+            let a1 = GroupAffine::<P>::from_y_coordinate(y, true).unwrap();
+            let a2 = GroupAffine::<P>::from_y_coordinate(y, false).unwrap();
+
+            assert!(a == a1 || a == a2);
+        }
     }
 }

--- a/models/src/curves/pairing_engine.rs
+++ b/models/src/curves/pairing_engine.rs
@@ -211,6 +211,14 @@ pub trait AffineCurve:
     /// largest y-coordinate be selected.
     fn from_x_coordinate(x: Self::BaseField, greatest: bool) -> Option<Self>;
 
+    /// Attempts to construct an affine point given a y-coordinate. The
+    /// point is not guaranteed to be in the prime order subgroup.
+    ///
+    /// If and only if `greatest` is set will the lexicographically
+    /// largest y-coordinate be selected.
+    fn from_y_coordinate(y: Self::BaseField, greatest: bool) -> Option<Self>;
+
+    /// Performs the standard addition operation of this element with a given other element.
     fn add(self, other: &Self) -> Self;
 
     /// Performs scalar multiplication of this element with mixed addition.


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Adds the interface for `from_y_coordinate` and implements it for twisted edwards curves.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Test samples random group elements and attempts to recover using just one of the coordinates. If at least one of the recovered forms (sign low or sign high) matches the original, test will pass.
