### PR TITLE
Make cargo bench operational

### DIFF
--- a/benchmarks/algorithms/snark/snark.rs
+++ b/benchmarks/algorithms/snark/snark.rs
@@ -17,7 +17,7 @@
 #[macro_use]
 extern crate criterion;
 
-use snarkos_algorithms::snark::GM17;
+use snarkos_algorithms::snark::gm17::GM17;
 use snarkos_curves::bls12_377::{Bls12_377, Fr};
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{


### PR DESCRIPTION
A tiny fix needed for `cargo +nightly bench --workspace` to work; I recommend adding a
```
cargo +nightly bench --workspace --no-run
```
line to one of the CI runs so that the benches are not accidentally broken in the future. This only compiles the benches without running them, so the build time impact should be acceptable.