### PR TITLE
Network reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ FLAGS:
         --no-jsonrpc     Run the node without running the json rpc server
 
 OPTIONS:
-        --connect <ip>                           Specify a node ip address to connect to on startup
+        --connect <ip>                           Specify one or more node ip addresses to connect to on startup
     -i, --ip <ip>                                Specify the ip of your node
         --max-peers <max-peers>                  Specify the maximum number of peers the node can connect to
         --mempool-interval <mempool-interval>    Specify the frequency in seconds the node should fetch a sync node's mempool

--- a/network/src/context/connections.rs
+++ b/network/src/context/connections.rs
@@ -40,4 +40,6 @@ impl Connections {
     pub fn store_channel(&mut self, channel: &Arc<Channel>) {
         self.channels.insert(channel.address, channel.clone());
     }
+
+    // TODO (raychu86) Clean up connections if peers are disconnected
 }

--- a/network/src/context/handshakes.rs
+++ b/network/src/context/handshakes.rs
@@ -164,6 +164,11 @@ impl Handshakes {
         }
     }
 
+    /// Returns a reference to the handshake at a peer address.
+    pub fn get(&self, address: &SocketAddr) -> Option<&Handshake> {
+        self.addresses.get(&address)
+    }
+
     /// Returns a mutable reference to the handshake at a peer address.
     fn get_mut(&mut self, address: &SocketAddr) -> Option<&mut Handshake> {
         self.addresses.get_mut(&address)

--- a/network/src/protocol/handshake.rs
+++ b/network/src/protocol/handshake.rs
@@ -42,10 +42,10 @@ pub enum HandshakeState {
 #[derive(Clone, Debug)]
 pub struct Handshake {
     pub channel: Arc<Channel>,
-    state: HandshakeState,
-    version: u64,
-    height: u32,
-    nonce: u64,
+    pub state: HandshakeState,
+    pub version: u64,
+    pub height: u32,
+    pub nonce: u64,
 }
 
 impl Handshake {

--- a/network/src/server/connection_handler.rs
+++ b/network/src/server/connection_handler.rs
@@ -53,6 +53,11 @@ impl Server {
                 let connections = context.connections.read().await;
                 let pings = &mut context.pings.write().await;
 
+                // Remove the local_address from the peer book
+                // if the node somehow discovered itself as a peer.
+                let local_address = *context.local_address.read().await;
+                peer_book.forget_peer(local_address);
+
                 // We have less peers than our minimum peer requirement. Look for more peers.
                 if peer_book.connected_total() < context.min_peers {
                     // Ask our connected peers.

--- a/network/src/server/connection_handler.rs
+++ b/network/src/server/connection_handler.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    message_types::{GetMemoryPool, GetPeers},
+    message_types::{GetMemoryPool, GetPeers, Version},
     Server,
 };
 
@@ -62,8 +62,15 @@ impl Server {
                 if peer_book.connected_total() < context.min_peers {
                     // Ask our connected peers.
                     for (address, _last_seen) in peer_book.get_connected() {
-                        if let Some(channel) = connections.get(&address) {
-                            if let Err(_) = channel.write(&GetPeers).await {
+                        match connections.get(&address) {
+                            Some(channel) => {
+                                // Disconnect from the peer if the get peers message was not sent properly
+                                if let Err(_) = channel.write(&GetPeers).await {
+                                    peer_book.disconnect_peer(address);
+                                }
+                            }
+                            // Disconnect from the peer if there is no active connection channel
+                            None => {
                                 peer_book.disconnect_peer(address);
                             }
                         }
@@ -77,7 +84,7 @@ impl Server {
                                 .write()
                                 .await
                                 .send_request(
-                                    1u64,
+                                    1u64, // TODO (raychu86) Establish a formal node version
                                     storage.get_latest_block_height(),
                                     *context.local_address.read().await,
                                     address,
@@ -97,8 +104,15 @@ impl Server {
                         && time_since_last_seen.is_positive()
                         && time_since_last_seen as u64 > (connection_frequency * 3)
                     {
-                        if let Some(channel) = connections.get(&address) {
-                            if let Err(_) = pings.send_ping(channel).await {
+                        match connections.get(&address) {
+                            Some(channel) => {
+                                // Disconnect from the peer if the ping message was not sent properly
+                                if let Err(_) = pings.send_ping(channel).await {
+                                    peer_book.disconnect_peer(address);
+                                }
+                            }
+                            // Disconnect from the peer if there is no active connection channel
+                            None => {
                                 peer_book.disconnect_peer(address);
                             }
                         }
@@ -128,8 +142,53 @@ impl Server {
                     .store(&storage)
                     .unwrap_or_else(|error| debug!("Failed to store connected peers in database {}", error));
 
+                // Every two frequency loops, send a version message to all peers for periodic syncs.
+                if interval_ticker % 2 == 1 {
+                    if peer_book.connected_total() > 0 {
+                        debug!("Sending out periodic version message to peers");
+                    }
+
+                    for (address, _last_seen) in peer_book.get_connected() {
+                        match connections.get(&address) {
+                            Some(channel) => {
+                                // Send a version message to peers.
+                                // If they are behind, they will attempt to sync.
+                                if let Some(handshake) = context.handshakes.read().await.get(&address) {
+                                    let nonce = handshake.nonce;
+                                    let version = 1u64; // TODO (raychu86) Establish a formal node version
+                                    let message = Version::from(
+                                        version,
+                                        storage.get_latest_block_height(),
+                                        address,
+                                        *context.local_address.read().await,
+                                        nonce,
+                                    );
+                                    if let Err(_) = channel.write(&message).await {
+                                        peer_book.disconnect_peer(address);
+                                    }
+                                }
+                            }
+                            // Disconnect from the peer if there is no active connection channel
+                            None => {
+                                peer_book.disconnect_peer(address);
+                            }
+                        }
+                    }
+                }
+
                 // Update our memory pool after memory_pool_interval frequency loops.
                 if interval_ticker >= context.memory_pool_interval {
+                    // Ask our sync node for more transactions.
+                    if *context.local_address.read().await != sync_handler.sync_node {
+                        if let Some(channel) = connections.get(&sync_handler.sync_node) {
+                            if let Err(_) = channel.write(&GetMemoryPool).await {
+                                peer_book.disconnect_peer(sync_handler.sync_node);
+                            }
+                        }
+                    }
+
+                    // Update our memory pool
+
                     let mut memory_pool = match memory_pool_lock.try_lock() {
                         Ok(memory_pool) => memory_pool,
                         _ => continue,
@@ -142,15 +201,6 @@ impl Server {
                     memory_pool.store(&storage).unwrap_or_else(|error| {
                         debug!("Failed to store memory pool transaction in database {}", error)
                     });
-
-                    // Ask our sync node for more transactions.
-                    if *context.local_address.read().await != sync_handler.sync_node {
-                        if let Some(channel) = connections.get(&sync_handler.sync_node) {
-                            if let Err(_) = channel.write(&GetMemoryPool).await {
-                                peer_book.disconnect_peer(sync_handler.sync_node);
-                            }
-                        }
-                    }
 
                     interval_ticker = 0;
                 } else {

--- a/network/src/server/message_handler.rs
+++ b/network/src/server/message_handler.rs
@@ -89,7 +89,10 @@ impl Server {
             } else {
                 debug!("Message name not recognized {:?}", name.to_string());
             }
-            tx.send(channel).expect("error resetting message handler");
+
+            if let Err(_) = tx.send(channel) {
+                warn!("error resetting connection thread");
+            }
         }
         Ok(())
     }
@@ -374,7 +377,7 @@ impl Server {
 
         let peer_book = &mut self.context.peer_book.read().await;
 
-        if peer_book.connected_total() < self.context.max_peers
+        if (peer_book.connected_total() < self.context.max_peers || peer_book.connected_contains(&peer_address))
             && *self.context.local_address.read().await != peer_address
         {
             self.context

--- a/network/src/server/server.rs
+++ b/network/src/server/server.rs
@@ -150,8 +150,8 @@ impl Server {
         task::spawn(async move {
             // Determines the criteria for disconnecting from a peer.
             fn should_disconnect(failure_count: &u8) -> bool {
-                // Tolerate up to 3 failed communications.
-                *failure_count >= 3
+                // Tolerate up to 10 failed communications.
+                *failure_count >= 10
             }
 
             // Logs the failure and determines whether to disconnect from a peer.

--- a/network/src/server/server.rs
+++ b/network/src/server/server.rs
@@ -331,13 +331,16 @@ impl Server {
         debug!("Starting connection handler");
         self.connection_handler().await;
 
-        // 4. Send handshake request to all bootnodes.
+        // 4. Send handshake request to bootnodes.
         debug!("Sending handshake request to bootnodes");
         self.connect_bootnodes().await?;
 
-        // 5. Send a handshake request to all stored peers.
-        debug!("Sending handshake request to all stored peers");
-        self.connect_peers_from_storage().await?;
+        // If the node is a bootnode, do not send requests to stored peers
+        if !self.context.is_bootnode {
+            // 5. Send a handshake request to all stored peers.
+            debug!("Sending handshake request to all stored peers");
+            self.connect_peers_from_storage().await?;
+        }
 
         // 6. Start the message handler.
         debug!("Starting message handler");

--- a/network/src/server/server.rs
+++ b/network/src/server/server.rs
@@ -261,7 +261,7 @@ impl Server {
                     }
                     Err(error) => {
                         error!("Listener failed to accept connection {}", error);
-                        break;
+                        continue;
                     }
                 };
 

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -252,8 +252,10 @@ impl Config {
     }
 
     fn connect(&mut self, argument: Option<&str>) {
-        if let Some(bootnode) = argument {
-            self.p2p.bootnodes = vec![bootnode.to_string()];
+        if let Some(bootnodes) = argument {
+            let sanitize_bootnodes = bootnodes.replace(&['[', ']', ' '][..], "");
+            let bootnodes: Vec<String> = sanitize_bootnodes.split(',').map(|s| s.to_string()).collect();
+            self.p2p.bootnodes = bootnodes;
         }
     }
 

--- a/snarkos/parameters/option.rs
+++ b/snarkos/parameters/option.rs
@@ -38,7 +38,7 @@ pub const PORT: OptionType = (
 );
 
 pub const CONNECT: OptionType = (
-    "[connect] --connect=[ip] 'Specify a node ip address to connect to on startup'",
+    "[connect] --connect=[ip] 'Specify one or more node ip addresses to connect to on startup'",
     &[],
     &[],
     &[],


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR adds additional network support for node reliability:

  - Periodic sync checks with peers
  - Auto disconnects from the `local_address` if the node attempts to connect to itself
  - `is-bootnode` flag will now prevent nodes from attempting to connect to stored peers
  - Fix bug that halts syncs when disconnects occur
  - More graceful error handing for channels in `message_handler`
  - Increased failure threshold from 3 to 10