### PR TITLE
Update the defaults for min and max peers

### DIFF
--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -112,8 +112,8 @@ impl Default for Config {
                     .map(|node| (*node).to_string())
                     .collect::<Vec<String>>(),
                 mempool_interval: 5,
-                min_peers: 2,
-                max_peers: 20,
+                min_peers: 7,
+                max_peers: 25,
             },
         }
     }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR updates the config settings for minimum peers to 7 and maximum peers to 25.