### PR TITLE
feat(polycommit): support an upper bound on hiding bounds

### DIFF
--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -136,8 +136,11 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
         }
 
         let coeff_support = AHPForR1CS::get_degree_bounds::<C>(&index.index_info);
+        // Marlin only needs degree 2 random polynomials
+        let supported_hiding_bound = 2;
         let (committer_key, verifier_key) =
-            PC::trim(&srs, index.max_degree(), Some(&coeff_support)).map_err(Error::from_pc_err)?;
+            PC::trim(&srs, index.max_degree(), supported_hiding_bound, Some(&coeff_support))
+                .map_err(Error::from_pc_err)?;
 
         let commit_time = start_timer!(|| "Commit to index polynomials");
         let (index_comms, index_comm_rands): (_, _) =

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -137,7 +137,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
 
         let coeff_support = AHPForR1CS::get_degree_bounds::<C>(&index.index_info);
         // Marlin only needs degree 2 random polynomials
-        let supported_hiding_bound = 2;
+        let supported_hiding_bound = 1;
         let (committer_key, verifier_key) =
             PC::trim(&srs, index.max_degree(), supported_hiding_bound, Some(&coeff_support))
                 .map_err(Error::from_pc_err)?;

--- a/marlin/src/snark.rs
+++ b/marlin/src/snark.rs
@@ -153,7 +153,7 @@ where
     ) -> Result<Self::Proof, SNARKError> {
         let proving_time = start_timer!(|| "{Marlin}::Proving");
         let proof = Marlin::prove(&pp.prover_key, circuit, rng)
-            .map_err(|e| SNARKError::Crate("marlin", "Could not generate proof".to_owned()))?;
+            .map_err(|_| SNARKError::Crate("marlin", "Could not generate proof".to_owned()))?;
         end_timer!(proving_time);
         Ok(proof)
     }

--- a/marlin/src/snark.rs
+++ b/marlin/src/snark.rs
@@ -153,7 +153,7 @@ where
     ) -> Result<Self::Proof, SNARKError> {
         let proving_time = start_timer!(|| "{Marlin}::Proving");
         let proof = Marlin::prove(&pp.prover_key, circuit, rng)
-            .map_err(|_| SNARKError::Crate("marlin", "Could not generate proof".to_owned()))?;
+            .map_err(|e| SNARKError::Crate("marlin", "Could not generate proof".to_owned()))?;
         end_timer!(proving_time);
         Ok(proof)
     }

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -165,6 +165,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     fn trim(
         pp: &Self::UniversalParams,
         supported_degree: usize,
+        supported_hiding_bound: usize,
         enforced_degree_bounds: Option<&[usize]>,
     ) -> Result<(Self::CommitterKey, Self::VerifierKey), Self::Error>;
 
@@ -526,7 +527,12 @@ pub mod tests {
             }
 
             println!("supported degree: {:?}", supported_degree);
-            let (ck, vk) = PC::trim(&pp, supported_degree, Some(degree_bounds.as_slice()))?;
+            let (ck, vk) = PC::trim(
+                &pp,
+                supported_degree,
+                supported_degree + 1,
+                Some(degree_bounds.as_slice()),
+            )?;
             println!("Trimmed");
 
             let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
@@ -614,7 +620,12 @@ pub mod tests {
             }
             println!("supported degree: {:?}", supported_degree);
             println!("num_points_in_query_set: {:?}", num_points_in_query_set);
-            let (ck, vk) = PC::trim(&pp, supported_degree, degree_bounds.as_ref().map(|s| s.as_slice()))?;
+            let (ck, vk) = PC::trim(
+                &pp,
+                supported_degree,
+                supported_degree + 1,
+                degree_bounds.as_ref().map(|s| s.as_slice()),
+            )?;
             println!("Trimmed");
 
             let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
@@ -724,7 +735,12 @@ pub mod tests {
             println!("{}", num_polynomials);
             println!("{}", enforce_degree_bounds);
 
-            let (ck, vk) = PC::trim(&pp, supported_degree, degree_bounds.as_ref().map(|s| s.as_slice()))?;
+            let (ck, vk) = PC::trim(
+                &pp,
+                supported_degree,
+                supported_degree + 1,
+                degree_bounds.as_ref().map(|s| s.as_slice()),
+            )?;
             println!("Trimmed");
 
             let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -527,12 +527,7 @@ pub mod tests {
             }
 
             println!("supported degree: {:?}", supported_degree);
-            let (ck, vk) = PC::trim(
-                &pp,
-                supported_degree,
-                supported_degree + 1,
-                Some(degree_bounds.as_slice()),
-            )?;
+            let (ck, vk) = PC::trim(&pp, supported_degree, supported_degree, Some(degree_bounds.as_slice()))?;
             println!("Trimmed");
 
             let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
@@ -623,7 +618,7 @@ pub mod tests {
             let (ck, vk) = PC::trim(
                 &pp,
                 supported_degree,
-                supported_degree + 1,
+                supported_degree,
                 degree_bounds.as_ref().map(|s| s.as_slice()),
             )?;
             println!("Trimmed");
@@ -738,7 +733,7 @@ pub mod tests {
             let (ck, vk) = PC::trim(
                 &pp,
                 supported_degree,
-                supported_degree + 1,
+                supported_degree,
                 degree_bounds.as_ref().map(|s| s.as_slice()),
             )?;
             println!("Trimmed");

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -185,12 +185,10 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         kzg10::KZG10::setup(max_degree, false, rng).map_err(Into::into)
     }
 
-    // TODO: should trim also take in the hiding_bounds? That way we don't
-    // have to store many powers of gamma_g.
-    // TODO: add an optional hiding_bound.
     fn trim(
         pp: &Self::UniversalParams,
         supported_degree: usize,
+        supported_hiding_bound: usize,
         enforced_degree_bounds: Option<&[usize]>,
     ) -> Result<(Self::CommitterKey, Self::VerifierKey), Self::Error> {
         let max_degree = pp.max_degree();
@@ -204,7 +202,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         let powers = pp.powers_of_g[..=supported_degree].to_vec();
         // We want to support making up to supported_degree queries to committed
         // polynomials.
-        let powers_of_gamma_g = pp.powers_of_gamma_g[..=(supported_degree + 1)].to_vec();
+        let powers_of_gamma_g = pp.powers_of_gamma_g[..=supported_hiding_bound].to_vec();
         end_timer!(ck_time);
 
         // Construct the core KZG10 verifier key.

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -200,9 +200,9 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         let ck_time =
             start_timer!(|| format!("Constructing `powers` of size {} for unshifted polys", supported_degree));
         let powers = pp.powers_of_g[..=supported_degree].to_vec();
-        // We want to support making up to supported_degree queries to committed
+        // We want to support making up to `supported_hiding_bound` queries to committed
         // polynomials.
-        let powers_of_gamma_g = pp.powers_of_gamma_g[..=supported_hiding_bound].to_vec();
+        let powers_of_gamma_g = pp.powers_of_gamma_g[..=supported_hiding_bound + 1].to_vec();
         end_timer!(ck_time);
 
         // Construct the core KZG10 verifier key.


### PR DESCRIPTION
This is done so we can use an SRS that has a limited amount of elements of the form `alpha*tau^i`.

