### PR TITLE
Fix bootnode test and add support for sync node selection

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -323,7 +323,7 @@ impl ConsensusParameters {
                 }
                 BlockPath::SideChain(side_chain_path) => {
                     debug!(
-                        "Processing a block that is on side chain - length: {}",
+                        "Processing a block that is on side chain - length {}",
                         side_chain_path.new_block_number
                     );
 

--- a/network/src/context/handshakes.rs
+++ b/network/src/context/handshakes.rs
@@ -104,7 +104,7 @@ impl Handshakes {
             Ok((handshake, receiver, Some(peer_message)))
         } else if Verack::name() == name {
             let peer_message = Verack::deserialize(bytes)?;
-            let peer_address = SocketAddr::new(peer_address.ip(), peer_message.address_sender.port());
+            let peer_address = peer_message.address_sender;
             let receiver = peer_message.address_receiver;
 
             match self.get_mut(&peer_address) {

--- a/network/src/server/message_handler.rs
+++ b/network/src/server/message_handler.rs
@@ -33,7 +33,7 @@ use snarkos_utilities::{
 };
 
 use chrono::Utc;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 impl Server {
     /// This method handles all messages sent from connected peers.
@@ -370,7 +370,7 @@ impl Server {
     /// This method may seem redundant to handshake protocol functions but a peer can send additional
     /// Version messages if they want to update their ip address/port or want to share their chain height.
     async fn receive_version(&mut self, message: Version, channel: Arc<Channel>) -> Result<Arc<Channel>, ServerError> {
-        let peer_address = channel.address;
+        let peer_address = message.address_sender;
         let peer_book = &mut self.context.peer_book.read().await;
 
         if peer_book.connected_total() < self.context.max_peers

--- a/network/src/server/message_handler.rs
+++ b/network/src/server/message_handler.rs
@@ -33,7 +33,7 @@ use snarkos_utilities::{
 };
 
 use chrono::Utc;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 impl Server {
     /// This method handles all messages sent from connected peers.
@@ -370,7 +370,8 @@ impl Server {
     /// This method may seem redundant to handshake protocol functions but a peer can send additional
     /// Version messages if they want to update their ip address/port or want to share their chain height.
     async fn receive_version(&mut self, message: Version, channel: Arc<Channel>) -> Result<Arc<Channel>, ServerError> {
-        let peer_address = message.address_sender;
+        let peer_address = SocketAddr::new(channel.address.ip(), message.address_sender.port());
+
         let peer_book = &mut self.context.peer_book.read().await;
 
         if peer_book.connected_total() < self.context.max_peers

--- a/network/src/server/message_handler.rs
+++ b/network/src/server/message_handler.rs
@@ -33,7 +33,7 @@ use snarkos_utilities::{
 };
 
 use chrono::Utc;
-use std::{net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 
 impl Server {
     /// This method handles all messages sent from connected peers.

--- a/network/tests/server_listen.rs
+++ b/network/tests/server_listen.rs
@@ -110,7 +110,6 @@ mod server_listen {
 
     #[test]
     #[serial]
-    #[ignore] // TODO (howardwu): channel.address does not match message.address_sender.
     fn startup_handshake_bootnode() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let path = storage.storage.db.path().to_owned();

--- a/network/tests/server_listen.rs
+++ b/network/tests/server_listen.rs
@@ -143,7 +143,7 @@ mod server_listen {
             // 4. Send handshake response from bootnode to server
 
             let mut bootnode_handshakes = Handshakes::new();
-            let (mut bootnode_hand, _) = bootnode_handshakes
+            let (mut bootnode_hand, _, _) = bootnode_handshakes
                 .receive_any(1u64, 1u32, bootnode_address, server_address, reader)
                 .await
                 .unwrap();


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR add support to select a sync node correctly on the first handshake and fixes the bootnode test error.