### PR TITLE
rocksdb secondary instance update efficiency

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -281,7 +281,7 @@ impl ConsensusParameters {
         Ok(())
     }
 
-    /// Receive a block from an external source and process it based on ledger state
+    /// Receive a block from an external source and process it based on ledger state.
     pub fn receive_block(
         &self,
         parameters: &PublicParameters<Components>,

--- a/network/src/server/miner_instance.rs
+++ b/network/src/server/miner_instance.rs
@@ -64,6 +64,7 @@ impl MinerInstance {
             let miner = Miner::new(self.miner_address.clone(), self.consensus.clone());
 
             let mut mining_failure_count = 0;
+            let mining_failure_threshold = 10;
 
             loop {
                 info!("Starting to mine the next block");
@@ -73,10 +74,18 @@ impl MinerInstance {
                     .await
                 {
                     Ok(mined_block) => mined_block,
-                    Err(_) => {
+                    Err(error) => {
+                        warn!(
+                            "Miner failed to mine a block {} time(s). (error message: {}).",
+                            mining_failure_count, error
+                        );
                         mining_failure_count += 1;
 
-                        if mining_failure_count >= 10 {
+                        if mining_failure_count >= mining_failure_threshold {
+                            warn!(
+                                "Miner has failed to mine a block {} times. Shutting down miner.",
+                                mining_failure_count
+                            );
                             break;
                         } else {
                             continue;

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -98,7 +98,7 @@ impl RpcFunctions for RpcImpl {
         let block_hash = hex::decode(&block_hash_string)?;
         assert_eq!(block_hash.len(), 32);
 
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
 
         let block_header_hash = BlockHeaderHash::new(block_hash);
         let height = match self.storage.get_block_number(&block_header_hash) {
@@ -142,13 +142,13 @@ impl RpcFunctions for RpcImpl {
 
     /// Returns the number of blocks in the canonical chain.
     fn get_block_count(&self) -> Result<u32, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         Ok(self.storage.get_block_count())
     }
 
     /// Returns the block hash of the head of the canonical chain.
     fn get_best_block_hash(&self) -> Result<String, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         let best_block_hash = self.storage.get_block_hash(self.storage.get_latest_block_height())?;
 
         Ok(hex::encode(&best_block_hash.0))
@@ -156,7 +156,7 @@ impl RpcFunctions for RpcImpl {
 
     /// Returns the block hash of the index specified if it exists in the canonical chain.
     fn get_block_hash(&self, block_height: u32) -> Result<String, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         let block_hash = self.storage.get_block_hash(block_height)?;
 
         Ok(hex::encode(&block_hash.0))
@@ -164,7 +164,7 @@ impl RpcFunctions for RpcImpl {
 
     /// Returns the hex encoded bytes of a transaction from its transaction id.
     fn get_raw_transaction(&self, transaction_id: String) -> Result<String, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         Ok(hex::encode(
             &self.storage.get_transaction_bytes(&hex::decode(transaction_id)?)?,
         ))
@@ -178,7 +178,7 @@ impl RpcFunctions for RpcImpl {
 
     /// Returns information about a transaction from serialized transaction bytes.
     fn decode_raw_transaction(&self, transaction_bytes: String) -> Result<TransactionInfo, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         let transaction_bytes = hex::decode(transaction_bytes)?;
         let transaction = Tx::read(&transaction_bytes[..])?;
 
@@ -244,7 +244,7 @@ impl RpcFunctions for RpcImpl {
     fn send_raw_transaction(&self, transaction_bytes: String) -> Result<String, RpcError> {
         let transaction_bytes = hex::decode(transaction_bytes)?;
         let transaction = Tx::read(&transaction_bytes[..])?;
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
 
         if !self
             .consensus
@@ -276,7 +276,7 @@ impl RpcFunctions for RpcImpl {
     fn validate_raw_transaction(&self, transaction_bytes: String) -> Result<bool, RpcError> {
         let transaction_bytes = hex::decode(transaction_bytes)?;
         let transaction = Tx::read(&transaction_bytes[..])?;
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
 
         Ok(self
             .consensus
@@ -307,7 +307,7 @@ impl RpcFunctions for RpcImpl {
 
     /// Returns the current mempool and consensus information known by this node.
     fn get_block_template(&self) -> Result<BlockTemplate, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
 
         let block_height = self.storage.get_latest_block_height();
         let block = self.storage.get_block_from_block_number(block_height)?;

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -377,7 +377,7 @@ impl ProtectedRpcFunctions for RpcImpl {
 
     /// Returns the number of record commitments that are stored on the full node.
     fn get_record_commitment_count(&self) -> Result<usize, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         let record_commitments = self.storage.get_record_commitments(None)?;
 
         Ok(record_commitments.len())
@@ -385,7 +385,7 @@ impl ProtectedRpcFunctions for RpcImpl {
 
     /// Returns a list of record commitments that are stored on the full node.
     fn get_record_commitments(&self) -> Result<Vec<String>, RpcError> {
-        self.storage.catch_up_secondary()?;
+        self.storage.catch_up_secondary(false)?;
         let record_commitments = self.storage.get_record_commitments(Some(100))?;
         let record_commitment_strings: Vec<String> = record_commitments.iter().map(|cm| hex::encode(cm)).collect();
 

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -166,12 +166,14 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     pub fn catch_up_secondary(&self) -> Result<(), StorageError> {
         // Sync the secondary and primary instances
         if self.storage.db.try_catch_up_with_primary().is_ok() {
-            // Update the latest block height of the secondary instance.
             let latest_block_height_bytes = self.get(COL_META, &KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec())?;
             let new_latest_block_height = bytes_to_u32(latest_block_height_bytes);
             let mut latest_block_height = self.latest_block_height.write();
 
+            // If the new block height is greater than the stored block height,
+            // update the block height and merkle tree.
             if new_latest_block_height > *latest_block_height {
+                // Update the latest block height of the secondary instance.
                 *latest_block_height = new_latest_block_height;
 
                 // Update the Merkle tree of the secondary instance.

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -171,7 +171,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
             let new_latest_block_height = bytes_to_u32(latest_block_height_bytes);
             let mut latest_block_height = self.latest_block_height.write();
 
-            if new_latest_block_height >= *latest_block_height {
+            if new_latest_block_height > *latest_block_height {
                 *latest_block_height = new_latest_block_height;
 
                 // Update the Merkle tree of the secondary instance.

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -112,6 +112,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         &self,
         additional_cms: Vec<(T::Commitment, usize)>,
     ) -> Result<MerkleTree<P>, StorageError> {
+        // TODO (raychu86) make this more efficient
         let mut cm_and_indices = additional_cms;
 
         for (commitment_key, index_value) in self.storage.get_iter(COL_COMMITMENT)? {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR is a quick fix to the rocksdb secondary instance to prevent regenerating the commitment merkle tree for every rpc request.