### PR TITLE
Wasm support for Account View Key

### DIFF
--- a/toolkit/src/wasm/tests.rs
+++ b/toolkit/src/wasm/tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::wasm::{Account, SignatureScheme, SignatureSchemePublicKey};
+use crate::wasm::{Account, SignatureScheme, SignatureSchemePublicKey, ViewKey};
 
 use wasm_bindgen_test::*;
 
@@ -30,6 +30,17 @@ pub fn account_from_private_key_test() {
 
     println!("{} == {}", given_address, account.address.to_string());
     assert_eq!(given_address, account.address.to_string());
+}
+
+#[wasm_bindgen_test]
+pub fn view_key_from_private_key_test() {
+    let given_private_key = "APrivateKey1tvv5YV1dipNiku2My8jMkqpqCyYKvR5Jq4y2mtjw7s77Zpn";
+    let given_view_key = "AViewKey1m8gvywHKHKfUzZiLiLoHedcdHEjKwo5TWo6efz8gK7wF";
+
+    let view_key = ViewKey::from_private_key(given_private_key);
+
+    println!("{} == {}", given_view_key, view_key.view_key.to_string());
+    assert_eq!(given_view_key, view_key.view_key.to_string());
 }
 
 #[wasm_bindgen_test]

--- a/toolkit/src/wasm/view_key.rs
+++ b/toolkit/src/wasm/view_key.rs
@@ -14,14 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod account;
-pub use account::*;
+use crate::account::{PrivateKey, ViewKey as ViewKeyNative};
 
-pub mod signature;
-pub use signature::*;
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
 
-pub mod view_key;
-pub use view_key::*;
+#[wasm_bindgen]
+pub struct ViewKey {
+    pub(crate) view_key: ViewKeyNative,
+}
 
-#[cfg(test)]
-pub mod tests;
+#[wasm_bindgen]
+impl ViewKey {
+    #[wasm_bindgen]
+    pub fn from_private_key(private_key: &str) -> Self {
+        let private_key = PrivateKey::from_str(private_key).unwrap();
+        let view_key = ViewKeyNative::from(&private_key).unwrap();
+        Self { view_key }
+    }
+
+    #[wasm_bindgen]
+    pub fn to_string(&self) -> String {
+        format!("ViewKey {{ view_key: {} }}", self.view_key)
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR extends wasm support for account view keys that can be derived from private keys.