### PR TITLE
Implement getnodeinfo RPC endpoint

### DIFF
--- a/network/src/internal/context/context.rs
+++ b/network/src/internal/context/context.rs
@@ -43,6 +43,9 @@ pub struct Context {
     /// Hardcoded nodes and user-specified nodes this node should connect to on startup.
     pub bootnodes: Vec<String>,
 
+    /// If enabled, node will operate as a miner
+    pub is_miner: bool,
+
     /// Manages connected, gossiped, and disconnected peers
     pub peer_book: RwLock<PeerBook>,
 
@@ -65,6 +68,7 @@ impl Context {
         max_peers: u16,
         is_bootnode: bool,
         bootnodes: Vec<String>,
+        is_miner: bool,
     ) -> Self {
         Self {
             local_address: RwLock::new(local_address),
@@ -73,6 +77,7 @@ impl Context {
             max_peers,
             is_bootnode,
             bootnodes,
+            is_miner,
             connections: RwLock::new(Connections::new()),
             peer_book: RwLock::new(PeerBook::new()),
             handshakes: RwLock::new(Handshakes::new()),

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -53,7 +53,7 @@ pub struct Server {
 impl Server {
     /// Constructs a new `Server`.
     pub fn new(
-        context: Context,
+        context: Arc<Context>,
         consensus: ConsensusParameters,
         storage: Arc<MerkleTreeLedger>,
         parameters: PublicParameters<Components>,
@@ -64,7 +64,7 @@ impl Server {
         let (sender, receiver) = mpsc::channel(1024);
         Server {
             consensus,
-            context: Arc::new(context),
+            context,
             storage,
             parameters,
             memory_pool_lock,

--- a/network/tests/server_listen.rs
+++ b/network/tests/server_listen.rs
@@ -59,9 +59,15 @@ mod server_listen {
         let sync_handler_lock = Arc::new(Mutex::new(sync_handler));
 
         let server = Server::new(
-            Context::new(server_address, 5, 0, 10, is_bootnode, vec![
-                bootnode_address.to_string(),
-            ]),
+            Arc::new(Context::new(
+                server_address,
+                5,
+                0,
+                10,
+                is_bootnode,
+                vec![bootnode_address.to_string()],
+                false,
+            )),
             consensus,
             storage,
             parameters,

--- a/rpc/documentation/public_endpoints/getnodeinfo.md
+++ b/rpc/documentation/public_endpoints/getnodeinfo.md
@@ -1,0 +1,16 @@
+Returns information about the node.
+
+### Arguments
+
+None 
+
+### Response
+
+|  Parameter | Type |               Description              |
+|:----------:|:----:|:--------------------------------------:|
+| `is_miner` | bool | Flag indicating if the node is a miner |
+
+### Example
+```ignore
+curl --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getnodeinfo", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:3030/
+```

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -305,6 +305,13 @@ impl RpcFunctions for RpcImpl {
         Ok(PeerInfo { peers })
     }
 
+    /// Returns data about the node.
+    fn get_node_info(&self) -> Result<NodeInfo, RpcError> {
+        Ok(NodeInfo {
+            is_miner: self.server_context.is_miner,
+        })
+    }
+
     /// Returns the current mempool and consensus information known by this node.
     fn get_block_template(&self) -> Result<BlockTemplate, RpcError> {
         self.storage.catch_up_secondary(false)?;

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -71,6 +71,7 @@ pub trait RpcFunctions {
     #[rpc(name = "getpeerinfo")]
     fn get_peer_info(&self) -> Result<PeerInfo, RpcError>;
 
+    #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getnodeinfo.md"))]
     #[rpc(name = "getnodeinfo")]
     fn get_node_info(&self) -> Result<NodeInfo, RpcError>;
 

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -71,6 +71,9 @@ pub trait RpcFunctions {
     #[rpc(name = "getpeerinfo")]
     fn get_peer_info(&self) -> Result<PeerInfo, RpcError>;
 
+    #[rpc(name = "getnodeinfo")]
+    fn get_node_info(&self) -> Result<NodeInfo, RpcError>;
+
     #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getblocktemplate.md"))]
     #[rpc(name = "getblocktemplate")]
     fn get_block_template(&self) -> Result<BlockTemplate, RpcError>;

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -119,6 +119,13 @@ pub struct DecryptRecordInput {
     pub account_view_key: String,
 }
 
+/// Returned value for the `getnodeinfo` rpc call
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeInfo {
+    /// Flag indicating if the node is operating as a miner
+    pub is_miner: bool,
+}
+
 /// Returned value for the `getpeerinfo` rpc call
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerInfo {

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -77,7 +77,7 @@ mod protected_rpc_tests {
         let memory_pool = MemoryPool::new();
         let memory_pool_lock = Arc::new(Mutex::new(memory_pool));
 
-        let context = Context::new(server_address, 5, 1, 10, true, vec![]);
+        let context = Context::new(server_address, 5, 1, 10, true, vec![], false);
 
         let storage = storage.clone();
         let storage_path = storage.storage.db.path().to_path_buf();

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -331,6 +331,23 @@ mod rpc_tests {
     }
 
     #[test]
+    fn test_rpc_get_node_info() {
+        let storage = Arc::new(FIXTURE_VK.ledger());
+        let rpc = initialize_test_rpc(&storage);
+
+        let method = "getnodeinfo".to_string();
+
+        let result = make_request_no_params(&rpc, method);
+
+        let peer_info: NodeInfo = serde_json::from_value(result).unwrap();
+
+        assert_eq!(peer_info.is_miner, false);
+
+        drop(rpc);
+        kill_storage_sync(storage);
+    }
+
+    #[test]
     fn test_rpc_get_block_template() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let rpc = initialize_test_rpc(&storage);

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -60,7 +60,7 @@ pub fn initialize_test_server(
     let sync_handler_lock = Arc::new(Mutex::new(sync_handler));
 
     Server::new(
-        Context::new(server_address, 5, 1, 10, true, vec![]),
+        Arc::new(Context::new(server_address, 5, 1, 10, true, vec![], false)),
         consensus,
         storage,
         parameters,


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR adds a `getnodeinfo` RPC endpoint to fetch information about the node. Currently this information only includes the `is_miner` flag for the node. 