### PR TITLE
Add support for secondary rocksdb instance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.3"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.7.4"
+version = "6.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
+checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
 dependencies = [
  "bindgen",
  "cc",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
+checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/algorithms/tests/snark/mimc.rs
+++ b/algorithms/tests/snark/mimc.rs
@@ -17,10 +17,10 @@
 #![deny(unused_import_braces, unused_qualifications, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_qualifications, variant_size_differences, stable_features)]
 #![deny(
-non_shorthand_field_patterns,
-unused_attributes,
-unused_imports,
-unused_extern_crates
+    non_shorthand_field_patterns,
+    unused_attributes,
+    unused_imports,
+    unused_extern_crates
 )]
 #![deny(renamed_and_removed_lints, stable_features, unused_allocation, unused_comparisons)]
 #![deny(unused_must_use, unused_mut, unused_unsafe, private_in_public, unsafe_code)]

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -310,8 +310,8 @@ impl ConsensusParameters {
             // If the block is not an unknown orphan, find the origin of the block
             match storage.get_block_path(&block.header)? {
                 BlockPath::ExistingBlock => {}
-                BlockPath::CanonChain(_) => {
-                    debug!("Processing a block that is on canon chain");
+                BlockPath::CanonChain(block_height) => {
+                    debug!("Processing a block that is on canon chain. Height {}", block_height);
 
                     self.process_block(parameters, &storage, memory_pool, block)?;
 
@@ -323,7 +323,7 @@ impl ConsensusParameters {
                 }
                 BlockPath::SideChain(side_chain_path) => {
                     debug!(
-                        "Processing a block that is on side chain - length {}",
+                        "Processing a block that is on side chain. Height {}",
                         side_chain_path.new_block_number
                     );
 

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -330,7 +330,10 @@ impl ConsensusParameters {
                     // If the side chain is now longer than the canon chain,
                     // perform a fork to the side chain.
                     if side_chain_path.new_block_number > storage.get_latest_block_height() {
-                        debug!("Determined side chain is longer than canon chain");
+                        debug!(
+                            "Determined side chain is longer than canon chain by {} blocks",
+                            side_chain_path.new_block_number - storage.get_latest_block_height()
+                        );
                         warn!("A valid fork has been detected. Performing a fork to the side chain.");
 
                         // Fork to superior side chain

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -314,12 +314,6 @@ impl ConsensusParameters {
                     debug!("Processing a block that is on canon chain. Height {}", block_height);
 
                     self.process_block(parameters, &storage, memory_pool, block)?;
-
-                    let (_, child_path) = storage.longest_child_path(block.header.get_hash())?;
-                    for child_block_hash in child_path {
-                        let new_block = storage.get_block(&child_block_hash)?;
-                        self.process_block(parameters, &storage, memory_pool, &new_block)?;
-                    }
                 }
                 BlockPath::SideChain(side_chain_path) => {
                     debug!(

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -314,6 +314,14 @@ impl ConsensusParameters {
                     debug!("Processing a block that is on canon chain. Height {}", block_height);
 
                     self.process_block(parameters, &storage, memory_pool, block)?;
+
+                    // Attempt to fast forward the block state if the node already stores
+                    // the children of the new canon block.
+                    let (_, child_path) = storage.longest_child_path(block.header.get_hash())?;
+                    for child_block_hash in child_path {
+                        let new_block = storage.get_block(&child_block_hash)?;
+                        self.process_block(parameters, &storage, memory_pool, &new_block)?;
+                    }
                 }
                 BlockPath::SideChain(side_chain_path) => {
                     debug!(

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -18,7 +18,7 @@ bincode = { version = "1.3.1" }
 curl = { version = "0.4.33", optional = true }
 hex = { version = "0.4.2" }
 jsonrpc-core = { version = "14.2.0" }
-rocksdb = { version = "0.13.0", optional = true }
+rocksdb = { version = "0.15.0", optional = true }
 thiserror = { version = "1.0" }
 toml = { version = "0.5.6" }
 

--- a/network/src/protocol/sync.rs
+++ b/network/src/protocol/sync.rs
@@ -44,7 +44,7 @@ pub struct SyncHandler {
     /// Current state of the sync handler
     pub sync_state: SyncState,
     /// Block headers of blocks that need to be downloaded
-    block_headers: Vec<BlockHeaderHash>,
+    pub block_headers: Vec<BlockHeaderHash>,
     /// Pending blocks - Blocks that have been requested and the time of the request
     pub pending_blocks: HashMap<BlockHeaderHash, DateTime<Utc>>,
 }

--- a/network/src/server/message_handler.rs
+++ b/network/src/server/message_handler.rs
@@ -377,25 +377,32 @@ impl Server {
 
         let peer_book = &mut self.context.peer_book.read().await;
 
-        if (peer_book.connected_total() < self.context.max_peers || peer_book.connected_contains(&peer_address))
-            && *self.context.local_address.read().await != peer_address
-        {
-            self.context
-                .handshakes
-                .write()
-                .await
-                .receive_request(message.clone(), peer_address)
-                .await?;
+        if *self.context.local_address.read().await != peer_address {
+            if peer_book.connected_total() < self.context.max_peers {
+                self.context
+                    .handshakes
+                    .write()
+                    .await
+                    .receive_request(message.clone(), peer_address)
+                    .await?;
+            }
 
             // If our peer has a longer chain, send a sync message
             if message.height > self.storage.get_latest_block_height() {
-                // Update the sync node if the sync_handler is Idle
+                // Update the sync node if the sync_handler is Idle or there are no requested block headers
                 if let Ok(mut sync_handler) = self.sync_handler_lock.try_lock() {
-                    if !sync_handler.is_syncing() {
+                    if !sync_handler.is_syncing()
+                        || (sync_handler.block_headers.len() == 0 && sync_handler.pending_blocks.is_empty())
+                    {
+                        debug!("Received a version message with a greater height. Attempting to sync.");
                         sync_handler.sync_node = peer_address;
 
                         if let Ok(block_locator_hashes) = self.storage.get_block_locator_hashes() {
                             channel.write(&GetSync::new(block_locator_hashes)).await?;
+                        }
+                    } else {
+                        if let Some(channel) = self.context.connections.read().await.get(&sync_handler.sync_node) {
+                            sync_handler.increment(channel, Arc::clone(&self.storage)).await?;
                         }
                     }
                 }

--- a/network/src/server/message_handler.rs
+++ b/network/src/server/message_handler.rs
@@ -43,6 +43,7 @@ impl Server {
     ///
     /// The oneshot sender lets the connection thread know when the message is handled.
     pub(in crate::server) async fn message_handler(&mut self) -> Result<(), ServerError> {
+        // TODO (raychu86) Update error handling to prevent breaking the message handler
         while let Some((tx, name, bytes, mut channel)) = self.receiver.recv().await {
             if name == Block::name() {
                 self.receive_block_message(Block::deserialize(bytes)?, channel.clone(), true)

--- a/network/src/server/miner_instance.rs
+++ b/network/src/server/miner_instance.rs
@@ -66,10 +66,13 @@ impl MinerInstance {
             loop {
                 info!("Starting to mine the next block");
 
-                let (block_serialized, _coinbase_records) = miner
+                let (block_serialized, _coinbase_records) = match miner
                     .mine_block(&self.parameters, &self.storage, &self.memory_pool_lock)
                     .await
-                    .unwrap();
+                {
+                    Ok(mined_block) => mined_block,
+                    Err(_) => continue,
+                };
 
                 match Block::<Tx>::deserialize(&block_serialized) {
                     Ok(block) => {

--- a/network/src/server/miner_instance.rs
+++ b/network/src/server/miner_instance.rs
@@ -63,6 +63,8 @@ impl MinerInstance {
             info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
             let miner = Miner::new(self.miner_address.clone(), self.consensus.clone());
 
+            let mut mining_failure_count = 0;
+
             loop {
                 info!("Starting to mine the next block");
 
@@ -71,7 +73,15 @@ impl MinerInstance {
                     .await
                 {
                     Ok(mined_block) => mined_block,
-                    Err(_) => continue,
+                    Err(_) => {
+                        mining_failure_count += 1;
+
+                        if mining_failure_count >= 10 {
+                            break;
+                        } else {
+                            continue;
+                        }
+                    }
                 };
 
                 match Block::<Tx>::deserialize(&block_serialized) {

--- a/network/src/server/mod.rs
+++ b/network/src/server/mod.rs
@@ -96,7 +96,9 @@ pub async fn propagate_block(context: Arc<Context>, data: Vec<u8>, block_miner: 
     for (socket, _) in &context.peer_book.read().await.get_connected() {
         if *socket != block_miner && *socket != *context.local_address.read().await {
             if let Some(channel) = context.connections.read().await.get(socket) {
-                channel.write(&Block::new(data.clone())).await?;
+                if let Err(_) = channel.write(&Block::new(data.clone())).await {
+                    warn!("Failed to send block to {}", socket);
+                }
             }
         }
     }

--- a/network/src/server/server.rs
+++ b/network/src/server/server.rs
@@ -309,11 +309,14 @@ impl Server {
                                         sync_handler.sync_node = handshake.channel.address;
 
                                         if let Ok(block_locator_hashes) = storage.get_block_locator_hashes() {
-                                            handshake
-                                                .channel
-                                                .write(&GetSync::new(block_locator_hashes))
-                                                .await
-                                                .unwrap();
+                                            if let Err(err) =
+                                                handshake.channel.write(&GetSync::new(block_locator_hashes)).await
+                                            {
+                                                error!(
+                                                    "Error sending GetSync message to {}, {}",
+                                                    handshake.channel.address, err
+                                                );
+                                            }
                                         }
                                     }
                                 }

--- a/posw/src/consensus.rs
+++ b/posw/src/consensus.rs
@@ -92,11 +92,8 @@ where
 
     /// Loads the PoSW runner from the locally stored parameters.
     pub fn load() -> Result<Self, PoswError> {
-        let params = PoswSNARKVKParameters::load_bytes()?;
-        let vk = S::VerificationParameters::read(&params[..])?;
-
-        let params = PoswSNARKPKParameters::load_bytes()?;
-        let pk = S::ProvingParameters::read(&params[..])?;
+        let vk = S::VerificationParameters::read(&PoswSNARKVKParameters::load_bytes()?[..])?;
+        let pk = S::ProvingParameters::read(&PoswSNARKPKParameters::load_bytes()?[..])?;
 
         Ok(Self {
             pk: Some(pk),

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -37,7 +37,7 @@ use tokio::sync::Mutex;
 /// This may be changed in the future to give the node more control of the rpc server.
 pub async fn start_rpc_server(
     rpc_port: u16,
-    storage: Arc<MerkleTreeLedger>,
+    secondary_storage: Arc<MerkleTreeLedger>,
     storage_path: PathBuf,
     parameters: PublicParameters<Components>,
     server_context: Arc<Context>,
@@ -54,7 +54,7 @@ pub async fn start_rpc_server(
     };
 
     let rpc_impl = RpcImpl::new(
-        storage,
+        secondary_storage,
         storage_path,
         parameters,
         server_context,

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -29,7 +29,7 @@ use snarkos_dpc::base_dpc::{
 use snarkos_network::context::Context;
 
 use jsonrpc_http_server::{cors::AccessControlAllowHeaders, hyper, ServerBuilder};
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
 
 /// Starts a local JSON-RPC HTTP server at rpc_port in a new thread.
@@ -38,6 +38,7 @@ use tokio::sync::Mutex;
 pub async fn start_rpc_server(
     rpc_port: u16,
     storage: Arc<MerkleTreeLedger>,
+    storage_path: PathBuf,
     parameters: PublicParameters<Components>,
     server_context: Arc<Context>,
     consensus: ConsensusParameters,
@@ -54,6 +55,7 @@ pub async fn start_rpc_server(
 
     let rpc_impl = RpcImpl::new(
         storage,
+        storage_path,
         parameters,
         server_context,
         consensus,

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -80,7 +80,7 @@ mod protected_rpc_tests {
         let context = Context::new(server_address, 5, 1, 10, true, vec![]);
 
         let storage = storage.clone();
-        let storage_path = storage.storage.db.path().into_path_buf();
+        let storage_path = storage.storage.db.path().to_path_buf();
 
         let rpc_impl = RpcImpl::new(
             storage,

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -79,8 +79,12 @@ mod protected_rpc_tests {
 
         let context = Context::new(server_address, 5, 1, 10, true, vec![]);
 
+        let storage = storage.clone();
+        let storage_path = storage.storage.db.path().into_path_buf();
+
         let rpc_impl = RpcImpl::new(
-            storage.clone(),
+            storage,
+            storage_path,
             parameters,
             Arc::new(context),
             consensus,

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -46,9 +46,14 @@ mod rpc_tests {
         );
 
         let consensus = TEST_CONSENSUS.clone();
+
+        let storage = storage.clone();
+        let storage_path = storage.storage.db.path().to_path_buf();
+
         Rpc::new(
             RpcImpl::new(
-                storage.clone(),
+                storage,
+                storage_path,
                 parameters,
                 server.context.clone(),
                 consensus,

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -128,11 +128,13 @@ async fn start_server(config: Config) -> Result<(), NodeError> {
         let proving_parameters = PublicParameters::<Components>::load(!config.miner.is_miner)?;
         info!("Loading complete.");
 
-        let secondary_storage = Arc::new(MerkleTreeLedger::open_secondary_at_path(path)?);
+        // Open a secondary storage instance to prevent resource sharing and bottle-necking.
+        let secondary_storage = Arc::new(MerkleTreeLedger::open_secondary_at_path(path.clone())?);
 
         start_rpc_server(
             config.rpc.port,
             secondary_storage.clone(),
+            path,
             proving_parameters,
             server.context.clone(),
             consensus.clone(),

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -67,7 +67,7 @@ async fn start_server(config: Config) -> Result<(), NodeError> {
 
     let mut path = config.node.dir;
     path.push(&config.node.db);
-    let storage = Arc::new(MerkleTreeLedger::open_at_path(path)?);
+    let storage = Arc::new(MerkleTreeLedger::open_at_path(path.clone())?);
 
     let memory_pool = MemoryPool::from_storage(&storage.clone())?;
     let memory_pool_lock = Arc::new(Mutex::new(memory_pool.clone()));
@@ -128,9 +128,11 @@ async fn start_server(config: Config) -> Result<(), NodeError> {
         let proving_parameters = PublicParameters::<Components>::load(!config.miner.is_miner)?;
         info!("Loading complete.");
 
+        let secondary_storage = Arc::new(MerkleTreeLedger::open_secondary_at_path(path)?);
+
         start_rpc_server(
             config.rpc.port,
-            storage.clone(),
+            secondary_storage.clone(),
             proving_parameters,
             server.context.clone(),
             consensus.clone(),

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -23,7 +23,7 @@ bincode = { version = "1.3.1" }
 hex = { version = "0.4.2" }
 parking_lot = { version = "0.11.0" }
 rand = { version = "0.7" }
-rocksdb = { version = "0.13.0" }
+rocksdb = { version = "0.15.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -165,20 +165,20 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     /// Attempt to catch the secondary read-only storage instance with the primary instance.
     pub fn catch_up_secondary(&self) -> Result<(), StorageError> {
         // Sync the secondary and primary instances
-        self.storage.db.try_catch_up_with_primary()?;
+        if self.storage.db.try_catch_up_with_primary().is_ok() {
+            // Update the latest block height of the secondary instance.
+            let latest_block_height_bytes = self.get(COL_META, &KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec())?;
+            let new_latest_block_height = bytes_to_u32(latest_block_height_bytes);
 
-        // Update the latest block height of the secondary instance.
-        let latest_block_height_bytes = self.get(COL_META, &KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec())?;
-        let new_latest_block_height = bytes_to_u32(latest_block_height_bytes);
+            let mut latest_block_height = self.latest_block_height.write();
 
-        let mut latest_block_height = self.latest_block_height.write();
+            if new_latest_block_height >= *latest_block_height {
+                *latest_block_height = new_latest_block_height;
 
-        if new_latest_block_height >= *latest_block_height {
-            *latest_block_height = new_latest_block_height;
-
-            // Update the Merkle tree of the secondary instance.
-            let mut merkle_tree = self.cm_merkle_tree.write();
-            *merkle_tree = self.build_merkle_tree(vec![])?;
+                // Update the Merkle tree of the secondary instance.
+                let mut merkle_tree = self.cm_merkle_tree.write();
+                *merkle_tree = self.build_merkle_tree(vec![])?;
+            }
         }
 
         Ok(())

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -167,14 +167,19 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         // Sync the secondary and primary instances
         self.storage.db.try_catch_up_with_primary()?;
 
-        // Update the Merkle tree of the secondary instance.
-        let mut merkle_tree = self.cm_merkle_tree.write();
-        *merkle_tree = self.build_merkle_tree(vec![])?;
-
         // Update the latest block height of the secondary instance.
         let latest_block_height_bytes = self.get(COL_META, &KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec())?;
+        let new_latest_block_height = bytes_to_u32(latest_block_height_bytes);
+
         let mut latest_block_height = self.latest_block_height.write();
-        *latest_block_height = bytes_to_u32(latest_block_height_bytes);
+
+        if new_latest_block_height >= *latest_block_height {
+            *latest_block_height = new_latest_block_height;
+
+            // Update the Merkle tree of the secondary instance.
+            let mut merkle_tree = self.cm_merkle_tree.write();
+            *merkle_tree = self.build_merkle_tree(vec![])?;
+        }
 
         Ok(())
     }

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -107,7 +107,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         }
     }
 
-    /// Get memo index
+    /// Build a new commitment merkle tree from the stored commitments
     pub fn build_merkle_tree(
         &self,
         additional_cms: Vec<(T::Commitment, usize)>,

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -75,7 +75,7 @@ impl Storage {
     /// Returns the iterator from a given col.
     /// If the given key does not exist, returns [StorageError](snarkos_errors::storage::StorageError).
     pub(crate) fn get_iter(&self, col: u32) -> Result<DBIterator, StorageError> {
-        Ok(self.db.iterator_cf(self.get_cf_ref(col), IteratorMode::Start)?)
+        Ok(self.db.iterator_cf(self.get_cf_ref(col), IteratorMode::Start))
     }
 
     /// Returns `Ok(())` after executing a database transaction
@@ -87,11 +87,11 @@ impl Storage {
             match operation {
                 Op::Insert { col, key, value } => {
                     let cf = self.get_cf_ref(col);
-                    batch.put_cf(cf, &key, value)?;
+                    batch.put_cf(cf, &key, value);
                 }
                 Op::Delete { col, key } => {
                     let cf = self.get_cf_ref(col);
-                    batch.delete_cf(cf, &key)?;
+                    batch.delete_cf(cf, &key);
                 }
             };
         }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -74,15 +74,16 @@ impl Storage {
         }
 
         let mut storage_opts = Options::default();
-        storage_opts.increase_parallelism(3);
+        storage_opts.increase_parallelism(2);
 
-        // TODO (raychu86) Test with open_cf_as_read_only to see if it works
         let storage = Arc::new(DB::open_cf_as_secondary(
             &storage_opts,
             primary_path,
             secondary_path,
             cf_names.clone(),
         )?);
+
+        storage.try_catch_up_with_primary()?;
 
         Ok(Self { db: storage, cf_names })
     }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR creates a read-only rocksdb [secondary instance](https://github.com/facebook/rocksdb/wiki/Secondary-instance) for the `rpc`. This will help prevent resource hogging by the rpc prevent the rpc from holding the storage locks that are required for processing blocks. 