### PR TITLE
Clippy compliance, part 1

### DIFF
--- a/algorithms/src/commitment_tree/mod.rs
+++ b/algorithms/src/commitment_tree/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod commitment_path;
 pub use commitment_path::*;
 

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -186,7 +186,7 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
                         cfg_chunks!(segment_bits, BOWE_HOPWOOD_CHUNK_SIZE)
                             .zip(segment_generators)
                             .map(|(chunk_bits, generator)| {
-                                let mut encoded = generator.clone();
+                                let mut encoded = *generator;
                                 if chunk_bits[0] {
                                     encoded = encoded + generator;
                                 }

--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -90,14 +90,14 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             // Let e = legendre(v^3 + Av^2 + Bv).
             let v2 = v.square();
             let v3 = v2 * &v;
-            let av2 = a.clone() * &v2;
-            let bv = b.clone() * &v;
+            let av2 = a * &v2;
+            let bv = b * &v;
             let e = (v3 + &(av2 + &bv)).legendre();
 
             // Let x = ev - ((1 - e) * A/2).
             let two = P::BaseField::one().double();
             let x = match e {
-                LegendreSymbol::Zero => -(a.clone() * &two.inverse().unwrap()),
+                LegendreSymbol::Zero => -(a * &two.inverse().unwrap()),
                 LegendreSymbol::QuadraticResidue => v,
                 LegendreSymbol::QuadraticNonResidue => (-v) - &a,
             };
@@ -105,8 +105,8 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             // Let y = -e * sqrt(x^3 + Ax^2 + Bx).
             let x2 = x.square();
             let x3 = x2 * &x;
-            let ax2 = a.clone() * &x2;
-            let bx = b.clone() * &x;
+            let ax2 = a * &x2;
+            let bx = b * &x;
             let value = (x3 + &(ax2 + &bx)).sqrt().unwrap();
             let y = match e {
                 LegendreSymbol::Zero => P::BaseField::zero(),
@@ -183,7 +183,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             let numerator = P::BaseField::one() + &y;
             let denominator = P::BaseField::one() - &y;
 
-            let u = numerator.clone() * &(denominator.inverse().unwrap());
+            let u = numerator * &(denominator.inverse().unwrap());
             let v = numerator * &((denominator * &x).inverse().unwrap());
 
             // Ensure (u, v) is a valid Montgomery element

--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -41,6 +41,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
     const D: P::BaseField = <P as TEModelParameters>::COEFF_D;
 
     /// Returns the encoded group element for a given base field element.
+    #[allow(clippy::many_single_char_names)]
     pub fn encode(input: &P::BaseField) -> Result<(<G as ProjectiveCurve>::Affine, bool), EncodingError> {
         // The input base field must be nonzero, otherwise inverses will fail.
         if input.is_zero() {
@@ -157,6 +158,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
         Ok((<G as ProjectiveCurve>::Affine::read(&to_bytes![x, y]?[..])?, sign_high))
     }
 
+    #[allow(clippy::many_single_char_names)]
     pub fn decode(
         group_element: &<G as ProjectiveCurve>::Affine,
         sign_high: bool,

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -165,7 +165,7 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
         &self,
         public_key: &Self::PublicKey,
         randomness: &Self::Randomness,
-        message: &Vec<Self::Text>,
+        message: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError> {
         let record_view_key = public_key.0.mul(&randomness);
 
@@ -202,7 +202,7 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
     fn decrypt(
         &self,
         private_key: &Self::PrivateKey,
-        ciphertext: &Vec<Self::Text>,
+        ciphertext: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError> {
         assert!(ciphertext.len() > 0);
         let c_0 = &ciphertext[0];

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -328,6 +328,7 @@ fn best_fft<F: PrimeField>(a: &mut [F], worker: &Worker, omega: F, log_n: u32) {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn serial_fft<F: PrimeField>(a: &mut [F], omega: F, log_n: u32) {
     #[inline]
     fn bitreverse(mut n: u32, l: u32) -> u32 {

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -228,6 +228,7 @@ impl<'a, 'b, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
 }
 
 impl<'a, 'b, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomial<F> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, (f, other): (F, &'a DensePolynomial<F>)) {
         if self.is_zero() {
             self.coeffs.truncate(0);

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -367,6 +367,7 @@ impl<'a, 'b, F: PrimeField> Mul<&'a DensePolynomial<F>> for &'b DensePolynomial<
     type Output = DensePolynomial<F>;
 
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, other: &'a DensePolynomial<F>) -> DensePolynomial<F> {
         if self.is_zero() || other.is_zero() {
             DensePolynomial::zero()

--- a/algorithms/src/merkle_tree/mod.rs
+++ b/algorithms/src/merkle_tree/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod merkle_path;
 pub use merkle_path::*;
 

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -250,7 +250,7 @@ where
     ) -> Result<Self::PublicKey, SignatureError> {
         let rand_pk_time = start_timer!(|| "SchnorrSignature::randomize_public_key");
 
-        let mut randomized_pk = public_key.0.clone();
+        let mut randomized_pk = public_key.0;
 
         let mut encoded = G::zero();
         for (bit, base_power) in bytes_to_bits(&to_bytes![randomness]?)

--- a/algorithms/src/snark/gm17/generator.rs
+++ b/algorithms/src/snark/gm17/generator.rs
@@ -142,6 +142,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 }
 
 /// Create parameters for a circuit, given some toxic waste.
+#[allow(clippy::many_single_char_names)]
 pub fn generate_parameters<E, C, R>(
     circuit: C,
     alpha: E::Fr,

--- a/algorithms/src/snark/gm17/r1cs_to_sap.rs
+++ b/algorithms/src/snark/gm17/r1cs_to_sap.rs
@@ -28,6 +28,7 @@ pub(crate) struct R1CStoSAP;
 
 impl R1CStoSAP {
     #[inline]
+    #[allow(clippy::many_single_char_names)]
     pub(crate) fn instance_map_with_evaluation<E: PairingEngine>(
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,

--- a/algorithms/src/snark/groth16/generator.rs
+++ b/algorithms/src/snark/groth16/generator.rs
@@ -133,6 +133,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 }
 
 /// Create parameters for a circuit, given some toxic waste.
+#[allow(clippy::many_single_char_names)]
 pub fn generate_parameters<E, C, R>(
     circuit: C,
     alpha: E::Fr,

--- a/algorithms/src/snark/groth16/r1cs_to_qap.rs
+++ b/algorithms/src/snark/groth16/r1cs_to_qap.rs
@@ -41,6 +41,7 @@ pub(crate) struct R1CStoQAP;
 
 impl R1CStoQAP {
     #[inline]
+    #[allow(clippy::many_single_char_names)]
     pub(crate) fn instance_map_with_evaluation<E: PairingEngine>(
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,

--- a/curves/src/lib.rs
+++ b/curves/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 // Compilation
+#![allow(clippy::module_inception)]
 #![deny(unused_import_braces, unused_qualifications, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_qualifications, variant_size_differences, stable_features, unreachable_pub)]
 #![deny(non_shorthand_field_patterns, unused_attributes, unused_extern_crates)]

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -106,6 +106,7 @@ impl<P: Bls12Parameters> G2Prepared<P> {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn doubling_step<B: Bls12Parameters>(
     r: &mut G2HomProjective<B>,
     two_inv: &B::Fp,
@@ -135,6 +136,7 @@ fn doubling_step<B: Bls12Parameters>(
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn addition_step<B: Bls12Parameters>(
     r: &mut G2HomProjective<B>,
     q: &G2Affine<B>,

--- a/curves/src/templates/bw6/bw6.rs
+++ b/curves/src/templates/bw6/bw6.rs
@@ -101,12 +101,12 @@ impl<P: BW6Parameters> BW6<P> {
         // (q^3-1)*(q+1)
 
         // elt_q3 = elt^(q^3)
-        let mut elt_q3 = elt.clone();
+        let mut elt_q3 = *elt;
         elt_q3.conjugate();
         // elt_q3_over_elt = elt^(q^3-1)
         let elt_q3_over_elt = elt_q3 * elt_inv;
         // alpha = elt^((q^3-1) * q)
-        let mut alpha = elt_q3_over_elt.clone();
+        let mut alpha = elt_q3_over_elt;
         alpha.frobenius_map(1);
         // beta = elt^((q^3-1)*(q+1)
         alpha * &elt_q3_over_elt
@@ -120,7 +120,7 @@ impl<P: BW6Parameters> BW6<P> {
         // f ^ R0(u) * (f ^ q) ^ R1(u) in a 2-NAF multi-exp fashion.
 
         // steps 1,2,3
-        let f0 = f.clone();
+        let f0 = *f;
         let mut f0p = f0;
         f0p.frobenius_map(1);
         let f1 = Self::exp_by_x(f0);

--- a/curves/src/templates/bw6/g2.rs
+++ b/curves/src/templates/bw6/g2.rs
@@ -144,6 +144,7 @@ impl<P: BW6Parameters> G2Prepared<P> {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn doubling_step<B: BW6Parameters>(r: &mut G2HomProjective<B>) -> (B::Fp, B::Fp, B::Fp) {
     // Formula for line function when working with
     // homogeneous projective coordinates, as described in https://eprint.iacr.org/2013/722.pdf.
@@ -169,6 +170,7 @@ fn doubling_step<B: BW6Parameters>(r: &mut G2HomProjective<B>) -> (B::Fp, B::Fp,
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn addition_step<B: BW6Parameters>(r: &mut G2HomProjective<B>, q: &G2Affine<B>) -> (B::Fp, B::Fp, B::Fp) {
     // Formula for line function when working with
     // homogeneous projective coordinates, as described in https://eprint.iacr.org/2013/722.pdf.

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -187,11 +187,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     fn to_x_coordinate(&self) -> Self::BaseField {
-        self.x.clone()
+        self.x
     }
 
     fn to_y_coordinate(&self) -> Self::BaseField {
-        self.y.clone()
+        self.y
     }
 
     /// Checks that the current point is on the elliptic curve.

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -641,6 +641,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         if self.is_zero() {
             *self = *other;

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -439,6 +439,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn double_in_place(&mut self) -> &mut Self {
         if self.is_zero() {
             return self;
@@ -507,6 +508,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn add_assign_mixed(&mut self, other: &Self::Affine) {
         if other.is_zero() {
             return;
@@ -638,6 +640,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
+    #[allow(clippy::many_single_char_names)]
     fn add_assign(&mut self, other: &'a Self) {
         if self.is_zero() {
             *self = *other;

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -413,6 +413,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn double_in_place(&mut self) -> &mut Self {
         if self.is_zero() {
             self

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -547,6 +547,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         if self.is_zero() {
             *self = *other;

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -183,11 +183,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     fn to_x_coordinate(&self) -> Self::BaseField {
-        self.x.clone()
+        self.x
     }
 
     fn to_y_coordinate(&self) -> Self::BaseField {
-        self.y.clone()
+        self.y
     }
 
     /// Checks that the current point is on the elliptic curve.

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -207,11 +207,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     fn to_x_coordinate(&self) -> Self::BaseField {
-        self.x.clone()
+        self.x
     }
 
     fn to_y_coordinate(&self) -> Self::BaseField {
-        self.y.clone()
+        self.y
     }
 
     /// Checks that the current point is on the elliptic curve.

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -534,6 +534,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         self
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn add_assign_mixed(&mut self, other: &Self::Affine) {
         // A = X1*X2
         let a = self.x * &other.x;
@@ -615,6 +616,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
+    #[allow(clippy::many_single_char_names)]
     fn add_assign(&mut self, other: &'a Self) {
         // See "Twisted Edwards Curves Revisited"
         // Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -245,6 +245,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupAffine<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         let y1y2 = self.y * &other.y;
         let x1x2 = self.x * &other.x;
@@ -617,6 +618,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         // See "Twisted Edwards Curves Revisited"
         // Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -992,7 +992,7 @@ where
     /// Returns true iff all the transactions in the block are valid according to the ledger.
     fn verify_transactions(
         parameters: &Self::Parameters,
-        transactions: &Vec<Self::Transaction>,
+        transactions: &[Self::Transaction],
         ledger: &L,
     ) -> Result<bool, DPCError> {
         for transaction in transactions {

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate thiserror;
 

--- a/models/src/algorithms/encryption.rs
+++ b/models/src/algorithms/encryption.rs
@@ -54,13 +54,13 @@ pub trait EncryptionScheme: Sized + Clone + From<<Self as EncryptionScheme>::Par
         &self,
         public_key: &Self::PublicKey,
         randomness: &Self::Randomness,
-        message: &Vec<Self::Text>,
+        message: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError>;
 
     fn decrypt(
         &self,
         private_key: &Self::PrivateKey,
-        ciphertext: &Vec<Self::Text>,
+        ciphertext: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError>;
 
     fn parameters(&self) -> &Self::Parameters;

--- a/models/src/curves/fp12_2over3over2.rs
+++ b/models/src/curves/fp12_2over3over2.rs
@@ -430,6 +430,7 @@ impl<'a, P: Fp12Parameters> SubAssign<&'a Self> for Fp12<P> {
 
 impl<'a, P: Fp12Parameters> MulAssign<&'a Self> for Fp12<P> {
     #[inline]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         let v0 = self.c0 * &other.c0;
         let v1 = self.c1 * &other.c1;

--- a/models/src/curves/fp2.rs
+++ b/models/src/curves/fp2.rs
@@ -400,6 +400,7 @@ impl<'a, P: Fp2Parameters> SubAssign<&'a Self> for Fp2<P> {
 
 impl<'a, P: Fp2Parameters> MulAssign<&'a Self> for Fp2<P> {
     #[inline]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         // Karatsuba multiplication;
         // Guide to Pairing-based cryprography, Algorithm 5.16.

--- a/models/src/curves/fp2.rs
+++ b/models/src/curves/fp2.rs
@@ -119,7 +119,7 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     }
 
     fn double(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.double_in_place();
         result
     }
@@ -324,7 +324,7 @@ impl<P: Fp2Parameters> Neg for Fp2<P> {
     #[inline]
     #[must_use]
     fn neg(self) -> Self {
-        let mut res = self.clone();
+        let mut res = self;
         res.c0 = res.c0.neg();
         res.c1 = res.c1.neg();
         res

--- a/models/src/curves/fp3.rs
+++ b/models/src/curves/fp3.rs
@@ -148,7 +148,7 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
     }
 
     fn double(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.double_in_place();
         result
     }
@@ -182,7 +182,7 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
     }
 
     fn square(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.square_in_place();
         result
     }
@@ -191,9 +191,9 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // AbstractPairing-Friendly
         // Fields.pdf; Section 4 (CH-SQR2)
-        let a = self.c0.clone();
-        let b = self.c1.clone();
-        let c = self.c2.clone();
+        let a = self.c0;
+        let b = self.c1;
+        let c = self.c2;
 
         let s0 = a.square();
         let ab = a * &b;
@@ -219,38 +219,38 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
             let t0 = self.c0.square();
             let t1 = self.c1.square();
             let t2 = self.c2.square();
-            let mut t3 = self.c0.clone();
+            let mut t3 = self.c0;
             t3.mul_assign(&self.c1);
-            let mut t4 = self.c0.clone();
+            let mut t4 = self.c0;
             t4.mul_assign(&self.c2);
-            let mut t5 = self.c1.clone();
+            let mut t5 = self.c1;
             t5.mul_assign(&self.c2);
             let n5 = P::mul_fp_by_nonresidue(&t5);
 
-            let mut s0 = t0.clone();
+            let mut s0 = t0;
             s0.sub_assign(&n5);
             let mut s1 = P::mul_fp_by_nonresidue(&t2);
             s1.sub_assign(&t3);
-            let mut s2 = t1.clone();
+            let mut s2 = t1;
             s2.sub_assign(&t4); // typo in paper referenced above. should be "-" as per Scott, but is "*"
 
-            let mut a1 = self.c2.clone();
+            let mut a1 = self.c2;
             a1.mul_assign(&s1);
-            let mut a2 = self.c1.clone();
+            let mut a2 = self.c1;
             a2.mul_assign(&s2);
-            let mut a3 = a1.clone();
+            let mut a3 = a1;
             a3.add_assign(&a2);
             a3 = P::mul_fp_by_nonresidue(&a3);
-            let mut t6 = self.c0.clone();
+            let mut t6 = self.c0;
             t6.mul_assign(&s0);
             t6.add_assign(&a3);
             t6.inverse_in_place();
 
-            let mut c0 = t6.clone();
+            let mut c0 = t6;
             c0.mul_assign(&s0);
-            let mut c1 = t6.clone();
+            let mut c1 = t6;
             c1.mul_assign(&s1);
-            let mut c2 = t6.clone();
+            let mut c2 = t6;
             c2.mul_assign(&s2);
 
             Some(Self::new(c0, c1, c2))
@@ -373,7 +373,7 @@ impl<P: Fp3Parameters> Neg for Fp3<P> {
 
     #[inline]
     fn neg(self) -> Self {
-        let mut res = self.clone();
+        let mut res = self;
         res.c0 = res.c0.neg();
         res.c1 = res.c1.neg();
         res.c2 = res.c2.neg();

--- a/models/src/curves/fp3.rs
+++ b/models/src/curves/fp3.rs
@@ -452,6 +452,7 @@ impl<'a, P: Fp3Parameters> SubAssign<&'a Self> for Fp3<P> {
 
 impl<'a, P: Fp3Parameters> MulAssign<&'a Self> for Fp3<P> {
     #[inline]
+    #[allow(clippy::many_single_char_names)]
     fn mul_assign(&mut self, other: &Self) {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // AbstractPairing-Friendly

--- a/models/src/curves/fp3.rs
+++ b/models/src/curves/fp3.rs
@@ -453,6 +453,7 @@ impl<'a, P: Fp3Parameters> SubAssign<&'a Self> for Fp3<P> {
 impl<'a, P: Fp3Parameters> MulAssign<&'a Self> for Fp3<P> {
     #[inline]
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // AbstractPairing-Friendly

--- a/models/src/curves/fp6_2over3.rs
+++ b/models/src/curves/fp6_2over3.rs
@@ -454,6 +454,7 @@ impl<'a, P: Fp6Parameters> SubAssign<&'a Self> for Fp6<P> {
 
 impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
     #[inline]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // Pairing-Friendly

--- a/models/src/curves/fp6_2over3.rs
+++ b/models/src/curves/fp6_2over3.rs
@@ -171,9 +171,9 @@ impl<P: Fp6Parameters> Fp6<P> {
                 found_nonzero = true;
 
                 if value > 0 {
-                    res = res * self;
+                    res *= self;
                 } else {
-                    res = res * &self_inverse;
+                    res *= &self_inverse;
                 }
             }
         }

--- a/models/src/curves/fp6_2over3.rs
+++ b/models/src/curves/fp6_2over3.rs
@@ -258,11 +258,11 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
         // Pairing-Friendly
         // Fields.pdf; Section 3 (Complex)
         let a = self.c0;
-        let mut b = self.c1;
+        let b = self.c1;
         let ab_add = a + &b;
-        let mut ab_mul = a * &b;
+        let ab_mul = a * &b;
 
-        let c0 = ab_add * &(a + &Self::mul_by_nonresidue(&mut b)) - &ab_mul - &Self::mul_by_nonresidue(&mut ab_mul);
+        let c0 = ab_add * &(a + &Self::mul_by_nonresidue(&b)) - &ab_mul - &Self::mul_by_nonresidue(&ab_mul);
         let c1 = ab_mul.double();
 
         self.c0 = c0;
@@ -280,8 +280,8 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
             let a = self.c0;
             let b = self.c1;
 
-            let mut t1 = b.square();
-            let t0 = a.square() - &Self::mul_by_nonresidue(&mut t1);
+            let t1 = b.square();
+            let t0 = a.square() - &Self::mul_by_nonresidue(&t1);
             let t2 = t0.inverse().unwrap();
 
             let c0 = a * &t2;
@@ -464,8 +464,8 @@ impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
         let b1 = other.c1;
 
         let a0a1 = a0 * &a1;
-        let mut b0b1 = b0 * &b1;
-        let beta_b0b1 = Self::mul_by_nonresidue(&mut b0b1);
+        let b0b1 = b0 * &b1;
+        let beta_b0b1 = Self::mul_by_nonresidue(&b0b1);
 
         let c0 = a0a1 + &beta_b0b1;
         let c1 = (a0 + &b0) * &(a1 + &b1) - &a0a1 - &b0b1;

--- a/models/src/curves/fp6_3over2.rs
+++ b/models/src/curves/fp6_3over2.rs
@@ -191,7 +191,7 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     }
 
     fn double(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.double_in_place();
         result
     }
@@ -225,7 +225,7 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     }
 
     fn square(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.square_in_place();
         result
     }

--- a/models/src/curves/fp_256.rs
+++ b/models/src/curves/fp_256.rs
@@ -69,6 +69,7 @@ impl<P: Fp256Parameters> Fp256<P> {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_256.rs
+++ b/models/src/curves/fp_256.rs
@@ -174,7 +174,7 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }

--- a/models/src/curves/fp_320.rs
+++ b/models/src/curves/fp_320.rs
@@ -190,7 +190,7 @@ impl<P: Fp320Parameters> Field for Fp320<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -503,7 +503,7 @@ impl<P: Fp320Parameters> Neg for Fp320<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp320::<P>(tmp, PhantomData)
         } else {
@@ -517,7 +517,7 @@ impl<'a, P: Fp320Parameters> Add<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -528,7 +528,7 @@ impl<'a, P: Fp320Parameters> Sub<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -539,7 +539,7 @@ impl<'a, P: Fp320Parameters> Mul<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -550,7 +550,7 @@ impl<'a, P: Fp320Parameters> Div<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/curves/fp_320.rs
+++ b/models/src/curves/fp_320.rs
@@ -69,6 +69,7 @@ impl<P: Fp320Parameters> Fp320<P> {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_384.rs
+++ b/models/src/curves/fp_384.rs
@@ -208,7 +208,7 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -530,7 +530,7 @@ impl<P: Fp384Parameters> Neg for Fp384<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp384::<P>(tmp, PhantomData)
         } else {
@@ -544,7 +544,7 @@ impl<'a, P: Fp384Parameters> Add<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -555,7 +555,7 @@ impl<'a, P: Fp384Parameters> Sub<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -566,7 +566,7 @@ impl<'a, P: Fp384Parameters> Mul<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -577,7 +577,7 @@ impl<'a, P: Fp384Parameters> Div<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/curves/fp_384.rs
+++ b/models/src/curves/fp_384.rs
@@ -69,6 +69,7 @@ impl<P: Fp384Parameters> Fp384<P> {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_768.rs
+++ b/models/src/curves/fp_768.rs
@@ -353,7 +353,7 @@ impl<P: Fp768Parameters> Field for Fp768<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -865,7 +865,7 @@ impl<P: Fp768Parameters> Neg for Fp768<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp768::<P>(tmp, PhantomData)
         } else {
@@ -879,7 +879,7 @@ impl<'a, P: Fp768Parameters> Add<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -890,7 +890,7 @@ impl<'a, P: Fp768Parameters> Sub<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -901,7 +901,7 @@ impl<'a, P: Fp768Parameters> Mul<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -912,7 +912,7 @@ impl<'a, P: Fp768Parameters> Div<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/curves/fp_768.rs
+++ b/models/src/curves/fp_768.rs
@@ -68,6 +68,7 @@ impl<P: Fp768Parameters> Fp768<P> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_832.rs
+++ b/models/src/curves/fp_832.rs
@@ -68,6 +68,7 @@ impl<P: Fp832Parameters> Fp832<P> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_832.rs
+++ b/models/src/curves/fp_832.rs
@@ -385,7 +385,7 @@ impl<P: Fp832Parameters> Field for Fp832<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -834,7 +834,7 @@ impl<P: Fp832Parameters> Neg for Fp832<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp832::<P>(tmp, PhantomData)
         } else {
@@ -848,7 +848,7 @@ impl<'a, P: Fp832Parameters> Add<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -859,7 +859,7 @@ impl<'a, P: Fp832Parameters> Sub<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -870,7 +870,7 @@ impl<'a, P: Fp832Parameters> Mul<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -881,7 +881,7 @@ impl<'a, P: Fp832Parameters> Div<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/dpc/dpc.rs
+++ b/models/src/dpc/dpc.rs
@@ -73,7 +73,7 @@ pub trait DPCScheme<L: LedgerScheme> {
     /// Returns true iff all the transactions in the block are valid according to the ledger.
     fn verify_transactions(
         parameters: &Self::Parameters,
-        block: &Vec<Self::Transaction>,
+        block: &[Self::Transaction],
         ledger: &L,
     ) -> Result<bool, DPCError>;
 }

--- a/models/src/dpc/dpc.rs
+++ b/models/src/dpc/dpc.rs
@@ -41,6 +41,7 @@ pub trait DPCScheme<L: LedgerScheme> {
     fn create_account<R: Rng>(parameters: &Self::Parameters, rng: &mut R) -> Result<Self::Account, DPCError>;
 
     /// Returns the execution context required for program snark and DPC transaction generation.
+    #[allow(clippy::too_many_arguments)]
     fn execute_offline<R: Rng>(
         parameters: &Self::SystemParameters,
         old_records: &[Self::Record],

--- a/models/src/gadgets/algorithms/crh.rs
+++ b/models/src/gadgets/algorithms/crh.rs
@@ -59,7 +59,7 @@ pub trait MaskedCRHGadget<H: CRH, F: PrimeField>: CRHGadget<H, F> {
                 m.to_bits_le()
                     .chunks(4)
                     .map(|c| {
-                        let new_byte = c.into_iter().flat_map(|b| vec![*b, b.not()]).collect::<Vec<_>>();
+                        let new_byte = c.iter().flat_map(|b| vec![*b, b.not()]).collect::<Vec<_>>();
                         UInt8::from_bits_le(&new_byte)
                     })
                     .collect::<Vec<_>>()

--- a/models/src/gadgets/curves/field.rs
+++ b/models/src/gadgets/curves/field.rs
@@ -177,7 +177,7 @@ pub trait FieldGadget<NativeF: Field, F: Field>:
     #[inline]
     fn pow<CS: ConstraintSystem<F>>(&self, mut cs: CS, bits: &[Boolean]) -> Result<Self, SynthesisError> {
         let mut res = Self::one(cs.ns(|| "Alloc result"))?;
-        for (i, bit) in bits.into_iter().enumerate() {
+        for (i, bit) in bits.iter().enumerate() {
             res = res.square(cs.ns(|| format!("Double {}", i)))?;
             let tmp = res.mul(cs.ns(|| format!("Add {}-th base power", i)), self)?;
             res = Self::conditionally_select(cs.ns(|| format!("Conditional Select {}", i)), bit, &tmp, &res)?;

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -352,7 +352,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpGadget<F> {
         let mut coeff = F::one();
 
         for bit in bits.iter().rev() {
-            lc = lc + (coeff, bit.get_variable());
+            lc += (coeff, bit.get_variable());
 
             coeff.double_in_place();
         }
@@ -391,7 +391,7 @@ impl<F: PrimeField> ToBytesGadget<F> for FpGadget<F> {
         for bit in bytes.iter().flat_map(|byte_gadget| byte_gadget.bits.clone()) {
             match bit {
                 Boolean::Is(bit) => {
-                    lc = lc + (coeff, bit.get_variable());
+                    lc += (coeff, bit.get_variable());
                     coeff.double_in_place();
                 }
                 Boolean::Constant(_) | Boolean::Not(_) => unreachable!(),

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -270,7 +270,7 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
 
 impl<F: PrimeField> PartialEq for FpGadget<F> {
     fn eq(&self, other: &Self) -> bool {
-        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+        self.value.is_some() && other.value.is_some() && self.value == other.value
     }
 }
 

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -149,7 +149,9 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
 
     #[inline]
     fn negate_in_place<CS: ConstraintSystem<F>>(&mut self, _cs: CS) -> Result<&mut Self, SynthesisError> {
-        self.value.as_mut().map(|val| *val = -(*val));
+        if let Some(val) = self.value.as_mut() {
+            *val = -(*val);
+        }
         self.variable.negate_in_place();
         Ok(self)
     }
@@ -181,7 +183,9 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         _cs: CS,
         other: &F,
     ) -> Result<&mut Self, SynthesisError> {
-        self.value.as_mut().map(|val| *val += other);
+        if let Some(val) = self.value.as_mut() {
+            *val += other;
+        }
         self.variable += (*other, CS::one());
         Ok(self)
     }
@@ -199,7 +203,9 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         mut _cs: CS,
         other: &F,
     ) -> Result<&mut Self, SynthesisError> {
-        self.value.as_mut().map(|val| *val *= other);
+        if let Some(val) = self.value.as_mut() {
+            *val *= other;
+        }
         self.variable *= *other;
         Ok(self)
     }

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -540,7 +540,7 @@ impl<F: PrimeField> ThreeBitCondNegLookupGadget<F> for FpGadget<F> {
 impl<F: PrimeField> Clone for FpGadget<F> {
     fn clone(&self) -> Self {
         Self {
-            value: self.value.clone(),
+            value: self.value,
             variable: self.variable.clone(),
         }
     }

--- a/models/src/gadgets/curves/fp2.rs
+++ b/models/src/gadgets/curves/fp2.rs
@@ -96,7 +96,7 @@ impl<P: Fp2Parameters<Fp = F>, F: PrimeField> FieldGadget<Fp2<P>, F> for Fp2Gadg
 
     #[inline]
     fn get_variable(&self) -> Self::Variable {
-        (self.c0.get_variable().clone(), self.c1.get_variable().clone())
+        (self.c0.get_variable(), self.c1.get_variable())
     }
 
     #[inline]

--- a/models/src/gadgets/curves/group.rs
+++ b/models/src/gadgets/curves/group.rs
@@ -156,7 +156,7 @@ pub trait GroupGadget<G: Group, F: Field>:
         Err(SynthesisError::AssignmentMissing)
     }
 
-    fn precomputed_base_3_bit_signed_digit_scalar_mul<'a, CS, I, J, B>(
+    fn precomputed_base_3_bit_signed_digit_scalar_mul<CS, I, J, B>(
         _: CS,
         _: &[B],
         _: &[J],

--- a/models/src/gadgets/curves/pairing.rs
+++ b/models/src/gadgets/curves/pairing.rs
@@ -54,7 +54,6 @@ pub trait PairingGadget<Pairing: PairingEngine, F: Field> {
     }
 
     /// Computes a product of pairings.
-    #[must_use]
     fn product_of_pairings<CS: ConstraintSystem<F>>(
         mut cs: CS,
         p: &[Self::G1PreparedGadget],

--- a/models/src/gadgets/r1cs/constraint_system.rs
+++ b/models/src/gadgets/r1cs/constraint_system.rs
@@ -79,7 +79,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     fn get_root(&mut self) -> &mut Self::Root;
 
     /// Begin a namespace for this constraint system.
-    fn ns<'a, NR, N>(&'a mut self, name_fn: N) -> Namespace<'a, F, Self::Root>
+    fn ns<NR, N>(&mut self, name_fn: N) -> Namespace<'_, F, Self::Root>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,

--- a/models/src/gadgets/r1cs/impl_constraint_var.rs
+++ b/models/src/gadgets/r1cs/impl_constraint_var.rs
@@ -289,6 +289,7 @@ impl<'a, F: Field> Sub<(F, &'a Self)> for ConstraintVar<F> {
     type Output = Self;
 
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, (coeff, other): (F, &'a Self)) -> Self {
         let mut lc = match self {
             LC(lc2) => lc2,

--- a/models/src/gadgets/r1cs/impl_lc.rs
+++ b/models/src/gadgets/r1cs/impl_lc.rs
@@ -84,7 +84,7 @@ impl<F: Field> LinearCombination<F> {
                     found_index += 1;
                 }
             }
-            return Err(found_index);
+            Err(found_index)
         } else {
             self.0.binary_search_by_key(search_var, |&(cur_var, _)| cur_var)
         }

--- a/models/src/gadgets/r1cs/impl_lc.rs
+++ b/models/src/gadgets/r1cs/impl_lc.rs
@@ -357,6 +357,7 @@ impl<F: Field> Sub<LinearCombination<F>> for LinearCombination<F> {
 impl<F: Field> Add<(F, &LinearCombination<F>)> for &LinearCombination<F> {
     type Output = LinearCombination<F>;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, other): (F, &LinearCombination<F>)) -> LinearCombination<F> {
         if other.0.is_empty() {
             return self.clone();
@@ -377,6 +378,7 @@ impl<F: Field> Add<(F, &LinearCombination<F>)> for &LinearCombination<F> {
 impl<'a, F: Field> Add<(F, &'a LinearCombination<F>)> for LinearCombination<F> {
     type Output = LinearCombination<F>;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, other): (F, &'a LinearCombination<F>)) -> LinearCombination<F> {
         if other.0.is_empty() {
             return self;
@@ -397,6 +399,7 @@ impl<'a, F: Field> Add<(F, &'a LinearCombination<F>)> for LinearCombination<F> {
 impl<F: Field> Add<(F, LinearCombination<F>)> for &LinearCombination<F> {
     type Output = LinearCombination<F>;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, mut other): (F, LinearCombination<F>)) -> LinearCombination<F> {
         if other.0.is_empty() {
             return self.clone();
@@ -416,6 +419,7 @@ impl<F: Field> Add<(F, LinearCombination<F>)> for &LinearCombination<F> {
 impl<F: Field> Add<(F, Self)> for LinearCombination<F> {
     type Output = Self;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, other): (F, Self)) -> Self {
         if other.0.is_empty() {
             return self;

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -215,7 +215,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     fn push_namespace<NR: Into<String>, N: FnOnce() -> NR>(&mut self, name_fn: N) {
         let name = name_fn().into();
         let path = compute_path(&self.current_namespace, name.clone());
-        self.set_named_obj(path.clone(), NamedObject::Namespace);
+        self.set_named_obj(path, NamedObject::Namespace);
         self.current_namespace.push(name);
     }
 

--- a/models/src/gadgets/utilities/arithmetic/add.rs
+++ b/models/src/gadgets/utilities/arithmetic/add.rs
@@ -30,7 +30,6 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn add<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }
 

--- a/models/src/gadgets/utilities/arithmetic/div.rs
+++ b/models/src/gadgets/utilities/arithmetic/div.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn div<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/arithmetic/mul.rs
+++ b/models/src/gadgets/utilities/arithmetic/mul.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn mul<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/arithmetic/neg.rs
+++ b/models/src/gadgets/utilities/arithmetic/neg.rs
@@ -30,7 +30,6 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn neg<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Self, Self::ErrorType>;
 }
 

--- a/models/src/gadgets/utilities/arithmetic/neg.rs
+++ b/models/src/gadgets/utilities/arithmetic/neg.rs
@@ -45,7 +45,7 @@ impl<F: Field> Neg<F> for Vec<Boolean> {
         let mut one = vec![Boolean::constant(true)];
         one.append(&mut vec![Boolean::Constant(false); self.len() - 1]);
 
-        let mut bits = flipped.add_bits(cs.ns(|| format!("add one")), &one)?;
+        let mut bits = flipped.add_bits(cs.ns(|| "add one"), &one)?;
         let _carry = bits.pop(); // we already accounted for overflow above
 
         Ok(bits)

--- a/models/src/gadgets/utilities/arithmetic/pow.rs
+++ b/models/src/gadgets/utilities/arithmetic/pow.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn pow<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/arithmetic/sub.rs
+++ b/models/src/gadgets/utilities/arithmetic/sub.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn sub<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/bits/adder.rs
+++ b/models/src/gadgets/utilities/bits/adder.rs
@@ -44,12 +44,12 @@ impl<'a, F: Field> FullAdder<'a, F> for Boolean {
         b: &'a Self,
         carry: &'a Self,
     ) -> Result<(Self, Self), SynthesisError> {
-        let a_x_b = Boolean::xor(cs.ns(|| format!("a XOR b")), a, b)?;
-        let sum = Boolean::xor(cs.ns(|| format!("adder sum")), &a_x_b, carry)?;
+        let a_x_b = Boolean::xor(cs.ns(|| "a XOR b"), a, b)?;
+        let sum = Boolean::xor(cs.ns(|| "adder sum"), &a_x_b, carry)?;
 
-        let c1 = Boolean::and(cs.ns(|| format!("a AND b")), a, b)?;
-        let c2 = Boolean::and(cs.ns(|| format!("carry AND (a XOR b)")), carry, &a_x_b)?;
-        let carry = Boolean::or(cs.ns(|| format!("c1 OR c2")), &c1, &c2)?;
+        let c1 = Boolean::and(cs.ns(|| "a AND b"), a, b)?;
+        let c2 = Boolean::and(cs.ns(|| "carry AND (a XOR b)"), carry, &a_x_b)?;
+        let carry = Boolean::or(cs.ns(|| "c1 OR c2"), &c1, &c2)?;
 
         Ok((sum, carry))
     }

--- a/models/src/gadgets/utilities/bits/rca.rs
+++ b/models/src/gadgets/utilities/bits/rca.rs
@@ -28,7 +28,6 @@ pub trait RippleCarryAdder<F: Field, Rhs = Self>
 where
     Self: std::marker::Sized,
 {
-    #[must_use]
     fn add_bits<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Vec<Boolean>, SynthesisError>;
 }
 

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -748,9 +748,9 @@ impl<F: PrimeField> CondSelectGadget<F> for Boolean {
             Boolean::Constant(false) => Ok(*second),
             cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
             cond @ Boolean::Is(_) => match (first, second) {
-                (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),
+                (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x),
                 (&Boolean::Constant(false), x) => Boolean::and(cs.ns(|| "and"), &cond.not(), x),
-                (&Boolean::Constant(true), x) => Boolean::or(cs.ns(|| "or"), cond, x).into(),
+                (&Boolean::Constant(true), x) => Boolean::or(cs.ns(|| "or"), cond, x),
                 (x, &Boolean::Constant(true)) => Boolean::or(cs.ns(|| "or"), &cond.not(), x),
                 (a @ Boolean::Is(_), b @ Boolean::Is(_))
                 | (a @ Boolean::Not(_), b @ Boolean::Not(_))

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -587,7 +587,7 @@ impl Boolean {
 
             if b {
                 // This is part of a run of ones.
-                current_run.push(a.clone());
+                current_run.push(*a);
             } else {
                 if !current_run.is_empty() {
                     // This is the start of a run of zeros, but we need
@@ -744,8 +744,8 @@ impl<F: PrimeField> CondSelectGadget<F> for Boolean {
         CS: ConstraintSystem<F>,
     {
         match cond {
-            Boolean::Constant(true) => Ok(first.clone()),
-            Boolean::Constant(false) => Ok(second.clone()),
+            Boolean::Constant(true) => Ok(first),
+            Boolean::Constant(false) => Ok(second),
             cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
             cond @ Boolean::Is(_) => match (first, second) {
                 (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -744,8 +744,8 @@ impl<F: PrimeField> CondSelectGadget<F> for Boolean {
         CS: ConstraintSystem<F>,
     {
         match cond {
-            Boolean::Constant(true) => Ok(first),
-            Boolean::Constant(false) => Ok(second),
+            Boolean::Constant(true) => Ok(*first),
+            Boolean::Constant(false) => Ok(*second),
             cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
             cond @ Boolean::Is(_) => match (first, second) {
                 (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),

--- a/models/src/gadgets/utilities/int/arithmetic/add.rs
+++ b/models/src/gadgets/utilities/int/arithmetic/add.rs
@@ -79,7 +79,7 @@ macro_rules! add_int_impl {
                             all_constants = false;
 
                             // Add the coeff * bit_gadget
-                            lc = lc + (coeff, bit.get_variable());
+                            lc += (coeff, bit.get_variable());
                         }
                         Boolean::Not(ref bit) => {
                             all_constants = false;
@@ -89,7 +89,7 @@ macro_rules! add_int_impl {
                         }
                         Boolean::Constant(bit) => {
                             if bit {
-                                lc = lc + (coeff, CS::one());
+                                lc += (coeff, CS::one());
                             }
                         }
                     }

--- a/models/src/gadgets/utilities/mod.rs
+++ b/models/src/gadgets/utilities/mod.rs
@@ -44,11 +44,11 @@ pub trait ToBitsGadget<F: Field> {
 
 impl<F: Field> ToBitsGadget<F> for Boolean {
     fn to_bits<CS: ConstraintSystem<F>>(&self, _: CS) -> Result<Vec<Boolean>, SynthesisError> {
-        Ok(vec![self.clone()])
+        Ok(vec![*self])
     }
 
     fn to_bits_strict<CS: ConstraintSystem<F>>(&self, _: CS) -> Result<Vec<Boolean>, SynthesisError> {
-        Ok(vec![self.clone()])
+        Ok(vec![*self])
     }
 }
 

--- a/models/src/gadgets/utilities/uint/macros.rs
+++ b/models/src/gadgets/utilities/uint/macros.rs
@@ -209,7 +209,7 @@ macro_rules! uint_impl {
                                     lc = lc - (coeff, bit.get_variable());
                                 } else {
                                     // Add coeff * bit_gadget
-                                    lc = lc + (coeff, bit.get_variable());
+                                    lc += (coeff, bit.get_variable());
                                 }
                             }
                             Boolean::Not(ref bit) => {
@@ -228,7 +228,7 @@ macro_rules! uint_impl {
                                     if op.negated {
                                         lc = lc - (coeff, CS::one());
                                     } else {
-                                        lc = lc + (coeff, CS::one());
+                                        lc += (coeff, CS::one());
                                     }
                                 }
                             }

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -625,7 +625,7 @@ impl UInt for UInt128 {
 
 impl PartialEq for UInt128 {
     fn eq(&self, other: &Self) -> bool {
-        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+        self.value.is_some() && other.value.is_some() && self.value == other.value
     }
 }
 

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -389,7 +389,7 @@ impl UInt for UInt128 {
             (_, _) => {
                 // If either of our operands have unknown value, we won't
                 // know the value of the result
-                return Err(SynthesisError::AssignmentMissing);
+                Err(SynthesisError::AssignmentMissing)
             }
         }
     }

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -241,7 +241,7 @@ impl UInt for UInt128 {
                             lc = lc - (coeff, bit.get_variable());
                         } else {
                             // Add coeff * bit_gadget
-                            lc = lc + (coeff, bit.get_variable());
+                            lc += (coeff, bit.get_variable());
                         }
                     }
                     Boolean::Not(ref bit) => {
@@ -260,7 +260,7 @@ impl UInt for UInt128 {
                             if op.negated {
                                 lc = lc - (coeff, CS::one());
                             } else {
-                                lc = lc + (coeff, CS::one());
+                                lc += (coeff, CS::one());
                             }
                         }
                     }

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -821,7 +821,7 @@ impl<F: Field> ToBytesGadget<F> for UInt128 {
             None => [None, None, None, None],
         };
         let mut bytes = Vec::new();
-        for (i, chunk8) in self.to_bits_le().chunks(8).into_iter().enumerate() {
+        for (i, chunk8) in self.to_bits_le().chunks(8).enumerate() {
             let byte = UInt8 {
                 bits: chunk8.to_vec(),
                 negated: false,

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -443,7 +443,7 @@ impl UInt for UInt128 {
             })
             .collect::<Vec<Self>>();
 
-        Self::addmany(&mut cs.ns(|| format!("partial_products")), &partial_products)
+        Self::addmany(&mut cs.ns(|| "partial_products"), &partial_products)
     }
 
     /// Perform long division of two `UInt128` objects.

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -110,24 +110,32 @@ impl UInt for UInt128 {
 
         let mut value = Some(0u128);
         for b in bits.iter().rev() {
-            value.as_mut().map(|v| *v <<= 1);
+            if let Some(v) = value.as_mut() {
+                *v <<= 1;
+            }
 
             match b {
                 &Boolean::Constant(b) => {
                     if b {
-                        value.as_mut().map(|v| *v |= 1);
+                        if let Some(v) = value.as_mut() {
+                            *v |= 1;
+                        }
                     }
                 }
                 &Boolean::Is(ref b) => match b.get_value() {
                     Some(true) => {
-                        value.as_mut().map(|v| *v |= 1);
+                        if let Some(v) = value.as_mut() {
+                            *v |= 1;
+                        }
                     }
                     Some(false) => {}
                     None => value = None,
                 },
                 &Boolean::Not(ref b) => match b.get_value() {
                     Some(false) => {
-                        value.as_mut().map(|v| *v |= 1);
+                        if let Some(v) = value.as_mut() {
+                            *v |= 1;
+                        }
                     }
                     Some(true) => {}
                     None => value = None,

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -76,7 +76,7 @@ impl UInt for UInt128 {
         Self {
             bits: self.bits.clone(),
             negated: true,
-            value: self.value.clone(),
+            value: self.value,
         }
     }
 
@@ -546,7 +546,7 @@ impl UInt for UInt128 {
             let index = 127 - i as usize;
             let bit_value = 1u128 << (index as u128);
             let mut new_quotient = quotient.clone();
-            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.bits[index] = true_bit;
             new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
 
             quotient = Self::conditionally_select(

--- a/models/src/gadgets/utilities/uint/unsigned_integer.rs
+++ b/models/src/gadgets/utilities/uint/unsigned_integer.rs
@@ -114,7 +114,7 @@ impl UInt8 {
         T: Into<Option<u8>> + Copy,
     {
         let mut output_vec = Vec::with_capacity(values.len());
-        for (i, value) in values.into_iter().enumerate() {
+        for (i, value) in values.iter().enumerate() {
             let byte: Option<u8> = Into::into(*value);
             let alloc_byte = Self::alloc(&mut cs.ns(|| format!("byte_{}", i)), || byte.get())?;
             output_vec.push(alloc_byte);

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate derivative;
 

--- a/parameters/src/lib.rs
+++ b/parameters/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod genesis;
 pub use genesis::*;
 

--- a/utilities/src/biginteger/mod.rs
+++ b/utilities/src/biginteger/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 mod macros;
 

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -359,7 +359,7 @@ pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
         let mut result = 0u8;
         for (i, bit) in bits.iter().enumerate() {
             let bit_value = *bit as u8;
-            result = result + (bit_value << i as u8);
+            result += bit_value << i as u8;
         }
         bytes.push(result);
     }

--- a/utilities/src/variable_length_integer.rs
+++ b/utilities/src/variable_length_integer.rs
@@ -38,13 +38,13 @@ pub fn variable_length_integer(value: u64) -> Vec<u8> {
 /// https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer
 pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<usize> {
     let mut flag = [0u8; 1];
-    reader.read(&mut flag)?;
+    reader.read_exact(&mut flag)?;
 
     match flag[0] {
         0..=252 => Ok(flag[0] as usize),
         0xfd => {
             let mut size = [0u8; 2];
-            reader.read(&mut size)?;
+            reader.read_exact(&mut size)?;
             match u16::from_le_bytes(size) {
                 s if s < 253 => Err(error("Invalid variable size integer")),
                 s => Ok(s as usize),
@@ -52,7 +52,7 @@ pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<usize> {
         }
         0xfe => {
             let mut size = [0u8; 4];
-            reader.read(&mut size)?;
+            reader.read_exact(&mut size)?;
             match u32::from_le_bytes(size) {
                 s if s < 65536 => Err(error("Invalid variable size integer")),
                 s => Ok(s as usize),
@@ -60,7 +60,7 @@ pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<usize> {
         }
         _ => {
             let mut size = [0u8; 8];
-            reader.read(&mut size)?;
+            reader.read_exact(&mut size)?;
             match u64::from_le_bytes(size) {
                 s if s < 4_294_967_296 => Err(error("Invalid variable size integer")),
                 s => Ok(s as usize),


### PR DESCRIPTION
This is the first round of adjustments suggested by `clippy`, paving the way towards enabling its lints in the CI or githooks. All the specific changes are confined to individual commits.

Some of the suggestions were silenced with `#[allow(clippy::x)]`, with `x` being:
- `module_inception` (not very important and adjusting would incur a lot of diff "traffic")
- `many_single_char_names` (fine in complex calculations, especially when following scientific names)
- `too_many_arguments` (better to treat those individually; they will be easy to find with the new attribute)
- `suspicious_arithmetic_impl` / `suspicious_op_assign_impl` (ditto)

Cc https://github.com/AleoHQ/snarkOS/issues/145