### PR TITLE
Minor RPC documentation fixes

### DIFF
--- a/rpc/documentation/public_endpoints/decoderawtransaction.md
+++ b/rpc/documentation/public_endpoints/decoderawtransaction.md
@@ -22,6 +22,7 @@ Returns information about a transaction from serialized transaction bytes.
 | `local_data_root`       | string | The local data root                       |
 | `value balance`         | number | The transaction value balance             |
 | `signatures`            | array  | The list of transaction signatures        |
+| `encrypted_records`     | array  | The list of new encrypted records         |
 | `transaction_metadata`  | object | The transaction metadata                  |
 
 ### Example

--- a/rpc/documentation/public_endpoints/getblockcount.md
+++ b/rpc/documentation/public_endpoints/getblockcount.md
@@ -8,7 +8,7 @@ None
 
 | Parameter |  Type  |                  Description                 |
 |:---------:|:------:|:--------------------------------------------:|
-| `result`  | string | The number of blocks in the best valid chain |
+| `result`  | number | The number of blocks in the best valid chain |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getblockhash.md
+++ b/rpc/documentation/public_endpoints/getblockhash.md
@@ -4,7 +4,7 @@ Returns the block hash of a block at the given block height in the best valid ch
 
 |    Parameter   |  Type  | Required |                  Description                 |
 |:-------------- |:------:|:--------:|:-------------------------------------------- |
-| `block_height` | string |    Yes   | The block height of the requested block hash |
+| `block_height` | number |    Yes   | The block height of the requested block hash |
 
 ### Response
 

--- a/rpc/documentation/public_endpoints/gettransactioninfo.md
+++ b/rpc/documentation/public_endpoints/gettransactioninfo.md
@@ -15,12 +15,14 @@ Returns information about a transaction from a transaction id.
 | `old_serial_numbers`    | array  | The list of old record serial numbers    |
 | `new_commitments`       | array  | The list of new record commitments       |
 | `memo`                  | string | The transaction memo                     |
+| `network_id`            | number | The transaction network id               |
 | `digest`                | string | The merkle tree digest                   |
 | `transaction_proof`     | string | The transaction zero knowledge proof     |
 | `program_commitment`    | string | The program verification key commitment  |
 | `local_data_root`       | string | The local data root                      |
 | `value balance`         | number | The transaction value balance            |
 | `signatures`            | array  | The list of transaction signatures       |
+| `encrypted_records`     | array  | The list of new encrypted records        |
 | `transaction_metadata`  | object | The transaction metadata                 |
 
 ### Example


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR fixes some errors in the rpc documentation and adds the `encrypted_record` field to the documentation of `decoderawtransaction` and `gettransactioninfo`.
