### PR TITLE
Change the logging setup from log to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,7 +2403,6 @@ dependencies = [
  "dirs",
  "env_logger",
  "hex",
- "log",
  "rand",
  "rustc_version",
  "rusty-hook",
@@ -2421,6 +2420,7 @@ dependencies = [
  "snarkos-utilities",
  "tokio 0.2.22",
  "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -2477,7 +2477,6 @@ dependencies = [
  "chrono",
  "futures-await-test",
  "hex",
- "log",
  "rand",
  "rand_xorshift",
  "serde",
@@ -2493,6 +2492,7 @@ dependencies = [
  "snarkos-testing",
  "snarkos-utilities",
  "tokio 0.2.22",
+ "tracing",
 ]
 
 [[package]]
@@ -2616,7 +2616,6 @@ dependencies = [
  "byteorder",
  "chrono",
  "hex",
- "log",
  "rand",
  "rustc_version",
  "serde",
@@ -2632,6 +2631,7 @@ dependencies = [
  "snarkos-utilities",
  "tokio 0.2.22",
  "tokio-test",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ dependencies = [
  "tokio 0.2.22",
  "toml",
  "tracing",
+ "tracing-futures",
  "tracing-subscriber",
 ]
 
@@ -2660,6 +2661,7 @@ dependencies = [
  "tokio 0.2.22",
  "tokio-test",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -3310,6 +3312,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,7 +345,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -1478,6 +1487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2358,6 +2377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,7 +2429,6 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
- "env_logger",
  "hex",
  "rand",
  "rustc_version",
@@ -2421,6 +2448,7 @@ dependencies = [
  "tokio 0.2.22",
  "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3282,6 +3310,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.4.2",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 toml = { version = "0.5.6" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
+tracing-futures = { version = "0.2" }
 tracing-subscriber = { version = "0.2" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,12 @@ colored = { version = "2.0" }
 dirs = { version = "3.0.1" }
 env_logger = { version = "0.7.1" }
 hex = { version = "0.4.1" }
-log = { version = "0.4.11" }
 rand = { version = "0.7" }
 self_update = { version = "0.20.0", features = ["archive-zip", "compression-zip-bzip2", "compression-zip-deflate", "compression-flate2"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 toml = { version = "0.5.6" }
+tracing = { default-features = false, features = ["log"], version = "0.1" }
 
 [dev-dependencies]
 rusty-hook = { version = "0.11.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ snarkos-utilities = { path = "./utilities", version = "1.1.4"}
 clap = { version = "2.33.3" }
 colored = { version = "2.0" }
 dirs = { version = "3.0.1" }
-env_logger = { version = "0.7.1" }
 hex = { version = "0.4.1" }
 rand = { version = "0.7" }
 self_update = { version = "0.20.0", features = ["archive-zip", "compression-zip-bzip2", "compression-zip-deflate", "compression-flate2"] }
@@ -63,6 +62,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 toml = { version = "0.5.6" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
+tracing-subscriber = { version = "0.2" }
 
 [dev-dependencies]
 rusty-hook = { version = "0.11.2" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -26,10 +26,10 @@ snarkos-utilities = { path = "../utilities", version = "1.1.4"}
 bincode = { version="1.3.1" }
 chrono = { version = "0.4", features = ["serde"] }
 hex = { version = "0.4.2" }
-log = { version = "0.4.11" }
 rand = { version = "0.7.3" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
+tracing = { default-features = false, features = ["log"], version = "0.1" }
 
 [dev-dependencies]
 snarkos-testing = { path = "../testing" }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -35,7 +35,7 @@
 #![forbid(unsafe_code)]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 pub mod consensus;
 pub use consensus::*;

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -29,6 +29,7 @@ rand = { version = "0.7.3" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
+tracing-futures = { version = "0.2" }
 
 [dev-dependencies]
 snarkos-testing = { path = "../testing" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -25,10 +25,10 @@ bincode = { version = "1.3.1" }
 byteorder = { version = "1" }
 chrono = { version = "0.4", features = ["serde"] }
 hex = { version="0.4.2" }
-log = { version = "0.4.11" }
 rand = { version = "0.7.3" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
+tracing = { default-features = false, features = ["log"], version = "0.1" }
 
 [dev-dependencies]
 snarkos-testing = { path = "../testing" }

--- a/network/src/internal/connection_handler.rs
+++ b/network/src/internal/connection_handler.rs
@@ -25,6 +25,7 @@ use crate::{
 use chrono::{Duration as ChronoDuration, Utc};
 use std::time::Duration;
 use tokio::{task, time::delay_for};
+use tracing_futures::Instrument;
 
 impl Server {
     /// Manages the number of active connections according to the connection frequency.
@@ -44,7 +45,7 @@ impl Server {
         let connection_frequency = self.connection_frequency;
 
         // Start a separate thread for the handler.
-        task::spawn(async move {
+        let handler_future = async move {
             let mut interval_ticker: u8 = 0;
 
             loop {
@@ -88,7 +89,7 @@ impl Server {
                                     let new_context = context.clone();
                                     let latest_block_height = storage.get_latest_block_height();
 
-                                    task::spawn(async move {
+                                    let handshake_future = async move {
                                         // TODO (raychu86) Establish a formal node version
                                         let version =
                                             Version::new(1u64, latest_block_height, remote_address, local_address);
@@ -97,7 +98,8 @@ impl Server {
                                         if let Err(_) = handshakes.send_request(&version).await {
                                             debug!("Could not connect to gossiped peer {}", remote_address);
                                         }
-                                    });
+                                    };
+                                    task::spawn(handshake_future.in_current_span());
                                 }
                             }
 
@@ -221,6 +223,7 @@ impl Server {
                     }
                 }
             }
-        });
+        };
+        task::spawn(handler_future.in_current_span());
     }
 }

--- a/network/src/internal/connection_handler.rs
+++ b/network/src/internal/connection_handler.rs
@@ -99,7 +99,9 @@ impl Server {
                                             debug!("Could not connect to gossiped peer {}", remote_address);
                                         }
                                     };
-                                    task::spawn(handshake_future.in_current_span());
+                                    task::spawn(
+                                        handshake_future.instrument(debug_span!("handshake", addr = %remote_address)),
+                                    );
                                 }
                             }
 
@@ -224,6 +226,6 @@ impl Server {
                 }
             }
         };
-        task::spawn(handler_future.in_current_span());
+        task::spawn(handler_future.instrument(debug_span!("connection_handler")));
     }
 }

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -284,7 +284,7 @@ impl Server {
 
             if let Ok(inserted) = memory_pool.insert(&self.storage, entry) {
                 if let Some(txid) = inserted {
-                    debug!("Transaction added to memory pool with txid: {:?}", hex::encode(txid));
+                    debug!("Transaction added to memory pool with txid: {:?}", hex::encode(&txid));
                 }
             }
         }
@@ -454,10 +454,10 @@ impl Server {
                 channel.write(&GetPeers).await?;
             }
             Err(error) => {
+                let error = ServerError::HandshakeError(error);
                 debug!(
                     "Invalid Verack message from: {:?} Full error: {:?}",
-                    channel.address,
-                    ServerError::HandshakeError(error)
+                    channel.address, &error
                 );
             }
         }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -22,7 +22,7 @@
 #![cfg_attr(nightly, doc(include = "../documentation/concepts/network_server.md"))]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 pub mod external;
 

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -178,7 +178,7 @@ impl Server {
                 }
             }
         };
-        task::spawn(future.in_current_span());
+        task::spawn(future.instrument(debug_span!("new_conn_handler")));
 
         // 3. Start the connection handler.
         debug!("Starting connection handler");
@@ -210,6 +210,7 @@ impl Server {
         mut channel: Arc<Channel>,
         mut message_handler_sender: mpsc::Sender<(oneshot::Sender<Arc<Channel>>, MessageName, Vec<u8>, Arc<Channel>)>,
     ) {
+        let peer_address = channel.address.clone();
         let future = async move {
             // Determines the criteria for disconnecting from a peer.
             fn should_disconnect(failure_count: &u8) -> bool {
@@ -293,7 +294,7 @@ impl Server {
                 }
             }
         };
-        task::spawn(future.in_current_span());
+        task::spawn(future.instrument(debug_span!("connection", addr = %peer_address)));
     }
 
     /// Send a handshake request to a node at address without blocking the server listener.
@@ -311,7 +312,7 @@ impl Server {
                 ()
             });
         };
-        task::spawn(future.in_current_span());
+        task::spawn(future.instrument(debug_span!("handshake", addr = %remote_address)));
     }
 
     /// Send a handshake request the first bootnode and store the rest as gossipped peers

--- a/snarkos/lib.rs
+++ b/snarkos/lib.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 pub mod cli;
 pub mod config;

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 use snarkos::{
     cli::CLI,

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -54,7 +54,7 @@ async fn start_server(config: Config) -> Result<(), NodeError> {
                 _ => std::env::set_var("RUST_LOG", "info"),
             };
 
-            env_logger::init();
+            tracing_subscriber::fmt::init();
             println!("{}", render_init(&config));
         }
     }


### PR DESCRIPTION
`tracing` is the go-to library for `async`-aware logging these days; it provides some very nice, structured diagnostics and is compatible with `log`'s macros, making the transition quite smooth.

This PR introduces a basic `tracing` configuration; I'll be happy to extend it further once I have a setup with multiple nodes and some RPC calls going on.

This is how some of the logs look right now (`--verbose 2`):
```[2020-09-28T14:36:43Z INFO  snarkos] Loading Aleo parameters...
[2020-09-28T14:36:44Z INFO  snarkos] Loading complete.
[2020-09-28T14:36:44Z INFO  snarkos] Loading Aleo parameters for RPC...
[2020-09-28T14:36:45Z INFO  snarkos] Loading complete.
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Starting listener...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Listening at V4(0.0.0.0:4131)
[2020-09-28T14:36:45Z DEBUG tokio_reactor] adding I/O source: 0
[2020-09-28T14:36:45Z DEBUG snarkos_network::server] Starting connection handler
[2020-09-28T14:36:45Z DEBUG snarkos_network::server] Sending handshake request to bootnodes
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(138.197.232.178:4131) (bootnode)...
[2020-09-28T14:36:45Z DEBUG tokio_reactor::registration] scheduling Read for: 0
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(64.225.91.42:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(64.225.91.43:4131) (bootnode)...
[2020-09-28T14:36:45Z DEBUG snarkos_network::server] Spawning a new thread to handle new connections
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(46.101.144.133:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(46.101.147.96:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(167.71.79.152:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(167.99.69.230:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(206.189.80.245:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(178.128.18.3:4131) (bootnode)...
[2020-09-28T14:36:45Z INFO  snarkos_network::server] Connecting to V4(50.18.83.123:4131) (bootnode)...
[2020-09-28T14:36:45Z DEBUG snarkos_network::server] Sending handshake request to all stored peers
[2020-09-28T14:36:45Z DEBUG snarkos_network::server] Starting message handler
[2020-09-28T14:38:55Z INFO  snarkos_network::server] Failed to connect to ConnectError(Crate("std::io", "Os { code: 110, kind: TimedOut, message: \"Connection timed out\" }"))
[2020-09-28T14:38:55Z DEBUG snarkos_network::external::channel] Message "version", Sent to V4(46.101.144.133:4131)
[2020-09-28T14:38:55Z INFO  snarkos_network::external::protocol::handshake::handshakes] Request handshake with: V4(46.101.144.133:4131)
[2020-09-28T14:38:56Z DEBUG snarkos_network::external::channel] Message "version", Sent to V4(64.225.91.42:4131)
[2020-09-28T14:38:56Z INFO  snarkos_network::external::protocol::handshake::handshakes] Request handshake with: V4(64.225.91.42:4131)
[2020-09-28T14:38:58Z DEBUG snarkos_network::external::channel] Message "version", Sent to V4(64.225.91.43:4131)
[2020-09-28T14:38:58Z INFO  snarkos_network::external::protocol::handshake::handshakes] Request handshake with: V4(64.225.91.43:4131)

```

And after the PR:
```
Sep 28 16:15:24.591  INFO node: Loading Aleo parameters...
Sep 28 16:15:25.472  INFO node: Loading complete.
Sep 28 16:15:25.674  INFO node: Loading Aleo parameters for RPC...
Sep 28 16:15:26.547  INFO node: Loading complete.
Sep 28 16:15:26.722  INFO node:server: Starting listener...
Sep 28 16:15:26.722  INFO node:server: Listening at V4(0.0.0.0:4131)
Sep 28 16:15:26.722 DEBUG node:server: Starting connection handler
Sep 28 16:15:26.722 DEBUG node:server: Sending handshake request to bootnodes
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(138.197.232.178:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(64.225.91.42:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(64.225.91.43:4131) (bootnode)...
Sep 28 16:15:26.722 DEBUG node:server:new_conn_handler: Spawning a new thread to handle new connections
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(46.101.144.133:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(46.101.147.96:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(167.71.79.152:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(167.99.69.230:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(206.189.80.245:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(178.128.18.3:4131) (bootnode)...
Sep 28 16:15:26.722  INFO node:server: Connecting to V4(50.18.83.123:4131) (bootnode)...
Sep 28 16:15:26.723 DEBUG node:server: Sending handshake request to all stored peers
Sep 28 16:15:26.723 DEBUG node:server: Starting message handler
Sep 28 16:15:26.912 DEBUG node:server:handshake{addr=64.225.91.42:4131}: Message "version", Sent to V4(64.225.91.42:4131)
Sep 28 16:15:26.912  INFO node:server:handshake{addr=64.225.91.42:4131}: Request handshake with: V4(64.225.91.42:4131)
Sep 28 16:17:37.269  INFO node:server:handshake{addr=138.197.232.178:4131}: Failed to connect to ConnectError(Crate("std::io", "Os { code: 110, kind: TimedOut, message: \"Connection timed out\" }"))
Sep 28 16:17:37.319 DEBUG node:server:handshake{addr=46.101.147.96:4131}: Message "version", Sent to V4(46.101.147.96:4131)
Sep 28 16:17:37.319  INFO node:server:handshake{addr=46.101.147.96:4131}: Request handshake with: V4(46.101.147.96:4131)
Sep 28 16:17:37.370 DEBUG node:server:handshake{addr=46.101.144.133:4131}: Message "version", Sent to V4(46.101.144.133:4131)
Sep 28 16:17:37.370  INFO node:server:handshake{addr=46.101.144.133:4131}: Request handshake with: V4(46.101.144.133:4131)
Sep 28 16:17:37.586 DEBUG node:server:handshake{addr=64.225.91.43:4131}: Message "version", Sent to V4(64.225.91.43:4131)
Sep 28 16:17:37.586  INFO node:server:handshake{addr=64.225.91.43:4131}: Request handshake with: V4(64.225.91.43:4131)
Sep 28 16:19:46.976  INFO node:server:handshake{addr=167.71.79.152:4131}: Failed to connect to ConnectError(Crate("std::io", "Os { code: 110, kind: TimedOut, message: \"Connection timed out\" }"))
Sep 28 16:21:56.682  INFO node:server:handshake{addr=167.99.69.230:4131}: Failed to connect to ConnectError(Crate("std::io", "Os { code: 110, kind: TimedOut, message: \"Connection timed out\" }"))
Sep 28 16:24:06.389  INFO node:server:handshake{addr=206.189.80.245:4131}: Failed to connect to ConnectError(Crate("std::io", "Os { code: 110, kind: TimedOut, message: \"Connection timed out\" }"))
```

Some of these changes introduce a little bit of duplicated information (e.g. double addresses in some handshake logs), which can be easily tweaked either on `tracing`'s side (the `Span`) or in the existing logs (which no longer need to be explicit about information common to the overarching `Span`) - I'd be leaning towards the former, but I'm leaving the choice to the maintainers - I'll be happy to adjust accordingly (same goes with the date format etc.).

Closes https://github.com/AleoHQ/snarkOS/issues/136