### PR TITLE
feat(polycommit): allow gamma_g to support a subset of elements

### DIFF
--- a/polycommit/src/kzg10/data_structures.rs
+++ b/polycommit/src/kzg10/data_structures.rs
@@ -33,7 +33,7 @@ pub struct UniversalParams<E: PairingEngine> {
     /// Group elements of the form `{ \beta^i G }`, where `i` ranges from 0 to `degree`.
     pub powers_of_g: Vec<E::G1Affine>,
     /// Group elements of the form `{ \beta^i \gamma G }`, where `i` ranges from 0 to `degree`.
-    pub powers_of_gamma_g: Vec<E::G1Affine>,
+    pub powers_of_gamma_g: BTreeMap<usize, E::G1Affine>,
     /// The generator of G2.
     pub h: E::G2Affine,
     /// \beta times the above generator of G2.

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -94,7 +94,10 @@ impl<E: PairingEngine> KZG10<E> {
         end_timer!(gamma_g_time);
 
         let powers_of_g = E::G1Projective::batch_normalization_into_affine(&powers_of_g);
-        let powers_of_gamma_g = E::G1Projective::batch_normalization_into_affine(&powers_of_gamma_g).into_iter().enumerate().collect();
+        let powers_of_gamma_g = E::G1Projective::batch_normalization_into_affine(&powers_of_gamma_g)
+            .into_iter()
+            .enumerate()
+            .collect();
 
         let prepared_neg_powers_of_h_time = start_timer!(|| "Generating negative powers of h in G2");
         let prepared_neg_powers_of_h = if produce_g2_powers {

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -94,7 +94,7 @@ impl<E: PairingEngine> KZG10<E> {
         end_timer!(gamma_g_time);
 
         let powers_of_g = E::G1Projective::batch_normalization_into_affine(&powers_of_g);
-        let powers_of_gamma_g = E::G1Projective::batch_normalization_into_affine(&powers_of_gamma_g);
+        let powers_of_gamma_g = E::G1Projective::batch_normalization_into_affine(&powers_of_gamma_g).into_iter().enumerate().collect();
 
         let prepared_neg_powers_of_h_time = start_timer!(|| "Generating negative powers of h in G2");
         let prepared_neg_powers_of_h = if produce_g2_powers {
@@ -458,7 +458,7 @@ mod tests {
                 supported_degree += 1;
             }
             let powers_of_g = pp.powers_of_g[..=supported_degree].to_vec();
-            let powers_of_gamma_g = pp.powers_of_gamma_g[..=supported_degree].to_vec();
+            let powers_of_gamma_g = (0..=supported_degree).map(|i| pp.powers_of_gamma_g[&i]).collect();
 
             let powers = Powers {
                 powers_of_g: Cow::Owned(powers_of_g),
@@ -466,7 +466,7 @@ mod tests {
             };
             let vk = VerifierKey {
                 g: pp.powers_of_g[0],
-                gamma_g: pp.powers_of_gamma_g[0],
+                gamma_g: pp.powers_of_gamma_g[&0],
                 h: pp.h,
                 beta_h: pp.beta_h,
                 prepared_h: pp.prepared_h.clone(),

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -625,12 +625,17 @@ pub mod tests {
 
                 polynomials.push(LabeledPolynomial::new_owned(label, poly, degree_bound, hiding_bound))
             }
+            let supported_hiding_bound = polynomials.iter().map(|p| match p.hiding_bound() {
+                Some(b) => b,
+                None => 0,
+            }).max().unwrap_or(0);
             println!("supported degree: {:?}", supported_degree);
+            println!("supported hiding bound: {:?}", supported_hiding_bound);
             println!("num_points_in_query_set: {:?}", num_points_in_query_set);
             let (ck, vk) = PC::trim(
                 &pp,
                 supported_degree,
-                supported_degree,
+                supported_hiding_bound,
                 degree_bounds.as_ref().map(|s| s.as_slice()),
             )?;
             println!("Trimmed");
@@ -736,7 +741,12 @@ pub mod tests {
 
                 polynomials.push(LabeledPolynomial::new_owned(label, poly, degree_bound, hiding_bound))
             }
+            let supported_hiding_bound = polynomials.iter().map(|p| match p.hiding_bound() {
+                Some(b) => b,
+                None => 0,
+            }).max().unwrap_or(0);
             println!("supported degree: {:?}", supported_degree);
+            println!("supported hiding bound: {:?}", supported_hiding_bound);
             println!("num_points_in_query_set: {:?}", num_points_in_query_set);
             println!("{:?}", degree_bounds);
             println!("{}", num_polynomials);
@@ -745,7 +755,7 @@ pub mod tests {
             let (ck, vk) = PC::trim(
                 &pp,
                 supported_degree,
-                supported_degree,
+                supported_hiding_bound,
                 degree_bounds.as_ref().map(|s| s.as_slice()),
             )?;
             println!("Trimmed");

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -625,10 +625,14 @@ pub mod tests {
 
                 polynomials.push(LabeledPolynomial::new_owned(label, poly, degree_bound, hiding_bound))
             }
-            let supported_hiding_bound = polynomials.iter().map(|p| match p.hiding_bound() {
-                Some(b) => b,
-                None => 0,
-            }).max().unwrap_or(0);
+            let supported_hiding_bound = polynomials
+                .iter()
+                .map(|p| match p.hiding_bound() {
+                    Some(b) => b,
+                    None => 0,
+                })
+                .max()
+                .unwrap_or(0);
             println!("supported degree: {:?}", supported_degree);
             println!("supported hiding bound: {:?}", supported_hiding_bound);
             println!("num_points_in_query_set: {:?}", num_points_in_query_set);
@@ -741,10 +745,14 @@ pub mod tests {
 
                 polynomials.push(LabeledPolynomial::new_owned(label, poly, degree_bound, hiding_bound))
             }
-            let supported_hiding_bound = polynomials.iter().map(|p| match p.hiding_bound() {
-                Some(b) => b,
-                None => 0,
-            }).max().unwrap_or(0);
+            let supported_hiding_bound = polynomials
+                .iter()
+                .map(|p| match p.hiding_bound() {
+                    Some(b) => b,
+                    None => 0,
+                })
+                .max()
+                .unwrap_or(0);
             println!("supported degree: {:?}", supported_degree);
             println!("supported hiding bound: {:?}", supported_hiding_bound);
             println!("num_points_in_query_set: {:?}", num_points_in_query_set);

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -202,13 +202,13 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         let powers = pp.powers_of_g[..=supported_degree].to_vec();
         // We want to support making up to `supported_hiding_bound` queries to committed
         // polynomials.
-        let powers_of_gamma_g = pp.powers_of_gamma_g[..=supported_hiding_bound + 1].to_vec();
+        let powers_of_gamma_g = (0..=supported_hiding_bound + 1).map(|i| pp.powers_of_gamma_g[&i]).collect::<Vec<_>>();
         end_timer!(ck_time);
 
         // Construct the core KZG10 verifier key.
         let vk = kzg10::VerifierKey {
             g: pp.powers_of_g[0],
-            gamma_g: pp.powers_of_gamma_g[0],
+            gamma_g: pp.powers_of_gamma_g[&0],
             h: pp.h,
             beta_h: pp.beta_h,
             prepared_h: pp.prepared_h.clone(),

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -202,7 +202,9 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         let powers = pp.powers_of_g[..=supported_degree].to_vec();
         // We want to support making up to `supported_hiding_bound` queries to committed
         // polynomials.
-        let powers_of_gamma_g = (0..=supported_hiding_bound + 1).map(|i| pp.powers_of_gamma_g[&i]).collect::<Vec<_>>();
+        let powers_of_gamma_g = (0..=supported_hiding_bound + 1)
+            .map(|i| pp.powers_of_gamma_g[&i])
+            .collect::<Vec<_>>();
         end_timer!(ck_time);
 
         // Construct the core KZG10 verifier key.

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -180,15 +180,13 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
                     let shifted_powers_of_g = pp.powers_of_g[lowest_shift_degree..].to_vec();
                     let mut shifted_powers_of_gamma_g = BTreeMap::new();
                     // Also add degree 0.
-                    for degree_bound in [enforced_degree_bounds.clone(), vec![max_degree]].concat() {
+                    for degree_bound in enforced_degree_bounds {
                         let shift_degree = max_degree - degree_bound;
                         let mut powers_for_degree_bound = vec![];
                         for i in 0..=supported_hiding_bound + 1 {
-                            if shift_degree + i < pp.powers_of_gamma_g.len() {
-                                powers_for_degree_bound.push(pp.powers_of_gamma_g[&(shift_degree + i)]);
-                            }
+                            powers_for_degree_bound.push(pp.powers_of_gamma_g[&(shift_degree + i)]);
                         }
-                        shifted_powers_of_gamma_g.insert(degree_bound, powers_for_degree_bound);
+                        shifted_powers_of_gamma_g.insert(*degree_bound, powers_for_degree_bound);
                     }
 
                     end_timer!(shifted_ck_time);

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -195,11 +195,15 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
                     let shifted_powers_of_g = pp.powers_of_g[lowest_shift_degree..].to_vec();
                     let mut shifted_powers_of_gamma_g = BTreeMap::new();
                     // Also add degree 0.
+                    let max_gamma_g = pp.powers_of_gamma_g.keys().last().unwrap();
                     for degree_bound in enforced_degree_bounds {
                         let shift_degree = max_degree - degree_bound;
                         let mut powers_for_degree_bound = vec![];
                         for i in 0..=supported_hiding_bound + 1 {
-                            powers_for_degree_bound.push(pp.powers_of_gamma_g[&(shift_degree + i)]);
+                            // We have an additional degree in `powers_of_gamma_g` beyond `powers_of_g`.
+                            if shift_degree + i < max_degree + 2 {
+                                powers_for_degree_bound.push(pp.powers_of_gamma_g[&(shift_degree + i)]);
+                            }
                         }
                         shifted_powers_of_gamma_g.insert(*degree_bound, powers_for_degree_bound);
                     }

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -1,7 +1,22 @@
 use crate::{
-    kzg10, BTreeMap, BTreeSet, BatchLCProof, Error, Evaluations, LabeledCommitment, LabeledPolynomial,
-    LinearCombination, PCCommitterKey, PCRandomness, PCUniversalParams, Polynomial, PolynomialCommitment, QuerySet,
-    String, ToString, Vec,
+    kzg10,
+    BTreeMap,
+    BTreeSet,
+    BatchLCProof,
+    Error,
+    Evaluations,
+    LabeledCommitment,
+    LabeledPolynomial,
+    LinearCombination,
+    PCCommitterKey,
+    PCRandomness,
+    PCUniversalParams,
+    Polynomial,
+    PolynomialCommitment,
+    QuerySet,
+    String,
+    ToString,
+    Vec,
 };
 
 use snarkos_models::curves::{AffineCurve, Group, One, PairingCurve, PairingEngine, ProjectiveCurve, Zero};

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -1,22 +1,7 @@
 use crate::{
-    kzg10,
-    BTreeMap,
-    BTreeSet,
-    BatchLCProof,
-    Error,
-    Evaluations,
-    LabeledCommitment,
-    LabeledPolynomial,
-    LinearCombination,
-    PCCommitterKey,
-    PCRandomness,
-    PCUniversalParams,
-    Polynomial,
-    PolynomialCommitment,
-    QuerySet,
-    String,
-    ToString,
-    Vec,
+    kzg10, BTreeMap, BTreeSet, BatchLCProof, Error, Evaluations, LabeledCommitment, LabeledPolynomial,
+    LinearCombination, PCCommitterKey, PCRandomness, PCUniversalParams, Polynomial, PolynomialCommitment, QuerySet,
+    String, ToString, Vec,
 };
 
 use snarkos_models::curves::{AffineCurve, Group, One, PairingCurve, PairingEngine, ProjectiveCurve, Zero};
@@ -193,7 +178,18 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
                     ));
 
                     let shifted_powers_of_g = pp.powers_of_g[lowest_shift_degree..].to_vec();
-                    let shifted_powers_of_gamma_g = pp.powers_of_gamma_g[lowest_shift_degree..].to_vec();
+                    let mut shifted_powers_of_gamma_g = BTreeMap::new();
+                    // Also add degree 0.
+                    for degree_bound in [enforced_degree_bounds.clone(), vec![max_degree]].concat() {
+                        let shift_degree = max_degree - degree_bound;
+                        let mut powers_for_degree_bound = vec![];
+                        for i in 0..=supported_hiding_bound + 1 {
+                            if shift_degree + i < pp.powers_of_gamma_g.len() {
+                                powers_for_degree_bound.push(pp.powers_of_gamma_g[&(shift_degree + i)]);
+                            }
+                        }
+                        shifted_powers_of_gamma_g.insert(degree_bound, powers_for_degree_bound);
+                    }
 
                     end_timer!(shifted_ck_time);
 
@@ -220,7 +216,9 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
             };
 
         let powers_of_g = pp.powers_of_g[..=supported_degree].to_vec();
-        let powers_of_gamma_g = pp.powers_of_gamma_g[..=supported_hiding_bound + 1].to_vec();
+        let powers_of_gamma_g = (0..=supported_hiding_bound + 1)
+            .map(|i| pp.powers_of_gamma_g[&i])
+            .collect();
 
         let ck = CommitterKey {
             powers_of_g,
@@ -234,7 +232,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let g = pp.powers_of_g[0];
         let h = pp.h;
         let beta_h = pp.beta_h;
-        let gamma_g = pp.powers_of_gamma_g[0];
+        let gamma_g = pp.powers_of_gamma_g[&0];
         let prepared_h = (&pp.prepared_h).clone();
         let prepared_beta_h = (&pp.prepared_beta_h).clone();
 


### PR DESCRIPTION
## Motivation

This allows the SRS to contain just log(N) elements in `gamma_g`. To facilitate the change, `powers_of_gamma_g` is now a BTreeMap.