### PR TITLE
Clippy compliance, part 3 (final)

### DIFF
--- a/algorithms/src/commitment_tree/mod.rs
+++ b/algorithms/src/commitment_tree/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod commitment_path;
 pub use commitment_path::*;
 

--- a/algorithms/src/commitment_tree/tests.rs
+++ b/algorithms/src/commitment_tree/tests.rs
@@ -59,12 +59,11 @@ fn generate_merkle_tree<C: CommitmentScheme, H: CRH, R: Rng>(
     let default = <C as CommitmentScheme>::Output::default();
     let mut leaves = [default.clone(), default.clone(), default.clone(), default];
 
-    for i in 0..4 {
+    for leaf in &mut leaves {
         let leaf_input: [u8; 32] = rng.gen();
         let randomness = <C as CommitmentScheme>::Randomness::rand(rng);
 
-        let leaf = commitment.commit(&leaf_input, &randomness).unwrap();
-        leaves[i] = leaf;
+        *leaf = commitment.commit(&leaf_input, &randomness).unwrap();
     }
 
     CommitmentMerkleTree::new(crh.clone(), &leaves).unwrap()

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -186,7 +186,7 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
                         cfg_chunks!(segment_bits, BOWE_HOPWOOD_CHUNK_SIZE)
                             .zip(segment_generators)
                             .map(|(chunk_bits, generator)| {
-                                let mut encoded = generator.clone();
+                                let mut encoded = *generator;
                                 if chunk_bits[0] {
                                     encoded = encoded + generator;
                                 }

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -188,7 +188,7 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
                             .map(|(chunk_bits, generator)| {
                                 let mut encoded = *generator;
                                 if chunk_bits[0] {
-                                    encoded = encoded + generator;
+                                    encoded += generator;
                                 }
                                 if chunk_bits[1] {
                                     encoded += &generator.double();

--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -90,14 +90,14 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             // Let e = legendre(v^3 + Av^2 + Bv).
             let v2 = v.square();
             let v3 = v2 * &v;
-            let av2 = a.clone() * &v2;
-            let bv = b.clone() * &v;
+            let av2 = a * &v2;
+            let bv = b * &v;
             let e = (v3 + &(av2 + &bv)).legendre();
 
             // Let x = ev - ((1 - e) * A/2).
             let two = P::BaseField::one().double();
             let x = match e {
-                LegendreSymbol::Zero => -(a.clone() * &two.inverse().unwrap()),
+                LegendreSymbol::Zero => -(a * &two.inverse().unwrap()),
                 LegendreSymbol::QuadraticResidue => v,
                 LegendreSymbol::QuadraticNonResidue => (-v) - &a,
             };
@@ -105,8 +105,8 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             // Let y = -e * sqrt(x^3 + Ax^2 + Bx).
             let x2 = x.square();
             let x3 = x2 * &x;
-            let ax2 = a.clone() * &x2;
-            let bx = b.clone() * &x;
+            let ax2 = a * &x2;
+            let bx = b * &x;
             let value = (x3 + &(ax2 + &bx)).sqrt().unwrap();
             let y = match e {
                 LegendreSymbol::Zero => P::BaseField::zero(),
@@ -183,7 +183,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
             let numerator = P::BaseField::one() + &y;
             let denominator = P::BaseField::one() - &y;
 
-            let u = numerator.clone() * &(denominator.inverse().unwrap());
+            let u = numerator * &(denominator.inverse().unwrap());
             let v = numerator * &((denominator * &x).inverse().unwrap());
 
             // Ensure (u, v) is a valid Montgomery element

--- a/algorithms/src/encoding/elligator2.rs
+++ b/algorithms/src/encoding/elligator2.rs
@@ -41,6 +41,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
     const D: P::BaseField = <P as TEModelParameters>::COEFF_D;
 
     /// Returns the encoded group element for a given base field element.
+    #[allow(clippy::many_single_char_names)]
     pub fn encode(input: &P::BaseField) -> Result<(<G as ProjectiveCurve>::Affine, bool), EncodingError> {
         // The input base field must be nonzero, otherwise inverses will fail.
         if input.is_zero() {
@@ -157,6 +158,7 @@ impl<P: MontgomeryModelParameters + TEModelParameters, G: Group + ProjectiveCurv
         Ok((<G as ProjectiveCurve>::Affine::read(&to_bytes![x, y]?[..])?, sign_high))
     }
 
+    #[allow(clippy::many_single_char_names)]
     pub fn decode(
         group_element: &<G as ProjectiveCurve>::Affine,
         sign_high: bool,

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -165,7 +165,7 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
         &self,
         public_key: &Self::PublicKey,
         randomness: &Self::Randomness,
-        message: &Vec<Self::Text>,
+        message: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError> {
         let record_view_key = public_key.0.mul(&randomness);
 
@@ -202,7 +202,7 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
     fn decrypt(
         &self,
         private_key: &Self::PrivateKey,
-        ciphertext: &Vec<Self::Text>,
+        ciphertext: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError> {
         assert!(ciphertext.len() > 0);
         let c_0 = &ciphertext[0];

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -204,7 +204,7 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
         private_key: &Self::PrivateKey,
         ciphertext: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError> {
-        assert!(ciphertext.len() > 0);
+        assert!(!ciphertext.is_empty());
         let c_0 = &ciphertext[0];
 
         let record_view_key = c_0.mul(&private_key);

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -207,9 +207,9 @@ impl<F: PrimeField> EvaluationDomain<F> {
         if t_size.is_one() {
             let mut u = vec![F::zero(); size];
             let mut omega_i = one;
-            for i in 0..size {
+            for x in u.iter_mut().take(size) {
                 if omega_i == tau {
-                    u[i] = one;
+                    *x = one;
                     break;
                 }
                 omega_i *= &self.group_gen;
@@ -392,12 +392,12 @@ pub(crate) fn parallel_fft<F: PrimeField>(a: &mut [F], worker: &Worker, omega: F
                 let omega_step = omega.pow(&[(j as u64) << log_new_n]);
 
                 let mut elt = F::one();
-                for i in 0..(1 << log_new_n) {
+                for (i, x) in tmp.iter_mut().enumerate().take(1 << log_new_n) {
                     for s in 0..num_cpus {
                         let idx = (i + (s << log_new_n)) % (1 << log_n);
                         let mut t = a[idx];
                         t *= &elt;
-                        tmp[i] += &t;
+                        *x += &t;
                         elt *= &omega_step;
                     }
                     elt *= &omega_j;

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -328,6 +328,7 @@ fn best_fft<F: PrimeField>(a: &mut [F], worker: &Worker, omega: F, log_n: u32) {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn serial_fft<F: PrimeField>(a: &mut [F], omega: F, log_n: u32) {
     #[inline]
     fn bitreverse(mut n: u32, l: u32) -> u32 {

--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -486,7 +486,7 @@ mod tests {
             let size = 1 << coeffs;
             let domain = EvaluationDomain::<Fr>::new(size).unwrap();
             let domain_size = domain.size();
-            assert_eq!(domain_size, domain.elements().collect::<Vec<_>>().len());
+            assert_eq!(domain_size, domain.elements().count());
         }
     }
 

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -72,7 +72,7 @@ impl<F: Field> DensePolynomial<F> {
 
     /// Checks if the given polynomial is zero.
     pub fn is_zero(&self) -> bool {
-        self.coeffs.len() == 0 || self.coeffs.iter().all(|coeff| coeff.is_zero())
+        self.coeffs.is_empty() || self.coeffs.iter().all(|coeff| coeff.is_zero())
     }
 
     /// Constructs a new polynomial from a list of coefficients.

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -228,6 +228,7 @@ impl<'a, 'b, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
 }
 
 impl<'a, 'b, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomial<F> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, (f, other): (F, &'a DensePolynomial<F>)) {
         if self.is_zero() {
             self.coeffs.truncate(0);

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -367,6 +367,7 @@ impl<'a, 'b, F: PrimeField> Mul<&'a DensePolynomial<F>> for &'b DensePolynomial<
     type Output = DensePolynomial<F>;
 
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, other: &'a DensePolynomial<F>) -> DensePolynomial<F> {
         if self.is_zero() || other.is_zero() {
             DensePolynomial::zero()

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -178,24 +178,22 @@ impl<'a, 'b, F: Field> Add<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
             other.clone()
         } else if other.is_zero() {
             self.clone()
-        } else {
-            if self.degree() >= other.degree() {
-                let mut result = self.clone();
-                for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a += b
-                }
-                result
-            } else {
-                let mut result = other.clone();
-                for (a, b) in result.coeffs.iter_mut().zip(&self.coeffs) {
-                    *a += b
-                }
-                // If the leading coefficient ends up being zero, pop it off.
-                while result.coeffs.last().unwrap().is_zero() {
-                    result.coeffs.pop();
-                }
-                result
+        } else if self.degree() >= other.degree() {
+            let mut result = self.clone();
+            for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
+                *a += b
             }
+            result
+        } else {
+            let mut result = other.clone();
+            for (a, b) in result.coeffs.iter_mut().zip(&self.coeffs) {
+                *a += b
+            }
+            // If the leading coefficient ends up being zero, pop it off.
+            while result.coeffs.last().unwrap().is_zero() {
+                result.coeffs.pop();
+            }
+            result
         }
     }
 }
@@ -206,22 +204,20 @@ impl<'a, 'b, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
             self.coeffs.truncate(0);
             self.coeffs.extend_from_slice(&other.coeffs);
         } else if other.is_zero() {
-            return;
+            // return
+        } else if self.degree() >= other.degree() {
+            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+                *a += b
+            }
         } else {
-            if self.degree() >= other.degree() {
-                for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a += b
-                }
-            } else {
-                // Add the necessary number of zero coefficients.
-                self.coeffs.resize(other.coeffs.len(), F::zero());
-                for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a += b
-                }
-                // If the leading coefficient ends up being zero, pop it off.
-                while self.coeffs.last().unwrap().is_zero() {
-                    self.coeffs.pop();
-                }
+            // Add the necessary number of zero coefficients.
+            self.coeffs.resize(other.coeffs.len(), F::zero());
+            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+                *a += b
+            }
+            // If the leading coefficient ends up being zero, pop it off.
+            while self.coeffs.last().unwrap().is_zero() {
+                self.coeffs.pop();
             }
         }
     }
@@ -235,22 +231,20 @@ impl<'a, 'b, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomia
             self.coeffs.extend_from_slice(&other.coeffs);
             self.coeffs.iter_mut().for_each(|c| *c *= &f);
         } else if other.is_zero() {
-            return;
+            // return
+        } else if self.degree() >= other.degree() {
+            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+                *a += &(f * b);
+            }
         } else {
-            if self.degree() >= other.degree() {
-                for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a += &(f * b);
-                }
-            } else {
-                // Add the necessary number of zero coefficients.
-                self.coeffs.resize(other.coeffs.len(), F::zero());
-                for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a += &(f * b);
-                }
-                // If the leading coefficient ends up being zero, pop it off.
-                while self.coeffs.last().unwrap().is_zero() {
-                    self.coeffs.pop();
-                }
+            // Add the necessary number of zero coefficients.
+            self.coeffs.resize(other.coeffs.len(), F::zero());
+            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+                *a += &(f * b);
+            }
+            // If the leading coefficient ends up being zero, pop it off.
+            while self.coeffs.last().unwrap().is_zero() {
+                self.coeffs.pop();
             }
         }
     }
@@ -295,28 +289,26 @@ impl<'a, 'b, F: Field> Sub<&'a DensePolynomial<F>> for &'b DensePolynomial<F> {
             result
         } else if other.is_zero() {
             self.clone()
-        } else {
-            if self.degree() >= other.degree() {
-                let mut result = self.clone();
-                for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a -= b
-                }
-                result
-            } else {
-                let mut result = self.clone();
-                result.coeffs.resize(other.coeffs.len(), F::zero());
-                for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a -= b;
-                }
-                if !result.is_zero() {
-                    // If the leading coefficient ends up being zero, pop it off.
-                    while result.coeffs.last().unwrap().is_zero() {
-                        result.coeffs.pop();
-                    }
-                }
-
-                result
+        } else if self.degree() >= other.degree() {
+            let mut result = self.clone();
+            for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
+                *a -= b
             }
+            result
+        } else {
+            let mut result = self.clone();
+            result.coeffs.resize(other.coeffs.len(), F::zero());
+            for (a, b) in result.coeffs.iter_mut().zip(&other.coeffs) {
+                *a -= b;
+            }
+            if !result.is_zero() {
+                // If the leading coefficient ends up being zero, pop it off.
+                while result.coeffs.last().unwrap().is_zero() {
+                    result.coeffs.pop();
+                }
+            }
+
+            result
         }
     }
 }
@@ -330,22 +322,20 @@ impl<'a, 'b, F: Field> SubAssign<&'a DensePolynomial<F>> for DensePolynomial<F> 
                 self.coeffs[i] -= coeff;
             }
         } else if other.is_zero() {
-            return;
+            // return
+        } else if self.degree() >= other.degree() {
+            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+                *a -= b
+            }
         } else {
-            if self.degree() >= other.degree() {
-                for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a -= b
-                }
-            } else {
-                // Add the necessary number of zero coefficients.
-                self.coeffs.resize(other.coeffs.len(), F::zero());
-                for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
-                    *a -= b
-                }
-                // If the leading coefficient ends up being zero, pop it off.
-                while self.coeffs.last().unwrap().is_zero() {
-                    self.coeffs.pop();
-                }
+            // Add the necessary number of zero coefficients.
+            self.coeffs.resize(other.coeffs.len(), F::zero());
+            for (a, b) in self.coeffs.iter_mut().zip(&other.coeffs) {
+                *a -= b
+            }
+            // If the leading coefficient ends up being zero, pop it off.
+            while self.coeffs.last().unwrap().is_zero() {
+                self.coeffs.pop();
             }
         }
     }

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -108,9 +108,9 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
     }
 
     #[inline]
-    fn iter_with_index<'a>(&'a self) -> Vec<(usize, F)> {
+    fn iter_with_index(&self) -> Vec<(usize, F)> {
         match self {
-            SPolynomial(p) => p.coeffs.iter().cloned().collect(),
+            SPolynomial(p) => p.coeffs.to_vec(),
             DPolynomial(p) => p.iter().cloned().enumerate().collect(),
         }
     }

--- a/algorithms/src/fft/polynomial/sparse.rs
+++ b/algorithms/src/fft/polynomial/sparse.rs
@@ -54,7 +54,7 @@ impl<F: Field> SparsePolynomial<F> {
 
     /// Checks if the given polynomial is zero.
     pub fn is_zero(&self) -> bool {
-        self.coeffs.len() == 0 || self.coeffs.iter().all(|(_, c)| c.is_zero())
+        self.coeffs.is_empty() || self.coeffs.iter().all(|(_, c)| c.is_zero())
     }
 
     /// Constructs a new polynomial from a list of coefficients.
@@ -104,7 +104,7 @@ impl<F: Field> SparsePolynomial<F> {
             let mut result = std::collections::HashMap::new();
             for (i, self_coeff) in self.coeffs.iter() {
                 for (j, other_coeff) in other.coeffs.iter() {
-                    let cur_coeff = result.entry(i + j).or_insert(F::zero());
+                    let cur_coeff = result.entry(i + j).or_insert_with(F::zero);
                     *cur_coeff += &(*self_coeff * other_coeff);
                 }
             }

--- a/algorithms/src/fft/tests.rs
+++ b/algorithms/src/fft/tests.rs
@@ -19,7 +19,6 @@ use snarkos_curves::bls12_377::Bls12_377;
 use snarkos_models::curves::PairingEngine;
 use snarkos_utilities::rand::UniformRand;
 
-use rand;
 use std::cmp::min;
 
 // Test multiplying various (low degree) polynomials together and

--- a/algorithms/src/merkle_tree/merkle_path.rs
+++ b/algorithms/src/merkle_tree/merkle_path.rs
@@ -25,11 +25,11 @@ pub type MerkleTreeDigest<P> = <<P as MerkleParameters>::H as CRH>::Output;
 #[derive(Clone, Debug)]
 pub struct MerklePath<P: MerkleParameters> {
     pub parameters: P,
-    pub path: Vec<(<P::H as CRH>::Output, <P::H as CRH>::Output)>,
+    pub path: Vec<(MerkleTreeDigest<P>, MerkleTreeDigest<P>)>,
 }
 
 impl<P: MerkleParameters> MerklePath<P> {
-    pub fn verify<L: ToBytes>(&self, root_hash: &<P::H as CRH>::Output, leaf: &L) -> Result<bool, MerkleError> {
+    pub fn verify<L: ToBytes>(&self, root_hash: &MerkleTreeDigest<P>, leaf: &L) -> Result<bool, MerkleError> {
         if self.path.len() != P::DEPTH {
             return Ok(false);
         }
@@ -72,7 +72,7 @@ impl<P: MerkleParameters> Default for MerklePath<P> {
     fn default() -> Self {
         let mut path = Vec::with_capacity(P::DEPTH);
         for _i in 0..P::DEPTH {
-            path.push((<P::H as CRH>::Output::default(), <P::H as CRH>::Output::default()));
+            path.push((MerkleTreeDigest::<P>::default(), MerkleTreeDigest::<P>::default()));
         }
         Self {
             parameters: P::default(),

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -14,24 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::merkle_tree::MerklePath;
+use crate::merkle_tree::{MerklePath, MerkleTreeDigest};
 use snarkos_errors::algorithms::MerkleError;
 use snarkos_models::algorithms::{MerkleParameters, CRH};
 use snarkos_utilities::ToBytes;
 
 pub struct MerkleTree<P: MerkleParameters> {
     /// The computed root of the full Merkle tree.
-    root: Option<<P::H as CRH>::Output>,
+    root: Option<MerkleTreeDigest<P>>,
 
     /// The internal hashes, from root to hashed leaves, of the full Merkle tree.
-    tree: Vec<<P::H as CRH>::Output>,
+    tree: Vec<MerkleTreeDigest<P>>,
 
     /// The hash of each non-empty leaf in the Merkle tree.
-    hashed_leaves: Vec<<P::H as CRH>::Output>,
+    hashed_leaves: Vec<MerkleTreeDigest<P>>,
 
     /// For each level after a full tree has been built from the leaves,
     /// keeps both the roots the siblings that are used to get to the desired depth.
-    padding_tree: Vec<(<P::H as CRH>::Output, <P::H as CRH>::Output)>,
+    padding_tree: Vec<(MerkleTreeDigest<P>, MerkleTreeDigest<P>)>,
 
     /// The Merkle tree parameters (e.g. the hash function).
     parameters: P,

--- a/algorithms/src/merkle_tree/mod.rs
+++ b/algorithms/src/merkle_tree/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod merkle_path;
 pub use merkle_path::*;
 

--- a/algorithms/src/merkle_tree/tests.rs
+++ b/algorithms/src/merkle_tree/tests.rs
@@ -37,7 +37,7 @@ fn generate_merkle_tree<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(
 }
 
 /// Generates a valid Merkle tree and verifies the Merkle path witness for each leaf does not verify to an invalid root hash.
-fn bad_merkle_tree_verify<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(leaves: &[L], parameters: &P) -> () {
+fn bad_merkle_tree_verify<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(leaves: &[L], parameters: &P) {
     let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
     for (i, leaf) in leaves.iter().enumerate() {
         let proof = tree.generate_proof(i, &leaf).unwrap();
@@ -47,7 +47,7 @@ fn bad_merkle_tree_verify<P: LoadableMerkleParameters, L: ToBytes + Clone + Eq>(
 
 fn run_empty_merkle_tree_test<P: LoadableMerkleParameters>() {
     let parameters = &P::default();
-    generate_merkle_tree::<P, Vec<u8>>(&vec![], parameters);
+    generate_merkle_tree::<P, Vec<u8>>(&[], parameters);
 }
 
 fn run_good_root_test<P: LoadableMerkleParameters>() {

--- a/algorithms/src/msm/fixed_base.rs
+++ b/algorithms/src/msm/fixed_base.rs
@@ -38,11 +38,11 @@ impl FixedBaseMSM {
         let mut multiples_of_g = vec![vec![T::zero(); in_window]; outerc];
 
         let mut g_outer = g;
-        for outer in 0..outerc {
+        for (outer, m) in multiples_of_g.iter_mut().enumerate().take(outerc) {
             let mut g_inner = T::zero();
             let cur_in_window = if outer == outerc - 1 { last_in_window } else { in_window };
-            for inner in 0..cur_in_window {
-                multiples_of_g[outer][inner] = g_inner;
+            for x in m.iter_mut().take(cur_in_window) {
+                *x = g_inner;
                 g_inner += &g_outer;
             }
             for _ in 0..window {

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -250,7 +250,7 @@ where
     ) -> Result<Self::PublicKey, SignatureError> {
         let rand_pk_time = start_timer!(|| "SchnorrSignature::randomize_public_key");
 
-        let mut randomized_pk = public_key.0.clone();
+        let mut randomized_pk = public_key.0;
 
         let mut encoded = G::zero();
         for (bit, base_power) in bytes_to_bits(&to_bytes![randomness]?)

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -191,7 +191,7 @@ where
         };
 
         // k - xe;
-        let prover_response = random_scalar - &(verifier_challenge * &private_key);
+        let prover_response = random_scalar - &(verifier_challenge * private_key);
         let signature = SchnorrOutput {
             prover_response,
             verifier_challenge,

--- a/algorithms/src/signature/tests.rs
+++ b/algorithms/src/signature/tests.rs
@@ -82,7 +82,7 @@ fn schnorr_signature_test() {
     let message = "Hi, I am a Schnorr signature!";
     let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
     sign_and_verify::<TestSignature>(message.as_bytes());
-    failed_verification::<TestSignature>(message.as_bytes(), "Bad message".as_bytes());
+    failed_verification::<TestSignature>(message.as_bytes(), b"Bad message");
     let random_scalar = to_bytes!(<Edwards as Group>::ScalarField::rand(rng)).unwrap();
     randomize_and_verify::<TestSignature>(message.as_bytes(), &random_scalar.as_slice());
 }

--- a/algorithms/src/snark/gm17/generator.rs
+++ b/algorithms/src/snark/gm17/generator.rs
@@ -142,6 +142,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 }
 
 /// Create parameters for a circuit, given some toxic waste.
+#[allow(clippy::many_single_char_names)]
 pub fn generate_parameters<E, C, R>(
     circuit: C,
     alpha: E::Fr,

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -17,7 +17,7 @@
 //! An implementation of the [Groth-Maller][GM17] simulation extractable zkSNARK.
 //! [GM17]: https://eprint.iacr.org/2017/540
 
-use snarkos_errors::gadgets::SynthesisError;
+use snarkos_errors::gadgets::SynthesisResult;
 use snarkos_models::curves::pairing_engine::{AffineCurve, PairingCurve, PairingEngine};
 use snarkos_utilities::bytes::{FromBytes, ToBytes};
 
@@ -427,64 +427,66 @@ impl<E: PairingEngine> ToBytes for PreparedVerifyingKey<E> {
     }
 }
 
+type AffinePair<'a, T> = (&'a [T], &'a [T]);
+
 impl<E: PairingEngine> Parameters<E> {
-    pub fn get_vk(&self, _: usize) -> Result<VerifyingKey<E>, SynthesisError> {
+    pub fn get_vk(&self, _: usize) -> SynthesisResult<VerifyingKey<E>> {
         Ok(self.vk.clone())
     }
 
-    pub fn get_a_query(&self, num_inputs: usize) -> Result<(&[E::G1Affine], &[E::G1Affine]), SynthesisError> {
+    pub fn get_a_query(&self, num_inputs: usize) -> SynthesisResult<AffinePair<E::G1Affine>> {
         Ok((&self.a_query[1..num_inputs], &self.a_query[num_inputs..]))
     }
 
-    pub fn get_b_query(&self, num_inputs: usize) -> Result<(&[E::G2Affine], &[E::G2Affine]), SynthesisError> {
+    pub fn get_b_query(&self, num_inputs: usize) -> SynthesisResult<AffinePair<E::G2Affine>> {
         Ok((&self.b_query[1..num_inputs], &self.b_query[num_inputs..]))
     }
 
-    pub fn get_c_query_1(&self, num_inputs: usize) -> Result<(&[E::G1Affine], &[E::G1Affine]), SynthesisError> {
+    pub fn get_c_query_1(&self, num_inputs: usize) -> SynthesisResult<AffinePair<E::G1Affine>> {
         Ok((&self.c_query_1[0..num_inputs], &self.c_query_1[num_inputs..]))
     }
 
-    pub fn get_c_query_2(&self, num_inputs: usize) -> Result<(&[E::G1Affine], &[E::G1Affine]), SynthesisError> {
+    pub fn get_c_query_2(&self, num_inputs: usize) -> SynthesisResult<AffinePair<E::G1Affine>> {
         Ok((&self.c_query_2[1..num_inputs], &self.c_query_2[num_inputs..]))
     }
 
-    pub fn get_g_gamma_z(&self) -> Result<E::G1Affine, SynthesisError> {
+    pub fn get_g_gamma_z(&self) -> SynthesisResult<E::G1Affine> {
         Ok(self.g_gamma_z)
     }
 
-    pub fn get_h_gamma_z(&self) -> Result<E::G2Affine, SynthesisError> {
+    pub fn get_h_gamma_z(&self) -> SynthesisResult<E::G2Affine> {
         Ok(self.h_gamma_z)
     }
 
-    pub fn get_g_ab_gamma_z(&self) -> Result<E::G1Affine, SynthesisError> {
+    pub fn get_g_ab_gamma_z(&self) -> SynthesisResult<E::G1Affine> {
         Ok(self.g_ab_gamma_z)
     }
 
-    pub fn get_g_gamma2_z2(&self) -> Result<E::G1Affine, SynthesisError> {
+    pub fn get_g_gamma2_z2(&self) -> SynthesisResult<E::G1Affine> {
         Ok(self.g_gamma2_z2)
     }
 
-    pub fn get_g_gamma2_z_t(&self, num_inputs: usize) -> Result<(&[E::G1Affine], &[E::G1Affine]), SynthesisError> {
+    pub fn get_g_gamma2_z_t(&self, num_inputs: usize) -> SynthesisResult<AffinePair<E::G1Affine>> {
         Ok((&self.g_gamma2_z_t[0..num_inputs], &self.g_gamma2_z_t[num_inputs..]))
     }
 
-    pub fn get_a_query_full(&self) -> Result<&[E::G1Affine], SynthesisError> {
+    pub fn get_a_query_full(&self) -> SynthesisResult<&[E::G1Affine]> {
         Ok(&self.a_query)
     }
 
-    pub fn get_b_query_full(&self) -> Result<&[E::G2Affine], SynthesisError> {
+    pub fn get_b_query_full(&self) -> SynthesisResult<&[E::G2Affine]> {
         Ok(&self.b_query)
     }
 
-    pub fn get_c_query_1_full(&self) -> Result<&[E::G1Affine], SynthesisError> {
+    pub fn get_c_query_1_full(&self) -> SynthesisResult<&[E::G1Affine]> {
         Ok(&self.c_query_1)
     }
 
-    pub fn get_c_query_2_full(&self) -> Result<&[E::G1Affine], SynthesisError> {
+    pub fn get_c_query_2_full(&self) -> SynthesisResult<&[E::G1Affine]> {
         Ok(&self.c_query_2)
     }
 
-    pub fn get_g_gamma2_z_t_full(&self) -> Result<&[E::G1Affine], SynthesisError> {
+    pub fn get_g_gamma2_z_t_full(&self) -> SynthesisResult<&[E::G1Affine]> {
         Ok(&self.g_gamma2_z_t)
     }
 }

--- a/algorithms/src/snark/gm17/r1cs_to_sap.rs
+++ b/algorithms/src/snark/gm17/r1cs_to_sap.rs
@@ -16,7 +16,7 @@
 
 use super::{generator::KeypairAssembly, prover::ProvingAssignment};
 use crate::fft::EvaluationDomain;
-use snarkos_errors::gadgets::SynthesisError;
+use snarkos_errors::gadgets::{SynthesisError, SynthesisResult};
 use snarkos_models::{
     curves::{Field, One, PairingEngine, Zero},
     gadgets::r1cs::Index,
@@ -29,10 +29,11 @@ pub(crate) struct R1CStoSAP;
 impl R1CStoSAP {
     #[inline]
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::type_complexity)]
     pub(crate) fn instance_map_with_evaluation<E: PairingEngine>(
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,
-    ) -> Result<(Vec<E::Fr>, Vec<E::Fr>, E::Fr, usize, usize), SynthesisError> {
+    ) -> SynthesisResult<(Vec<E::Fr>, Vec<E::Fr>, E::Fr, usize, usize)> {
         let domain_size = 2 * assembly.num_constraints + 2 * (assembly.num_inputs - 1) + 1;
         let domain = EvaluationDomain::<E::Fr>::new(domain_size).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
         let domain_size = domain.size();
@@ -112,11 +113,12 @@ impl R1CStoSAP {
     }
 
     #[inline]
+    #[allow(clippy::type_complexity)]
     pub(crate) fn witness_map<E: PairingEngine>(
         prover: &ProvingAssignment<E>,
         d1: &E::Fr,
         d2: &E::Fr,
-    ) -> Result<(Vec<E::Fr>, Vec<E::Fr>, usize), SynthesisError> {
+    ) -> SynthesisResult<(Vec<E::Fr>, Vec<E::Fr>, usize)> {
         #[inline]
         fn evaluate_constraint<E: PairingEngine>(
             terms: &[(E::Fr, Index)],

--- a/algorithms/src/snark/gm17/r1cs_to_sap.rs
+++ b/algorithms/src/snark/gm17/r1cs_to_sap.rs
@@ -28,6 +28,7 @@ pub(crate) struct R1CStoSAP;
 
 impl R1CStoSAP {
     #[inline]
+    #[allow(clippy::many_single_char_names)]
     pub(crate) fn instance_map_with_evaluation<E: PairingEngine>(
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,

--- a/algorithms/src/snark/groth16/generator.rs
+++ b/algorithms/src/snark/groth16/generator.rs
@@ -133,6 +133,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 }
 
 /// Create parameters for a circuit, given some toxic waste.
+#[allow(clippy::many_single_char_names)]
 pub fn generate_parameters<E, C, R>(
     circuit: C,
     alpha: E::Fr,

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -156,8 +156,10 @@ where
     let h = R1CStoQAP::witness_map::<E>(&prover)?;
     end_timer!(witness_map_time);
 
-    let input_assignment = prover.input_assignment[1..]
-        .into_iter()
+    let input_assignment = prover
+        .input_assignment
+        .iter()
+        .skip(1)
         .map(|s| s.into_repr())
         .collect::<Vec<_>>();
 

--- a/algorithms/src/snark/groth16/r1cs_to_qap.rs
+++ b/algorithms/src/snark/groth16/r1cs_to_qap.rs
@@ -67,14 +67,14 @@ impl R1CStoQAP {
             a[i] = u[assembly.num_constraints + i];
         }
 
-        for i in 0..assembly.num_constraints {
+        for (i, x) in u.iter().enumerate().take(assembly.num_constraints) {
             for &(ref coeff, index) in assembly.at[i].iter() {
                 let index = match index {
                     Index::Input(i) => i,
                     Index::Aux(i) => assembly.num_inputs + i,
                 };
 
-                a[index] += &(u[i] * coeff);
+                a[index] += &(*x * coeff);
             }
             for &(ref coeff, index) in assembly.bt[i].iter() {
                 let index = match index {
@@ -121,9 +121,7 @@ impl R1CStoQAP {
                 *b = evaluate_constraint::<E>(&bt_i, &full_input_assignment, num_inputs);
             });
 
-        for i in 0..num_inputs {
-            a[num_constraints + i] = full_input_assignment[i];
-        }
+        a[num_constraints..(num_inputs + num_constraints)].clone_from_slice(&full_input_assignment[..num_inputs]);
 
         domain.ifft_in_place(&mut a);
         domain.ifft_in_place(&mut b);

--- a/algorithms/src/snark/groth16/r1cs_to_qap.rs
+++ b/algorithms/src/snark/groth16/r1cs_to_qap.rs
@@ -41,6 +41,7 @@ pub(crate) struct R1CStoQAP;
 
 impl R1CStoQAP {
     #[inline]
+    #[allow(clippy::many_single_char_names)]
     pub(crate) fn instance_map_with_evaluation<E: PairingEngine>(
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,

--- a/algorithms/src/snark/groth16/r1cs_to_qap.rs
+++ b/algorithms/src/snark/groth16/r1cs_to_qap.rs
@@ -16,7 +16,7 @@
 
 use super::{generator::KeypairAssembly, prover::ProvingAssignment, Vec};
 use crate::{cfg_iter, cfg_iter_mut, fft::EvaluationDomain};
-use snarkos_errors::gadgets::SynthesisError;
+use snarkos_errors::gadgets::{SynthesisError, SynthesisResult};
 use snarkos_models::{
     curves::{PairingEngine, Zero},
     gadgets::r1cs::{ConstraintSystem, Index},
@@ -42,10 +42,11 @@ pub(crate) struct R1CStoQAP;
 impl R1CStoQAP {
     #[inline]
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::type_complexity)]
     pub(crate) fn instance_map_with_evaluation<E: PairingEngine>(
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,
-    ) -> Result<(Vec<E::Fr>, Vec<E::Fr>, Vec<E::Fr>, E::Fr, usize, usize), SynthesisError> {
+    ) -> SynthesisResult<(Vec<E::Fr>, Vec<E::Fr>, Vec<E::Fr>, E::Fr, usize, usize)> {
         let domain_size = assembly.num_constraints + (assembly.num_inputs - 1) + 1;
         let domain = EvaluationDomain::<E::Fr>::new(domain_size).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
         let domain_size = domain.size();
@@ -98,7 +99,7 @@ impl R1CStoQAP {
     }
 
     #[inline]
-    pub(crate) fn witness_map<E: PairingEngine>(prover: &ProvingAssignment<E>) -> Result<Vec<E::Fr>, SynthesisError> {
+    pub(crate) fn witness_map<E: PairingEngine>(prover: &ProvingAssignment<E>) -> SynthesisResult<Vec<E::Fr>> {
         let zero = E::Fr::zero();
         let num_inputs = prover.input_assignment.len();
         let num_constraints = prover.num_constraints();

--- a/algorithms/tests/snark/mimc.rs
+++ b/algorithms/tests/snark/mimc.rs
@@ -59,9 +59,9 @@ const MIMC_ROUNDS: usize = 322;
 fn mimc<F: Field>(mut xl: F, mut xr: F, constants: &[F]) -> F {
     assert_eq!(constants.len(), MIMC_ROUNDS);
 
-    for i in 0..MIMC_ROUNDS {
+    for c in constants.iter().take(MIMC_ROUNDS) {
         let mut tmp1 = xl;
-        tmp1.add_assign(&constants[i]);
+        tmp1.add_assign(&c);
         let mut tmp2 = tmp1;
         tmp2.square_in_place();
         tmp2.mul_assign(&tmp1);

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -183,7 +183,7 @@ impl ConsensusParameters {
     pub fn verify_transactions(
         &self,
         parameters: &<InstantiatedDPC as DPCScheme<MerkleTreeLedger>>::Parameters,
-        transactions: &Vec<Tx>,
+        transactions: &[Tx],
         ledger: &MerkleTreeLedger,
     ) -> Result<bool, ConsensusError> {
         for tx in transactions {
@@ -363,12 +363,13 @@ impl ConsensusParameters {
     }
 
     /// Generate a coinbase transaction given candidate block transactions
+    #[allow(clippy::too_many_arguments)]
     pub fn create_coinbase_transaction<R: Rng>(
         &self,
         block_num: u32,
         transactions: &DPCTransactions<Tx>,
         parameters: &PublicParameters<Components>,
-        program_vk_hash: &Vec<u8>,
+        program_vk_hash: &[u8],
         new_birth_program_ids: Vec<Vec<u8>>,
         new_death_program_ids: Vec<Vec<u8>>,
         recipient: AccountAddress<Components>,
@@ -421,7 +422,7 @@ impl ConsensusParameters {
             old_records.push(old_record);
         }
 
-        let new_record_owners = vec![recipient.clone(); Components::NUM_OUTPUT_RECORDS];
+        let new_record_owners = vec![recipient; Components::NUM_OUTPUT_RECORDS];
         let new_is_dummy_flags = [vec![false], vec![true; Components::NUM_OUTPUT_RECORDS - 1]].concat();
         let new_values = [vec![total_value_balance.0 as u64], vec![
             0;
@@ -450,6 +451,7 @@ impl ConsensusParameters {
     }
 
     /// Generate a transaction by spending old records and specifying new record attributes
+    #[allow(clippy::too_many_arguments)]
     pub fn create_transaction<R: Rng>(
         &self,
         parameters: &<InstantiatedDPC as DPCScheme<MerkleTreeLedger>>::Parameters,

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -598,10 +598,10 @@ mod tests {
         };
 
         let b1 = DATA.block_1.clone();
-        let h1 = b1.header.clone();
+        let h1 = b1.header;
 
         let b2 = DATA.block_2.clone();
-        let h2 = b2.header.clone();
+        let h2 = b2.header;
         let merkle_root_hash = h2.merkle_root_hash.clone();
         let pedersen_merkle_root = h2.pedersen_merkle_root_hash.clone();
 
@@ -660,7 +660,7 @@ mod tests {
             .unwrap_err();
 
         // expected difficulty did not match the difficulty target
-        let mut h2_err = h2.clone();
+        let mut h2_err = h2;
         h2_err.difficulty_target = consensus.get_block_difficulty(&h1, Utc::now().timestamp()) + 1;
         consensus
             .verify_header(&h2_err, &h1, &merkle_root_hash, &pedersen_merkle_root)

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -284,10 +284,7 @@ mod tests {
         let transaction = Tx::read(&TRANSACTION_2[..]).unwrap();
         let size = TRANSACTION_2.len();
 
-        let entry = Entry::<Tx> {
-            size,
-            transaction: transaction.clone(),
-        };
+        let entry = Entry::<Tx> { size, transaction };
 
         mem_pool.insert(&blockchain, entry.clone()).unwrap();
 
@@ -360,7 +357,7 @@ mod tests {
         mem_pool
             .insert(&blockchain, Entry {
                 size: TRANSACTION_2.len(),
-                transaction: transaction.clone(),
+                transaction,
             })
             .unwrap();
 
@@ -384,7 +381,7 @@ mod tests {
         mem_pool
             .insert(&blockchain, Entry {
                 size: TRANSACTION_2.len(),
-                transaction: transaction.clone(),
+                transaction,
             })
             .unwrap();
 

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -57,10 +57,7 @@ impl<T: Transaction> MemoryPool<T> {
     /// Initialize a new memory pool with no transactions
     #[inline]
     pub fn new() -> Self {
-        Self {
-            total_size: 0,
-            transactions: HashMap::<Vec<u8>, Entry<T>>::new(),
-        }
+        Self::default()
     }
 
     /// Load the memory pool from previously stored state in storage
@@ -228,6 +225,15 @@ impl<T: Transaction> MemoryPool<T> {
         }
 
         Ok(transactions)
+    }
+}
+
+impl<T: Transaction> Default for MemoryPool<T> {
+    fn default() -> Self {
+        Self {
+            total_size: 0,
+            transactions: HashMap::<Vec<u8>, Entry<T>>::new(),
+        }
     }
 }
 

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -179,7 +179,7 @@ impl<T: Transaction> MemoryPool<T> {
 
     /// Removes transaction from memory pool based on the transaction id.
     #[inline]
-    pub fn remove_by_hash(&mut self, transaction_id: &Vec<u8>) -> Result<Option<Entry<T>>, ConsensusError> {
+    pub fn remove_by_hash(&mut self, transaction_id: &[u8]) -> Result<Option<Entry<T>>, ConsensusError> {
         match self.transactions.clone().get(transaction_id) {
             Some(entry) => {
                 self.total_size -= entry.size;

--- a/consensus/src/miner.rs
+++ b/consensus/src/miner.rs
@@ -172,13 +172,13 @@ impl Miner {
         storage: &Arc<MerkleTreeLedger>,
         memory_pool: &Arc<Mutex<MemoryPool<Tx>>>,
     ) -> Result<(Vec<u8>, Vec<DPCRecord<Components>>), ConsensusError> {
-        let mut candidate_transactions =
+        let candidate_transactions =
             Self::fetch_memory_pool_transactions(&storage.clone(), memory_pool, self.consensus.max_block_size).await?;
 
         println!("Miner creating block");
 
         let (previous_block_header, transactions, coinbase_records) =
-            self.establish_block(parameters, storage, &mut candidate_transactions)?;
+            self.establish_block(parameters, storage, &candidate_transactions)?;
 
         println!("Miner generated coinbase transaction");
 

--- a/consensus/src/miner.rs
+++ b/consensus/src/miner.rs
@@ -109,6 +109,7 @@ impl Miner {
     }
 
     /// Acquires the storage lock and returns the previous block header and verified transactions.
+    #[allow(clippy::type_complexity)]
     pub fn establish_block(
         &self,
         parameters: &PublicParameters<Components>,

--- a/consensus/tests/consensus_dpc.rs
+++ b/consensus/tests/consensus_dpc.rs
@@ -71,7 +71,7 @@ mod consensus_dpc {
 
         // OUTPUTS
 
-        let new_record_owners = vec![recipient.address.clone(); NUM_OUTPUT_RECORDS];
+        let new_record_owners = vec![recipient.address; NUM_OUTPUT_RECORDS];
         let new_death_program_ids = vec![program.into_compact_repr(); NUM_OUTPUT_RECORDS];
         let new_is_dummy_flags = vec![false; NUM_OUTPUT_RECORDS];
         let new_values = vec![10; NUM_OUTPUT_RECORDS];

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -87,7 +87,7 @@ mod consensus_sidechain {
         // 2. Receive sidechain block 1.
 
         consensus
-            .receive_block(&parameters, &blockchain, &mut memory_pool, &block_1_side.clone())
+            .receive_block(&parameters, &blockchain, &mut memory_pool, &block_1_side)
             .unwrap();
 
         let new_block_height = blockchain.get_latest_block_height();

--- a/curves/src/bls12_377/fq6.rs
+++ b/curves/src/bls12_377/fq6.rs
@@ -273,7 +273,7 @@ mod test {
         for _ in 0..1000 {
             let mut a = Fq2::rand(&mut rng);
             let mut b = a;
-            a = a * &Fq6Parameters::NONRESIDUE;
+            a *= &Fq6Parameters::NONRESIDUE;
             b *= &nqr;
 
             assert_eq!(a, b);

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -425,7 +425,7 @@ fn test_fq_legendre() {
 #[test]
 fn test_fq2_ordering() {
     let mut a = Fq2::new(Fq::zero(), Fq::zero());
-    let mut b = a.clone();
+    let mut b = a;
 
     assert!(a.cmp(&b) == Ordering::Equal);
     b.c0.add_assign(&Fq::one());

--- a/curves/src/edwards_bls12/tests.rs
+++ b/curves/src/edwards_bls12/tests.rs
@@ -104,6 +104,7 @@ fn test_montgomery_conversion() {
 }
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_edwards_to_montgomery_point() {
     let a: EdwardsAffine = rand::random();
     let (x, y) = (a.x, a.y);
@@ -113,7 +114,7 @@ fn test_edwards_to_montgomery_point() {
         let numerator = Fq::one() + &y;
         let denominator = Fq::one() - &y;
 
-        let u = numerator.clone() * &(denominator.inverse().unwrap());
+        let u = numerator * &(denominator.inverse().unwrap());
         let v = numerator * &((denominator * &x).inverse().unwrap());
         (u, v)
     };
@@ -153,8 +154,8 @@ fn print_montgomery_to_weierstrass_parameters() {
 
     let two = Fq::one() + &Fq::one();
     let three = Fq::one() + &two;
-    let nine = three.clone() + &(three.clone() + &three);
-    let twenty_seven = nine.clone() + &(nine.clone() + &nine);
+    let nine = three + &(three + &three);
+    let twenty_seven = nine + &(nine + &nine);
 
     let a2 = A.square();
     let a3 = A * &a2;
@@ -162,7 +163,7 @@ fn print_montgomery_to_weierstrass_parameters() {
     let b3 = B * &b2;
 
     // Let a = (3 - A^2) / (3 * B^2).
-    let numerator = three.clone() - &a2;
+    let numerator = three - &a2;
     let denominator = three * &b2;
     let a = numerator * &denominator.inverse().unwrap();
 
@@ -175,6 +176,7 @@ fn print_montgomery_to_weierstrass_parameters() {
 }
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_isomorphism() {
     let rng = &mut thread_rng();
 
@@ -236,14 +238,14 @@ fn test_isomorphism() {
         // Let e = legendre(v^3 + Av^2 + Bv).
         let v2 = v.square();
         let v3 = v2 * &v;
-        let av2 = a.clone() * &v2;
-        let bv = b.clone() * &v;
+        let av2 = a * &v2;
+        let bv = b * &v;
         let e = (v3 + &(av2 + &bv)).legendre();
 
         // Let x = ev - ((1 - e) * A/2).
         let two = Fq::one().double();
         let x = match e {
-            LegendreSymbol::Zero => -(a.clone() * &two.inverse().unwrap()),
+            LegendreSymbol::Zero => -(a * &two.inverse().unwrap()),
             LegendreSymbol::QuadraticResidue => v,
             LegendreSymbol::QuadraticNonResidue => (-v) - &a,
         };
@@ -251,8 +253,8 @@ fn test_isomorphism() {
         // Let y = -e * sqrt(x^3 + Ax^2 + Bx).
         let x2 = x.square();
         let x3 = x2 * &x;
-        let ax2 = a.clone() * &x2;
-        let bx = b.clone() * &x;
+        let ax2 = a * &x2;
+        let bx = b * &x;
         let value = (x3 + &(ax2 + &bx)).sqrt().unwrap();
         let y = match e {
             LegendreSymbol::Zero => Fq::zero(),
@@ -309,7 +311,7 @@ fn test_isomorphism() {
         let numerator = Fq::one() + &y;
         let denominator = Fq::one() - &y;
 
-        let u = numerator.clone() * &(denominator.inverse().unwrap());
+        let u = numerator * &(denominator.inverse().unwrap());
         let v = numerator * &((denominator * &x).inverse().unwrap());
 
         // Ensure (u, v) is a valid Montgomery element

--- a/curves/src/edwards_sw6/tests.rs
+++ b/curves/src/edwards_sw6/tests.rs
@@ -26,8 +26,6 @@ use snarkos_models::curves::{
     ProjectiveCurve,
 };
 
-use rand;
-
 #[test]
 fn test_edwards_sw6_fr() {
     let a: Fr = rand::random();

--- a/curves/src/lib.rs
+++ b/curves/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 // Compilation
+#![allow(clippy::module_inception)]
 #![deny(unused_import_braces, unused_qualifications, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_qualifications, variant_size_differences, stable_features, unreachable_pub)]
 #![deny(non_shorthand_field_patterns, unused_attributes, unused_extern_crates)]

--- a/curves/src/templates/bls12/bls12.rs
+++ b/curves/src/templates/bls12/bls12.rs
@@ -61,13 +61,11 @@ pub trait Bls12Parameters: 'static {
 #[derivative(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Bls12<P: Bls12Parameters>(PhantomData<fn() -> P>);
 
+type CoeffTriplet<T> = (Fp2<T>, Fp2<T>, Fp2<T>);
+
 impl<P: Bls12Parameters> Bls12<P> {
     // Evaluate the line function at point p.
-    fn ell(
-        f: &mut Fp12<P::Fp12Params>,
-        coeffs: &(Fp2<P::Fp2Params>, Fp2<P::Fp2Params>, Fp2<P::Fp2Params>),
-        p: &G1Affine<P>,
-    ) {
+    fn ell(f: &mut Fp12<P::Fp12Params>, coeffs: &CoeffTriplet<P::Fp2Params>, p: &G1Affine<P>) {
         let mut c0 = coeffs.0;
         let mut c1 = coeffs.1;
         let mut c2 = coeffs.2;

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -26,6 +26,7 @@ use std::io::{Result as IoResult, Write};
 
 pub type G2Affine<P> = GroupAffine<<P as Bls12Parameters>::G2Parameters>;
 pub type G2Projective<P> = GroupProjective<<P as Bls12Parameters>::G2Parameters>;
+type CoeffTriplet<T> = (Fp2<T>, Fp2<T>, Fp2<T>);
 
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(
@@ -37,7 +38,7 @@ pub type G2Projective<P> = GroupProjective<<P as Bls12Parameters>::G2Parameters>
 pub struct G2Prepared<P: Bls12Parameters> {
     // Stores the coefficients of the line evaluations as calculated in
     // https://eprint.iacr.org/2013/722.pdf
-    pub ell_coeffs: Vec<(Fp2<P::Fp2Params>, Fp2<P::Fp2Params>, Fp2<P::Fp2Params>)>,
+    pub ell_coeffs: Vec<CoeffTriplet<P::Fp2Params>>,
     pub infinity: bool,
 }
 
@@ -107,10 +108,7 @@ impl<P: Bls12Parameters> G2Prepared<P> {
 }
 
 #[allow(clippy::many_single_char_names)]
-fn doubling_step<B: Bls12Parameters>(
-    r: &mut G2HomProjective<B>,
-    two_inv: &B::Fp,
-) -> (Fp2<B::Fp2Params>, Fp2<B::Fp2Params>, Fp2<B::Fp2Params>) {
+fn doubling_step<B: Bls12Parameters>(r: &mut G2HomProjective<B>, two_inv: &B::Fp) -> CoeffTriplet<B::Fp2Params> {
     // Formula for line function when working with
     // homogeneous projective coordinates.
 
@@ -137,10 +135,7 @@ fn doubling_step<B: Bls12Parameters>(
 }
 
 #[allow(clippy::many_single_char_names)]
-fn addition_step<B: Bls12Parameters>(
-    r: &mut G2HomProjective<B>,
-    q: &G2Affine<B>,
-) -> (Fp2<B::Fp2Params>, Fp2<B::Fp2Params>, Fp2<B::Fp2Params>) {
+fn addition_step<B: Bls12Parameters>(r: &mut G2HomProjective<B>, q: &G2Affine<B>) -> CoeffTriplet<B::Fp2Params> {
     // Formula for line function when working with
     // homogeneous projective coordinates.
     let theta = r.y - &(q.y * &r.z);

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -106,6 +106,7 @@ impl<P: Bls12Parameters> G2Prepared<P> {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn doubling_step<B: Bls12Parameters>(
     r: &mut G2HomProjective<B>,
     two_inv: &B::Fp,
@@ -135,6 +136,7 @@ fn doubling_step<B: Bls12Parameters>(
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn addition_step<B: Bls12Parameters>(
     r: &mut G2HomProjective<B>,
     q: &G2Affine<B>,

--- a/curves/src/templates/bw6/bw6.rs
+++ b/curves/src/templates/bw6/bw6.rs
@@ -101,12 +101,12 @@ impl<P: BW6Parameters> BW6<P> {
         // (q^3-1)*(q+1)
 
         // elt_q3 = elt^(q^3)
-        let mut elt_q3 = elt.clone();
+        let mut elt_q3 = *elt;
         elt_q3.conjugate();
         // elt_q3_over_elt = elt^(q^3-1)
         let elt_q3_over_elt = elt_q3 * elt_inv;
         // alpha = elt^((q^3-1) * q)
-        let mut alpha = elt_q3_over_elt.clone();
+        let mut alpha = elt_q3_over_elt;
         alpha.frobenius_map(1);
         // beta = elt^((q^3-1)*(q+1)
         alpha * &elt_q3_over_elt
@@ -120,7 +120,7 @@ impl<P: BW6Parameters> BW6<P> {
         // f ^ R0(u) * (f ^ q) ^ R1(u) in a 2-NAF multi-exp fashion.
 
         // steps 1,2,3
-        let f0 = f.clone();
+        let f0 = *f;
         let mut f0p = f0;
         f0p.frobenius_map(1);
         let f1 = Self::exp_by_x(f0);

--- a/curves/src/templates/bw6/bw6.rs
+++ b/curves/src/templates/bw6/bw6.rs
@@ -213,9 +213,7 @@ impl<P: BW6Parameters> BW6<P> {
         let result18 = result17.square();
         let mut tmp8_p3 = f2_4p * &f4_2p_5p * &f9p;
         tmp8_p3.conjugate();
-        let result19 = result18 * &f1_7 * &f5_7p * &f0p * &tmp8_p3;
-
-        result19
+        result18 * &f1_7 * &f5_7p * &f0p * &tmp8_p3
     }
 }
 

--- a/curves/src/templates/bw6/g2.rs
+++ b/curves/src/templates/bw6/g2.rs
@@ -144,6 +144,7 @@ impl<P: BW6Parameters> G2Prepared<P> {
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn doubling_step<B: BW6Parameters>(r: &mut G2HomProjective<B>) -> (B::Fp, B::Fp, B::Fp) {
     // Formula for line function when working with
     // homogeneous projective coordinates, as described in https://eprint.iacr.org/2013/722.pdf.
@@ -169,6 +170,7 @@ fn doubling_step<B: BW6Parameters>(r: &mut G2HomProjective<B>) -> (B::Fp, B::Fp,
     }
 }
 
+#[allow(clippy::many_single_char_names)]
 fn addition_step<B: BW6Parameters>(r: &mut G2HomProjective<B>, q: &G2Affine<B>) -> (B::Fp, B::Fp, B::Fp) {
     // Formula for line function when working with
     // homogeneous projective coordinates, as described in https://eprint.iacr.org/2013/722.pdf.

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -187,11 +187,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     fn to_x_coordinate(&self) -> Self::BaseField {
-        self.x.clone()
+        self.x
     }
 
     fn to_y_coordinate(&self) -> Self::BaseField {
-        self.y.clone()
+        self.y
     }
 
     /// Checks that the current point is on the elliptic curve.

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -641,6 +641,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         if self.is_zero() {
             *self = *other;

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -439,6 +439,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn double_in_place(&mut self) -> &mut Self {
         if self.is_zero() {
             return self;
@@ -507,6 +508,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn add_assign_mixed(&mut self, other: &Self::Affine) {
         if other.is_zero() {
             return;
@@ -638,6 +640,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
+    #[allow(clippy::many_single_char_names)]
     fn add_assign(&mut self, other: &'a Self) {
         if self.is_zero() {
             *self = *other;

--- a/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_jacobian.rs
@@ -287,13 +287,7 @@ impl<P: Parameters> PartialEq for GroupProjective<P> {
         let z1 = self.z.square();
         let z2 = other.z.square();
 
-        if self.x * &z2 != other.x * &z1 {
-            false
-        } else if self.y * &(z2 * &other.z) != other.y * &(z1 * &self.z) {
-            false
-        } else {
-            true
-        }
+        !(self.x * &z2 != other.x * &z1 || self.y * &(z2 * &other.z) != other.y * &(z1 * &self.z))
     }
 }
 

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -413,6 +413,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn double_in_place(&mut self) -> &mut Self {
         if self.is_zero() {
             self

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -547,6 +547,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         if self.is_zero() {
             *self = *other;

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -278,13 +278,7 @@ impl<P: Parameters> PartialEq for GroupProjective<P> {
         }
 
         // x1/z1 == x2/z2  <==> x1 * z2 == x2 * z1
-        if (self.x * &other.z) != (other.x * &self.z) {
-            false
-        } else if (self.y * &other.z) != (other.y * &self.z) {
-            false
-        } else {
-            true
-        }
+        (self.x * &other.z) == (other.x * &self.z) && (self.y * &other.z) == (other.y * &self.z)
     }
 }
 

--- a/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
+++ b/curves/src/templates/short_weierstrass/short_weierstrass_projective.rs
@@ -183,11 +183,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     fn to_x_coordinate(&self) -> Self::BaseField {
-        self.x.clone()
+        self.x
     }
 
     fn to_y_coordinate(&self) -> Self::BaseField {
-        self.y.clone()
+        self.y
     }
 
     /// Checks that the current point is on the elliptic curve.

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -207,11 +207,11 @@ impl<P: Parameters> AffineCurve for GroupAffine<P> {
     }
 
     fn to_x_coordinate(&self) -> Self::BaseField {
-        self.x.clone()
+        self.x
     }
 
     fn to_y_coordinate(&self) -> Self::BaseField {
-        self.y.clone()
+        self.y
     }
 
     /// Checks that the current point is on the elliptic curve.

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -534,6 +534,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
         self
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn add_assign_mixed(&mut self, other: &Self::Affine) {
         // A = X1*X2
         let a = self.x * &other.x;
@@ -615,6 +616,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
+    #[allow(clippy::many_single_char_names)]
     fn add_assign(&mut self, other: &'a Self) {
         // See "Twisted Edwards Curves Revisited"
         // Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson

--- a/curves/src/templates/twisted_edwards_extended/mod.rs
+++ b/curves/src/templates/twisted_edwards_extended/mod.rs
@@ -245,6 +245,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupAffine<P> {
 }
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         let y1y2 = self.y * &other.y;
         let x1x2 = self.x * &other.x;
@@ -617,6 +618,7 @@ impl<'a, P: Parameters> Add<&'a Self> for GroupProjective<P> {
 
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, other: &'a Self) {
         // See "Twisted Edwards Curves Revisited"
         // Huseyin Hisil, Kenneth Koon-Ho Wong, Gary Carter, and Ed Dawson

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit.rs
@@ -146,6 +146,7 @@ impl<C: BaseDPCComponents> InnerCircuit<C> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         // Parameters
         system_parameters: &SystemParameters<C>,
@@ -242,7 +243,7 @@ impl<C: BaseDPCComponents> InnerCircuit<C> {
             local_data_root: Some(local_data_root.clone()),
             local_data_commitment_randomizers: Some(local_data_commitment_randomizers.to_vec()),
 
-            memo: Some(memo.clone()),
+            memo: Some(*memo),
 
             value_balance: Some(value_balance),
 

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
@@ -62,6 +62,7 @@ use snarkos_utilities::{
 use snarkos_models::gadgets::utilities::eq::NEqGadget;
 use std::ops::Mul;
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_inner_proof_gadget<C: BaseDPCComponents, CS: ConstraintSystem<C::InnerField>>(
     cs: &mut CS,
     // Parameters
@@ -146,6 +147,7 @@ pub fn execute_inner_proof_gadget<C: BaseDPCComponents, CS: ConstraintSystem<C::
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn base_dpc_execute_gadget_helper<
     C,
     CS: ConstraintSystem<C::InnerField>,
@@ -389,7 +391,7 @@ where
 
             let given_commitment =
                 RecordCommitmentGadget::OutputGadget::alloc(&mut declare_cs.ns(|| "given_commitment"), || {
-                    Ok(record.commitment().clone())
+                    Ok(record.commitment())
                 })?;
             old_record_commitments_gadgets.push(given_commitment.clone());
 
@@ -941,7 +943,7 @@ where
             );
 
             let fq_high_and_payload_and_value_bits = [
-                &vec![Boolean::Constant(true)],
+                &[Boolean::Constant(true)],
                 &fq_high_bits[..],
                 &value_bits[..],
                 &payload_field_bits[..],

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
@@ -1224,12 +1224,12 @@ where
         let commitment_cs = &mut cs.ns(|| "Check that program commitment is well-formed");
 
         let mut input = Vec::new();
-        for i in 0..C::NUM_INPUT_RECORDS {
-            input.extend_from_slice(&old_death_program_ids_gadgets[i]);
+        for id_gadget in old_death_program_ids_gadgets.iter().take(C::NUM_INPUT_RECORDS) {
+            input.extend_from_slice(id_gadget);
         }
 
-        for j in 0..C::NUM_OUTPUT_RECORDS {
-            input.extend_from_slice(&new_birth_program_ids_gadgets[j]);
+        for id_gadget in new_birth_program_ids_gadgets.iter().take(C::NUM_OUTPUT_RECORDS) {
+            input.extend_from_slice(id_gadget);
         }
 
         let given_commitment_randomness =

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -546,8 +546,7 @@ where
         }
 
         let mut new_record_commitments = Vec::with_capacity(Components::NUM_OUTPUT_RECORDS);
-        for j in 0..Components::NUM_OUTPUT_RECORDS {
-            let record = &new_records[j];
+        for record in new_records.iter().take(Components::NUM_OUTPUT_RECORDS) {
             let input_bytes = to_bytes![record.commitment(), memorandum, network_id]?;
 
             let commitment_randomness = <Components::LocalDataCommitment as CommitmentScheme>::Randomness::rand(rng);

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -992,7 +992,7 @@ where
     /// Returns true iff all the transactions in the block are valid according to the ledger.
     fn verify_transactions(
         parameters: &Self::Parameters,
-        transactions: &Vec<Self::Transaction>,
+        transactions: &[Self::Transaction],
         ledger: &L,
     ) -> Result<bool, DPCError> {
         for transaction in transactions {

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -155,6 +155,7 @@ pub struct ExecuteContext<Components: BaseDPCComponents> {
 }
 
 impl<Components: BaseDPCComponents> ExecuteContext<Components> {
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_local_data(&self) -> LocalData<Components> {
         LocalData {
             system_parameters: self.system_parameters.clone(),
@@ -167,7 +168,7 @@ impl<Components: BaseDPCComponents> ExecuteContext<Components> {
             local_data_merkle_tree: self.local_data_merkle_tree.clone(),
             local_data_commitment_randomizers: self.local_data_commitment_randomizers.clone(),
 
-            memorandum: self.memorandum.clone(),
+            memorandum: self.memorandum,
             network_id: self.network_id,
         }
     }
@@ -289,6 +290,7 @@ impl<Components: BaseDPCComponents> DPC<Components> {
         Ok((sn, sig_and_pk_randomizer))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_record<R: Rng>(
         system_parameters: &SystemParameters<Components>,
         sn_nonce: &<Components::SerialNumberNonceCRH as CRH>::Output,
@@ -296,8 +298,8 @@ impl<Components: BaseDPCComponents> DPC<Components> {
         is_dummy: bool,
         value: u64,
         payload: &RecordPayload,
-        birth_program_id: &Vec<u8>,
-        death_program_id: &Vec<u8>,
+        birth_program_id: &[u8],
+        death_program_id: &[u8],
         rng: &mut R,
     ) -> Result<DPCRecord<Components>, DPCError> {
         let record_time = start_timer!(|| "Generate record");
@@ -635,7 +637,7 @@ where
             local_data_commitment_randomizers,
 
             value_balance,
-            memorandum: memorandum.clone(),
+            memorandum: *memorandum,
             network_id,
         };
         Ok(context)
@@ -796,7 +798,7 @@ where
                 old_serial_numbers: old_serial_numbers.clone(),
                 new_commitments: new_commitments.clone(),
                 new_encrypted_record_hashes: new_encrypted_record_hashes.clone(),
-                memo: memorandum.clone(),
+                memo: memorandum,
                 program_commitment: program_commitment.clone(),
                 local_data_root: local_data_root.clone(),
                 value_balance,
@@ -850,7 +852,7 @@ where
         let transaction = Self::Transaction::new(
             old_serial_numbers,
             new_commitments,
-            memorandum.clone(),
+            memorandum,
             ledger_digest,
             inner_snark_id,
             transaction_proof,
@@ -954,7 +956,7 @@ where
             old_serial_numbers: transaction.old_serial_numbers().to_vec(),
             new_commitments: transaction.new_commitments().to_vec(),
             new_encrypted_record_hashes,
-            memo: transaction.memorandum().clone(),
+            memo: *transaction.memorandum(),
             program_commitment: transaction.program_commitment().clone(),
             local_data_root: transaction.local_data_root().clone(),
             value_balance: transaction.value_balance(),

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit.rs
@@ -124,14 +124,15 @@ impl<C: BaseDPCComponents> OuterCircuit<C> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         system_parameters: &SystemParameters<C>,
 
         // Inner SNARK public inputs
         ledger_parameters: &C::MerkleParameters,
         ledger_digest: &MerkleTreeDigest<C::MerkleParameters>,
-        old_serial_numbers: &Vec<<C::AccountSignature as SignatureScheme>::PublicKey>,
-        new_commitments: &Vec<<C::RecordCommitment as CommitmentScheme>::Output>,
+        old_serial_numbers: &[<C::AccountSignature as SignatureScheme>::PublicKey],
+        new_commitments: &[<C::RecordCommitment as CommitmentScheme>::Output],
         new_encrypted_record_hashes: &[<C::EncryptedRecordCRH as CRH>::Output],
         memo: &[u8; 32],
         value_balance: AleoAmount,
@@ -172,7 +173,7 @@ impl<C: BaseDPCComponents> OuterCircuit<C> {
             old_serial_numbers: Some(old_serial_numbers.to_vec()),
             new_commitments: Some(new_commitments.to_vec()),
             new_encrypted_record_hashes: Some(new_encrypted_record_hashes.to_vec()),
-            memo: Some(memo.clone()),
+            memo: Some(*memo),
             value_balance: Some(value_balance),
             network_id: Some(network_id),
 

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -38,7 +38,7 @@ use itertools::Itertools;
 
 fn field_element_to_bytes<C: BaseDPCComponents, CS: ConstraintSystem<C::OuterField>>(
     cs: &mut CS,
-    field_elements: &Vec<C::InnerField>,
+    field_elements: &[C::InnerField],
     name: &str,
 ) -> Result<Vec<Vec<UInt8>>, SynthesisError> {
     if field_elements.len() <= 1 {
@@ -58,6 +58,7 @@ fn field_element_to_bytes<C: BaseDPCComponents, CS: ConstraintSystem<C::OuterFie
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_outer_proof_gadget<C: BaseDPCComponents, CS: ConstraintSystem<C::OuterField>>(
     cs: &mut CS,
     // Parameters
@@ -66,9 +67,9 @@ pub fn execute_outer_proof_gadget<C: BaseDPCComponents, CS: ConstraintSystem<C::
     // Inner snark verifier public inputs
     ledger_parameters: &C::MerkleParameters,
     ledger_digest: &MerkleTreeDigest<C::MerkleParameters>,
-    old_serial_numbers: &Vec<<C::AccountSignature as SignatureScheme>::PublicKey>,
-    new_commitments: &Vec<<C::RecordCommitment as CommitmentScheme>::Output>,
-    new_encrypted_record_hashes: &Vec<<C::EncryptedRecordCRH as CRH>::Output>,
+    old_serial_numbers: &[<C::AccountSignature as SignatureScheme>::PublicKey],
+    new_commitments: &[<C::RecordCommitment as CommitmentScheme>::Output],
+    new_encrypted_record_hashes: &[<C::EncryptedRecordCRH as CRH>::Output],
     memo: &[u8; 32],
     value_balance: AleoAmount,
     network_id: u8,

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -364,18 +364,22 @@ where
 
     let mut old_death_program_ids = Vec::new();
     let mut new_birth_program_ids = Vec::new();
-    for i in 0..C::NUM_INPUT_RECORDS {
+    for (i, input) in old_death_program_verification_inputs
+        .iter()
+        .enumerate()
+        .take(C::NUM_INPUT_RECORDS)
+    {
         let cs = &mut cs.ns(|| format!("Check death program for input record {}", i));
 
         let death_program_proof = <C::ProgramSNARKGadget as SNARKVerifierGadget<_, _>>::ProofGadget::alloc_bytes(
             &mut cs.ns(|| "Allocate proof"),
-            || Ok(&old_death_program_verification_inputs[i].proof),
+            || Ok(&input.proof),
         )?;
 
         let death_program_vk =
             <C::ProgramSNARKGadget as SNARKVerifierGadget<_, _>>::VerificationKeyGadget::alloc_bytes(
                 &mut cs.ns(|| "Allocate verification key"),
-                || Ok(&old_death_program_verification_inputs[i].verification_key),
+                || Ok(&input.verification_key),
             )?;
 
         let death_program_vk_bytes = death_program_vk.to_bytes(&mut cs.ns(|| "Convert death pred vk to bytes"))?;
@@ -403,18 +407,22 @@ where
         )?;
     }
 
-    for j in 0..C::NUM_OUTPUT_RECORDS {
+    for (j, input) in new_birth_program_verification_inputs
+        .iter()
+        .enumerate()
+        .take(C::NUM_OUTPUT_RECORDS)
+    {
         let cs = &mut cs.ns(|| format!("Check birth program for output record {}", j));
 
         let birth_program_proof = <C::ProgramSNARKGadget as SNARKVerifierGadget<_, _>>::ProofGadget::alloc_bytes(
             &mut cs.ns(|| "Allocate proof"),
-            || Ok(&new_birth_program_verification_inputs[j].proof),
+            || Ok(&input.proof),
         )?;
 
         let birth_program_vk =
             <C::ProgramSNARKGadget as SNARKVerifierGadget<_, _>>::VerificationKeyGadget::alloc_bytes(
                 &mut cs.ns(|| "Allocate verification key"),
-                || Ok(&new_birth_program_verification_inputs[j].verification_key),
+                || Ok(&input.verification_key),
             )?;
 
         let birth_program_vk_bytes = birth_program_vk.to_bytes(&mut cs.ns(|| "Convert birth pred vk to bytes"))?;
@@ -450,12 +458,12 @@ where
         let commitment_cs = &mut cs.ns(|| "Check that program commitment is well-formed");
 
         let mut input = Vec::new();
-        for i in 0..C::NUM_INPUT_RECORDS {
-            input.extend_from_slice(&old_death_program_ids[i]);
+        for id in old_death_program_ids.iter().take(C::NUM_INPUT_RECORDS) {
+            input.extend_from_slice(&id);
         }
 
-        for j in 0..C::NUM_OUTPUT_RECORDS {
-            input.extend_from_slice(&new_birth_program_ids[j]);
+        for id in new_birth_program_ids.iter().take(C::NUM_OUTPUT_RECORDS) {
+            input.extend_from_slice(&id);
         }
 
         let given_commitment_randomness =

--- a/dpc/src/base_dpc/parameters.rs
+++ b/dpc/src/base_dpc/parameters.rs
@@ -92,10 +92,10 @@ impl<C: BaseDPCComponents> NoopProgramSNARKParameters<C> {
     // TODO (howardwu): Why are we not preparing the VK here?
     pub fn load() -> IoResult<Self> {
         let proving_key: <C::NoopProgramSNARK as SNARK>::ProvingParameters =
-            From::from(FromBytes::read(NoopProgramSNARKPKParameters::load_bytes()?.as_slice())?);
-        let verification_key = From::from(<C::NoopProgramSNARK as SNARK>::VerificationParameters::read(
+            FromBytes::read(NoopProgramSNARKPKParameters::load_bytes()?.as_slice())?;
+        let verification_key = <C::NoopProgramSNARK as SNARK>::VerificationParameters::read(
             NoopProgramSNARKVKParameters::load_bytes()?.as_slice(),
-        )?);
+        )?;
 
         Ok(Self {
             proving_key,
@@ -189,15 +189,15 @@ impl<C: BaseDPCComponents> PublicParameters<C> {
         let inner_snark_parameters = {
             let inner_snark_pk = match verify_only {
                 true => None,
-                false => Some(From::from(<C::InnerSNARK as SNARK>::ProvingParameters::read(
+                false => Some(<C::InnerSNARK as SNARK>::ProvingParameters::read(
                     InnerSNARKPKParameters::load_bytes()?.as_slice(),
-                )?)),
+                )?),
             };
 
             let inner_snark_vk: <C::InnerSNARK as SNARK>::VerificationParameters =
-                From::from(<C::InnerSNARK as SNARK>::VerificationParameters::read(
+                <C::InnerSNARK as SNARK>::VerificationParameters::read(
                     InnerSNARKVKParameters::load_bytes()?.as_slice(),
-                )?);
+                )?;
 
             (inner_snark_pk, inner_snark_vk.into())
         };
@@ -205,15 +205,15 @@ impl<C: BaseDPCComponents> PublicParameters<C> {
         let outer_snark_parameters = {
             let outer_snark_pk = match verify_only {
                 true => None,
-                false => Some(From::from(<C::OuterSNARK as SNARK>::ProvingParameters::read(
+                false => Some(<C::OuterSNARK as SNARK>::ProvingParameters::read(
                     OuterSNARKPKParameters::load_bytes()?.as_slice(),
-                )?)),
+                )?),
             };
 
             let outer_snark_vk: <C::OuterSNARK as SNARK>::VerificationParameters =
-                From::from(<C::OuterSNARK as SNARK>::VerificationParameters::read(
+                <C::OuterSNARK as SNARK>::VerificationParameters::read(
                     OuterSNARKVKParameters::load_bytes()?.as_slice(),
-                )?);
+                )?;
 
             (outer_snark_pk, outer_snark_vk.into())
         };
@@ -233,18 +233,18 @@ impl<C: BaseDPCComponents> PublicParameters<C> {
         let inner_snark_parameters = {
             let inner_snark_pk = None;
             let inner_snark_vk: <C::InnerSNARK as SNARK>::VerificationParameters =
-                From::from(<C::InnerSNARK as SNARK>::VerificationParameters::read(
+                <C::InnerSNARK as SNARK>::VerificationParameters::read(
                     InnerSNARKVKParameters::load_bytes()?.as_slice(),
-                )?);
+                )?;
             (inner_snark_pk, inner_snark_vk.into())
         };
 
         let outer_snark_parameters = {
             let outer_snark_pk = None;
             let outer_snark_vk: <C::OuterSNARK as SNARK>::VerificationParameters =
-                From::from(<C::OuterSNARK as SNARK>::VerificationParameters::read(
+                <C::OuterSNARK as SNARK>::VerificationParameters::read(
                     OuterSNARKVKParameters::load_bytes()?.as_slice(),
-                )?);
+                )?;
             (outer_snark_pk, outer_snark_vk.into())
         };
 

--- a/dpc/src/base_dpc/record/record_encryption.rs
+++ b/dpc/src/base_dpc/record/record_encryption.rs
@@ -230,7 +230,7 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
             // Fetch the ciphertext selector bit
             let selector =
                 match <<C as BaseDPCComponents>::EncryptionGroup as ProjectiveCurve>::Affine::from_x_coordinate(
-                    ciphertext_x_coordinate.clone(),
+                    ciphertext_x_coordinate,
                     true,
                 ) {
                     Some(affine) => ciphertext_element_affine == affine,

--- a/dpc/src/base_dpc/record/record_encryption.rs
+++ b/dpc/src/base_dpc/record/record_encryption.rs
@@ -34,6 +34,8 @@ use itertools::Itertools;
 use rand::Rng;
 use std::marker::PhantomData;
 
+type BaseField<T> = <<T as BaseDPCComponents>::EncryptionModelParameters as ModelParameters>::BaseField;
+
 #[derive(Derivative)]
 #[derivative(
     Clone(bound = "C: BaseDPCComponents"),
@@ -44,10 +46,7 @@ pub struct RecordEncryptionGadgetComponents<C: BaseDPCComponents> {
     /// Record field element representations
     pub record_field_elements: Vec<<C::EncryptionModelParameters as ModelParameters>::BaseField>,
     /// Record group element encodings - Represented in (x,y) affine coordinates
-    pub record_group_encoding: Vec<(
-        <C::EncryptionModelParameters as ModelParameters>::BaseField,
-        <C::EncryptionModelParameters as ModelParameters>::BaseField,
-    )>,
+    pub record_group_encoding: Vec<(BaseField<C>, BaseField<C>)>,
     /// Record ciphertext selectors - Used for ciphertext compression/decompression
     pub ciphertext_selectors: Vec<bool>,
     /// Record fq high selectors - Used for plaintext serialization/deserialization

--- a/dpc/src/base_dpc/test.rs
+++ b/dpc/src/base_dpc/test.rs
@@ -131,8 +131,8 @@ fn test_execute_base_dpc_constraints() {
     .unwrap();
 
     // Set the input records for our transaction to be the initial dummy records.
-    let old_records = vec![old_record.clone(); NUM_INPUT_RECORDS];
-    let old_account_private_keys = vec![dummy_account.private_key.clone(); NUM_INPUT_RECORDS];
+    let old_records = vec![old_record; NUM_INPUT_RECORDS];
+    let old_account_private_keys = vec![dummy_account.private_key; NUM_INPUT_RECORDS];
 
     // Construct new records.
 
@@ -148,7 +148,7 @@ fn test_execute_base_dpc_constraints() {
 
     // Set the new record's program to be the "always-accept" program.
 
-    let new_record_owners = vec![new_account.address.clone(); NUM_OUTPUT_RECORDS];
+    let new_record_owners = vec![new_account.address; NUM_OUTPUT_RECORDS];
     let new_is_dummy_flags = vec![false; NUM_OUTPUT_RECORDS];
     let new_values = vec![10; NUM_OUTPUT_RECORDS];
     let new_payloads = vec![RecordPayload::default(); NUM_OUTPUT_RECORDS];

--- a/dpc/src/base_dpc/transaction.rs
+++ b/dpc/src/base_dpc/transaction.rs
@@ -86,6 +86,7 @@ pub struct DPCTransaction<C: BaseDPCComponents> {
 }
 
 impl<C: BaseDPCComponents> DPCTransaction<C> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         old_serial_numbers: Vec<<Self as Transaction>::SerialNumber>,
         new_commitments: Vec<<Self as Transaction>::Commitment>,

--- a/dpc/src/lib.rs
+++ b/dpc/src/lib.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
 #![deny(unused_import_braces, unused_qualifications, trivial_casts, trivial_numeric_casts)]
 #![deny(
     single_use_lifetimes,

--- a/dpc/tests/base_dpc.rs
+++ b/dpc/tests/base_dpc.rs
@@ -198,7 +198,7 @@ fn base_dpc_integration_test() {
         // Check that new_records can be decrypted from the transaction
 
         let encrypted_records = transaction.encrypted_records();
-        let new_account_private_keys = vec![recipient.private_key.clone(); NUM_OUTPUT_RECORDS];
+        let new_account_private_keys = vec![recipient.private_key; NUM_OUTPUT_RECORDS];
 
         for ((encrypted_record, private_key), new_record) in
             encrypted_records.iter().zip(new_account_private_keys).zip(new_records)

--- a/errors/src/gadgets/synthesis.rs
+++ b/errors/src/gadgets/synthesis.rs
@@ -16,6 +16,8 @@
 
 use std::{error::Error, fmt, io};
 
+pub type SynthesisResult<T> = Result<T, SynthesisError>;
+
 /// This is an error that could occur during circuit synthesis contexts,
 /// such as CRS generation, proving or verification.
 #[derive(Debug)]

--- a/errors/src/gadgets/synthesis.rs
+++ b/errors/src/gadgets/synthesis.rs
@@ -61,7 +61,7 @@ impl Error for SynthesisError {
 
 impl fmt::Display for SynthesisError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        if let &SynthesisError::IoError(ref e) = self {
+        if let SynthesisError::IoError(ref e) = *self {
             write!(f, "I/O error: ")?;
             e.fmt(f)
         } else {

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate thiserror;
 

--- a/errors/src/storage/storage.rs
+++ b/errors/src/storage/storage.rs
@@ -20,11 +20,7 @@ use crate::{
     parameters::ParametersError,
 };
 
-use bincode;
 use std::fmt::Debug;
-
-#[cfg(feature = "librocksdb")]
-use rocksdb;
 
 #[derive(Debug, Error)]
 pub enum StorageError {

--- a/gadgets/src/algorithms/commitment/tests.rs
+++ b/gadgets/src/algorithms/commitment/tests.rs
@@ -69,8 +69,8 @@ fn blake2s_commitment_gadget_test() {
     )
     .unwrap();
 
-    for i in 0..32 {
-        assert_eq!(native_result[i], gadget_result.0[i].value.unwrap());
+    for (i, nr) in native_result.iter().enumerate() {
+        assert_eq!(*nr, gadget_result.0[i].value.unwrap());
     }
     assert!(cs.is_satisfied());
 }

--- a/gadgets/src/algorithms/commitment_tree/tests.rs
+++ b/gadgets/src/algorithms/commitment_tree/tests.rs
@@ -73,12 +73,11 @@ fn generate_merkle_tree<C: CommitmentScheme, H: CRH, R: Rng>(
     let default = <C as CommitmentScheme>::Output::default();
     let mut leaves = [default.clone(), default.clone(), default.clone(), default];
 
-    for i in 0..4 {
+    for leaf in &mut leaves {
         let leaf_input: [u8; 32] = rng.gen();
         let randomness = <C as CommitmentScheme>::Randomness::rand(rng);
 
-        let leaf = commitment.commit(&leaf_input, &randomness).unwrap();
-        leaves[i] = leaf;
+        *leaf = commitment.commit(&leaf_input, &randomness).unwrap();
     }
 
     CommitmentMerkleTree::new(crh.clone(), &leaves).unwrap()

--- a/gadgets/src/algorithms/encryption/group.rs
+++ b/gadgets/src/algorithms/encryption/group.rs
@@ -260,7 +260,7 @@ impl<G: Group, F: Field, GG: GroupGadget<G, F>> ConditionalEqGadget<F> for Group
         condition: &Boolean,
     ) -> Result<(), SynthesisError> {
         self.public_key.conditional_enforce_equal(
-            &mut cs.ns(|| format!("conditional_enforce_equal")),
+            &mut cs.ns(|| "conditional_enforce_equal"),
             &other.public_key,
             condition,
         )?;

--- a/gadgets/src/algorithms/merkle_tree/tests.rs
+++ b/gadgets/src/algorithms/merkle_tree/tests.rs
@@ -60,7 +60,7 @@ impl PedersenSize for BoweHopwoodSize {
 fn generate_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, F>>(
     leaves: &[[u8; 30]],
     use_bad_root: bool,
-) -> () {
+) {
     let parameters = P::default();
     let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
     let root = tree.root();
@@ -129,7 +129,7 @@ fn generate_merkle_tree<P: MerkleParameters, F: PrimeField, HG: CRHGadget<P::H, 
 fn generate_masked_merkle_tree<P: MaskedMerkleParameters, F: PrimeField, HG: MaskedCRHGadget<P::H, F>>(
     leaves: &[[u8; 30]],
     use_bad_root: bool,
-) -> () {
+) {
     let parameters = P::default();
     let tree = MerkleTree::<P>::new(parameters.clone(), leaves).unwrap();
     let root = tree.root();

--- a/gadgets/src/algorithms/prf/blake2s.rs
+++ b/gadgets/src/algorithms/prf/blake2s.rs
@@ -104,6 +104,7 @@ const SIGMA: [[usize; 16]; 10] = [
 // END FUNCTION.
 //
 
+#[allow(clippy::many_single_char_names)]
 fn mixing_g<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     v: &mut [UInt32],
@@ -173,6 +174,7 @@ fn mixing_g<F: PrimeField, CS: ConstraintSystem<F>>(
 // END FUNCTION.
 //
 
+#[allow(clippy::many_single_char_names)]
 fn blake2s_compression<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     h: &mut [UInt32],

--- a/gadgets/src/algorithms/prf/blake2s.rs
+++ b/gadgets/src/algorithms/prf/blake2s.rs
@@ -105,6 +105,7 @@ const SIGMA: [[usize; 16]; 10] = [
 //
 
 #[allow(clippy::many_single_char_names)]
+#[allow(clippy::too_many_arguments)]
 fn mixing_g<F: PrimeField, CS: ConstraintSystem<F>>(
     mut cs: CS,
     v: &mut [UInt32],

--- a/gadgets/src/curves/templates/bls12/g2.rs
+++ b/gadgets/src/curves/templates/bls12/g2.rs
@@ -79,6 +79,7 @@ impl<P: Bls12Parameters> G2PreparedGadget<P> {
         Ok(Self { ell_coeffs })
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn double<CS: ConstraintSystem<P::Fp>>(
         mut cs: CS,
         r: &mut G2Gadget<P>,
@@ -106,6 +107,7 @@ impl<P: Bls12Parameters> G2PreparedGadget<P> {
         }
     }
 
+    #[allow(clippy::many_single_char_names)]
     fn add<CS: ConstraintSystem<P::Fp>>(
         mut cs: CS,
         r: &mut G2Gadget<P>,

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -95,6 +95,7 @@ mod montgomery_affine_impl {
             Ok(Self::new(u, v))
         }
 
+        #[allow(clippy::wrong_self_convention)]
         pub fn into_edwards<CS: ConstraintSystem<F>>(
             &self,
             mut cs: CS,
@@ -117,7 +118,7 @@ mod montgomery_affine_impl {
 
             let v = FG::alloc(cs.ns(|| "v"), || {
                 let mut t0 = self.x.get_value().get()?;
-                let mut t1 = t0.clone();
+                let mut t1 = t0;
                 t0.sub_assign(&P::BaseField::one());
                 t1.add_assign(&P::BaseField::one());
 
@@ -618,7 +619,7 @@ mod projective_impl {
     /// 10 => table[1]
     /// 01 => table[2]
     /// 11 => table[3]
-    fn two_bit_lookup_helper<'a, P: TEModelParameters, F: Field, FG: FieldGadget<P::BaseField, F>, CS>(
+    fn two_bit_lookup_helper<P: TEModelParameters, F: Field, FG: FieldGadget<P::BaseField, F>, CS>(
         mut cs: CS,
         bits: [Boolean; 2],
         mut table: [TEProjective<P>; 4],
@@ -839,7 +840,7 @@ mod projective_impl {
             B: Borrow<Boolean>,
         {
             let scalar_bits_with_base_powers: Vec<_> = scalar_bits_with_base_powers
-                .map(|(bit, base)| (bit.borrow().clone(), base.clone()))
+                .map(|(bit, base)| (*bit.borrow(), *base))
                 .collect();
             let zero = TEProjective::zero();
             for (i, bits_base_powers) in scalar_bits_with_base_powers.chunks(2).enumerate() {
@@ -872,7 +873,7 @@ mod projective_impl {
             B: Borrow<Boolean>,
         {
             let scalar_bits_with_base_powers: Vec<_> = scalar_bits_with_base_powers
-                .map(|(bit, base)| (bit.borrow().clone(), base.clone()))
+                .map(|(bit, base)| (*bit.borrow(), *base))
                 .collect();
             for (i, bits_base_powers) in scalar_bits_with_base_powers.chunks(2).enumerate() {
                 let mut cs = cs.ns(|| format!("Chunk {}", i));
@@ -979,11 +980,10 @@ mod projective_impl {
                 };
 
             // Compute ∏(h_i^{m_i}) for all i.
-            for (segment_i, (segment_bits_chunks, segment_powers)) in scalars.into_iter().zip(bases.iter()).enumerate()
-            {
+            for (segment_i, (segment_bits_chunks, segment_powers)) in scalars.iter().zip(bases.iter()).enumerate() {
                 for (i, (bits, base_power)) in segment_bits_chunks
                     .borrow()
-                    .into_iter()
+                    .iter()
                     .zip(segment_powers.borrow().iter())
                     .enumerate()
                 {
@@ -992,7 +992,7 @@ mod projective_impl {
                     let mut coords = vec![];
                     for _ in 0..4 {
                         coords.push(acc_power);
-                        acc_power = acc_power + base_power;
+                        acc_power += base_power;
                     }
 
                     let bits = bits

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -74,14 +74,12 @@ mod montgomery_affine_impl {
         pub fn from_edwards_to_coords(p: &TEAffine<P>) -> Result<(P::BaseField, P::BaseField), SynthesisError> {
             let montgomery_point: GroupAffine<P> = if p.y == P::BaseField::one() {
                 GroupAffine::zero()
+            } else if p.x == P::BaseField::zero() {
+                GroupAffine::new(P::BaseField::zero(), P::BaseField::zero())
             } else {
-                if p.x == P::BaseField::zero() {
-                    GroupAffine::new(P::BaseField::zero(), P::BaseField::zero())
-                } else {
-                    let u = (P::BaseField::one() + &p.y) * &(P::BaseField::one() - &p.y).inverse().unwrap();
-                    let v = u * &p.x.inverse().unwrap();
-                    GroupAffine::new(u, v)
-                }
+                let u = (P::BaseField::one() + &p.y) * &(P::BaseField::one() - &p.y).inverse().unwrap();
+                let v = u * &p.x.inverse().unwrap();
+                GroupAffine::new(u, v)
             };
 
             Ok((montgomery_point.x, montgomery_point.y))

--- a/gadgets/src/curves/tests_curve.rs
+++ b/gadgets/src/curves/tests_curve.rs
@@ -58,24 +58,23 @@ fn bls12_377_gadget_bilinearity_test() {
     let sb_prep_g = G2PreparedGadget::from_affine(&mut cs.ns(|| "sb_prep"), &sb_g).unwrap();
 
     let (ans1_g, ans1_n) = {
-        let ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(sa, b)"), sa_prep_g.clone(), b_prep_g.clone()).unwrap();
+        let ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(sa, b)"), sa_prep_g, b_prep_g.clone()).unwrap();
         let ans_n = Bls12_377::pairing(sa, b);
         (ans_g, ans_n)
     };
 
     let (ans2_g, ans2_n) = {
-        let ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(a, sb)"), a_prep_g.clone(), sb_prep_g.clone()).unwrap();
+        let ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(a, sb)"), a_prep_g.clone(), sb_prep_g).unwrap();
         let ans_n = Bls12_377::pairing(a, sb);
         (ans_g, ans_n)
     };
 
     let (ans3_g, ans3_n) = {
         let s_iter = BitIterator::new(s.into_repr())
-            .map(|bit| Boolean::constant(bit))
+            .map(Boolean::constant)
             .collect::<Vec<_>>();
 
-        let mut ans_g =
-            Bls12PairingGadget::pairing(cs.ns(|| "pair(a, b)"), a_prep_g.clone(), b_prep_g.clone()).unwrap();
+        let mut ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(a, b)"), a_prep_g, b_prep_g).unwrap();
         let mut ans_n = Bls12_377::pairing(a, b);
         ans_n = ans_n.pow(s.into_repr());
         ans_g = ans_g.pow(cs.ns(|| "pow"), &s_iter).unwrap();

--- a/gadgets/src/curves/tests_field.rs
+++ b/gadgets/src/curves/tests_field.rs
@@ -167,9 +167,7 @@ fn field_test<NativeF: Field, F: Field, FG: FieldGadget<NativeF, F>, CS: Constra
     assert_eq!(a_inv.get_value().unwrap(), a.get_value().unwrap().inverse().unwrap());
     assert_eq!(a_inv.get_value().unwrap(), a_native.inverse().unwrap());
     // a * a * a = a^3
-    let bits = BitIterator::new([0x3])
-        .map(|bit| Boolean::constant(bit))
-        .collect::<Vec<_>>();
+    let bits = BitIterator::new([0x3]).map(Boolean::constant).collect::<Vec<_>>();
     assert_eq!(
         a_native * &(a_native * &a_native),
         a.pow(cs.ns(|| "test_pow"), &bits).unwrap().get_value().unwrap()

--- a/gadgets/src/curves/tests_group.rs
+++ b/gadgets/src/curves/tests_group.rs
@@ -25,8 +25,6 @@ use snarkos_models::{
     },
 };
 
-use rand;
-
 pub fn group_test<F: Field, G: Group, GG: GroupGadget<G, F>, CS: ConstraintSystem<F>>(cs: &mut CS, a: GG, b: GG) {
     let zero = GG::zero(cs.ns(|| "Zero")).unwrap();
     assert_eq!(zero, zero);

--- a/marlin/src/ahp/constraint_systems.rs
+++ b/marlin/src/ahp/constraint_systems.rs
@@ -299,7 +299,7 @@ pub(crate) fn arithmetize_matrix<'a, F: PrimeField>(
 
     // Recall that we are computing the arithmetization of M^*,
     // where `M^*(i, j) := M(j, i) * u_H(j, j)`.
-    for (r, row) in matrix.into_iter().enumerate() {
+    for (r, row) in matrix.iter_mut().enumerate() {
         if !is_in_ascending_order(&row, |(_, a), (_, b)| a < b) {
             row.sort_by(|(_, a), (_, b)| a.cmp(b));
         };

--- a/marlin/src/ahp/constraint_systems.rs
+++ b/marlin/src/ahp/constraint_systems.rs
@@ -363,7 +363,7 @@ pub(crate) fn arithmetize_matrix<'a, F: PrimeField>(
         row: LabeledPolynomial::new_owned(m_name.clone() + "_row", row, None, None),
         col: LabeledPolynomial::new_owned(m_name.clone() + "_col", col, None, None),
         val: LabeledPolynomial::new_owned(m_name.clone() + "_val", val, None, None),
-        row_col: LabeledPolynomial::new_owned(m_name.clone() + "_row_col", row_col, None, None),
+        row_col: LabeledPolynomial::new_owned(m_name + "_row_col", row_col, None, None),
         evals_on_K,
         evals_on_B,
         row_col_evals_on_B: Cow::Owned(row_col_evals_on_B),

--- a/marlin/src/ahp/indexer.rs
+++ b/marlin/src/ahp/indexer.rs
@@ -150,7 +150,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         }
 
         if !Self::num_formatted_public_inputs_is_admissible(num_formatted_input_variables) {
-            Err(Error::InvalidPublicInputLength)?
+            return Err(Error::InvalidPublicInputLength);
         }
 
         let index_info = IndexInfo {

--- a/marlin/src/ahp/mod.rs
+++ b/marlin/src/ahp/mod.rs
@@ -265,7 +265,9 @@ pub trait EvaluationsProvider<F: Field> {
 impl<'a, F: Field> EvaluationsProvider<F> for snarkos_polycommit::Evaluations<'a, F> {
     fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F, Error> {
         let key = (lc.label.clone(), point);
-        self.get(&key).map(|v| *v).ok_or(Error::MissingEval(lc.label.clone()))
+        self.get(&key)
+            .copied()
+            .ok_or_else(|| Error::MissingEval(lc.label.clone()))
     }
 }
 
@@ -279,7 +281,7 @@ impl<'a, F: Field, T: Borrow<LabeledPolynomial<'a, F>>> EvaluationsProvider<F> f
                         let p: &LabeledPolynomial<F> = (*p).borrow();
                         p.label() == label
                     })
-                    .ok_or(Error::MissingEval(format!("Missing {} for {}", label, lc.label)))?
+                    .ok_or_else(|| Error::MissingEval(format!("Missing {} for {}", label, lc.label)))?
                     .borrow()
                     .evaluate(point)
             } else {

--- a/marlin/src/ahp/mod.rs
+++ b/marlin/src/ahp/mod.rs
@@ -134,7 +134,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
         let public_input = constraint_systems::ProverConstraintSystem::format_public_input(public_input);
         if !Self::formatted_public_input_is_admissible(&public_input) {
-            Err(Error::InvalidPublicInputLength)?
+            return Err(Error::InvalidPublicInputLength);
         }
         let x_domain = EvaluationDomain::new(public_input.len()).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
 

--- a/marlin/src/ahp/prover.rs
+++ b/marlin/src/ahp/prover.rs
@@ -235,6 +235,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the first round message and the next state.
+    #[allow(clippy::type_complexity)]
     pub fn prover_first_round<'a, 'b, R: RngCore, C: ConstraintSynthesizer<F>>(
         mut state: ProverState<'a, 'b, F, C>,
         rng: &mut R,

--- a/marlin/src/ahp/prover.rs
+++ b/marlin/src/ahp/prover.rs
@@ -175,11 +175,11 @@ impl<F: PrimeField> AHPForR1CS<F> {
         if index.index_info.num_constraints != num_constraints
             || num_input_variables + num_witness_variables != index.index_info.num_variables
         {
-            Err(Error::InstanceDoesNotMatchIndex)?;
+            return Err(Error::InstanceDoesNotMatchIndex);
         }
 
         if !Self::formatted_public_input_is_admissible(&formatted_input_assignment) {
-            Err(Error::InvalidPublicInputLength)?
+            return Err(Error::InvalidPublicInputLength);
         }
 
         // Perform matrix multiplications
@@ -299,15 +299,15 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
         let msg = ProverMsg { field_elements: vec![] };
 
-        assert!(w_poly.degree() <= domain_h.size() - domain_x.size() + zk_bound - 1);
-        assert!(z_a_poly.degree() <= domain_h.size() + zk_bound - 1);
-        assert!(z_b_poly.degree() <= domain_h.size() + zk_bound - 1);
+        assert!(w_poly.degree() < domain_h.size() - domain_x.size() + zk_bound);
+        assert!(z_a_poly.degree() < domain_h.size() + zk_bound);
+        assert!(z_b_poly.degree() < domain_h.size() + zk_bound);
         assert!(mask_poly.degree() <= 3 * domain_h.size() + 2 * zk_bound - 3);
 
         let w = LabeledPolynomial::new_owned("w".to_string(), w_poly, None, Some(1));
         let z_a = LabeledPolynomial::new_owned("z_a".to_string(), z_a_poly, None, Some(1));
         let z_b = LabeledPolynomial::new_owned("z_b".to_string(), z_b_poly, None, Some(1));
-        let mask_poly = LabeledPolynomial::new_owned("mask_poly".to_string(), mask_poly.clone(), None, None);
+        let mask_poly = LabeledPolynomial::new_owned("mask_poly".to_string(), mask_poly, None, None);
 
         let oracles = ProverFirstOracles {
             w: w.clone(),
@@ -425,7 +425,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         cfg_iter_mut!(z_poly.coeffs)
             .zip(&x_poly.coeffs)
             .for_each(|(z, x)| *z += x);
-        assert!(z_poly.degree() <= domain_h.size() + zk_bound - 1);
+        assert!(z_poly.degree() < domain_h.size() + zk_bound);
 
         end_timer!(z_poly_time);
 
@@ -452,7 +452,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
             .zip(&t_poly_m_evals.evals)
             .for_each(|(((a, b), &c), d)| {
                 *a *= &b;
-                *a -= &(c * &d);
+                *a -= &(c * d);
             });
         let rhs = r_alpha_evals.interpolate();
         let q_1 = mask_poly.polynomial() + &rhs;
@@ -565,19 +565,19 @@ impl<F: PrimeField> AHPForR1CS<F> {
         let a_denom: Vec<_> = cfg_iter!(a_star.evals_on_B.row.evals)
             .zip(&a_star.evals_on_B.col.evals)
             .zip(&a_star.row_col_evals_on_B.evals)
-            .map(|((&r, c), r_c)| beta * &alpha - &(r * &alpha) - &(beta * &c) + &r_c)
+            .map(|((&r, c), r_c)| beta * &alpha - &(r * &alpha) - &(beta * c) + r_c)
             .collect();
 
         let b_denom: Vec<_> = cfg_iter!(b_star.evals_on_B.row.evals)
             .zip(&b_star.evals_on_B.col.evals)
             .zip(&b_star.row_col_evals_on_B.evals)
-            .map(|((&r, c), r_c)| beta * &alpha - &(r * &alpha) - &(beta * &c) + &r_c)
+            .map(|((&r, c), r_c)| beta * &alpha - &(r * &alpha) - &(beta * c) + r_c)
             .collect();
 
         let c_denom: Vec<_> = cfg_iter!(c_star.evals_on_B.row.evals)
             .zip(&c_star.evals_on_B.col.evals)
             .zip(&c_star.row_col_evals_on_B.evals)
-            .map(|((&r, c), r_c)| beta * &alpha - &(r * &alpha) - &(beta * &c) + &r_c)
+            .map(|((&r, c), r_c)| beta * &alpha - &(r * &alpha) - &(beta * c) + r_c)
             .collect();
         end_timer!(denom_eval_time);
 

--- a/marlin/src/data_structures.rs
+++ b/marlin/src/data_structures.rs
@@ -153,7 +153,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, C: ConstraintSynthesizer<F>> Pr
         let mut size_bytes_comms_without_degree_bounds = 0;
         let mut size_bytes_comms_with_degree_bounds = 0;
         let mut size_bytes_proofs = 0;
-        for c in self.commitments.iter().flat_map(|c| c) {
+        for c in self.commitments.iter().flatten() {
             if !c.has_degree_bound() {
                 num_comms_without_degree_bounds += 1;
                 size_bytes_comms_without_degree_bounds += c.serialized_size();

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -279,7 +279,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
             let lc = lc_s
                 .iter()
                 .find(|lc| &lc.label == label)
-                .ok_or(ahp::Error::MissingEval(label.to_string()))?;
+                .ok_or_else(|| ahp::Error::MissingEval(label.to_string()))?;
             let eval = polynomials.get_lc_eval(&lc, *point)?;
             if !AHPForR1CS::<F>::LC_WITH_ZERO_EVAL.contains(&lc.label.as_ref()) {
                 evaluations.push(eval);

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -123,6 +123,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
 
     /// Generate the index-specific (i.e., circuit-specific) prover and verifier
     /// keys. This is a deterministic algorithm that anyone can rerun.
+    #[allow(clippy::type_complexity)]
     pub fn index<'a, C: ConstraintSynthesizer<F>>(
         srs: UniversalSRS<F, PC>,
         c: C,

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -133,7 +133,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
         // TODO: Add check that c is in the correct mode.
         let index = AHPForR1CS::index(c)?;
         if srs.max_degree() < index.max_degree() {
-            Err(Error::IndexTooLarge)?;
+            return Err(Error::IndexTooLarge);
         }
 
         let coeff_support = AHPForR1CS::get_degree_bounds::<C>(&index.index_info);
@@ -383,7 +383,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
             if AHPForR1CS::<F>::LC_WITH_ZERO_EVAL.contains(&q.0.as_ref()) {
                 evaluations.insert(q, F::zero());
             } else {
-                evaluations.insert(q, proof_evals.next().unwrap().clone());
+                evaluations.insert(q, *proof_evals.next().unwrap());
             }
         }
 

--- a/marlin/src/rng.rs
+++ b/marlin/src/rng.rs
@@ -49,7 +49,8 @@ impl<D: Digest> RngCore for FiatShamirRng<D> {
 
     #[inline]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        Ok(self.r.fill_bytes(dest))
+        self.r.fill_bytes(dest);
+        Ok(())
     }
 }
 

--- a/models/src/algorithms/encryption.rs
+++ b/models/src/algorithms/encryption.rs
@@ -54,13 +54,13 @@ pub trait EncryptionScheme: Sized + Clone + From<<Self as EncryptionScheme>::Par
         &self,
         public_key: &Self::PublicKey,
         randomness: &Self::Randomness,
-        message: &Vec<Self::Text>,
+        message: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError>;
 
     fn decrypt(
         &self,
         private_key: &Self::PrivateKey,
-        ciphertext: &Vec<Self::Text>,
+        ciphertext: &[Self::Text],
     ) -> Result<Vec<Self::Text>, EncryptionError>;
 
     fn parameters(&self) -> &Self::Parameters;

--- a/models/src/curves/fp12_2over3over2.rs
+++ b/models/src/curves/fp12_2over3over2.rs
@@ -430,6 +430,7 @@ impl<'a, P: Fp12Parameters> SubAssign<&'a Self> for Fp12<P> {
 
 impl<'a, P: Fp12Parameters> MulAssign<&'a Self> for Fp12<P> {
     #[inline]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         let v0 = self.c0 * &other.c0;
         let v1 = self.c1 * &other.c1;

--- a/models/src/curves/fp2.rs
+++ b/models/src/curves/fp2.rs
@@ -400,6 +400,7 @@ impl<'a, P: Fp2Parameters> SubAssign<&'a Self> for Fp2<P> {
 
 impl<'a, P: Fp2Parameters> MulAssign<&'a Self> for Fp2<P> {
     #[inline]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         // Karatsuba multiplication;
         // Guide to Pairing-based cryprography, Algorithm 5.16.

--- a/models/src/curves/fp2.rs
+++ b/models/src/curves/fp2.rs
@@ -119,7 +119,7 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     }
 
     fn double(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.double_in_place();
         result
     }
@@ -324,7 +324,7 @@ impl<P: Fp2Parameters> Neg for Fp2<P> {
     #[inline]
     #[must_use]
     fn neg(self) -> Self {
-        let mut res = self.clone();
+        let mut res = self;
         res.c0 = res.c0.neg();
         res.c1 = res.c1.neg();
         res

--- a/models/src/curves/fp3.rs
+++ b/models/src/curves/fp3.rs
@@ -148,7 +148,7 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
     }
 
     fn double(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.double_in_place();
         result
     }
@@ -182,7 +182,7 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
     }
 
     fn square(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.square_in_place();
         result
     }
@@ -191,9 +191,9 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // AbstractPairing-Friendly
         // Fields.pdf; Section 4 (CH-SQR2)
-        let a = self.c0.clone();
-        let b = self.c1.clone();
-        let c = self.c2.clone();
+        let a = self.c0;
+        let b = self.c1;
+        let c = self.c2;
 
         let s0 = a.square();
         let ab = a * &b;
@@ -219,38 +219,38 @@ impl<P: Fp3Parameters> Field for Fp3<P> {
             let t0 = self.c0.square();
             let t1 = self.c1.square();
             let t2 = self.c2.square();
-            let mut t3 = self.c0.clone();
+            let mut t3 = self.c0;
             t3.mul_assign(&self.c1);
-            let mut t4 = self.c0.clone();
+            let mut t4 = self.c0;
             t4.mul_assign(&self.c2);
-            let mut t5 = self.c1.clone();
+            let mut t5 = self.c1;
             t5.mul_assign(&self.c2);
             let n5 = P::mul_fp_by_nonresidue(&t5);
 
-            let mut s0 = t0.clone();
+            let mut s0 = t0;
             s0.sub_assign(&n5);
             let mut s1 = P::mul_fp_by_nonresidue(&t2);
             s1.sub_assign(&t3);
-            let mut s2 = t1.clone();
+            let mut s2 = t1;
             s2.sub_assign(&t4); // typo in paper referenced above. should be "-" as per Scott, but is "*"
 
-            let mut a1 = self.c2.clone();
+            let mut a1 = self.c2;
             a1.mul_assign(&s1);
-            let mut a2 = self.c1.clone();
+            let mut a2 = self.c1;
             a2.mul_assign(&s2);
-            let mut a3 = a1.clone();
+            let mut a3 = a1;
             a3.add_assign(&a2);
             a3 = P::mul_fp_by_nonresidue(&a3);
-            let mut t6 = self.c0.clone();
+            let mut t6 = self.c0;
             t6.mul_assign(&s0);
             t6.add_assign(&a3);
             t6.inverse_in_place();
 
-            let mut c0 = t6.clone();
+            let mut c0 = t6;
             c0.mul_assign(&s0);
-            let mut c1 = t6.clone();
+            let mut c1 = t6;
             c1.mul_assign(&s1);
-            let mut c2 = t6.clone();
+            let mut c2 = t6;
             c2.mul_assign(&s2);
 
             Some(Self::new(c0, c1, c2))
@@ -373,7 +373,7 @@ impl<P: Fp3Parameters> Neg for Fp3<P> {
 
     #[inline]
     fn neg(self) -> Self {
-        let mut res = self.clone();
+        let mut res = self;
         res.c0 = res.c0.neg();
         res.c1 = res.c1.neg();
         res.c2 = res.c2.neg();

--- a/models/src/curves/fp3.rs
+++ b/models/src/curves/fp3.rs
@@ -452,6 +452,7 @@ impl<'a, P: Fp3Parameters> SubAssign<&'a Self> for Fp3<P> {
 
 impl<'a, P: Fp3Parameters> MulAssign<&'a Self> for Fp3<P> {
     #[inline]
+    #[allow(clippy::many_single_char_names)]
     fn mul_assign(&mut self, other: &Self) {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // AbstractPairing-Friendly

--- a/models/src/curves/fp3.rs
+++ b/models/src/curves/fp3.rs
@@ -453,6 +453,7 @@ impl<'a, P: Fp3Parameters> SubAssign<&'a Self> for Fp3<P> {
 impl<'a, P: Fp3Parameters> MulAssign<&'a Self> for Fp3<P> {
     #[inline]
     #[allow(clippy::many_single_char_names)]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // AbstractPairing-Friendly

--- a/models/src/curves/fp6_2over3.rs
+++ b/models/src/curves/fp6_2over3.rs
@@ -454,6 +454,7 @@ impl<'a, P: Fp6Parameters> SubAssign<&'a Self> for Fp6<P> {
 
 impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
     #[inline]
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn mul_assign(&mut self, other: &Self) {
         // Devegili OhEig Scott Dahab --- Multiplication and Squaring on
         // Pairing-Friendly

--- a/models/src/curves/fp6_2over3.rs
+++ b/models/src/curves/fp6_2over3.rs
@@ -171,9 +171,9 @@ impl<P: Fp6Parameters> Fp6<P> {
                 found_nonzero = true;
 
                 if value > 0 {
-                    res = res * self;
+                    res *= self;
                 } else {
-                    res = res * &self_inverse;
+                    res *= &self_inverse;
                 }
             }
         }

--- a/models/src/curves/fp6_2over3.rs
+++ b/models/src/curves/fp6_2over3.rs
@@ -258,11 +258,11 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
         // Pairing-Friendly
         // Fields.pdf; Section 3 (Complex)
         let a = self.c0;
-        let mut b = self.c1;
+        let b = self.c1;
         let ab_add = a + &b;
-        let mut ab_mul = a * &b;
+        let ab_mul = a * &b;
 
-        let c0 = ab_add * &(a + &Self::mul_by_nonresidue(&mut b)) - &ab_mul - &Self::mul_by_nonresidue(&mut ab_mul);
+        let c0 = ab_add * &(a + &Self::mul_by_nonresidue(&b)) - &ab_mul - &Self::mul_by_nonresidue(&ab_mul);
         let c1 = ab_mul.double();
 
         self.c0 = c0;
@@ -280,8 +280,8 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
             let a = self.c0;
             let b = self.c1;
 
-            let mut t1 = b.square();
-            let t0 = a.square() - &Self::mul_by_nonresidue(&mut t1);
+            let t1 = b.square();
+            let t0 = a.square() - &Self::mul_by_nonresidue(&t1);
             let t2 = t0.inverse().unwrap();
 
             let c0 = a * &t2;
@@ -464,8 +464,8 @@ impl<'a, P: Fp6Parameters> MulAssign<&'a Self> for Fp6<P> {
         let b1 = other.c1;
 
         let a0a1 = a0 * &a1;
-        let mut b0b1 = b0 * &b1;
-        let beta_b0b1 = Self::mul_by_nonresidue(&mut b0b1);
+        let b0b1 = b0 * &b1;
+        let beta_b0b1 = Self::mul_by_nonresidue(&b0b1);
 
         let c0 = a0a1 + &beta_b0b1;
         let c1 = (a0 + &b0) * &(a1 + &b1) - &a0a1 - &b0b1;

--- a/models/src/curves/fp6_3over2.rs
+++ b/models/src/curves/fp6_3over2.rs
@@ -191,7 +191,7 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     }
 
     fn double(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.double_in_place();
         result
     }
@@ -225,7 +225,7 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     }
 
     fn square(&self) -> Self {
-        let mut result = self.clone();
+        let mut result = *self;
         result.square_in_place();
         result
     }

--- a/models/src/curves/fp_256.rs
+++ b/models/src/curves/fp_256.rs
@@ -69,6 +69,7 @@ impl<P: Fp256Parameters> Fp256<P> {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_256.rs
+++ b/models/src/curves/fp_256.rs
@@ -174,7 +174,7 @@ impl<P: Fp256Parameters> Field for Fp256<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }

--- a/models/src/curves/fp_320.rs
+++ b/models/src/curves/fp_320.rs
@@ -190,7 +190,7 @@ impl<P: Fp320Parameters> Field for Fp320<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -503,7 +503,7 @@ impl<P: Fp320Parameters> Neg for Fp320<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp320::<P>(tmp, PhantomData)
         } else {
@@ -517,7 +517,7 @@ impl<'a, P: Fp320Parameters> Add<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -528,7 +528,7 @@ impl<'a, P: Fp320Parameters> Sub<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -539,7 +539,7 @@ impl<'a, P: Fp320Parameters> Mul<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -550,7 +550,7 @@ impl<'a, P: Fp320Parameters> Div<&'a Fp320<P>> for Fp320<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/curves/fp_320.rs
+++ b/models/src/curves/fp_320.rs
@@ -69,6 +69,7 @@ impl<P: Fp320Parameters> Fp320<P> {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_384.rs
+++ b/models/src/curves/fp_384.rs
@@ -208,7 +208,7 @@ impl<P: Fp384Parameters> Field for Fp384<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -530,7 +530,7 @@ impl<P: Fp384Parameters> Neg for Fp384<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp384::<P>(tmp, PhantomData)
         } else {
@@ -544,7 +544,7 @@ impl<'a, P: Fp384Parameters> Add<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -555,7 +555,7 @@ impl<'a, P: Fp384Parameters> Sub<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -566,7 +566,7 @@ impl<'a, P: Fp384Parameters> Mul<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -577,7 +577,7 @@ impl<'a, P: Fp384Parameters> Div<&'a Fp384<P>> for Fp384<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/curves/fp_384.rs
+++ b/models/src/curves/fp_384.rs
@@ -69,6 +69,7 @@ impl<P: Fp384Parameters> Fp384<P> {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_768.rs
+++ b/models/src/curves/fp_768.rs
@@ -353,7 +353,7 @@ impl<P: Fp768Parameters> Field for Fp768<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -865,7 +865,7 @@ impl<P: Fp768Parameters> Neg for Fp768<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp768::<P>(tmp, PhantomData)
         } else {
@@ -879,7 +879,7 @@ impl<'a, P: Fp768Parameters> Add<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -890,7 +890,7 @@ impl<'a, P: Fp768Parameters> Sub<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -901,7 +901,7 @@ impl<'a, P: Fp768Parameters> Mul<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -912,7 +912,7 @@ impl<'a, P: Fp768Parameters> Div<&'a Fp768<P>> for Fp768<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/curves/fp_768.rs
+++ b/models/src/curves/fp_768.rs
@@ -68,6 +68,7 @@ impl<P: Fp768Parameters> Fp768<P> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_832.rs
+++ b/models/src/curves/fp_832.rs
@@ -68,6 +68,7 @@ impl<P: Fp832Parameters> Fp832<P> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn mont_reduce(
         &mut self,
         r0: u64,

--- a/models/src/curves/fp_832.rs
+++ b/models/src/curves/fp_832.rs
@@ -385,7 +385,7 @@ impl<P: Fp832Parameters> Field for Fp832<P> {
 
     #[inline]
     fn square(&self) -> Self {
-        let mut temp = self.clone();
+        let mut temp = *self;
         temp.square_in_place();
         temp
     }
@@ -834,7 +834,7 @@ impl<P: Fp832Parameters> Neg for Fp832<P> {
     #[must_use]
     fn neg(self) -> Self {
         if !self.is_zero() {
-            let mut tmp = P::MODULUS.clone();
+            let mut tmp = P::MODULUS;
             tmp.sub_noborrow(&self.0);
             Fp832::<P>(tmp, PhantomData)
         } else {
@@ -848,7 +848,7 @@ impl<'a, P: Fp832Parameters> Add<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn add(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.add_assign(other);
         result
     }
@@ -859,7 +859,7 @@ impl<'a, P: Fp832Parameters> Sub<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn sub(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.sub_assign(other);
         result
     }
@@ -870,7 +870,7 @@ impl<'a, P: Fp832Parameters> Mul<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn mul(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(other);
         result
     }
@@ -881,7 +881,7 @@ impl<'a, P: Fp832Parameters> Div<&'a Fp832<P>> for Fp832<P> {
 
     #[inline]
     fn div(self, other: &Self) -> Self {
-        let mut result = self.clone();
+        let mut result = self;
         result.mul_assign(&other.inverse().unwrap());
         result
     }

--- a/models/src/dpc/dpc.rs
+++ b/models/src/dpc/dpc.rs
@@ -73,7 +73,7 @@ pub trait DPCScheme<L: LedgerScheme> {
     /// Returns true iff all the transactions in the block are valid according to the ledger.
     fn verify_transactions(
         parameters: &Self::Parameters,
-        block: &Vec<Self::Transaction>,
+        block: &[Self::Transaction],
         ledger: &L,
     ) -> Result<bool, DPCError>;
 }

--- a/models/src/dpc/dpc.rs
+++ b/models/src/dpc/dpc.rs
@@ -41,6 +41,7 @@ pub trait DPCScheme<L: LedgerScheme> {
     fn create_account<R: Rng>(parameters: &Self::Parameters, rng: &mut R) -> Result<Self::Account, DPCError>;
 
     /// Returns the execution context required for program snark and DPC transaction generation.
+    #[allow(clippy::too_many_arguments)]
     fn execute_offline<R: Rng>(
         parameters: &Self::SystemParameters,
         old_records: &[Self::Record],

--- a/models/src/gadgets/algorithms/crh.rs
+++ b/models/src/gadgets/algorithms/crh.rs
@@ -59,7 +59,7 @@ pub trait MaskedCRHGadget<H: CRH, F: PrimeField>: CRHGadget<H, F> {
                 m.to_bits_le()
                     .chunks(4)
                     .map(|c| {
-                        let new_byte = c.into_iter().flat_map(|b| vec![*b, b.not()]).collect::<Vec<_>>();
+                        let new_byte = c.iter().flat_map(|b| vec![*b, b.not()]).collect::<Vec<_>>();
                         UInt8::from_bits_le(&new_byte)
                     })
                     .collect::<Vec<_>>()

--- a/models/src/gadgets/curves/field.rs
+++ b/models/src/gadgets/curves/field.rs
@@ -177,7 +177,7 @@ pub trait FieldGadget<NativeF: Field, F: Field>:
     #[inline]
     fn pow<CS: ConstraintSystem<F>>(&self, mut cs: CS, bits: &[Boolean]) -> Result<Self, SynthesisError> {
         let mut res = Self::one(cs.ns(|| "Alloc result"))?;
-        for (i, bit) in bits.into_iter().enumerate() {
+        for (i, bit) in bits.iter().enumerate() {
             res = res.square(cs.ns(|| format!("Double {}", i)))?;
             let tmp = res.mul(cs.ns(|| format!("Add {}-th base power", i)), self)?;
             res = Self::conditionally_select(cs.ns(|| format!("Conditional Select {}", i)), bit, &tmp, &res)?;

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -352,7 +352,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpGadget<F> {
         let mut coeff = F::one();
 
         for bit in bits.iter().rev() {
-            lc = lc + (coeff, bit.get_variable());
+            lc += (coeff, bit.get_variable());
 
             coeff.double_in_place();
         }
@@ -391,7 +391,7 @@ impl<F: PrimeField> ToBytesGadget<F> for FpGadget<F> {
         for bit in bytes.iter().flat_map(|byte_gadget| byte_gadget.bits.clone()) {
             match bit {
                 Boolean::Is(bit) => {
-                    lc = lc + (coeff, bit.get_variable());
+                    lc += (coeff, bit.get_variable());
                     coeff.double_in_place();
                 }
                 Boolean::Constant(_) | Boolean::Not(_) => unreachable!(),

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -270,7 +270,7 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
 
 impl<F: PrimeField> PartialEq for FpGadget<F> {
     fn eq(&self, other: &Self) -> bool {
-        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+        self.value.is_some() && other.value.is_some() && self.value == other.value
     }
 }
 

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -149,7 +149,9 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
 
     #[inline]
     fn negate_in_place<CS: ConstraintSystem<F>>(&mut self, _cs: CS) -> Result<&mut Self, SynthesisError> {
-        self.value.as_mut().map(|val| *val = -(*val));
+        if let Some(val) = self.value.as_mut() {
+            *val = -(*val);
+        }
         self.variable.negate_in_place();
         Ok(self)
     }
@@ -181,7 +183,9 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         _cs: CS,
         other: &F,
     ) -> Result<&mut Self, SynthesisError> {
-        self.value.as_mut().map(|val| *val += other);
+        if let Some(val) = self.value.as_mut() {
+            *val += other;
+        }
         self.variable += (*other, CS::one());
         Ok(self)
     }
@@ -199,7 +203,9 @@ impl<F: PrimeField> FieldGadget<F, F> for FpGadget<F> {
         mut _cs: CS,
         other: &F,
     ) -> Result<&mut Self, SynthesisError> {
-        self.value.as_mut().map(|val| *val *= other);
+        if let Some(val) = self.value.as_mut() {
+            *val *= other;
+        }
         self.variable *= *other;
         Ok(self)
     }

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -540,7 +540,7 @@ impl<F: PrimeField> ThreeBitCondNegLookupGadget<F> for FpGadget<F> {
 impl<F: PrimeField> Clone for FpGadget<F> {
     fn clone(&self) -> Self {
         Self {
-            value: self.value.clone(),
+            value: self.value,
             variable: self.variable.clone(),
         }
     }

--- a/models/src/gadgets/curves/fp2.rs
+++ b/models/src/gadgets/curves/fp2.rs
@@ -96,7 +96,7 @@ impl<P: Fp2Parameters<Fp = F>, F: PrimeField> FieldGadget<Fp2<P>, F> for Fp2Gadg
 
     #[inline]
     fn get_variable(&self) -> Self::Variable {
-        (self.c0.get_variable().clone(), self.c1.get_variable().clone())
+        (self.c0.get_variable(), self.c1.get_variable())
     }
 
     #[inline]

--- a/models/src/gadgets/curves/fp6_3over2.rs
+++ b/models/src/gadgets/curves/fp6_3over2.rs
@@ -165,16 +165,14 @@ where
     }
 }
 
+type ConstraintPair<T> = (ConstraintVar<T>, ConstraintVar<T>);
+
 impl<P, F: PrimeField> FieldGadget<Fp6<P>, F> for Fp6Gadget<P, F>
 where
     P: Fp6Parameters,
     P::Fp2Params: Fp2Parameters<Fp = F>,
 {
-    type Variable = (
-        (ConstraintVar<F>, ConstraintVar<F>),
-        (ConstraintVar<F>, ConstraintVar<F>),
-        (ConstraintVar<F>, ConstraintVar<F>),
-    );
+    type Variable = (ConstraintPair<F>, ConstraintPair<F>, ConstraintPair<F>);
 
     #[inline]
     fn get_value(&self) -> Option<Fp6<P>> {

--- a/models/src/gadgets/curves/group.rs
+++ b/models/src/gadgets/curves/group.rs
@@ -156,7 +156,7 @@ pub trait GroupGadget<G: Group, F: Field>:
         Err(SynthesisError::AssignmentMissing)
     }
 
-    fn precomputed_base_3_bit_signed_digit_scalar_mul<'a, CS, I, J, B>(
+    fn precomputed_base_3_bit_signed_digit_scalar_mul<CS, I, J, B>(
         _: CS,
         _: &[B],
         _: &[J],

--- a/models/src/gadgets/curves/pairing.rs
+++ b/models/src/gadgets/curves/pairing.rs
@@ -54,7 +54,6 @@ pub trait PairingGadget<Pairing: PairingEngine, F: Field> {
     }
 
     /// Computes a product of pairings.
-    #[must_use]
     fn product_of_pairings<CS: ConstraintSystem<F>>(
         mut cs: CS,
         p: &[Self::G1PreparedGadget],

--- a/models/src/gadgets/r1cs/constraint_counter.rs
+++ b/models/src/gadgets/r1cs/constraint_counter.rs
@@ -21,6 +21,7 @@ use crate::{
 use snarkos_errors::gadgets::SynthesisError;
 
 /// Constraint counter for testing purposes.
+#[derive(Default)]
 pub struct ConstraintCounter {
     pub num_inputs: usize,
     pub num_aux: usize,
@@ -28,14 +29,6 @@ pub struct ConstraintCounter {
 }
 
 impl ConstraintCounter {
-    pub fn new() -> Self {
-        Self {
-            num_aux: 0,
-            num_inputs: 0,
-            num_constraints: 0,
-        }
-    }
-
     pub fn num_constraints(&self) -> usize {
         self.num_constraints
     }

--- a/models/src/gadgets/r1cs/constraint_system.rs
+++ b/models/src/gadgets/r1cs/constraint_system.rs
@@ -79,7 +79,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     fn get_root(&mut self) -> &mut Self::Root;
 
     /// Begin a namespace for this constraint system.
-    fn ns<'a, NR, N>(&'a mut self, name_fn: N) -> Namespace<'a, F, Self::Root>
+    fn ns<NR, N>(&mut self, name_fn: N) -> Namespace<'_, F, Self::Root>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,

--- a/models/src/gadgets/r1cs/impl_constraint_var.rs
+++ b/models/src/gadgets/r1cs/impl_constraint_var.rs
@@ -289,6 +289,7 @@ impl<'a, F: Field> Sub<(F, &'a Self)> for ConstraintVar<F> {
     type Output = Self;
 
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, (coeff, other): (F, &'a Self)) -> Self {
         let mut lc = match self {
             LC(lc2) => lc2,

--- a/models/src/gadgets/r1cs/impl_lc.rs
+++ b/models/src/gadgets/r1cs/impl_lc.rs
@@ -84,7 +84,7 @@ impl<F: Field> LinearCombination<F> {
                     found_index += 1;
                 }
             }
-            return Err(found_index);
+            Err(found_index)
         } else {
             self.0.binary_search_by_key(search_var, |&(cur_var, _)| cur_var)
         }

--- a/models/src/gadgets/r1cs/impl_lc.rs
+++ b/models/src/gadgets/r1cs/impl_lc.rs
@@ -20,7 +20,10 @@ use crate::{
 };
 
 use smallvec::smallvec;
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+use std::{
+    cmp::Ordering,
+    ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
+};
 
 impl<F: Field> AsRef<[(Variable, F)]> for LinearCombination<F> {
     #[inline]
@@ -181,16 +184,20 @@ where
     while i < cur.0.len() && j < other.0.len() {
         let self_cur = &cur.0[i];
         let other_cur = &other.0[j];
-        if self_cur.0 > other_cur.0 {
-            new_vec.push((other.0[j].0, push_fn(other.0[j].1)));
-            j += 1;
-        } else if self_cur.0 < other_cur.0 {
-            new_vec.push(*self_cur);
-            i += 1;
-        } else {
-            new_vec.push((self_cur.0, combine_fn(self_cur.1, other_cur.1)));
-            i += 1;
-            j += 1;
+        match self_cur.0.cmp(&other_cur.0) {
+            Ordering::Greater => {
+                new_vec.push((other.0[j].0, push_fn(other.0[j].1)));
+                j += 1;
+            }
+            Ordering::Less => {
+                new_vec.push(*self_cur);
+                i += 1;
+            }
+            Ordering::Equal => {
+                new_vec.push((self_cur.0, combine_fn(self_cur.1, other_cur.1)));
+                i += 1;
+                j += 1;
+            }
         }
     }
     new_vec.extend_from_slice(&cur.0[i..]);

--- a/models/src/gadgets/r1cs/impl_lc.rs
+++ b/models/src/gadgets/r1cs/impl_lc.rs
@@ -357,6 +357,7 @@ impl<F: Field> Sub<LinearCombination<F>> for LinearCombination<F> {
 impl<F: Field> Add<(F, &LinearCombination<F>)> for &LinearCombination<F> {
     type Output = LinearCombination<F>;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, other): (F, &LinearCombination<F>)) -> LinearCombination<F> {
         if other.0.is_empty() {
             return self.clone();
@@ -377,6 +378,7 @@ impl<F: Field> Add<(F, &LinearCombination<F>)> for &LinearCombination<F> {
 impl<'a, F: Field> Add<(F, &'a LinearCombination<F>)> for LinearCombination<F> {
     type Output = LinearCombination<F>;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, other): (F, &'a LinearCombination<F>)) -> LinearCombination<F> {
         if other.0.is_empty() {
             return self;
@@ -397,6 +399,7 @@ impl<'a, F: Field> Add<(F, &'a LinearCombination<F>)> for LinearCombination<F> {
 impl<F: Field> Add<(F, LinearCombination<F>)> for &LinearCombination<F> {
     type Output = LinearCombination<F>;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, mut other): (F, LinearCombination<F>)) -> LinearCombination<F> {
         if other.0.is_empty() {
             return self.clone();
@@ -416,6 +419,7 @@ impl<F: Field> Add<(F, LinearCombination<F>)> for &LinearCombination<F> {
 impl<F: Field> Add<(F, Self)> for LinearCombination<F> {
     type Output = Self;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, (mul_coeff, other): (F, Self)) -> Self {
         if other.0.is_empty() {
             return self;

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -29,11 +29,13 @@ enum NamedObject {
     Namespace,
 }
 
+type TestConstraint<T> = (LinearCombination<T>, LinearCombination<T>, LinearCombination<T>, String);
+
 /// Constraint system for testing purposes.
 pub struct TestConstraintSystem<F: Field> {
     named_objects: BTreeMap<String, NamedObject>,
     current_namespace: Vec<String>,
-    pub constraints: Vec<(LinearCombination<F>, LinearCombination<F>, LinearCombination<F>, String)>,
+    pub constraints: Vec<TestConstraint<F>>,
     inputs: Vec<(F, String)>,
     aux: Vec<(F, String)>,
 }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -56,8 +56,8 @@ impl<F: Field> TestConstraintSystem<F> {
     }
 }
 
-impl<F: Field> TestConstraintSystem<F> {
-    pub fn new() -> TestConstraintSystem<F> {
+impl<F: Field> Default for TestConstraintSystem<F> {
+    fn default() -> Self {
         let mut map = BTreeMap::new();
         map.insert("ONE".into(), NamedObject::Var(TestConstraintSystem::<F>::one()));
 
@@ -68,6 +68,12 @@ impl<F: Field> TestConstraintSystem<F> {
             inputs: vec![(F::one(), "ONE".into())],
             aux: vec![],
         }
+    }
+}
+
+impl<F: Field> TestConstraintSystem<F> {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn print_named_objects(&self) {

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -215,7 +215,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     fn push_namespace<NR: Into<String>, N: FnOnce() -> NR>(&mut self, name_fn: N) {
         let name = name_fn().into();
         let path = compute_path(&self.current_namespace, name.clone());
-        self.set_named_obj(path.clone(), NamedObject::Namespace);
+        self.set_named_obj(path, NamedObject::Namespace);
         self.current_namespace.push(name);
     }
 

--- a/models/src/gadgets/utilities/arithmetic/add.rs
+++ b/models/src/gadgets/utilities/arithmetic/add.rs
@@ -30,7 +30,6 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn add<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }
 

--- a/models/src/gadgets/utilities/arithmetic/div.rs
+++ b/models/src/gadgets/utilities/arithmetic/div.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn div<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/arithmetic/mul.rs
+++ b/models/src/gadgets/utilities/arithmetic/mul.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn mul<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/arithmetic/neg.rs
+++ b/models/src/gadgets/utilities/arithmetic/neg.rs
@@ -30,7 +30,6 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn neg<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Self, Self::ErrorType>;
 }
 

--- a/models/src/gadgets/utilities/arithmetic/neg.rs
+++ b/models/src/gadgets/utilities/arithmetic/neg.rs
@@ -45,7 +45,7 @@ impl<F: Field> Neg<F> for Vec<Boolean> {
         let mut one = vec![Boolean::constant(true)];
         one.append(&mut vec![Boolean::Constant(false); self.len() - 1]);
 
-        let mut bits = flipped.add_bits(cs.ns(|| format!("add one")), &one)?;
+        let mut bits = flipped.add_bits(cs.ns(|| "add one"), &one)?;
         let _carry = bits.pop(); // we already accounted for overflow above
 
         Ok(bits)

--- a/models/src/gadgets/utilities/arithmetic/pow.rs
+++ b/models/src/gadgets/utilities/arithmetic/pow.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn pow<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/arithmetic/sub.rs
+++ b/models/src/gadgets/utilities/arithmetic/sub.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn sub<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/models/src/gadgets/utilities/bits/adder.rs
+++ b/models/src/gadgets/utilities/bits/adder.rs
@@ -44,12 +44,12 @@ impl<'a, F: Field> FullAdder<'a, F> for Boolean {
         b: &'a Self,
         carry: &'a Self,
     ) -> Result<(Self, Self), SynthesisError> {
-        let a_x_b = Boolean::xor(cs.ns(|| format!("a XOR b")), a, b)?;
-        let sum = Boolean::xor(cs.ns(|| format!("adder sum")), &a_x_b, carry)?;
+        let a_x_b = Boolean::xor(cs.ns(|| "a XOR b"), a, b)?;
+        let sum = Boolean::xor(cs.ns(|| "adder sum"), &a_x_b, carry)?;
 
-        let c1 = Boolean::and(cs.ns(|| format!("a AND b")), a, b)?;
-        let c2 = Boolean::and(cs.ns(|| format!("carry AND (a XOR b)")), carry, &a_x_b)?;
-        let carry = Boolean::or(cs.ns(|| format!("c1 OR c2")), &c1, &c2)?;
+        let c1 = Boolean::and(cs.ns(|| "a AND b"), a, b)?;
+        let c2 = Boolean::and(cs.ns(|| "carry AND (a XOR b)"), carry, &a_x_b)?;
+        let carry = Boolean::or(cs.ns(|| "c1 OR c2"), &c1, &c2)?;
 
         Ok((sum, carry))
     }

--- a/models/src/gadgets/utilities/bits/rca.rs
+++ b/models/src/gadgets/utilities/bits/rca.rs
@@ -28,7 +28,6 @@ pub trait RippleCarryAdder<F: Field, Rhs = Self>
 where
     Self: std::marker::Sized,
 {
-    #[must_use]
     fn add_bits<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Vec<Boolean>, SynthesisError>;
 }
 

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -1043,6 +1043,19 @@ mod test {
         NegatedAllocatedFalse,
     }
 
+    fn dyn_construct(cs: &mut TestConstraintSystem<Fr>, operand: OperandType, name: &str) -> Boolean {
+        let cs = cs.ns(|| name);
+
+        match operand {
+            OperandType::True => Boolean::constant(true),
+            OperandType::False => Boolean::constant(false),
+            OperandType::AllocatedTrue => Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()),
+            OperandType::AllocatedFalse => Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap()),
+            OperandType::NegatedAllocatedTrue => Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()).not(),
+            OperandType::NegatedAllocatedFalse => Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap()).not(),
+        }
+    }
+
     #[test]
     fn test_boolean_xor() {
         let variants = [
@@ -1062,27 +1075,8 @@ mod test {
                 let b;
 
                 {
-                    let mut dyn_construct = |operand, name| {
-                        let cs = cs.ns(|| name);
-
-                        match operand {
-                            OperandType::True => Boolean::constant(true),
-                            OperandType::False => Boolean::constant(false),
-                            OperandType::AllocatedTrue => Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()),
-                            OperandType::AllocatedFalse => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap())
-                            }
-                            OperandType::NegatedAllocatedTrue => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()).not()
-                            }
-                            OperandType::NegatedAllocatedFalse => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap()).not()
-                            }
-                        }
-                    };
-
-                    a = dyn_construct(first_operand, "a");
-                    b = dyn_construct(second_operand, "b");
+                    a = dyn_construct(&mut cs, first_operand, "a");
+                    b = dyn_construct(&mut cs, second_operand, "b");
                 }
 
                 let c = Boolean::xor(&mut cs, &a, &b).unwrap();
@@ -1207,30 +1201,9 @@ mod test {
                     let b;
 
                     {
-                        let mut dyn_construct = |operand, name| {
-                            let cs = cs.ns(|| name);
-
-                            match operand {
-                                OperandType::True => Boolean::constant(true),
-                                OperandType::False => Boolean::constant(false),
-                                OperandType::AllocatedTrue => {
-                                    Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap())
-                                }
-                                OperandType::AllocatedFalse => {
-                                    Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap())
-                                }
-                                OperandType::NegatedAllocatedTrue => {
-                                    Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()).not()
-                                }
-                                OperandType::NegatedAllocatedFalse => {
-                                    Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap()).not()
-                                }
-                            }
-                        };
-
-                        cond = dyn_construct(condition, "cond");
-                        a = dyn_construct(first_operand, "a");
-                        b = dyn_construct(second_operand, "b");
+                        cond = dyn_construct(&mut cs, condition, "cond");
+                        a = dyn_construct(&mut cs, first_operand, "a");
+                        b = dyn_construct(&mut cs, second_operand, "b");
                     }
 
                     let before = cs.num_constraints();
@@ -1277,27 +1250,8 @@ mod test {
                 let b;
 
                 {
-                    let mut dyn_construct = |operand, name| {
-                        let cs = cs.ns(|| name);
-
-                        match operand {
-                            OperandType::True => Boolean::constant(true),
-                            OperandType::False => Boolean::constant(false),
-                            OperandType::AllocatedTrue => Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()),
-                            OperandType::AllocatedFalse => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap())
-                            }
-                            OperandType::NegatedAllocatedTrue => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()).not()
-                            }
-                            OperandType::NegatedAllocatedFalse => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap()).not()
-                            }
-                        }
-                    };
-
-                    a = dyn_construct(first_operand, "a");
-                    b = dyn_construct(second_operand, "b");
+                    a = dyn_construct(&mut cs, first_operand, "a");
+                    b = dyn_construct(&mut cs, second_operand, "b");
                 }
 
                 let c = Boolean::or(&mut cs, &a, &b).unwrap();
@@ -1407,27 +1361,8 @@ mod test {
                 let b;
 
                 {
-                    let mut dyn_construct = |operand, name| {
-                        let cs = cs.ns(|| name);
-
-                        match operand {
-                            OperandType::True => Boolean::constant(true),
-                            OperandType::False => Boolean::constant(false),
-                            OperandType::AllocatedTrue => Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()),
-                            OperandType::AllocatedFalse => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap())
-                            }
-                            OperandType::NegatedAllocatedTrue => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(true)).unwrap()).not()
-                            }
-                            OperandType::NegatedAllocatedFalse => {
-                                Boolean::from(AllocatedBit::alloc(cs, || Ok(false)).unwrap()).not()
-                            }
-                        }
-                    };
-
-                    a = dyn_construct(first_operand, "a");
-                    b = dyn_construct(second_operand, "b");
+                    a = dyn_construct(&mut cs, first_operand, "a");
+                    b = dyn_construct(&mut cs, second_operand, "b");
                 }
 
                 let c = Boolean::and(&mut cs, &a, &b).unwrap();

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -748,9 +748,9 @@ impl<F: PrimeField> CondSelectGadget<F> for Boolean {
             Boolean::Constant(false) => Ok(*second),
             cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
             cond @ Boolean::Is(_) => match (first, second) {
-                (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),
+                (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x),
                 (&Boolean::Constant(false), x) => Boolean::and(cs.ns(|| "and"), &cond.not(), x),
-                (&Boolean::Constant(true), x) => Boolean::or(cs.ns(|| "or"), cond, x).into(),
+                (&Boolean::Constant(true), x) => Boolean::or(cs.ns(|| "or"), cond, x),
                 (x, &Boolean::Constant(true)) => Boolean::or(cs.ns(|| "or"), &cond.not(), x),
                 (a @ Boolean::Is(_), b @ Boolean::Is(_))
                 | (a @ Boolean::Not(_), b @ Boolean::Not(_))

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -587,7 +587,7 @@ impl Boolean {
 
             if b {
                 // This is part of a run of ones.
-                current_run.push(a.clone());
+                current_run.push(*a);
             } else {
                 if !current_run.is_empty() {
                     // This is the start of a run of zeros, but we need
@@ -744,8 +744,8 @@ impl<F: PrimeField> CondSelectGadget<F> for Boolean {
         CS: ConstraintSystem<F>,
     {
         match cond {
-            Boolean::Constant(true) => Ok(first.clone()),
-            Boolean::Constant(false) => Ok(second.clone()),
+            Boolean::Constant(true) => Ok(first),
+            Boolean::Constant(false) => Ok(second),
             cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
             cond @ Boolean::Is(_) => match (first, second) {
                 (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -744,8 +744,8 @@ impl<F: PrimeField> CondSelectGadget<F> for Boolean {
         CS: ConstraintSystem<F>,
     {
         match cond {
-            Boolean::Constant(true) => Ok(first),
-            Boolean::Constant(false) => Ok(second),
+            Boolean::Constant(true) => Ok(*first),
+            Boolean::Constant(false) => Ok(*second),
             cond @ Boolean::Not(_) => Self::conditionally_select(cs, &cond.not(), second, first),
             cond @ Boolean::Is(_) => match (first, second) {
                 (x, &Boolean::Constant(false)) => Boolean::and(cs.ns(|| "and"), cond, x).into(),

--- a/models/src/gadgets/utilities/int/arithmetic/add.rs
+++ b/models/src/gadgets/utilities/int/arithmetic/add.rs
@@ -79,7 +79,7 @@ macro_rules! add_int_impl {
                             all_constants = false;
 
                             // Add the coeff * bit_gadget
-                            lc = lc + (coeff, bit.get_variable());
+                            lc += (coeff, bit.get_variable());
                         }
                         Boolean::Not(ref bit) => {
                             all_constants = false;
@@ -89,7 +89,7 @@ macro_rules! add_int_impl {
                         }
                         Boolean::Constant(bit) => {
                             if bit {
-                                lc = lc + (coeff, CS::one());
+                                lc += (coeff, CS::one());
                             }
                         }
                     }

--- a/models/src/gadgets/utilities/int/tests/int64.rs
+++ b/models/src/gadgets/utilities/int/tests/int64.rs
@@ -32,10 +32,10 @@ fn check_all_constant_bits(expected: i64, actual: Int64) {
         let mask = 1 << i as i64;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 let bit = result == mask;
                 assert_eq!(b, bit);
             }
@@ -49,16 +49,16 @@ fn check_all_allocated_bits(expected: i64, actual: Int64) {
         let mask = 1 << i as i64;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 let bit = result == mask;
                 assert_eq!(b.get_value().unwrap(), bit);
             }
-            &Boolean::Not(ref b) => {
+            Boolean::Not(ref b) => {
                 let bit = result == mask;
                 assert_eq!(!b.get_value().unwrap(), bit);
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
     }
 }

--- a/models/src/gadgets/utilities/mod.rs
+++ b/models/src/gadgets/utilities/mod.rs
@@ -44,11 +44,11 @@ pub trait ToBitsGadget<F: Field> {
 
 impl<F: Field> ToBitsGadget<F> for Boolean {
     fn to_bits<CS: ConstraintSystem<F>>(&self, _: CS) -> Result<Vec<Boolean>, SynthesisError> {
-        Ok(vec![self.clone()])
+        Ok(vec![*self])
     }
 
     fn to_bits_strict<CS: ConstraintSystem<F>>(&self, _: CS) -> Result<Vec<Boolean>, SynthesisError> {
-        Ok(vec![self.clone()])
+        Ok(vec![*self])
     }
 }
 

--- a/models/src/gadgets/utilities/uint/macros.rs
+++ b/models/src/gadgets/utilities/uint/macros.rs
@@ -209,7 +209,7 @@ macro_rules! uint_impl {
                                     lc = lc - (coeff, bit.get_variable());
                                 } else {
                                     // Add coeff * bit_gadget
-                                    lc = lc + (coeff, bit.get_variable());
+                                    lc += (coeff, bit.get_variable());
                                 }
                             }
                             Boolean::Not(ref bit) => {
@@ -228,7 +228,7 @@ macro_rules! uint_impl {
                                     if op.negated {
                                         lc = lc - (coeff, CS::one());
                                     } else {
-                                        lc = lc + (coeff, CS::one());
+                                        lc += (coeff, CS::one());
                                     }
                                 }
                             }

--- a/models/src/gadgets/utilities/uint/tests/uint128.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint128.rs
@@ -32,10 +32,10 @@ use std::convert::TryInto;
 
 fn check_all_constant_bits(mut expected: u128, actual: UInt128) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 assert!(b == (expected & 1 == 1));
             }
         }
@@ -46,14 +46,14 @@ fn check_all_constant_bits(mut expected: u128, actual: UInt128) {
 
 fn check_all_allocated_bits(mut expected: u128, actual: UInt128) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 assert!(b.get_value().unwrap() == (expected & 1 == 1));
             }
-            &Boolean::Not(ref b) => {
-                assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+            Boolean::Not(ref b) => {
+                assert!(b.get_value().unwrap() != (expected & 1 == 1));
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
 
         expected >>= 1;
@@ -70,8 +70,8 @@ fn test_uint128_from_bits() {
         let b = UInt128::from_bits_le(&v);
 
         for (i, bit_gadget) in b.bits.iter().enumerate() {
-            match bit_gadget {
-                &Boolean::Constant(bit_gadget) => {
+            match *bit_gadget {
+                Boolean::Constant(bit_gadget) => {
                     assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
                 }
                 _ => unreachable!(),
@@ -105,8 +105,8 @@ fn test_uint128_rotr() {
 
         let mut tmp = num;
         for b in &b.bits {
-            match b {
-                &Boolean::Constant(b) => {
+            match *b {
+                Boolean::Constant(b) => {
                     assert_eq!(b, tmp & 1 == 1);
                 }
                 _ => unreachable!(),
@@ -144,14 +144,14 @@ fn test_uint128_xor() {
         assert!(r.value == Some(expected));
 
         for b in r.bits.iter() {
-            match b {
-                &Boolean::Is(ref b) => {
+            match *b {
+                Boolean::Is(ref b) => {
                     assert!(b.get_value().unwrap() == (expected & 1 == 1));
                 }
-                &Boolean::Not(ref b) => {
-                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                Boolean::Not(ref b) => {
+                    assert!(b.get_value().unwrap() != (expected & 1 == 1));
                 }
-                &Boolean::Constant(b) => {
+                Boolean::Constant(b) => {
                     assert!(b == (expected & 1 == 1));
                 }
             }

--- a/models/src/gadgets/utilities/uint/tests/uint16.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint16.rs
@@ -31,10 +31,10 @@ use rand_xorshift::XorShiftRng;
 
 fn check_all_constant_bits(mut expected: u16, actual: UInt16) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 assert!(b == (expected & 1 == 1));
             }
         }
@@ -45,14 +45,14 @@ fn check_all_constant_bits(mut expected: u16, actual: UInt16) {
 
 fn check_all_allocated_bits(mut expected: u16, actual: UInt16) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 assert!(b.get_value().unwrap() == (expected & 1 == 1));
             }
-            &Boolean::Not(ref b) => {
-                assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+            Boolean::Not(ref b) => {
+                assert!(b.get_value().unwrap() != (expected & 1 == 1));
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
 
         expected >>= 1;
@@ -69,8 +69,8 @@ fn test_uint16_from_bits() {
         let b = UInt16::from_bits_le(&v);
 
         for (i, bit_gadget) in b.bits.iter().enumerate() {
-            match bit_gadget {
-                &Boolean::Constant(bit_gadget) => {
+            match *bit_gadget {
+                Boolean::Constant(bit_gadget) => {
                     assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
                 }
                 _ => unreachable!(),
@@ -104,8 +104,8 @@ fn test_uint16_rotr() {
 
         let mut tmp = num;
         for b in &b.bits {
-            match b {
-                &Boolean::Constant(b) => {
+            match *b {
+                Boolean::Constant(b) => {
                     assert_eq!(b, tmp & 1 == 1);
                 }
                 _ => unreachable!(),
@@ -143,14 +143,14 @@ fn test_uint16_xor() {
         assert!(r.value == Some(expected));
 
         for b in r.bits.iter() {
-            match b {
-                &Boolean::Is(ref b) => {
+            match *b {
+                Boolean::Is(ref b) => {
                     assert!(b.get_value().unwrap() == (expected & 1 == 1));
                 }
-                &Boolean::Not(ref b) => {
-                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                Boolean::Not(ref b) => {
+                    assert!(b.get_value().unwrap() != (expected & 1 == 1));
                 }
-                &Boolean::Constant(b) => {
+                Boolean::Constant(b) => {
                     assert!(b == (expected & 1 == 1));
                 }
             }
@@ -186,6 +186,7 @@ fn test_uint16_addmany_constants() {
 }
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_uint16_addmany() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 

--- a/models/src/gadgets/utilities/uint/tests/uint32.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint32.rs
@@ -31,10 +31,10 @@ use rand_xorshift::XorShiftRng;
 
 fn check_all_constant_bits(mut expected: u32, actual: UInt32) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 assert!(b == (expected & 1 == 1));
             }
         }
@@ -45,14 +45,14 @@ fn check_all_constant_bits(mut expected: u32, actual: UInt32) {
 
 fn check_all_allocated_bits(mut expected: u32, actual: UInt32) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 assert!(b.get_value().unwrap() == (expected & 1 == 1));
             }
-            &Boolean::Not(ref b) => {
-                assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+            Boolean::Not(ref b) => {
+                assert!(b.get_value().unwrap() != (expected & 1 == 1));
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
 
         expected >>= 1;
@@ -69,8 +69,8 @@ fn test_uint32_from_bits() {
         let b = UInt32::from_bits_le(&v);
 
         for (i, bit_gadget) in b.bits.iter().enumerate() {
-            match bit_gadget {
-                &Boolean::Constant(bit_gadget) => {
+            match *bit_gadget {
+                Boolean::Constant(bit_gadget) => {
                     assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
                 }
                 _ => unreachable!(),
@@ -104,8 +104,8 @@ fn test_uint32_rotr() {
 
         let mut tmp = num;
         for b in &b.bits {
-            match b {
-                &Boolean::Constant(b) => {
+            match *b {
+                Boolean::Constant(b) => {
                     assert_eq!(b, tmp & 1 == 1);
                 }
                 _ => unreachable!(),
@@ -143,14 +143,14 @@ fn test_uint32_xor() {
         assert!(r.value == Some(expected));
 
         for b in r.bits.iter() {
-            match b {
-                &Boolean::Is(ref b) => {
+            match *b {
+                Boolean::Is(ref b) => {
                     assert!(b.get_value().unwrap() == (expected & 1 == 1));
                 }
-                &Boolean::Not(ref b) => {
-                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                Boolean::Not(ref b) => {
+                    assert!(b.get_value().unwrap() != (expected & 1 == 1));
                 }
-                &Boolean::Constant(b) => {
+                Boolean::Constant(b) => {
                     assert!(b == (expected & 1 == 1));
                 }
             }
@@ -186,6 +186,7 @@ fn test_uint32_addmany_constants() {
 }
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_uint32_addmany() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 

--- a/models/src/gadgets/utilities/uint/tests/uint64.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint64.rs
@@ -32,10 +32,10 @@ use std::convert::TryInto;
 
 fn check_all_constant_bits(mut expected: u64, actual: UInt64) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 assert!(b == (expected & 1 == 1));
             }
         }
@@ -46,14 +46,14 @@ fn check_all_constant_bits(mut expected: u64, actual: UInt64) {
 
 fn check_all_allocated_bits(mut expected: u64, actual: UInt64) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 assert!(b.get_value().unwrap() == (expected & 1 == 1));
             }
-            &Boolean::Not(ref b) => {
-                assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+            Boolean::Not(ref b) => {
+                assert!(b.get_value().unwrap() != (expected & 1 == 1));
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
 
         expected >>= 1;
@@ -70,8 +70,8 @@ fn test_uint64_from_bits() {
         let b = UInt64::from_bits_le(&v);
 
         for (i, bit_gadget) in b.bits.iter().enumerate() {
-            match bit_gadget {
-                &Boolean::Constant(bit_gadget) => {
+            match *bit_gadget {
+                Boolean::Constant(bit_gadget) => {
                     assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
                 }
                 _ => unreachable!(),
@@ -105,8 +105,8 @@ fn test_uint64_rotr() {
 
         let mut tmp = num;
         for b in &b.bits {
-            match b {
-                &Boolean::Constant(b) => {
+            match *b {
+                Boolean::Constant(b) => {
                     assert_eq!(b, tmp & 1 == 1);
                 }
                 _ => unreachable!(),
@@ -144,14 +144,14 @@ fn test_uint64_xor() {
         assert!(r.value == Some(expected));
 
         for b in r.bits.iter() {
-            match b {
-                &Boolean::Is(ref b) => {
+            match *b {
+                Boolean::Is(ref b) => {
                     assert!(b.get_value().unwrap() == (expected & 1 == 1));
                 }
-                &Boolean::Not(ref b) => {
-                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                Boolean::Not(ref b) => {
+                    assert!(b.get_value().unwrap() != (expected & 1 == 1));
                 }
-                &Boolean::Constant(b) => {
+                Boolean::Constant(b) => {
                     assert!(b == (expected & 1 == 1));
                 }
             }
@@ -187,6 +187,7 @@ fn test_uint64_addmany_constants() {
 }
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_uint64_addmany() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 

--- a/models/src/gadgets/utilities/uint/tests/uint8.rs
+++ b/models/src/gadgets/utilities/uint/tests/uint8.rs
@@ -31,10 +31,10 @@ use rand_xorshift::XorShiftRng;
 
 fn check_all_constant_bits(mut expected: u8, actual: UInt8) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 assert!(b == (expected & 1 == 1));
             }
         }
@@ -45,14 +45,14 @@ fn check_all_constant_bits(mut expected: u8, actual: UInt8) {
 
 fn check_all_allocated_bits(mut expected: u8, actual: UInt8) {
     for b in actual.bits.iter() {
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 assert!(b.get_value().unwrap() == (expected & 1 == 1));
             }
-            &Boolean::Not(ref b) => {
-                assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+            Boolean::Not(ref b) => {
+                assert!(b.get_value().unwrap() != (expected & 1 == 1));
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
 
         expected >>= 1;
@@ -73,7 +73,7 @@ fn test_uint8_from_bits_to_bits() {
 #[test]
 fn test_uint8_alloc_input_vec() {
     let mut cs = TestConstraintSystem::<Fr>::new();
-    let byte_vals = (64u8..128u8).into_iter().collect::<Vec<_>>();
+    let byte_vals = (64u8..128u8).collect::<Vec<_>>();
     let bytes = UInt8::alloc_input_vec(cs.ns(|| "alloc value"), &byte_vals).unwrap();
     for (native_byte, gadget_byte) in byte_vals.into_iter().zip(bytes) {
         let bits = gadget_byte.to_bits_le();
@@ -93,8 +93,8 @@ fn test_uint8_from_bits() {
         let b = UInt8::from_bits_le(&v);
 
         for (i, bit_gadget) in b.bits.iter().enumerate() {
-            match bit_gadget {
-                &Boolean::Constant(bit_gadget) => {
+            match *bit_gadget {
+                Boolean::Constant(bit_gadget) => {
                     assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
                 }
                 _ => unreachable!(),
@@ -128,8 +128,8 @@ fn test_uint8_rotr() {
 
         let mut tmp = num;
         for b in &b.bits {
-            match b {
-                &Boolean::Constant(b) => {
+            match *b {
+                Boolean::Constant(b) => {
                     assert_eq!(b, tmp & 1 == 1);
                 }
                 _ => unreachable!(),
@@ -167,14 +167,14 @@ fn test_uint8_xor() {
         assert!(r.value == Some(expected));
 
         for b in r.bits.iter() {
-            match b {
-                &Boolean::Is(ref b) => {
+            match *b {
+                Boolean::Is(ref b) => {
                     assert!(b.get_value().unwrap() == (expected & 1 == 1));
                 }
-                &Boolean::Not(ref b) => {
-                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                Boolean::Not(ref b) => {
+                    assert!(b.get_value().unwrap() != (expected & 1 == 1));
                 }
-                &Boolean::Constant(b) => {
+                Boolean::Constant(b) => {
                     assert!(b == (expected & 1 == 1));
                 }
             }
@@ -210,6 +210,7 @@ fn test_uint8_addmany_constants() {
 }
 
 #[test]
+#[allow(clippy::many_single_char_names)]
 fn test_uint8_addmany() {
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
 

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -625,7 +625,7 @@ impl UInt for UInt128 {
 
 impl PartialEq for UInt128 {
     fn eq(&self, other: &Self) -> bool {
-        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+        self.value.is_some() && other.value.is_some() && self.value == other.value
     }
 }
 

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -389,7 +389,7 @@ impl UInt for UInt128 {
             (_, _) => {
                 // If either of our operands have unknown value, we won't
                 // know the value of the result
-                return Err(SynthesisError::AssignmentMissing);
+                Err(SynthesisError::AssignmentMissing)
             }
         }
     }

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -241,7 +241,7 @@ impl UInt for UInt128 {
                             lc = lc - (coeff, bit.get_variable());
                         } else {
                             // Add coeff * bit_gadget
-                            lc = lc + (coeff, bit.get_variable());
+                            lc += (coeff, bit.get_variable());
                         }
                     }
                     Boolean::Not(ref bit) => {
@@ -260,7 +260,7 @@ impl UInt for UInt128 {
                             if op.negated {
                                 lc = lc - (coeff, CS::one());
                             } else {
-                                lc = lc + (coeff, CS::one());
+                                lc += (coeff, CS::one());
                             }
                         }
                     }

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -821,7 +821,7 @@ impl<F: Field> ToBytesGadget<F> for UInt128 {
             None => [None, None, None, None],
         };
         let mut bytes = Vec::new();
-        for (i, chunk8) in self.to_bits_le().chunks(8).into_iter().enumerate() {
+        for (i, chunk8) in self.to_bits_le().chunks(8).enumerate() {
             let byte = UInt8 {
                 bits: chunk8.to_vec(),
                 negated: false,

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -443,7 +443,7 @@ impl UInt for UInt128 {
             })
             .collect::<Vec<Self>>();
 
-        Self::addmany(&mut cs.ns(|| format!("partial_products")), &partial_products)
+        Self::addmany(&mut cs.ns(|| "partial_products"), &partial_products)
     }
 
     /// Perform long division of two `UInt128` objects.

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -281,11 +281,13 @@ impl UInt for UInt128 {
         // The value of the actual result is modulo 2^128
         let modular_value = big_result_value.map(|v| v.to_u128());
 
-        if all_constants && modular_value.is_some() {
-            // We can just return a constant, rather than
-            // unpacking the result into allocated bits.
+        if all_constants {
+            if let Some(val) = modular_value {
+                // We can just return a constant, rather than
+                // unpacking the result into allocated bits.
 
-            return Ok(Self::constant(modular_value.unwrap()));
+                return Ok(Self::constant(val));
+            }
         }
 
         // Storage area for the resulting bits
@@ -503,7 +505,7 @@ impl UInt for UInt128 {
 
         let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0u128)));
         let mut quotient = zero.clone();
-        let mut remainder = zero.clone();
+        let mut remainder = zero;
 
         for (i, bit) in self.bits.iter().rev().enumerate() {
             // Left shift remainder by 1

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -110,24 +110,32 @@ impl UInt for UInt128 {
 
         let mut value = Some(0u128);
         for b in bits.iter().rev() {
-            value.as_mut().map(|v| *v <<= 1);
+            if let Some(v) = value.as_mut() {
+                *v <<= 1;
+            }
 
             match b {
                 &Boolean::Constant(b) => {
                     if b {
-                        value.as_mut().map(|v| *v |= 1);
+                        if let Some(v) = value.as_mut() {
+                            *v |= 1;
+                        }
                     }
                 }
                 &Boolean::Is(ref b) => match b.get_value() {
                     Some(true) => {
-                        value.as_mut().map(|v| *v |= 1);
+                        if let Some(v) = value.as_mut() {
+                            *v |= 1;
+                        }
                     }
                     Some(false) => {}
                     None => value = None,
                 },
                 &Boolean::Not(ref b) => match b.get_value() {
                     Some(false) => {
-                        value.as_mut().map(|v| *v |= 1);
+                        if let Some(v) = value.as_mut() {
+                            *v |= 1;
+                        }
                     }
                     Some(true) => {}
                     None => value = None,

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -114,15 +114,15 @@ impl UInt for UInt128 {
                 *v <<= 1;
             }
 
-            match b {
-                &Boolean::Constant(b) => {
+            match *b {
+                Boolean::Constant(b) => {
                     if b {
                         if let Some(v) = value.as_mut() {
                             *v |= 1;
                         }
                     }
                 }
-                &Boolean::Is(ref b) => match b.get_value() {
+                Boolean::Is(ref b) => match b.get_value() {
                     Some(true) => {
                         if let Some(v) = value.as_mut() {
                             *v |= 1;
@@ -131,7 +131,7 @@ impl UInt for UInt128 {
                     Some(false) => {}
                     None => value = None,
                 },
-                &Boolean::Not(ref b) => match b.get_value() {
+                Boolean::Not(ref b) => match b.get_value() {
                     Some(false) => {
                         if let Some(v) = value.as_mut() {
                             *v |= 1;

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -76,7 +76,7 @@ impl UInt for UInt128 {
         Self {
             bits: self.bits.clone(),
             negated: true,
-            value: self.value.clone(),
+            value: self.value,
         }
     }
 
@@ -546,7 +546,7 @@ impl UInt for UInt128 {
             let index = 127 - i as usize;
             let bit_value = 1u128 << (index as u128);
             let mut new_quotient = quotient.clone();
-            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.bits[index] = true_bit;
             new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
 
             quotient = Self::conditionally_select(

--- a/models/src/gadgets/utilities/uint/unsigned_integer.rs
+++ b/models/src/gadgets/utilities/uint/unsigned_integer.rs
@@ -114,7 +114,7 @@ impl UInt8 {
         T: Into<Option<u8>> + Copy,
     {
         let mut output_vec = Vec::with_capacity(values.len());
-        for (i, value) in values.into_iter().enumerate() {
+        for (i, value) in values.iter().enumerate() {
             let byte: Option<u8> = Into::into(*value);
             let alloc_byte = Self::alloc(&mut cs.ns(|| format!("byte_{}", i)), || byte.get())?;
             output_vec.push(alloc_byte);

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate derivative;
 

--- a/models/src/objects/ledger.rs
+++ b/models/src/objects/ledger.rs
@@ -19,6 +19,7 @@ use snarkos_errors::dpc::LedgerError;
 
 use std::path::PathBuf;
 
+#[allow(clippy::len_without_is_empty)]
 pub trait LedgerScheme: Sized {
     type Block: BlockScheme;
     type Commitment;

--- a/network/src/external/channel.rs
+++ b/network/src/external/channel.rs
@@ -67,7 +67,7 @@ impl Channel {
         Ok(Self {
             address,
             reader: stream.clone(),
-            writer: stream.clone(),
+            writer: stream,
         })
     }
 

--- a/network/src/external/message/read.rs
+++ b/network/src/external/message/read.rs
@@ -40,7 +40,7 @@ pub async fn read_header<T: AsyncRead + Unpin>(mut stream: &mut T) -> Result<Mes
 /// Reads bytes from an input stream to fill the buffer.
 async fn stream_read<'a, T: AsyncRead + Unpin>(stream: &'a mut T, buffer: &'a mut [u8]) -> Result<(), StreamReadError> {
     stream.read_exact(buffer).await?;
-    return Ok(());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/network/src/external/message_types/getmemorypool.rs
+++ b/network/src/external/message_types/getmemorypool.rs
@@ -27,7 +27,7 @@ impl Message for GetMemoryPool {
     }
 
     fn deserialize(vec: Vec<u8>) -> Result<Self, MessageError> {
-        if vec.len() != 0 {
+        if !vec.is_empty() {
             return Err(MessageError::InvalidLength(vec.len(), 0));
         }
 

--- a/network/src/external/message_types/getpeers.rs
+++ b/network/src/external/message_types/getpeers.rs
@@ -27,7 +27,7 @@ impl Message for GetPeers {
     }
 
     fn deserialize(vec: Vec<u8>) -> Result<Self, MessageError> {
-        if vec.len() != 0 {
+        if !vec.is_empty() {
             return Err(MessageError::InvalidLength(vec.len(), 0));
         }
 

--- a/network/src/external/message_types/ping.rs
+++ b/network/src/external/message_types/ping.rs
@@ -28,12 +28,18 @@ pub struct Ping {
     pub nonce: u64,
 }
 
-impl Ping {
-    pub fn new() -> Self {
+impl Default for Ping {
+    fn default() -> Self {
         let mut rng = rand::thread_rng();
         Self {
             nonce: rng.gen::<u64>(),
         }
+    }
+}
+
+impl Ping {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/network/src/external/propagate.rs
+++ b/network/src/external/propagate.rs
@@ -19,7 +19,7 @@ pub async fn propagate_transaction(
     let connections = context.connections.read().await;
     let mut num_peers = 0;
 
-    for (socket, _) in &peer_book.get_connected() {
+    for socket in peer_book.get_connected().keys() {
         if *socket != transaction_sender && *socket != local_address {
             if let Some(channel) = connections.get(socket) {
                 match channel.write(&Transaction::new(transaction_bytes.clone())).await {
@@ -51,7 +51,7 @@ pub async fn propagate_block(
     let connections = context.connections.read().await;
     let mut num_peers = 0;
 
-    for (socket, _) in &peer_book.get_connected() {
+    for socket in peer_book.get_connected().keys() {
         if *socket != block_miner && *socket != local_address {
             if let Some(channel) = connections.get(socket) {
                 match channel.write(&Block::new(block_bytes.clone())).await {

--- a/network/src/external/protocol/handshake/handshakes.rs
+++ b/network/src/external/protocol/handshake/handshakes.rs
@@ -27,7 +27,7 @@ use std::{collections::HashMap, net::SocketAddr};
 use tokio::net::TcpStream;
 
 /// Stores the address and latest state of peers we are handshaking with.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Handshakes {
     handshakes: HashMap<SocketAddr, Handshake>,
 }
@@ -35,9 +35,7 @@ pub struct Handshakes {
 impl Handshakes {
     /// Construct a new store of connected peer `Handshakes`.
     pub fn new() -> Self {
-        Self {
-            handshakes: HashMap::default(),
-        }
+        Self::default()
     }
 
     /// Create a new handshake with a peer and send a handshake request to them.

--- a/network/src/external/protocol/handshake/handshakes.rs
+++ b/network/src/external/protocol/handshake/handshakes.rs
@@ -43,7 +43,7 @@ impl Handshakes {
     pub async fn send_request(&mut self, version: &Version) -> Result<(), HandshakeError> {
         let handshake = Handshake::send_new(version).await?;
 
-        self.handshakes.insert(version.address_receiver.clone(), handshake);
+        self.handshakes.insert(version.address_receiver, handshake);
         info!("Request handshake with: {:?}", version.address_receiver);
 
         Ok(())

--- a/network/src/external/protocol/ping/pings.rs
+++ b/network/src/external/protocol/ping/pings.rs
@@ -25,7 +25,7 @@ use snarkos_errors::network::PingProtocolError;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 /// Stores connected peers and the latest state of a ping/pong protocol.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Pings {
     addresses: HashMap<SocketAddr, PingProtocol>,
 }
@@ -33,9 +33,7 @@ pub struct Pings {
 impl Pings {
     /// Construct new store of connected peer `Pings`.
     pub fn new() -> Self {
-        Self {
-            addresses: HashMap::default(),
-        }
+        Self::default()
     }
 
     /// Send a ping request to a peer.

--- a/network/src/external/protocol/sync/sync.rs
+++ b/network/src/external/protocol/sync/sync.rs
@@ -75,8 +75,8 @@ impl SyncHandler {
 
     /// Remove the blocks that are now included in the chain.
     pub fn clear_pending<T: Transaction, P: LoadableMerkleParameters>(&mut self, storage: Arc<Ledger<T, P>>) {
-        for (block_hash, _time_sent) in &self.pending_blocks.clone() {
-            if !storage.block_hash_exists(&block_hash) {
+        for block_hash in self.pending_blocks.clone().keys() {
+            if !storage.block_hash_exists(block_hash) {
                 self.pending_blocks.remove(block_hash);
             }
         }

--- a/network/src/external/protocol/sync/sync.rs
+++ b/network/src/external/protocol/sync/sync.rs
@@ -70,7 +70,7 @@ impl SyncHandler {
 
     /// Returns if the time of the block request, or None if the block was not requested.
     pub fn is_pending(&self, block_header_hash: &BlockHeaderHash) -> Option<DateTime<Utc>> {
-        self.pending_blocks.get(block_header_hash).map(|time| time.clone())
+        self.pending_blocks.get(block_header_hash).copied()
     }
 
     /// Remove the blocks that are now included in the chain.
@@ -98,7 +98,7 @@ impl SyncHandler {
     /// Process a vector of block header hashes.
     /// Push new hashes to the sync handler so we can ask the sync node for them.
     pub fn receive_hashes(&mut self, hashes: Vec<BlockHeaderHash>, height: u32) {
-        if hashes.len() > 0 {
+        if !hashes.is_empty() {
             for block_hash in hashes {
                 if !self.block_headers.contains(&block_hash) && self.pending_blocks.get(&block_hash).is_none() {
                     self.block_headers.push(block_hash.clone());
@@ -139,7 +139,7 @@ impl SyncHandler {
                 let should_request = match self.pending_blocks.get(&block_header_hash) {
                     Some(request_time) => {
                         // Request the block again if the block was not downloaded in 5 seconds
-                        Utc::now() - request_time.clone() > ChronoDuration::seconds(5)
+                        Utc::now() - *request_time > ChronoDuration::seconds(5)
                     }
                     None => !storage.block_hash_exists(&block_header_hash),
                 };
@@ -160,7 +160,7 @@ impl SyncHandler {
                 }
             } else {
                 for (block_header_hash, request_time) in &self.pending_blocks.clone() {
-                    if Utc::now() - request_time.clone() > ChronoDuration::seconds(5) {
+                    if Utc::now() - *request_time > ChronoDuration::seconds(5) {
                         channel.write(&GetBlock::new(block_header_hash.clone())).await?;
                         self.pending_blocks.insert(block_header_hash.clone(), Utc::now());
                     }

--- a/network/src/internal/context/address_book.rs
+++ b/network/src/internal/context/address_book.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use std::{collections::HashMap, net::SocketAddr};
 
 /// Stores the existence of a peer and the date they were last seen.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct AddressBook {
     addresses: HashMap<SocketAddr, DateTime<Utc>>,
 }
@@ -26,9 +26,7 @@ pub struct AddressBook {
 impl AddressBook {
     /// Construct a new `AddressBook`.
     pub fn new() -> Self {
-        Self {
-            addresses: HashMap::default(),
-        }
+        Self::default()
     }
 
     /// Insert or update a new date for an address. Returns true if the new date is stored.

--- a/network/src/internal/context/connections.rs
+++ b/network/src/internal/context/connections.rs
@@ -19,6 +19,7 @@ use crate::external::Channel;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 /// Stores connected peers and the channels for reading/writing messages to them.
+#[derive(Default)]
 pub struct Connections {
     channels: HashMap<SocketAddr, Arc<Channel>>,
 }
@@ -26,9 +27,7 @@ pub struct Connections {
 impl Connections {
     /// Construct new store of peer `Connections`.
     pub fn new() -> Self {
-        Connections {
-            channels: HashMap::<SocketAddr, Arc<Channel>>::new(),
-        }
+        Self::default()
     }
 
     /// Returns the channel stored at address if any.

--- a/network/src/internal/context/peer_book.rs
+++ b/network/src/internal/context/peer_book.rs
@@ -23,7 +23,7 @@ use chrono::{DateTime, Utc};
 use std::{collections::HashMap, net::SocketAddr};
 
 /// Stores connected, disconnected, and known peers.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct PeerBook {
     /// Connected peers
     connected: AddressBook,
@@ -37,11 +37,7 @@ pub struct PeerBook {
 
 impl PeerBook {
     pub fn new() -> Self {
-        Self {
-            connected: AddressBook::new(),
-            disconnected: AddressBook::new(),
-            gossiped: AddressBook::new(),
-        }
+        Self::default()
     }
 
     /// Returns copy of connected peers.

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -314,9 +314,9 @@ impl Server {
             if &*self.context.local_address.read().await == addr {
                 continue;
             } else if peer_book.connected_contains(addr) {
-                peer_book.update_connected(addr.clone(), time.clone());
+                peer_book.update_connected(*addr, *time);
             } else {
-                peer_book.update_gossiped(addr.clone(), time.clone());
+                peer_book.update_gossiped(*addr, *time);
             }
         }
 
@@ -491,7 +491,7 @@ impl Server {
                 // Update the sync node if the sync_handler is Idle and there are no requested block headers
                 if let Ok(mut sync_handler) = self.sync_handler_lock.try_lock() {
                     if !sync_handler.is_syncing()
-                        && (sync_handler.block_headers.len() == 0 && sync_handler.pending_blocks.is_empty())
+                        && (sync_handler.block_headers.is_empty() && sync_handler.pending_blocks.is_empty())
                     {
                         debug!("Attempting to sync with peer {}", peer_address);
                         sync_handler.sync_node = peer_address;

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -258,7 +258,7 @@ impl Server {
 
         let mut transactions = vec![];
 
-        for (_tx_id, entry) in &memory_pool.transactions {
+        for entry in memory_pool.transactions.values() {
             if let Ok(transaction_bytes) = to_bytes![entry.transaction] {
                 transactions.push(transaction_bytes);
             }

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -499,10 +499,8 @@ impl Server {
                         if let Ok(block_locator_hashes) = self.storage.get_block_locator_hashes() {
                             channel.write(&GetSync::new(block_locator_hashes)).await?;
                         }
-                    } else {
-                        if let Some(channel) = self.context.connections.read().await.get(&sync_handler.sync_node) {
-                            sync_handler.increment(channel, Arc::clone(&self.storage)).await?;
-                        }
+                    } else if let Some(channel) = self.context.connections.read().await.get(&sync_handler.sync_node) {
+                        sync_handler.increment(channel, Arc::clone(&self.storage)).await?;
                     }
                 }
             }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 // Compilation
+#![allow(clippy::module_inception)]
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Documentation

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -307,7 +307,6 @@ impl Server {
             let mut handshakes = context.handshakes.write().await;
             handshakes.send_request(&version).await.unwrap_or_else(|error| {
                 info!("Failed to connect to {:?}", error);
-                ()
             });
         });
     }

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -38,6 +38,7 @@ use tokio::{
 };
 
 /// The main networking component of a node.
+#[allow(clippy::type_complexity)]
 pub struct Server {
     pub consensus: ConsensusParameters,
     pub context: Arc<Context>,
@@ -204,6 +205,7 @@ impl Server {
     /// Each thread is given a handle to the channel and a handle to the server mpsc sender.
     /// To ensure concurrency, each connection thread sends a tokio oneshot sender handle with every message to the server mpsc receiver.
     /// The thread then waits for the oneshot receiver to receive a signal from the server before reading again.
+    #[allow(clippy::type_complexity)]
     fn spawn_connection_thread(
         mut channel: Arc<Channel>,
         mut message_handler_sender: mpsc::Sender<(oneshot::Sender<Arc<Channel>>, MessageName, Vec<u8>, Arc<Channel>)>,

--- a/network/tests/server_connection_handler.rs
+++ b/network/tests/server_connection_handler.rs
@@ -319,11 +319,9 @@ mod server_connection_handler {
 
             // 2. Add sync handler to connections
 
-            context
-                .connections
-                .write()
-                .await
-                .store_channel(&Arc::new(Channel::new_write_only(bootnode_address).await.unwrap()));
+            let bootnode_channel = Arc::new(Channel::new_write_only(bootnode_address).await.unwrap());
+
+            context.connections.write().await.store_channel(&bootnode_channel);
 
             let channel_sync_side = accept_channel(&mut sync_node_listener, local_address).await;
 

--- a/network/tests/server_message_handler.rs
+++ b/network/tests/server_message_handler.rs
@@ -321,11 +321,10 @@ mod server_message_handler {
             );
             let mut server_sender = server.sender.clone();
             let context = server.context.clone();
-            context
-                .connections
-                .write()
-                .await
-                .store_channel(&Arc::new(Channel::new_write_only(bootnode_address).await.unwrap()));
+
+            let bootnode_channel = Arc::new(Channel::new_write_only(bootnode_address).await.unwrap());
+
+            context.connections.write().await.store_channel(&bootnode_channel);
 
             let block_hash = BlockHeaderHash::new(BLOCK_1_HEADER_HASH.to_vec());
             let block_hash_clone = block_hash.clone();

--- a/objects/src/account/account_address.rs
+++ b/objects/src/account/account_address.rs
@@ -65,6 +65,7 @@ impl<C: DPCComponents> AccountAddress<C> {
         Ok(Self { encryption_key })
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_repr(&self) -> &<C::AccountEncryption as EncryptionScheme>::PublicKey {
         &self.encryption_key
     }
@@ -96,7 +97,7 @@ impl<C: DPCComponents> FromStr for AccountAddress<C> {
         }
 
         let prefix = &address.to_lowercase()[0..4];
-        if prefix != account_format::ADDRESS_PREFIX.to_string() {
+        if prefix != account_format::ADDRESS_PREFIX {
             return Err(AccountError::InvalidPrefix(prefix.to_string()));
         };
 

--- a/objects/src/account/account_private_key.rs
+++ b/objects/src/account/account_private_key.rs
@@ -248,7 +248,7 @@ impl<C: DPCComponents> FromStr for AccountPrivateKey<C> {
             return Err(AccountError::InvalidByteLength(data.len()));
         }
 
-        if &data[0..9] != account_format::PRIVATE_KEY_PREFIX {
+        if data[0..9] != account_format::PRIVATE_KEY_PREFIX {
             return Err(AccountError::InvalidPrefixBytes(data[0..9].to_vec()));
         }
 

--- a/objects/src/account/account_view_key.rs
+++ b/objects/src/account/account_view_key.rs
@@ -82,7 +82,7 @@ impl<C: DPCComponents> FromStr for AccountViewKey<C> {
             return Err(AccountError::InvalidByteLength(data.len()));
         }
 
-        if &data[0..7] != account_format::VIEW_KEY_PREFIX {
+        if data[0..7] != account_format::VIEW_KEY_PREFIX {
             return Err(AccountError::InvalidPrefixBytes(data[0..7].to_vec()));
         }
 

--- a/objects/src/account/mod.rs
+++ b/objects/src/account/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod account;
 pub use account::*;
 

--- a/objects/src/amount.rs
+++ b/objects/src/amount.rs
@@ -86,11 +86,13 @@ impl AleoAmount {
     }
 
     /// Add the values of two `AleoAmount`s
+    #[allow(clippy::should_implement_trait)]
     pub fn add(self, b: Self) -> Self {
         Self::from_bytes(self.0 + b.0)
     }
 
     /// Subtract the value of two `AleoAmounts`
+    #[allow(clippy::should_implement_trait)]
     pub fn sub(self, b: AleoAmount) -> Self {
         Self::from_bytes(self.0 - b.0)
     }

--- a/objects/src/block.rs
+++ b/objects/src/block.rs
@@ -80,7 +80,7 @@ impl<T: Transaction> Block<T> {
         Ok(serialization)
     }
 
-    pub fn deserialize(bytes: &Vec<u8>) -> Result<Self, BlockError> {
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, BlockError> {
         const HEADER_SIZE: usize = BlockHeader::size();
         let (header_bytes, transactions_bytes) = bytes.split_at(HEADER_SIZE);
 

--- a/objects/src/block_header_hash.rs
+++ b/objects/src/block_header_hash.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use hex;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 

--- a/objects/src/merkle_root_hash.rs
+++ b/objects/src/merkle_root_hash.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use hex;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 

--- a/objects/src/merkle_tree.rs
+++ b/objects/src/merkle_tree.rs
@@ -51,7 +51,7 @@ fn merkle_root_with_subroots_inner(
     if hashes.len() == 1 {
         // Tree was too shallow.
         let root = hashes[0].clone();
-        let subroots = if subroots.len() == 0 {
+        let subroots = if subroots.is_empty() {
             vec![root.clone()]
         } else {
             subroots.to_vec()
@@ -79,7 +79,7 @@ pub fn merkle_root(hashes: &[Vec<u8>]) -> Vec<u8> {
 }
 
 /// Calculate the Merkle tree hash by concatenating the left and right children nodes.
-pub fn merkle_hash(left: &Vec<u8>, right: &Vec<u8>) -> Vec<u8> {
+pub fn merkle_hash(left: &[u8], right: &[u8]) -> Vec<u8> {
     let mut result = [0u8; 64];
     result[0..32].copy_from_slice(&left);
     result[32..64].copy_from_slice(&right);

--- a/objects/src/posw.rs
+++ b/objects/src/posw.rs
@@ -16,7 +16,6 @@
 
 use snarkos_utilities::bytes::{FromBytes, ToBytes};
 
-use hex;
 use serde::{
     de::{Error as DeserializeError, SeqAccess, Visitor},
     ser::SerializeTuple,

--- a/objects/src/posw.rs
+++ b/objects/src/posw.rs
@@ -68,7 +68,7 @@ impl Debug for ProofOfSuccinctWork {
 
 impl PartialEq for ProofOfSuccinctWork {
     fn eq(&self, other: &ProofOfSuccinctWork) -> bool {
-        &self.0[..] == &other.0[..]
+        self.0[..] == other.0[..]
     }
 }
 

--- a/parameters/examples/create_genesis_block.rs
+++ b/parameters/examples/create_genesis_block.rs
@@ -55,7 +55,7 @@ pub fn generate<C: BaseDPCComponents>() -> Result<Vec<u8>, TransactionError> {
     Ok(genesis_header.serialize().to_vec())
 }
 
-pub fn store(path: &PathBuf, bytes: &Vec<u8>) -> IoResult<()> {
+pub fn store(path: &PathBuf, bytes: &[u8]) -> IoResult<()> {
     let mut file = File::create(path)?;
     file.write_all(&bytes)?;
     drop(file);

--- a/parameters/examples/encrypted_record_crh.rs
+++ b/parameters/examples/encrypted_record_crh.rs
@@ -20,7 +20,6 @@ use snarkos_errors::algorithms::CRHError;
 use snarkos_models::{algorithms::CRH, dpc::DPCComponents};
 use snarkos_utilities::{bytes::ToBytes, to_bytes};
 
-use hex;
 use rand::thread_rng;
 use std::{
     fs::{self, File},
@@ -39,7 +38,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     Ok(encrypted_record_crh_parameters_bytes)
 }
 
-pub fn store(file_path: &PathBuf, checksum_path: &PathBuf, bytes: &Vec<u8>) -> IoResult<()> {
+pub fn store(file_path: &PathBuf, checksum_path: &PathBuf, bytes: &[u8]) -> IoResult<()> {
     // Save checksum to file
     fs::write(checksum_path, hex::encode(sha256(bytes)))?;
 

--- a/parameters/examples/generate_transaction.rs
+++ b/parameters/examples/generate_transaction.rs
@@ -33,7 +33,6 @@ use snarkos_utilities::{
     to_bytes,
 };
 
-use hex;
 use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
 use std::{
@@ -68,7 +67,7 @@ fn empty_ledger<T: Transaction, P: LoadableMerkleParameters>(
     })
 }
 
-pub fn generate(recipient: &String, value: u64, network_id: u8, file_name: &String) -> Result<Vec<u8>, DPCError> {
+pub fn generate(recipient: &str, value: u64, network_id: u8, file_name: &str) -> Result<Vec<u8>, DPCError> {
     let rng = &mut thread_rng();
 
     let consensus = ConsensusParameters {
@@ -128,10 +127,10 @@ pub fn generate(recipient: &String, value: u64, network_id: u8, file_name: &Stri
 
     // Construct new records
 
-    let new_record_owners = vec![recipient.clone(); Components::NUM_OUTPUT_RECORDS];
+    let new_record_owners = vec![recipient; Components::NUM_OUTPUT_RECORDS];
     let new_payloads = vec![RecordPayload::default(); Components::NUM_OUTPUT_RECORDS];
     let new_birth_program_ids = vec![noop_program_id.clone(); Components::NUM_OUTPUT_RECORDS];
-    let new_death_program_ids = vec![noop_program_id.clone(); Components::NUM_OUTPUT_RECORDS];
+    let new_death_program_ids = vec![noop_program_id; Components::NUM_OUTPUT_RECORDS];
 
     let mut new_is_dummy_flags = vec![false];
     new_is_dummy_flags.extend(vec![true; Components::NUM_OUTPUT_RECORDS - 1]);
@@ -184,7 +183,7 @@ pub fn generate(recipient: &String, value: u64, network_id: u8, file_name: &Stri
     Ok(transaction_bytes)
 }
 
-pub fn store(path: &PathBuf, bytes: &Vec<u8>) -> IoResult<()> {
+pub fn store(path: &PathBuf, bytes: &[u8]) -> IoResult<()> {
     let mut file = File::create(path)?;
     file.write_all(&bytes)?;
     drop(file);
@@ -195,11 +194,7 @@ pub fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 5 {
-        println!(
-            "Invalid number of arguments.  Given: {} - Required: {}",
-            args.len() - 1,
-            4
-        );
+        println!("Invalid number of arguments.  Given: {} - Required: 4", args.len() - 1);
         return;
     }
 

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -63,7 +63,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 fn versioned_filename(checksum: &str) -> String {
     match checksum.get(0..7) {
         Some(sum) => format!("inner_snark_pk-{}.params", sum),
-        _ => format!("inner_snark_pk.params"),
+        _ => "inner_snark_pk.params".to_string(),
     }
 }
 

--- a/parameters/examples/local_data_crh.rs
+++ b/parameters/examples/local_data_crh.rs
@@ -20,7 +20,6 @@ use snarkos_errors::algorithms::CRHError;
 use snarkos_models::{algorithms::CRH, dpc::DPCComponents};
 use snarkos_utilities::{bytes::ToBytes, to_bytes};
 
-use hex;
 use rand::thread_rng;
 use std::{
     fs::{self, File},
@@ -39,7 +38,7 @@ pub fn setup<C: DPCComponents>() -> Result<Vec<u8>, CRHError> {
     Ok(local_data_crh_parameters_bytes)
 }
 
-pub fn store(file_path: &PathBuf, checksum_path: &PathBuf, bytes: &Vec<u8>) -> IoResult<()> {
+pub fn store(file_path: &PathBuf, checksum_path: &PathBuf, bytes: &[u8]) -> IoResult<()> {
     // Save checksum to file
     fs::write(checksum_path, hex::encode(sha256(bytes)))?;
 

--- a/parameters/examples/noop_program_snark.rs
+++ b/parameters/examples/noop_program_snark.rs
@@ -32,7 +32,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     let noop_program_snark_parameters = DPC::<C>::generate_noop_program_snark_parameters(&system_parameters, rng)?;
     let noop_program_snark_pk = to_bytes![noop_program_snark_parameters.proving_key]?;
     let noop_program_snark_vk: <C::NoopProgramSNARK as SNARK>::VerificationParameters =
-        noop_program_snark_parameters.verification_key.into();
+        noop_program_snark_parameters.verification_key;
     let noop_program_snark_vk = to_bytes![noop_program_snark_vk]?;
 
     println!("noop_program_snark_pk.params\n\tsize - {}", noop_program_snark_pk.len());

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -34,7 +34,6 @@ use snarkos_utilities::{
     to_bytes,
 };
 
-use hex;
 use rand::thread_rng;
 use std::path::PathBuf;
 
@@ -49,13 +48,11 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
         From::from(FromBytes::read(&LedgerMerkleTreeParameters::load_bytes()?[..])?);
     let ledger_merkle_tree_parameters = From::from(merkle_tree_hash_parameters);
 
-    let inner_snark_pk: <C::InnerSNARK as SNARK>::ProvingParameters = From::from(
-        <C::InnerSNARK as SNARK>::ProvingParameters::read(InnerSNARKPKParameters::load_bytes()?.as_slice())?,
-    );
+    let inner_snark_pk: <C::InnerSNARK as SNARK>::ProvingParameters =
+        <C::InnerSNARK as SNARK>::ProvingParameters::read(InnerSNARKPKParameters::load_bytes()?.as_slice())?;
 
-    let inner_snark_vk: <C::InnerSNARK as SNARK>::VerificationParameters = From::from(
-        <C::InnerSNARK as SNARK>::VerificationParameters::read(InnerSNARKVKParameters::load_bytes()?.as_slice())?,
-    );
+    let inner_snark_vk: <C::InnerSNARK as SNARK>::VerificationParameters =
+        <C::InnerSNARK as SNARK>::VerificationParameters::read(InnerSNARKVKParameters::load_bytes()?.as_slice())?;
 
     let inner_snark_proof = C::InnerSNARK::prove(
         &inner_snark_pk,
@@ -99,7 +96,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 fn versioned_filename(checksum: &str) -> String {
     match checksum.get(0..7) {
         Some(sum) => format!("outer_snark_pk-{}.params", sum),
-        _ => format!("outer_snark_pk.params"),
+        _ => "outer_snark_pk.params".to_string(),
     }
 }
 

--- a/parameters/examples/posw_snark.rs
+++ b/parameters/examples/posw_snark.rs
@@ -18,8 +18,7 @@ use snarkos_algorithms::crh::sha256;
 use snarkos_curves::bls12_377::Bls12_377;
 use snarkos_errors::dpc::DPCError;
 use snarkos_marlin::snark;
-use snarkos_models::algorithms::SNARK;
-use snarkos_posw::{Marlin, PoswMarlin};
+use snarkos_posw::PoswMarlin;
 use snarkos_utilities::{bytes::ToBytes, to_bytes};
 
 use rand::thread_rng;
@@ -28,6 +27,7 @@ use std::path::PathBuf;
 mod utils;
 use utils::store;
 
+#[allow(clippy::type_complexity)]
 pub fn setup() -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), DPCError> {
     let rng = &mut thread_rng();
 
@@ -36,7 +36,7 @@ pub fn setup() -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), DPCError> {
     let posw_snark = PoswMarlin::index(srs).expect("could not setup params");
 
     let posw_snark_pk = to_bytes![posw_snark.pk.expect("posw_snark_pk should be populated")]?;
-    let posw_snark_vk = <Marlin<Bls12_377> as SNARK>::VerificationParameters::from(posw_snark.vk);
+    let posw_snark_vk = posw_snark.vk;
     let posw_snark_vk = to_bytes![posw_snark_vk]?;
 
     println!("posw_snark_pk.params\n\tsize - {}", posw_snark_pk.len());
@@ -48,7 +48,7 @@ pub fn setup() -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), DPCError> {
 fn versioned_filename(checksum: &str) -> String {
     match checksum.get(0..7) {
         Some(sum) => format!("posw_snark_pk-{}.params", sum),
-        _ => format!("posw_snark_pk.params"),
+        _ => "posw_snark_pk.params".to_string(),
     }
 }
 

--- a/parameters/examples/utils/mod.rs
+++ b/parameters/examples/utils/mod.rs
@@ -16,14 +16,13 @@
 
 use snarkos_algorithms::crh::sha256::sha256;
 
-use hex;
 use std::{
     fs::{self, File},
     io::{BufWriter, Result as IoResult, Write},
     path::PathBuf,
 };
 
-pub fn store(file_path: &PathBuf, checksum_path: &PathBuf, bytes: &Vec<u8>) -> IoResult<()> {
+pub fn store(file_path: &PathBuf, checksum_path: &PathBuf, bytes: &[u8]) -> IoResult<()> {
     // Save checksum to file
     fs::write(checksum_path, hex::encode(sha256(bytes)))?;
 

--- a/parameters/src/lib.rs
+++ b/parameters/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod genesis;
 pub use genesis::*;
 

--- a/parameters/src/params.rs
+++ b/parameters/src/params.rs
@@ -150,7 +150,7 @@ macro_rules! impl_params_remote {
             }
 
             fn store_bytes(
-                buffer: &Vec<u8>,
+                buffer: &[u8],
                 relative_path: &PathBuf,
                 absolute_path: &PathBuf,
                 file_path: &PathBuf,

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -321,6 +321,7 @@ impl<F: Field> LinearCombination<F> {
 }
 
 impl<'a, F: Field> AddAssign<(F, &'a LinearCombination<F>)> for LinearCombination<F> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, (coeff, other): (F, &'a LinearCombination<F>)) {
         self.terms
             .extend(other.terms.iter().map(|(c, t)| (coeff * c, t.clone())));

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -199,6 +199,7 @@ impl<E: PairingEngine> KZG10<E> {
     /// The witness polynomial w(x) the quotient of the division (p(x) - p(z)) / (x - z)
     /// Observe that this quotient does not change with z because
     /// p(z) is the remainder term. We can therefore omit p(z) when computing the quotient.
+    #[allow(clippy::type_complexity)]
     pub fn compute_witness_polynomial(
         p: &Polynomial<E::Fr>,
         point: E::Fr,

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -225,7 +225,7 @@ impl<E: PairingEngine> KZG10<E> {
         Ok((witness_polynomial, random_witness_polynomial))
     }
 
-    pub(crate) fn open_with_witness_polynomial<'a>(
+    pub(crate) fn open_with_witness_polynomial(
         powers: &Powers<E>,
         point: E::Fr,
         randomness: &Randomness<E>,
@@ -261,7 +261,7 @@ impl<E: PairingEngine> KZG10<E> {
     }
 
     /// On input a polynomial `p` and a point `point`, outputs a proof for the same.
-    pub(crate) fn open<'a>(
+    pub(crate) fn open(
         powers: &Powers<E>,
         p: &Polynomial<E::Fr>,
         point: E::Fr,
@@ -332,7 +332,7 @@ impl<E: PairingEngine> KZG10<E> {
             let mut temp = w.mul(*z);
             temp.add_assign_mixed(&c.0);
             let c = temp;
-            g_multiplier += &(randomizer * &v);
+            g_multiplier += &(randomizer * v);
             if let Some(random_v) = proof.random_v {
                 gamma_g_multiplier += &(randomizer * &random_v);
             }
@@ -410,12 +410,12 @@ impl<E: PairingEngine> KZG10<E> {
             if enforced_degree_bounds.binary_search(&bound).is_err() {
                 Err(Error::UnsupportedDegreeBound(bound))
             } else if bound < p.degree() || bound > max_degree {
-                return Err(Error::IncorrectDegreeBound {
+                Err(Error::IncorrectDegreeBound {
                     poly_degree: p.degree(),
                     degree_bound: p.degree_bound().unwrap(),
                     supported_degree,
                     label: p.label().to_string(),
-                });
+                })
             } else {
                 Ok(())
             }

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -589,12 +589,12 @@ pub mod tests {
         } = info;
 
         let rng = &mut test_rng();
-        let max_degree = max_degree.unwrap_or(rand::distributions::Uniform::from(2..=64).sample(rng));
+        let max_degree = max_degree.unwrap_or_else(|| rand::distributions::Uniform::from(2..=64).sample(rng));
         let pp = PC::setup(max_degree, rng)?;
 
         for _ in 0..num_iters {
             let supported_degree =
-                supported_degree.unwrap_or(rand::distributions::Uniform::from(1..=max_degree).sample(rng));
+                supported_degree.unwrap_or_else(|| rand::distributions::Uniform::from(1..=max_degree).sample(rng));
             assert!(max_degree >= supported_degree, "max_degree < supported_degree");
             let mut polynomials = Vec::new();
             let mut degree_bounds = if enforce_degree_bounds { Some(Vec::new()) } else { None };
@@ -639,12 +639,7 @@ pub mod tests {
             println!("supported degree: {:?}", supported_degree);
             println!("supported hiding bound: {:?}", supported_hiding_bound);
             println!("num_points_in_query_set: {:?}", num_points_in_query_set);
-            let (ck, vk) = PC::trim(
-                &pp,
-                supported_degree,
-                supported_hiding_bound,
-                degree_bounds.as_ref().map(|s| s.as_slice()),
-            )?;
+            let (ck, vk) = PC::trim(&pp, supported_degree, supported_hiding_bound, degree_bounds.as_deref())?;
             println!("Trimmed");
 
             let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;
@@ -705,12 +700,12 @@ pub mod tests {
         } = info;
 
         let rng = &mut test_rng();
-        let max_degree = max_degree.unwrap_or(rand::distributions::Uniform::from(2..=64).sample(rng));
+        let max_degree = max_degree.unwrap_or_else(|| rand::distributions::Uniform::from(2..=64).sample(rng));
         let pp = PC::setup(max_degree, rng)?;
 
         for _ in 0..num_iters {
             let supported_degree =
-                supported_degree.unwrap_or(rand::distributions::Uniform::from(1..=max_degree).sample(rng));
+                supported_degree.unwrap_or_else(|| rand::distributions::Uniform::from(1..=max_degree).sample(rng));
             assert!(max_degree >= supported_degree, "max_degree < supported_degree");
             let mut polynomials = Vec::new();
             let mut degree_bounds = if enforce_degree_bounds { Some(Vec::new()) } else { None };
@@ -763,12 +758,7 @@ pub mod tests {
             println!("{}", num_polynomials);
             println!("{}", enforce_degree_bounds);
 
-            let (ck, vk) = PC::trim(
-                &pp,
-                supported_degree,
-                supported_hiding_bound,
-                degree_bounds.as_ref().map(|s| s.as_slice()),
-            )?;
+            let (ck, vk) = PC::trim(&pp, supported_degree, supported_hiding_bound, degree_bounds.as_deref())?;
             println!("Trimmed");
 
             let (comms, rands) = PC::commit(&ck, &polynomials, Some(rng))?;

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -244,7 +244,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
         let mut query_to_labels_map = BTreeMap::new();
 
         for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert(BTreeSet::new());
+            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
             labels.insert(label);
         }
 
@@ -315,7 +315,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
         for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert(BTreeSet::new());
+            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
             labels.insert(label);
         }
 
@@ -353,6 +353,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     /// On input a list of polynomials, linear combinations of those polynomials,
     /// and a query set, `open_combination` outputs a proof of evaluation of
     /// the combinations at the points in the query set.
+    #[allow(clippy::too_many_arguments)]
     fn open_combinations<'a>(
         ck: &Self::CommitterKey,
         linear_combinations: impl IntoIterator<Item = &'a LinearCombination<F>>,
@@ -388,6 +389,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
 
     /// Checks that `evaluations` are the true evaluations at `query_set` of the
     /// linear combinations of polynomials committed in `commitments`.
+    #[allow(clippy::too_many_arguments)]
     fn check_combinations<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         linear_combinations: impl IntoIterator<Item = &'a LinearCombination<F>>,
@@ -422,7 +424,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
                     let eval = match label {
                         LCTerm::One => F::one(),
                         LCTerm::PolyLabel(l) => *poly_evals
-                            .get(&(l.clone().into(), point))
+                            .get(&(l.clone(), point))
                             .ok_or(Error::MissingEvaluation { label: l.clone() })?,
                     };
 

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -190,6 +190,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     ///
     /// If for some `i`, `polynomials[i].degree_bound().is_some()`, then that
     /// polynomial will have the corresponding degree bound enforced.
+    #[allow(clippy::type_complexity)]
     fn commit<'a>(
         ck: &Self::CommitterKey,
         polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<'a, F>>,

--- a/polycommit/src/marlin_pc/data_structures.rs
+++ b/polycommit/src/marlin_pc/data_structures.rs
@@ -57,7 +57,7 @@ impl_bytes!(CommitterKey);
 
 impl<E: PairingEngine> CommitterKey<E> {
     /// Obtain powers for the underlying KZG10 construction
-    pub fn powers<'a>(&'a self) -> kzg10::Powers<'a, E> {
+    pub fn powers(&self) -> kzg10::Powers<'_, E> {
         kzg10::Powers {
             powers_of_g: self.powers.as_slice().into(),
             powers_of_gamma_g: self.powers_of_gamma_g.as_slice().into(),
@@ -65,7 +65,7 @@ impl<E: PairingEngine> CommitterKey<E> {
     }
 
     /// Obtain powers for committing to shifted polynomials.
-    pub fn shifted_powers<'a>(&'a self, degree_bound: impl Into<Option<usize>>) -> Option<kzg10::Powers<'a, E>> {
+    pub fn shifted_powers(&self, degree_bound: impl Into<Option<usize>>) -> Option<kzg10::Powers<'_, E>> {
         self.shifted_powers.as_ref().map(|shifted_powers| {
             let powers_range = if let Some(degree_bound) = degree_bound.into() {
                 assert!(self.enforced_degree_bounds.as_ref().unwrap().contains(&degree_bound));
@@ -198,7 +198,7 @@ impl<'a, E: PairingEngine> AddAssign<&'a Self> for Randomness<E> {
         if let Some(r1) = &mut self.shifted_rand {
             *r1 += other.shifted_rand.as_ref().unwrap_or(&kzg10::Randomness::empty());
         } else {
-            self.shifted_rand = other.shifted_rand.as_ref().map(|r| r.clone());
+            self.shifted_rand = other.shifted_rand.clone();
         }
     }
 }

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -101,7 +101,7 @@ impl<E: PairingEngine> MarlinKZG10<E> {
         (combined_comm, combined_shifted_comm)
     }
 
-    fn normalize_commitments<'a>(commitments: Vec<(E::G1Projective, Option<E::G1Projective>)>) -> Vec<Commitment<E>> {
+    fn normalize_commitments(commitments: Vec<(E::G1Projective, Option<E::G1Projective>)>) -> Vec<Commitment<E>> {
         let mut comms = Vec::with_capacity(commitments.len());
         let mut s_comms = Vec::with_capacity(commitments.len());
         let mut s_flags = Vec::with_capacity(commitments.len());
@@ -116,7 +116,7 @@ impl<E: PairingEngine> MarlinKZG10<E> {
             }
         }
         let comms = E::G1Projective::batch_normalization_into_affine(&comms);
-        let s_comms = E::G1Projective::batch_normalization_into_affine(&mut s_comms);
+        let s_comms = E::G1Projective::batch_normalization_into_affine(&s_comms);
         comms
             .into_iter()
             .zip(s_comms)
@@ -287,8 +287,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
             let hiding_bound = p.hiding_bound();
             let polynomial = p.polynomial();
 
-            let enforced_degree_bounds: Option<&[usize]> =
-                ck.enforced_degree_bounds.as_ref().map(|bounds| bounds.as_slice());
+            let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
             kzg10::KZG10::<E>::check_degrees_and_bounds(
                 ck.supported_degree(),
                 ck.max_degree,
@@ -350,8 +349,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         for (j, (polynomial, rand)) in labeled_polynomials.into_iter().zip(rands).enumerate() {
             let degree_bound = polynomial.degree_bound();
 
-            let enforced_degree_bounds: Option<&[usize]> =
-                ck.enforced_degree_bounds.as_ref().map(|bounds| bounds.as_slice());
+            let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
             kzg10::KZG10::<E>::check_degrees_and_bounds(
                 ck.supported_degree(),
                 ck.max_degree,
@@ -451,7 +449,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         let mut query_to_labels_map = BTreeMap::new();
 
         for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert(BTreeSet::new());
+            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
             labels.insert(label);
         }
         assert_eq!(proof.len(), query_to_labels_map.len());

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -269,6 +269,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
     }
 
     /// Outputs a commitment to `polynomial`.
+    #[allow(clippy::type_complexity)]
     fn commit<'a>(
         ck: &Self::CommitterKey,
         polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<'a, E::Fr>>,

--- a/polycommit/src/sonic_pc/data_structures.rs
+++ b/polycommit/src/sonic_pc/data_structures.rs
@@ -69,7 +69,7 @@ impl<E: PairingEngine> CommitterKey<E> {
                 };
 
                 let ck = kzg10::Powers {
-                    powers_of_g: shifted_powers_of_g[powers_range.clone()].into(),
+                    powers_of_g: shifted_powers_of_g[powers_range].into(),
                     powers_of_gamma_g: shifted_powers_of_gamma_g[&bound].clone().into(),
                 };
 

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -44,6 +44,7 @@ pub struct SonicKZG10<E: PairingEngine> {
 }
 
 impl<E: PairingEngine> SonicKZG10<E> {
+    #[allow(clippy::too_many_arguments)]
     fn accumulate_elems<'a>(
         combined_comms: &mut BTreeMap<Option<usize>, E::G1Projective>,
         combined_witness: &mut E::G1Projective,
@@ -77,7 +78,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
             }
 
             // Accumulate values in the BTreeMap
-            *combined_comms.entry(degree_bound).or_insert(E::G1Projective::zero()) += &comm_with_challenge;
+            *combined_comms.entry(degree_bound).or_insert_with(E::G1Projective::zero) += &comm_with_challenge;
             curr_challenge *= &opening_challenge;
         }
 
@@ -283,8 +284,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let mut randomness: Vec<Self::Randomness> = Vec::new();
 
         for labeled_polynomial in polynomials {
-            let enforced_degree_bounds: Option<&[usize]> =
-                ck.enforced_degree_bounds.as_ref().map(|bounds| bounds.as_slice());
+            let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
                 ck.supported_degree(),
@@ -341,8 +341,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let mut curr_challenge = opening_challenge;
 
         for (polynomial, rand) in labeled_polynomials.into_iter().zip(rands) {
-            let enforced_degree_bounds: Option<&[usize]> =
-                ck.enforced_degree_bounds.as_ref().map(|bounds| bounds.as_slice());
+            let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
                 ck.supported_degree(),
@@ -414,7 +413,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
         let mut query_to_labels_map = BTreeMap::new();
 
         for (label, point) in query_set.iter() {
-            let labels = query_to_labels_map.entry(point).or_insert(BTreeSet::new());
+            let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
             labels.insert(label);
         }
 
@@ -526,7 +525,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
 
         let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(&lc_commitments)
             .into_iter()
-            .map(|c| kzg10::Commitment::<E>(c))
+            .map(kzg10::Commitment::<E>)
             .collect();
 
         let lc_commitments = lc_info
@@ -607,7 +606,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
 
         let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(&lc_commitments)
             .into_iter()
-            .map(|c| kzg10::Commitment(c))
+            .map(kzg10::Commitment)
             .collect();
 
         let lc_commitments = lc_info

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -98,6 +98,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         end_timer!(acc_time);
     }
 
+    #[allow(clippy::type_complexity)]
     fn check_elems(
         combined_comms: BTreeMap<Option<usize>, E::G1Projective>,
         combined_witness: E::G1Projective,
@@ -270,6 +271,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
     }
 
     /// Outputs a commitment to `polynomial`.
+    #[allow(clippy::type_complexity)]
     fn commit<'a>(
         ck: &Self::CommitterKey,
         polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<'a, E::Fr>>,

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -197,7 +197,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
                     let shifted_powers_of_g = pp.powers_of_g[lowest_shift_degree..].to_vec();
                     let mut shifted_powers_of_gamma_g = BTreeMap::new();
                     // Also add degree 0.
-                    let max_gamma_g = pp.powers_of_gamma_g.keys().last().unwrap();
+                    let _max_gamma_g = pp.powers_of_gamma_g.keys().last().unwrap();
                     for degree_bound in enforced_degree_bounds {
                         let shift_degree = max_degree - degree_bound;
                         let mut powers_for_degree_bound = vec![];

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -58,7 +58,7 @@ impl<F: PrimeField, M: MaskedMerkleParameters, HG: MaskedCRHGadget<M::H, F>, CP:
 {
     fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         // Compute the mask if it exists.
-        let mask = self.mask.clone().unwrap_or(vec![0; CP::MASK_LENGTH]);
+        let mask = self.mask.clone().unwrap_or_else(|| vec![0; CP::MASK_LENGTH]);
         if mask.len() != CP::MASK_LENGTH {
             return Err(SynthesisError::Unsatisfiable);
         }

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -186,7 +186,7 @@ mod test {
         let proof = create_random_proof(
             POSWCircuit::<_, EdwardsMaskedMerkleParameters, HashGadget, TestPOSWCircuitParameters> {
                 leaves: snark_leaves,
-                merkle_parameters: parameters.clone(),
+                merkle_parameters: parameters,
                 mask: Some(mask.clone()),
                 root: Some(root),
                 field_type: PhantomData,

--- a/posw/src/consensus.rs
+++ b/posw/src/consensus.rs
@@ -110,7 +110,7 @@ where
         let mask = commit(nonce, &root.into());
 
         // Convert the leaves to Options for the SNARK
-        let leaves = leaves.into_iter().map(|l| Some(l)).collect();
+        let leaves = leaves.into_iter().map(Some).collect();
 
         POSWCircuit {
             leaves,

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -306,8 +306,8 @@ impl RpcFunctions for RpcImpl {
 
         let mut peers = vec![];
 
-        for (peer, _last_seen) in &peer_book.get_connected() {
-            peers.push(peer.clone());
+        for peer in peer_book.get_connected().keys() {
+            peers.push(*peer);
         }
 
         Ok(PeerInfo { peers })

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -72,6 +72,7 @@ pub struct RpcImpl {
 
 impl RpcImpl {
     /// Creates a new struct for calling public and private RPC endpoints.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         storage: Arc<MerkleTreeLedger>,
         storage_path: PathBuf,

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -38,7 +38,6 @@ use snarkos_utilities::{
     to_bytes,
 };
 
-use base64;
 use jsonrpc_http_server::jsonrpc_core::{IoDelegate, MetaIoHandler, Params, Value};
 use rand::{thread_rng, Rng};
 use std::{str::FromStr, sync::Arc};
@@ -237,11 +236,11 @@ impl ProtectedRpcFunctions for RpcImpl {
     ) -> Result<CreateRawTransactionOuput, RpcError> {
         let rng = &mut thread_rng();
 
-        assert!(transaction_input.old_records.len() > 0);
+        assert!(!transaction_input.old_records.is_empty());
         assert!(transaction_input.old_records.len() <= Components::NUM_OUTPUT_RECORDS);
-        assert!(transaction_input.old_account_private_keys.len() > 0);
+        assert!(!transaction_input.old_account_private_keys.is_empty());
         assert!(transaction_input.old_account_private_keys.len() <= Components::NUM_OUTPUT_RECORDS);
-        assert!(transaction_input.recipients.len() > 0);
+        assert!(!transaction_input.recipients.is_empty());
         assert!(transaction_input.recipients.len() <= Components::NUM_OUTPUT_RECORDS);
 
         // Fetch birth/death programs
@@ -387,7 +386,7 @@ impl ProtectedRpcFunctions for RpcImpl {
     fn get_record_commitments(&self) -> Result<Vec<String>, RpcError> {
         self.storage.catch_up_secondary(false)?;
         let record_commitments = self.storage.get_record_commitments(Some(100))?;
-        let record_commitment_strings: Vec<String> = record_commitments.iter().map(|cm| hex::encode(cm)).collect();
+        let record_commitment_strings: Vec<String> = record_commitments.iter().map(hex::encode).collect();
 
         Ok(record_commitment_strings)
     }

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -35,6 +35,7 @@ use tokio::sync::Mutex;
 /// Starts a local JSON-RPC HTTP server at rpc_port in a new thread.
 /// Rpc failures will error on the thread level but not affect the main network server.
 /// This may be changed in the future to give the node more control of the rpc server.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_rpc_server(
     rpc_port: u16,
     secondary_storage: Arc<MerkleTreeLedger>,

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -77,7 +77,7 @@ mod protected_rpc_tests {
         let memory_pool = MemoryPool::new();
         let memory_pool_lock = Arc::new(Mutex::new(memory_pool));
 
-        let sync_handler = SyncHandler::new(server_address.clone());
+        let sync_handler = SyncHandler::new(server_address);
         let sync_handler_lock = Arc::new(Mutex::new(sync_handler));
 
         let context = Context::new(server_address, 5, 1, 10, true, vec![], false);
@@ -280,7 +280,7 @@ mod protected_rpc_tests {
 
             let extracted: Value = serde_json::from_str(&response).unwrap();
 
-            let expected_result = Value::String(format!("{}", hex::encode(to_bytes![record].unwrap())));
+            let expected_result = Value::String(hex::encode(to_bytes![record].unwrap()).to_string());
             assert_eq!(extracted["result"], expected_result);
         }
 

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -28,12 +28,11 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use toml;
 
 /// Bootnodes maintained by Aleo.
 /// A node should try and connect to these first after coming online.
-pub const MAINNET_BOOTNODES: &'static [&str] = &[]; // "192.168.0.1:4130"
-pub const TESTNET_BOOTNODES: &'static [&str] = &[
+pub const MAINNET_BOOTNODES: &[&str] = &[]; // "192.168.0.1:4130"
+pub const TESTNET_BOOTNODES: &[&str] = &[
     "138.197.232.178:4131",
     "64.225.91.42:4131",
     "64.225.91.43:4131",

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -256,10 +256,9 @@ impl Config {
     }
 
     fn path(&mut self, argument: Option<&str>) {
-        match argument {
-            Some(path) => self.node.db = path.into(),
-            _ => (),
-        };
+        if let Some(path) = argument {
+            self.node.db = path.into();
+        }
     }
 
     fn connect(&mut self, argument: Option<&str>) {
@@ -367,12 +366,9 @@ impl CLI for ConfigCli {
             "verbose",
         ]);
 
-        match arguments.subcommand() {
-            ("update", Some(arguments)) => {
-                UpdateCLI::parse(arguments)?;
-                std::process::exit(0x0100);
-            }
-            _ => {}
+        if let ("update", Some(arguments)) = arguments.subcommand() {
+            UpdateCLI::parse(arguments)?;
+            std::process::exit(0x0100);
         }
 
         Ok(config)

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -133,7 +133,7 @@ impl Default for Config {
 impl Config {
     /// The directory that snarkOS system files will be stored
     fn snarkos_dir() -> PathBuf {
-        let mut path = home_dir().unwrap_or(std::env::current_dir().unwrap());
+        let mut path = home_dir().unwrap_or_else(|| std::env::current_dir().unwrap());
         path.push(".snarkOS/");
 
         path

--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -24,8 +24,7 @@ use std::str::FromStr;
 pub fn render_init(config: &Config) -> String {
     let mut output = String::new();
 
-    output += &format!(
-        r#"
+    output += &r#"
 
          ╦╬╬╬╬╬╦
         ╬╬╬╬╬╬╬╬╬                    ▄▄▄▄        ▄▄▄
@@ -39,14 +38,10 @@ pub fn render_init(config: &Config) -> String {
 ╚╬╬╬╬╬╩           ╩╬╬╬╬╩
 
 "#
-    )
     .white()
-    .bold()
-    .to_string();
+    .bold();
 
-    output += &format!("Welcome to Aleo! We thank you for running a network node and supporting privacy.\n\n")
-        .bold()
-        .to_string();
+    output += &"Welcome to Aleo! We thank you for running a network node and supporting privacy.\n\n".bold();
 
     let mut is_miner = config.miner.is_miner;
     if is_miner {
@@ -57,10 +52,9 @@ pub fn render_init(config: &Config) -> String {
                     .to_string();
             }
             Err(_) => {
-                output += &format!(
-                    "Miner not started. Please specify a valid miner address in your ~/.snarkOS/snarkOS.toml file or by using the --miner-address option in the CLI.\n\n"
-                ).red().bold()
-                    .to_string();
+                output +=
+                    &"Miner not started. Please specify a valid miner address in your ~/.snarkOS/snarkOS.toml file or by using the --miner-address option in the CLI.\n\n"
+                .red().bold();
 
                 is_miner = false;
             }
@@ -81,5 +75,5 @@ pub fn render_init(config: &Config) -> String {
         output += &format!("Listening for RPC requests on port {}\n", config.rpc.port);
     }
 
-    format!("{}", output)
+    output
 }

--- a/snarkos/update.rs
+++ b/snarkos/update.rs
@@ -65,11 +65,9 @@ impl UpdateCLI {
                 println!("Could not get snarkOS versions");
                 println!("Error: {}", e);
             }
-        } else {
-            if let Err(e) = Self::update_to_latest_release() {
-                println!("Could not update snarkOS");
-                println!("Error: {}", e);
-            }
+        } else if let Err(e) = Self::update_to_latest_release() {
+            println!("Could not update snarkOS");
+            println!("Error: {}", e);
         }
 
         Ok(())

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -190,7 +190,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     }
 
     /// Retrieve a value given a key.
-    pub(crate) fn get(&self, col: u32, key: &Vec<u8>) -> Result<Vec<u8>, StorageError> {
+    pub(crate) fn get(&self, col: u32, key: &[u8]) -> Result<Vec<u8>, StorageError> {
         match self.storage.get(col, key)? {
             Some(data) => Ok(data),
             None => Err(StorageError::MissingValue(hex::encode(key))),

--- a/storage/src/objects/block_path.rs
+++ b/storage/src/objects/block_path.rs
@@ -51,7 +51,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         }
 
         // The given block header is valid on the canon chain
-        if &self.get_latest_block()?.header.get_hash() == &block_header.previous_block_hash {
+        if self.get_latest_block()?.header.get_hash() == block_header.previous_block_hash {
             return Ok(BlockPath::CanonChain(self.get_latest_block_height() + 1));
         }
 
@@ -98,7 +98,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
 
         let mut final_path = vec![block_hash];
 
-        if children.len() == 0 {
+        if children.is_empty() {
             Ok((1, final_path))
         } else {
             let mut paths = vec![];

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -41,7 +41,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
             ops.push(Op::Insert {
                 col: COL_SERIAL_NUMBER,
                 key: sn_bytes,
-                value: (sn_index.clone() as u32).to_le_bytes().to_vec(),
+                value: (*sn_index as u32).to_le_bytes().to_vec(),
             });
             *sn_index += 1;
         }
@@ -55,9 +55,9 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
             ops.push(Op::Insert {
                 col: COL_COMMITMENT,
                 key: cm_bytes,
-                value: (cm_index.clone() as u32).to_le_bytes().to_vec(),
+                value: (*cm_index as u32).to_le_bytes().to_vec(),
             });
-            cms.push((cm.clone(), cm_index.clone()));
+            cms.push((cm.clone(), *cm_index));
 
             *cm_index += 1;
         }
@@ -69,7 +69,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
             ops.push(Op::Insert {
                 col: COL_MEMO,
                 key: memo_bytes,
-                value: (memo_index.clone() as u32).to_le_bytes().to_vec(),
+                value: (*memo_index as u32).to_le_bytes().to_vec(),
             });
             *memo_index += 1;
         }

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -22,6 +22,7 @@ use snarkos_utilities::{bytes::ToBytes, has_duplicates, to_bytes};
 
 impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     /// Commit a transaction to the canon chain
+    #[allow(clippy::type_complexity)]
     pub(crate) fn commit_transaction(
         &self,
         sn_index: &mut usize,

--- a/storage/src/objects/records.rs
+++ b/storage/src/objects/records.rs
@@ -43,7 +43,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     }
 
     /// Get a transaction bytes given the transaction id.
-    pub fn get_record<R: Record>(&self, record_commitment: &Vec<u8>) -> Result<Option<R>, StorageError> {
+    pub fn get_record<R: Record>(&self, record_commitment: &[u8]) -> Result<Option<R>, StorageError> {
         match self.storage.get(COL_RECORDS, &record_commitment)? {
             Some(record_bytes) => {
                 let record: R = FromBytes::read(&record_bytes[..])?;
@@ -67,7 +67,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     }
 
     /// Get a transaction bytes given the transaction id.
-    pub fn store_records<R: Record>(&self, records: &Vec<R>) -> Result<(), StorageError> {
+    pub fn store_records<R: Record>(&self, records: &[R]) -> Result<(), StorageError> {
         let mut database_transaction = DatabaseTransaction::new();
 
         for record in records {

--- a/storage/src/objects/transaction.rs
+++ b/storage/src/objects/transaction.rs
@@ -29,10 +29,7 @@ use snarkos_utilities::{
 
 impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     /// Returns a transaction location given the transaction ID if it exists. Returns `None` otherwise.
-    pub fn get_transaction_location(
-        &self,
-        transaction_id: &Vec<u8>,
-    ) -> Result<Option<TransactionLocation>, StorageError> {
+    pub fn get_transaction_location(&self, transaction_id: &[u8]) -> Result<Option<TransactionLocation>, StorageError> {
         match self.storage.get(COL_TRANSACTION_LOCATION, &transaction_id)? {
             Some(transaction_locator) => {
                 let transaction_location = TransactionLocation::read(&transaction_locator[..])?;
@@ -43,7 +40,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     }
 
     /// Returns a transaction given the transaction ID if it exists. Returns `None` otherwise.
-    pub fn get_transaction(&self, transaction_id: &Vec<u8>) -> Result<Option<T>, StorageError> {
+    pub fn get_transaction(&self, transaction_id: &[u8]) -> Result<Option<T>, StorageError> {
         match self.get_transaction_location(&transaction_id)? {
             Some(transaction_location) => {
                 let block_transactions =
@@ -55,8 +52,8 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     }
 
     /// Returns a transaction in bytes given a transaction ID.
-    pub fn get_transaction_bytes(&self, transaction_id: &Vec<u8>) -> Result<Vec<u8>, StorageError> {
-        match self.get_transaction(&transaction_id.clone())? {
+    pub fn get_transaction_bytes(&self, transaction_id: &[u8]) -> Result<Vec<u8>, StorageError> {
+        match self.get_transaction(transaction_id)? {
             Some(transaction) => Ok(to_bytes![transaction]?),
             None => Err(StorageError::InvalidTransactionId(hex::encode(&transaction_id))),
         }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -143,7 +143,7 @@ impl Storage {
     /// If RocksDB fails to destroy storage, returns [StorageError](snarkos_errors::storage::StorageError).
     pub fn destroy(&self) -> Result<(), StorageError> {
         let path = self.db.path();
-        drop(&self.db);
+        // drop(&self.db); FIXME: this didn't actually drop self.db
         Self::destroy_storage(path.into())
     }
 

--- a/testing/examples/test_data.rs
+++ b/testing/examples/test_data.rs
@@ -112,6 +112,7 @@ fn mine_block(
 
 /// Spends some value from inputs owned by the sender, to the receiver,
 /// and pays back whatever we are left with.
+#[allow(clippy::too_many_arguments)]
 fn send<R: Rng>(
     ledger: &MerkleTreeLedger,
     parameters: &<InstantiatedDPC as DPCScheme<MerkleTreeLedger>>::Parameters,

--- a/testing/src/consensus/e2e.rs
+++ b/testing/src/consensus/e2e.rs
@@ -27,7 +27,7 @@ use once_cell::sync::Lazy;
 use std::io::{Read, Result as IoResult, Write};
 
 /// Helper providing pre-calculated data for e2e tests
-pub static DATA: Lazy<TestData> = Lazy::new(|| load_test_data());
+pub static DATA: Lazy<TestData> = Lazy::new(load_test_data);
 
 pub static GENESIS_BLOCK_HEADER_HASH: Lazy<[u8; 32]> = Lazy::new(|| genesis().header.get_hash().0);
 
@@ -81,10 +81,10 @@ impl ToBytes for TestData {
 
         self.block_2.write(&mut writer)?;
 
-        writer.write(&(self.records_1.len() as u64).to_le_bytes())?;
+        writer.write_all(&(self.records_1.len() as u64).to_le_bytes())?;
         self.records_1.write(&mut writer)?;
 
-        writer.write(&(self.records_2.len() as u64).to_le_bytes())?;
+        writer.write_all(&(self.records_2.len() as u64).to_le_bytes())?;
         self.records_2.write(&mut writer)?;
 
         self.alternative_block_1_header.write(&mut writer)?;

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -27,7 +27,7 @@ use rand::Rng;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::TcpListener, sync::Mutex};
 
-pub const LOCALHOST: &'static str = "0.0.0.0:";
+pub const LOCALHOST: &str = "0.0.0.0:";
 pub const CONNECTION_FREQUENCY_LONG: u64 = 100000; // 100 seconds
 pub const CONNECTION_FREQUENCY_SHORT: u64 = 100; // .1 seconds
 pub const CONNECTION_FREQUENCY_SHORT_TIMEOUT: u64 = 200; // .2 seconds

--- a/testing/src/storage/mod.rs
+++ b/testing/src/storage/mod.rs
@@ -43,9 +43,7 @@ pub fn initialize_test_blockchain<T: Transaction, P: LoadableMerkleParameters>(
 
     Ledger::<T, P>::destroy_storage(path.clone()).unwrap();
 
-    let storage = Ledger::<T, P>::new(&path, parameters, genesis_block).unwrap();
-
-    storage
+    Ledger::<T, P>::new(&path, parameters, genesis_block).unwrap()
 }
 
 // Open a test blockchain from stored genesis attributes

--- a/toolkit/src/lib.rs
+++ b/toolkit/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate thiserror;
 

--- a/utilities/src/biginteger/mod.rs
+++ b/utilities/src/biginteger/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 mod macros;
 

--- a/utilities/src/biginteger/tests.rs
+++ b/utilities/src/biginteger/tests.rs
@@ -30,24 +30,24 @@ fn biginteger_arithmetic_test<B: BigInteger>(a: B, b: B, zero: B) {
     assert_eq!(a, a);
 
     // a + 0 = a
-    let mut a0_add = a.clone();
+    let mut a0_add = a;
     a0_add.add_nocarry(&zero);
     assert_eq!(a0_add, a);
 
     // a - 0 = a
-    let mut a0_sub = a.clone();
+    let mut a0_sub = a;
     a0_sub.sub_noborrow(&zero);
     assert_eq!(a0_sub, a);
 
     // a - a = 0
-    let mut aa_sub = a.clone();
+    let mut aa_sub = a;
     aa_sub.sub_noborrow(&a);
     assert_eq!(aa_sub, zero);
 
     // a + b = b + a
-    let mut ab_add = a.clone();
+    let mut ab_add = a;
     ab_add.add_nocarry(&b);
-    let mut ba_add = b.clone();
+    let mut ba_add = b;
     ba_add.add_nocarry(&a);
     assert_eq!(ab_add, ba_add);
 }

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -359,7 +359,7 @@ pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
         let mut result = 0u8;
         for (i, bit) in bits.iter().enumerate() {
             let bit_value = *bit as u8;
-            result = result + (bit_value << i as u8);
+            result += bit_value << i as u8;
         }
         bytes.push(result);
     }

--- a/utilities/src/variable_length_integer.rs
+++ b/utilities/src/variable_length_integer.rs
@@ -38,13 +38,13 @@ pub fn variable_length_integer(value: u64) -> Vec<u8> {
 /// https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer
 pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<usize> {
     let mut flag = [0u8; 1];
-    reader.read(&mut flag)?;
+    reader.read_exact(&mut flag)?;
 
     match flag[0] {
         0..=252 => Ok(flag[0] as usize),
         0xfd => {
             let mut size = [0u8; 2];
-            reader.read(&mut size)?;
+            reader.read_exact(&mut size)?;
             match u16::from_le_bytes(size) {
                 s if s < 253 => Err(error("Invalid variable size integer")),
                 s => Ok(s as usize),
@@ -52,7 +52,7 @@ pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<usize> {
         }
         0xfe => {
             let mut size = [0u8; 4];
-            reader.read(&mut size)?;
+            reader.read_exact(&mut size)?;
             match u32::from_le_bytes(size) {
                 s if s < 65536 => Err(error("Invalid variable size integer")),
                 s => Ok(s as usize),
@@ -60,7 +60,7 @@ pub fn read_variable_length_integer<R: Read>(mut reader: R) -> IoResult<usize> {
         }
         _ => {
             let mut size = [0u8; 8];
-            reader.read(&mut size)?;
+            reader.read_exact(&mut size)?;
             match u64::from_le_bytes(size) {
                 s if s < 4_294_967_296 => Err(error("Invalid variable size integer")),
                 s => Ok(s as usize),


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/477 (which builds on https://github.com/AleoHQ/snarkOS/pull/473); can be merged in sequence or be the only one merged.

Most of the changes this time around were similar to the ones in the previous PRs, with 2 notable exceptions which were put in separate commits:
- changing a common closure in `gadgets::utilities::boolean` to a free function (prompted by `clippy`, but useful on its own)
- two `clippy::eval_order_dependence` fixes

This PR concludes the `clippy` compliance series, making `cargo clippy --workspace --examples --tests` pass without warnings, allowing the repo to be configured so that either a CI run or a git hook includes a `clippy` pass.

Cc #145