### PR TITLE
Wrap blocking operations into individual tasks

### DIFF
--- a/network/src/external/channel.rs
+++ b/network/src/external/channel.rs
@@ -23,7 +23,7 @@ use crate::external::message::{
 use snarkos_errors::network::ConnectError;
 
 use std::{net::SocketAddr, sync::Arc};
-use tokio::{io::AsyncWriteExt, net::TcpStream, sync::Mutex};
+use tokio::{io::AsyncWriteExt, net::TcpStream, sync::Mutex, task};
 
 /// A channel for reading and writing messages to a peer.
 /// The channel manages two streams to allow for simultaneous reading and writing.
@@ -102,12 +102,29 @@ impl Channel {
     pub async fn write<M: Message>(&self, message: &M) -> Result<(), ConnectError> {
         debug!("Message {:?}, Sent to {:?}", M::name().to_string(), self.address);
 
-        let serialized = message.serialize()?;
-        let header = MessageHeader::new(M::name(), serialized.len() as u32);
+        let serialized_message = message.serialize()?;
+        let header = MessageHeader::new(M::name(), serialized_message.len() as u32);
+        let header_bytes = header.serialize()?;
 
-        let mut writer = self.writer.lock().await;
-        writer.write_all(&header.serialize()?).await?;
-        writer.write_all(&serialized).await?;
+        let writer = self.writer.clone();
+
+        // Spawn a tokio task to send the message.
+        task::spawn(async move {
+            let mut writer = writer.lock().await;
+
+            match writer.write_all(&header_bytes).await {
+                Ok(_) => {
+                    if let Err(error) = writer.write_all(&serialized_message).await {
+                        error!(
+                            "Failed to send message body {} (error {})",
+                            M::name().to_string(),
+                            error
+                        )
+                    }
+                }
+                Err(error) => error!("Failed to send message header {} (error {})", M::name(), error),
+            }
+        });
 
         Ok(())
     }

--- a/network/src/external/propagate.rs
+++ b/network/src/external/propagate.rs
@@ -5,6 +5,7 @@ use crate::{
 use snarkos_errors::network::SendError;
 
 use std::{net::SocketAddr, sync::Arc};
+use tokio::task;
 
 /// Broadcast transaction to connected peers
 pub async fn propagate_transaction(
@@ -12,28 +13,31 @@ pub async fn propagate_transaction(
     transaction_bytes: Vec<u8>,
     transaction_sender: SocketAddr,
 ) -> Result<(), SendError> {
-    debug!("Propagating a transaction to peers");
+    // Spawn a new transaction propagation task to help prevent deadlock conditions.
+    task::spawn(async move {
+        debug!("Propagating a transaction to peers");
 
-    let peer_book = context.peer_book.read().await;
-    let local_address = *context.local_address.read().await;
-    let connections = context.connections.read().await;
-    let mut num_peers = 0;
+        let peer_book = context.peer_book.read().await;
+        let local_address = *context.local_address.read().await;
+        let connections = context.connections.read().await;
+        let mut num_peers = 0;
 
-    for (socket, _) in &peer_book.get_connected() {
-        if *socket != transaction_sender && *socket != local_address {
-            if let Some(channel) = connections.get(socket) {
-                match channel.write(&Transaction::new(transaction_bytes.clone())).await {
-                    Ok(_) => num_peers += 1,
-                    Err(error) => warn!(
-                        "Failed to propagate transaction to peer {}. (error message: {})",
-                        channel.address, error
-                    ),
+        for (socket, _) in &peer_book.get_connected() {
+            if *socket != transaction_sender && *socket != local_address {
+                if let Some(channel) = connections.get(socket) {
+                    match channel.write(&Transaction::new(transaction_bytes.clone())).await {
+                        Ok(_) => num_peers += 1,
+                        Err(error) => warn!(
+                            "Failed to propagate transaction to peer {}. (error message: {})",
+                            channel.address, error
+                        ),
+                    }
                 }
             }
         }
-    }
 
-    debug!("Transaction propagated to {} peers", num_peers);
+        debug!("Transaction propagated to {} peers", num_peers);
+    });
 
     Ok(())
 }
@@ -44,28 +48,31 @@ pub async fn propagate_block(
     block_bytes: Vec<u8>,
     block_miner: SocketAddr,
 ) -> Result<(), SendError> {
-    debug!("Propagating a block to peers");
+    // Spawn a new block propagation task to help prevent deadlock conditions.
+    task::spawn(async move {
+        debug!("Propagating a block to peers");
 
-    let peer_book = context.peer_book.read().await;
-    let local_address = *context.local_address.read().await;
-    let connections = context.connections.read().await;
-    let mut num_peers = 0;
+        let peer_book = context.peer_book.read().await;
+        let local_address = *context.local_address.read().await;
+        let connections = context.connections.read().await;
+        let mut num_peers = 0;
 
-    for (socket, _) in &peer_book.get_connected() {
-        if *socket != block_miner && *socket != local_address {
-            if let Some(channel) = connections.get(socket) {
-                match channel.write(&Block::new(block_bytes.clone())).await {
-                    Ok(_) => num_peers += 1,
-                    Err(error) => warn!(
-                        "Failed to propagate block to peer {}. (error message: {})",
-                        channel.address, error
-                    ),
+        for (socket, _) in &peer_book.get_connected() {
+            if *socket != block_miner && *socket != local_address {
+                if let Some(channel) = connections.get(socket) {
+                    match channel.write(&Block::new(block_bytes.clone())).await {
+                        Ok(_) => num_peers += 1,
+                        Err(error) => warn!(
+                            "Failed to propagate block to peer {}. (error message: {})",
+                            channel.address, error
+                        ),
+                    }
                 }
             }
         }
-    }
 
-    debug!("Block propagated to {} peers", num_peers);
+        debug!("Block propagated to {} peers", num_peers);
+    });
 
     Ok(())
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR wraps blocking operations such as block/transaction propagation and message sending into individual tokio tasks to prevent halting on the main handlers. 

Additionally, the connection handler will attempt to connect to bootnodes that the node is currently not connected to.