### PR TITLE
toolkit wasm pack release build  bug fix

### DIFF
--- a/toolkit/Cargo.toml
+++ b/toolkit/Cargo.toml
@@ -35,3 +35,6 @@ wasm-bindgen = { version = "0.2.68" }
 criterion = { version = "0.3.1" }
 rand_chacha = { version = "0.2", default-features = false }
 wasm-bindgen-test = { version = "0.3.18" }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
Toolkit wasm release build has following issue. This PR fixes it.

[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
    Finished release [optimized] target(s) in 0.10s
[INFO]: ⬇️  Installing wasm-bindgen...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[wasm-validator error in module] unexpected true: Exported global cannot be mutable, on 
global$0
(module
 (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
 (type $i32_=>_none (func (param i32)))
 (type $i32_i32_=>_none (func (param i32 i32)))
 (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
 (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
 (type $i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32)))
 (type $i32_=>_i32 (func (param i32) (result i32)))
 (type $i32_i64_i64_i64_i64_i64_i64_i64_i64_=>_none (func (param i32 i64 i64 i64 i64 i64 i64 i64 i64)))
 (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
 (type $i32_=>_i64 (func (param i32) (result i64)))
 (type $none_=>_none (func))
...