### PR TITLE
Additional handling of sync locks

### DIFF
--- a/network/src/external/channel.rs
+++ b/network/src/external/channel.rs
@@ -23,7 +23,7 @@ use crate::external::message::{
 use snarkos_errors::network::ConnectError;
 
 use std::{net::SocketAddr, sync::Arc};
-use tokio::{io::AsyncWriteExt, net::TcpStream, sync::Mutex};
+use tokio::{io::AsyncWriteExt, net::TcpStream, sync::Mutex, task};
 
 /// A channel for reading and writing messages to a peer.
 /// The channel manages two streams to allow for simultaneous reading and writing.
@@ -102,12 +102,29 @@ impl Channel {
     pub async fn write<M: Message>(&self, message: &M) -> Result<(), ConnectError> {
         debug!("Message {:?}, Sent to {:?}", M::name().to_string(), self.address);
 
-        let serialized = message.serialize()?;
-        let header = MessageHeader::new(M::name(), serialized.len() as u32);
+        let serialized_message = message.serialize()?;
+        let header = MessageHeader::new(M::name(), serialized_message.len() as u32);
+        let header_bytes = header.serialize()?;
 
-        let mut writer = self.writer.lock().await;
-        writer.write_all(&header.serialize()?).await?;
-        writer.write_all(&serialized).await?;
+        let writer = self.writer.clone();
+
+        // Spawn a tokio task to send the message.
+        task::spawn(async move {
+            let mut writer = writer.lock().await;
+
+            match writer.write_all(&header_bytes).await {
+                Ok(_) => {
+                    if let Err(error) = writer.write_all(&serialized_message).await {
+                        error!(
+                            "Failed to send message body {} (error {})",
+                            M::name().to_string(),
+                            error
+                        )
+                    }
+                }
+                Err(error) => error!("Failed to send message header {} (error {})", M::name(), error),
+            }
+        });
 
         Ok(())
     }

--- a/network/src/external/propagate.rs
+++ b/network/src/external/propagate.rs
@@ -5,6 +5,7 @@ use crate::{
 use snarkos_errors::network::SendError;
 
 use std::{net::SocketAddr, sync::Arc};
+use tokio::task;
 
 /// Broadcast transaction to connected peers
 pub async fn propagate_transaction(
@@ -12,28 +13,31 @@ pub async fn propagate_transaction(
     transaction_bytes: Vec<u8>,
     transaction_sender: SocketAddr,
 ) -> Result<(), SendError> {
-    debug!("Propagating a transaction to peers");
+    // Spawn a new transaction propagation task to help prevent deadlock conditions.
+    task::spawn(async move {
+        debug!("Propagating a transaction to peers");
 
-    let peer_book = context.peer_book.read().await;
-    let local_address = *context.local_address.read().await;
-    let connections = context.connections.read().await;
-    let mut num_peers = 0;
+        let peer_book = context.peer_book.read().await;
+        let local_address = *context.local_address.read().await;
+        let connections = context.connections.read().await;
+        let mut num_peers = 0;
 
-    for (socket, _) in &peer_book.get_connected() {
-        if *socket != transaction_sender && *socket != local_address {
-            if let Some(channel) = connections.get(socket) {
-                match channel.write(&Transaction::new(transaction_bytes.clone())).await {
-                    Ok(_) => num_peers += 1,
-                    Err(error) => warn!(
-                        "Failed to propagate transaction to peer {}. (error message: {})",
-                        channel.address, error
-                    ),
+        for (socket, _) in &peer_book.get_connected() {
+            if *socket != transaction_sender && *socket != local_address {
+                if let Some(channel) = connections.get(socket) {
+                    match channel.write(&Transaction::new(transaction_bytes.clone())).await {
+                        Ok(_) => num_peers += 1,
+                        Err(error) => warn!(
+                            "Failed to propagate transaction to peer {}. (error message: {})",
+                            channel.address, error
+                        ),
+                    }
                 }
             }
         }
-    }
 
-    debug!("Transaction propagated to {} peers", num_peers);
+        debug!("Transaction propagated to {} peers", num_peers);
+    });
 
     Ok(())
 }
@@ -44,28 +48,31 @@ pub async fn propagate_block(
     block_bytes: Vec<u8>,
     block_miner: SocketAddr,
 ) -> Result<(), SendError> {
-    debug!("Propagating a block to peers");
+    // Spawn a new block propagation task to help prevent deadlock conditions.
+    task::spawn(async move {
+        debug!("Propagating a block to peers");
 
-    let peer_book = context.peer_book.read().await;
-    let local_address = *context.local_address.read().await;
-    let connections = context.connections.read().await;
-    let mut num_peers = 0;
+        let peer_book = context.peer_book.read().await;
+        let local_address = *context.local_address.read().await;
+        let connections = context.connections.read().await;
+        let mut num_peers = 0;
 
-    for (socket, _) in &peer_book.get_connected() {
-        if *socket != block_miner && *socket != local_address {
-            if let Some(channel) = connections.get(socket) {
-                match channel.write(&Block::new(block_bytes.clone())).await {
-                    Ok(_) => num_peers += 1,
-                    Err(error) => warn!(
-                        "Failed to propagate block to peer {}. (error message: {})",
-                        channel.address, error
-                    ),
+        for (socket, _) in &peer_book.get_connected() {
+            if *socket != block_miner && *socket != local_address {
+                if let Some(channel) = connections.get(socket) {
+                    match channel.write(&Block::new(block_bytes.clone())).await {
+                        Ok(_) => num_peers += 1,
+                        Err(error) => warn!(
+                            "Failed to propagate block to peer {}. (error message: {})",
+                            channel.address, error
+                        ),
+                    }
                 }
             }
         }
-    }
 
-    debug!("Block propagated to {} peers", num_peers);
+        debug!("Block propagated to {} peers", num_peers);
+    });
 
     Ok(())
 }

--- a/network/src/external/protocol/sync/sync.rs
+++ b/network/src/external/protocol/sync/sync.rs
@@ -74,7 +74,7 @@ impl SyncHandler {
     }
 
     /// Remove the blocks that are now included in the chain.
-    pub fn clear_pending<T: Transaction, P: LoadableMerkleParameters>(&mut self, storage: Arc<Ledger<T, P>>) {
+    pub fn update_pending_blocks<T: Transaction, P: LoadableMerkleParameters>(&mut self, storage: Arc<Ledger<T, P>>) {
         for (block_hash, _time_sent) in &self.pending_blocks.clone() {
             if !storage.block_hash_exists(&block_hash) {
                 self.pending_blocks.remove(block_hash);
@@ -83,7 +83,7 @@ impl SyncHandler {
     }
 
     /// Set the SyncState to syncing and update the latest block height.
-    pub fn update_syncing(&mut self, block_height: u32) {
+    pub fn update_sync_state(&mut self, block_height: u32) {
         match self.sync_state {
             SyncState::Idle => {
                 info!("Syncing blocks");
@@ -103,7 +103,7 @@ impl SyncHandler {
                 if !self.block_headers.contains(&block_hash) && self.pending_blocks.get(&block_hash).is_none() {
                     self.block_headers.push(block_hash.clone());
                 }
-                self.update_syncing(height);
+                self.update_sync_state(height);
             }
         } else if self.pending_blocks.is_empty() {
             info!("Sync state is set to Idle");
@@ -124,7 +124,7 @@ impl SyncHandler {
                     storage.get_latest_block_height() - height,
                     (Utc::now() - date_time).num_milliseconds() as f64 / 1000.
                 );
-                self.update_syncing(storage.get_latest_block_height());
+                self.update_sync_state(storage.get_latest_block_height());
             }
 
             // Sync up to 3 blocks at once
@@ -166,11 +166,9 @@ impl SyncHandler {
                     }
                 }
             }
-
-            self.clear_pending(Arc::clone(&storage));
-        } else {
-            self.clear_pending(Arc::clone(&storage));
         }
+
+        self.update_pending_blocks(Arc::clone(&storage));
 
         Ok(())
     }

--- a/network/src/external/protocol/sync/sync.rs
+++ b/network/src/external/protocol/sync/sync.rs
@@ -106,8 +106,10 @@ impl SyncHandler {
                 self.update_sync_state(height);
             }
         } else if self.pending_blocks.is_empty() {
-            info!("Sync state is set to Idle");
-            self.sync_state = SyncState::Idle;
+            if self.sync_state != SyncState::Idle {
+                info!("Sync state is set to Idle");
+                self.sync_state = SyncState::Idle;
+            }
         }
     }
 

--- a/network/src/external/protocol/sync/sync.rs
+++ b/network/src/external/protocol/sync/sync.rs
@@ -111,8 +111,8 @@ impl SyncHandler {
         }
     }
 
-    /// Finish syncing or ask for the next block from the sync node.
-    pub async fn increment<T: Transaction, P: LoadableMerkleParameters>(
+    /// Poll the sync handler to finish syncing or ask for the next block from the sync node.
+    pub async fn poll<T: Transaction, P: LoadableMerkleParameters>(
         &mut self,
         channel: Arc<Channel>,
         storage: Arc<Ledger<T, P>>,

--- a/network/src/internal/connection_handler.rs
+++ b/network/src/internal/connection_handler.rs
@@ -169,9 +169,9 @@ impl Server {
                     }
 
                     // Store connected peers in database.
-                    peer_book
-                        .store(&storage)
-                        .unwrap_or_else(|error| debug!("Failed to store connected peers in database {}", error));
+                    if let Err(error) = peer_book.store(&storage) {
+                        debug!("Failed to store connected peers in database {}", error);
+                    }
 
                     // Every two frequency loops, send a version message to all peers for periodic syncs.
                     if interval_ticker % 2 == 1 {
@@ -226,13 +226,13 @@ impl Server {
                             _ => continue,
                         };
 
-                        memory_pool.cleanse(&storage).unwrap_or_else(|error| {
+                        if let Err(error) = memory_pool.cleanse(&storage) {
                             debug!("Failed to cleanse memory pool transactions in database {}", error)
-                        });
+                        };
 
-                        memory_pool.store(&storage).unwrap_or_else(|error| {
+                        if let Err(error) = memory_pool.store(&storage) {
                             debug!("Failed to store memory pool transaction in database {}", error)
-                        });
+                        };
 
                         interval_ticker = 0;
                     } else {

--- a/network/src/internal/connection_handler.rs
+++ b/network/src/internal/connection_handler.rs
@@ -210,15 +210,9 @@ impl Server {
                         // Ask our connected peers for their memory pool transactions
                         {
                             for (address, _last_seen) in peer_book.get_connected() {
-                                match connections.get(&address) {
-                                    Some(channel) => {
-                                        // Disconnect from the peer if the GetMemoryPool message was not sent properly
-                                        if let Err(_) = channel.write(&GetMemoryPool).await {
-                                            peer_book.disconnect_peer(address);
-                                        }
-                                    }
-                                    // Disconnect from the peer if there is no active connection channel
-                                    None => {
+                                if let Some(channel) = connections.get(&address) {
+                                    // Disconnect from the peer if the GetMemoryPool message was not sent properly
+                                    if let Err(_) = channel.write(&GetMemoryPool).await {
                                         peer_book.disconnect_peer(address);
                                     }
                                 }

--- a/network/src/internal/connection_handler.rs
+++ b/network/src/internal/connection_handler.rs
@@ -207,12 +207,19 @@ impl Server {
 
                     // Update our memory pool after memory_pool_interval frequency loops.
                     if interval_ticker >= context.memory_pool_interval {
-                        if let Ok(sync_handler) = sync_handler_lock.try_lock() {
-                            // Ask our sync node for more transactions.
-                            if local_address != sync_handler.sync_node {
-                                if let Some(channel) = connections.get(&sync_handler.sync_node) {
-                                    if let Err(_) = channel.write(&GetMemoryPool).await {
-                                        peer_book.disconnect_peer(sync_handler.sync_node);
+                        // Ask our connected peers for their memory pool transactions
+                        {
+                            for (address, _last_seen) in peer_book.get_connected() {
+                                match connections.get(&address) {
+                                    Some(channel) => {
+                                        // Disconnect from the peer if the GetMemoryPool message was not sent properly
+                                        if let Err(_) = channel.write(&GetMemoryPool).await {
+                                            peer_book.disconnect_peer(address);
+                                        }
+                                    }
+                                    // Disconnect from the peer if there is no active connection channel
+                                    None => {
+                                        peer_book.disconnect_peer(address);
                                     }
                                 }
                             }

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -232,7 +232,7 @@ impl Server {
                                 if let Some(channel) =
                                     self.context.connections.read().await.get(&sync_handler.sync_node)
                                 {
-                                    sync_handler.increment(channel, Arc::clone(&self.storage)).await?;
+                                    sync_handler.poll(channel, Arc::clone(&self.storage)).await?;
                                 }
                             }
                         }
@@ -413,7 +413,7 @@ impl Server {
 
         // Received block headers
         if let Some(channel) = self.context.connections.read().await.get(&sync_handler.sync_node) {
-            sync_handler.increment(channel, Arc::clone(&self.storage)).await?;
+            sync_handler.poll(channel, Arc::clone(&self.storage)).await?;
         }
 
         Ok(())
@@ -494,7 +494,7 @@ impl Server {
                         }
                     } else {
                         if let Some(channel) = self.context.connections.read().await.get(&sync_handler.sync_node) {
-                            sync_handler.increment(channel, Arc::clone(&self.storage)).await?;
+                            sync_handler.poll(channel, Arc::clone(&self.storage)).await?;
                         }
                     }
                 }

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -499,7 +499,12 @@ impl Server {
                         SyncState::Syncing(last_updated, _height) => {
                             // If the node is currently syncing and the sync_node has not responded in 15 seconds,
                             // attempt to connect to a new sync node
-                            if Utc::now().timestamp() - last_updated.timestamp() > 15 {
+                            let last_sync_response = Utc::now().timestamp() - last_updated.timestamp();
+                            if last_sync_response > 15 {
+                                debug!(
+                                    "Current sync node has not responded in {} seconds. Attempting to find new sync node.",
+                                    last_sync_response
+                                );
                                 swap_sync_nodes = true;
                             } else {
                                 // We are currently syncing with a node. Poll the sync handler to continue syncing.

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -153,18 +153,20 @@ impl Server {
                         // If our peer has a longer chain, send a sync message
                         if version.height > storage.get_latest_block_height() {
                             // Update the sync node if the sync_handler is Idle
-                            if let Ok(mut sync_handler) = sync_handler_lock.try_lock() {
-                                if !sync_handler.is_syncing() {
-                                    sync_handler.sync_node = handshake.channel.address;
+                            {
+                                if let Ok(mut sync_handler) = sync_handler_lock.try_lock() {
+                                    if !sync_handler.is_syncing() {
+                                        sync_handler.sync_node = handshake.channel.address;
 
-                                    if let Ok(block_locator_hashes) = storage.get_block_locator_hashes() {
-                                        if let Err(err) =
-                                            handshake.channel.write(&GetSync::new(block_locator_hashes)).await
-                                        {
-                                            error!(
-                                                "Error sending GetSync message to {}, {}",
-                                                handshake.channel.address, err
-                                            );
+                                        if let Ok(block_locator_hashes) = storage.get_block_locator_hashes() {
+                                            if let Err(err) =
+                                                handshake.channel.write(&GetSync::new(block_locator_hashes)).await
+                                            {
+                                                error!(
+                                                    "Error sending GetSync message to {}, {}",
+                                                    handshake.channel.address, err
+                                                );
+                                            }
                                         }
                                     }
                                 }

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -325,7 +325,7 @@ impl Server {
                     if local_address != bootnode_address {
                         info!("Connecting to {:?} (bootnode)...", bootnode_address);
                         Server::send_handshake_non_blocking(context.clone(), storage.clone(), bootnode_address);
-                        delay_for(Duration::from_millis(100)).await;
+                        delay_for(Duration::from_millis(500)).await;
                     }
                 }
             }
@@ -349,7 +349,7 @@ impl Server {
                         if local_address != saved_address {
                             info!("Connecting to {:?} (saved peer)...", saved_address);
                             Server::send_handshake_non_blocking(context.clone(), storage.clone(), saved_address);
-                            delay_for(Duration::from_millis(100)).await;
+                            delay_for(Duration::from_millis(500)).await;
                         }
                     }
                 });

--- a/network/tests/server_listen.rs
+++ b/network/tests/server_listen.rs
@@ -160,8 +160,6 @@ mod server_listen {
 
             let (name, bytes) = bootnode_hand.channel.read().await.unwrap();
 
-            println!("GetPeers::name(): {:?}", GetPeers::name());
-
             assert_eq!(Verack::name(), name);
             let verack_message = Verack::deserialize(bytes).unwrap();
             bootnode_hand.accept(verack_message).await.unwrap();

--- a/network/tests/server_listen.rs
+++ b/network/tests/server_listen.rs
@@ -160,6 +160,8 @@ mod server_listen {
 
             let (name, bytes) = bootnode_hand.channel.read().await.unwrap();
 
+            println!("GetPeers::name(): {:?}", GetPeers::name());
+
             assert_eq!(Verack::name(), name);
             let verack_message = Verack::deserialize(bytes).unwrap();
             bootnode_hand.accept(verack_message).await.unwrap();

--- a/network/tests/sync_integration.rs
+++ b/network/tests/sync_integration.rs
@@ -48,7 +48,7 @@ mod sync_integration {
             let (tx, rx) = oneshot::channel();
             tokio::spawn(async move {
                 sync_handler
-                    .increment(
+                    .poll(
                         Arc::new(Channel::new_write_only(bootnode_address).await.unwrap()),
                         storage,
                     )
@@ -89,7 +89,7 @@ mod sync_integration {
             let (tx, rx) = oneshot::channel();
             tokio::spawn(async move {
                 sync_handler
-                    .increment(
+                    .poll(
                         Arc::new(Channel::new_write_only(bootnode_address).await.unwrap()),
                         storage,
                     )

--- a/network/tests/sync_integration.rs
+++ b/network/tests/sync_integration.rs
@@ -83,7 +83,7 @@ mod sync_integration {
             // 1. Set syncing to true
 
             let mut sync_handler = SyncHandler::new(bootnode_address);
-            sync_handler.update_syncing(0);
+            sync_handler.update_sync_state(0);
 
             // 2. Call increment_sync_handler_internally
             let (tx, rx) = oneshot::channel();


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR is built off of #457 and implements better handling of the `sync_handler_lock`. Additionally, it wraps bootnode connections with a timeout function to prevent unnecessary waiting.