### PR TITLE
Use criterion in curve benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
 name = "snarkos-curves"
 version = "1.1.4"
 dependencies = [
+ "criterion",
  "derivative",
  "rand",
  "rand_xorshift",

--- a/benchmarks/algorithms/snark/snark.rs
+++ b/benchmarks/algorithms/snark/snark.rs
@@ -17,7 +17,7 @@
 #[macro_use]
 extern crate criterion;
 
-use snarkos_algorithms::snark::GM17;
+use snarkos_algorithms::snark::gm17::GM17;
 use snarkos_curves::bls12_377::{Bls12_377, Fr};
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -27,3 +27,10 @@ sw6 = []
 
 [build-dependencies]
 rustc_version = "0.2"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "curve_and_field_benches"
+harness = false

--- a/curves/benches/bls12_377/ec.rs
+++ b/curves/benches/bls12_377/ec.rs
@@ -14,23 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod g1 {
+pub(crate) mod g1 {
     use snarkos_curves::bls12_377::{Fr, G1Affine, G1Projective as G1};
     use snarkos_models::curves::ProjectiveCurve;
     use snarkos_utilities::rand::UniformRand;
 
+    use criterion::Criterion;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use std::ops::AddAssign;
 
-    #[bench]
-    fn bench_g1_rand(b: &mut ::test::Bencher) {
+    pub fn bench_g1_rand(c: &mut Criterion) {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
-        b.iter(|| G1::rand(&mut rng));
+        c.bench_function("bls12_377: g1_rand", |c| c.iter(|| G1::rand(&mut rng)));
     }
 
-    #[bench]
-    fn bench_g1_mul_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g1_mul_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -38,16 +37,16 @@ mod g1 {
         let v: Vec<(G1, Fr)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.mul_assign(v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g1_mul_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.mul_assign(v[count].1);
+                count = (count + 1) % SAMPLES;
+            })
         });
     }
 
-    #[bench]
-    fn bench_g1_add_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g1_add_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -55,16 +54,17 @@ mod g1 {
         let v: Vec<(G1, G1)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G1::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g1_add_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g1_add_assign_mixed(b: &mut ::test::Bencher) {
+    pub fn bench_g1_add_assign_mixed(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -74,16 +74,17 @@ mod g1 {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign_mixed(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g1_add_assign_mixed", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign_mixed(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g1_double(b: &mut ::test::Bencher) {
+    pub fn bench_g1_double(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -91,32 +92,33 @@ mod g1 {
         let v: Vec<(G1, G1)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G1::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.double_in_place();
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g1_double", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.double_in_place();
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 }
 
-mod g2 {
+pub(crate) mod g2 {
     use snarkos_curves::bls12_377::{Fr, G2Affine, G2Projective as G2};
     use snarkos_models::curves::ProjectiveCurve;
     use snarkos_utilities::rand::UniformRand;
 
+    use criterion::Criterion;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use std::ops::AddAssign;
 
-    #[bench]
-    fn bench_g2_rand(b: &mut ::test::Bencher) {
+    pub fn bench_g2_rand(c: &mut Criterion) {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
-        b.iter(|| G2::rand(&mut rng));
+        c.bench_function("bls12_377: g2_rand", |c| c.iter(|| G2::rand(&mut rng)));
     }
 
-    #[bench]
-    fn bench_g2_mul_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g2_mul_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -124,16 +126,17 @@ mod g2 {
         let v: Vec<(G2, Fr)> = (0..SAMPLES).map(|_| (G2::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.mul_assign(v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g2_mul_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.mul_assign(v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g2_add_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g2_add_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -141,16 +144,17 @@ mod g2 {
         let v: Vec<(G2, G2)> = (0..SAMPLES).map(|_| (G2::rand(&mut rng), G2::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g2_add_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g2_add_assign_mixed(b: &mut ::test::Bencher) {
+    pub fn bench_g2_add_assign_mixed(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -160,16 +164,17 @@ mod g2 {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign_mixed(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g2_add_assign_mixed", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign_mixed(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g2_double(b: &mut ::test::Bencher) {
+    pub fn bench_g2_double(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -177,11 +182,13 @@ mod g2 {
         let v: Vec<(G2, G2)> = (0..SAMPLES).map(|_| (G2::rand(&mut rng), G2::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.double_in_place();
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: g2_double", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.double_in_place();
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 }

--- a/curves/benches/bls12_377/fq.rs
+++ b/curves/benches/bls12_377/fq.rs
@@ -21,12 +21,12 @@ use snarkos_utilities::{
     rand::UniformRand,
 };
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_repr_add_nocarry(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -45,16 +45,17 @@ fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_nocarry(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_repr_add_nocarry", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_nocarry(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_sub_noborrow(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_repr_sub_noborrow(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -72,16 +73,17 @@ fn bench_fq_repr_sub_noborrow(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_noborrow(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_repr_sub_noborrow", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_noborrow(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_num_bits(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_repr_num_bits(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -89,15 +91,16 @@ fn bench_fq_repr_num_bits(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| FqRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].num_bits();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_repr_num_bits", |c| {
+        c.iter(|| {
+            let tmp = v[count].num_bits();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_mul2(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_repr_mul2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +108,17 @@ fn bench_fq_repr_mul2(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| FqRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.mul2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_repr_mul2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.mul2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_div2(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_repr_div2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,16 +126,17 @@ fn bench_fq_repr_div2(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| FqRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.div2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_repr_div2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.div2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_add_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -139,16 +144,17 @@ fn bench_fq_add_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fq, Fq)> = (0..SAMPLES).map(|_| (Fq::rand(&mut rng), Fq::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_sub_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -156,16 +162,17 @@ fn bench_fq_sub_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fq, Fq)> = (0..SAMPLES).map(|_| (Fq::rand(&mut rng), Fq::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_mul_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -173,16 +180,17 @@ fn bench_fq_mul_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fq, Fq)> = (0..SAMPLES).map(|_| (Fq::rand(&mut rng), Fq::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_double(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -190,16 +198,17 @@ fn bench_fq_double(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_square(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -207,16 +216,17 @@ fn bench_fq_square(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_inverse(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -224,14 +234,15 @@ fn bench_fq_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].inverse()
+    c.bench_function("bls12_377: fq_inverse", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].inverse()
+        })
     });
 }
 
-#[bench]
-fn bench_fq_negate(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_negate(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -239,16 +250,17 @@ fn bench_fq_negate(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp = -tmp;
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq_negate", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp = -tmp;
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_sqrt(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_sqrt(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -262,14 +274,15 @@ fn bench_fq_sqrt(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].sqrt()
+    c.bench_function("bls12_377: fq_sqrt", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].sqrt()
+        })
     });
 }
 
-#[bench]
-fn bench_fq_into_repr(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_into_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -277,14 +290,15 @@ fn bench_fq_into_repr(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].into_repr()
+    c.bench_function("bls12_377: fq_into_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].into_repr()
+        })
     });
 }
 
-#[bench]
-fn bench_fq_from_repr(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq_from_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -292,8 +306,10 @@ fn bench_fq_from_repr(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| Fq::rand(&mut rng).into_repr()).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        Fq::from_repr(v[count])
+    c.bench_function("bls12_377: fq_from_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            Fq::from_repr(v[count])
+        })
     });
 }

--- a/curves/benches/bls12_377/fq12.rs
+++ b/curves/benches/bls12_377/fq12.rs
@@ -18,12 +18,12 @@ use snarkos_curves::bls12_377::Fq12;
 use snarkos_models::curves::Field;
 use snarkos_utilities::rand::UniformRand;
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fq12_add_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq12_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -33,16 +33,17 @@ fn bench_fq12_add_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq12_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq12_sub_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq12_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -52,16 +53,17 @@ fn bench_fq12_sub_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq12_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq12_mul_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq12_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -71,16 +73,17 @@ fn bench_fq12_mul_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq12_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq12_double(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq12_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -88,16 +91,17 @@ fn bench_fq12_double(b: &mut ::test::Bencher) {
     let v: Vec<Fq12> = (0..SAMPLES).map(|_| Fq12::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq12_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq12_square(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq12_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +109,17 @@ fn bench_fq12_square(b: &mut ::test::Bencher) {
     let v: Vec<Fq12> = (0..SAMPLES).map(|_| Fq12::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq12_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq12_inverse(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq12_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,9 +127,11 @@ fn bench_fq12_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fq12> = (0..SAMPLES).map(|_| Fq12::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].inverse();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq12_inverse", |c| {
+        c.iter(|| {
+            let tmp = v[count].inverse();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }

--- a/curves/benches/bls12_377/fq2.rs
+++ b/curves/benches/bls12_377/fq2.rs
@@ -18,12 +18,12 @@ use snarkos_curves::bls12_377::Fq2;
 use snarkos_models::curves::{Field, SquareRootField};
 use snarkos_utilities::rand::UniformRand;
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fq2_add_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -33,16 +33,17 @@ fn bench_fq2_add_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq2_sub_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -52,16 +53,17 @@ fn bench_fq2_sub_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq2_mul_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -71,16 +73,17 @@ fn bench_fq2_mul_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq2_double(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -88,16 +91,17 @@ fn bench_fq2_double(b: &mut ::test::Bencher) {
     let v: Vec<Fq2> = (0..SAMPLES).map(|_| Fq2::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq2_square(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +109,17 @@ fn bench_fq2_square(b: &mut ::test::Bencher) {
     let v: Vec<Fq2> = (0..SAMPLES).map(|_| Fq2::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq2_inverse(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,15 +127,16 @@ fn bench_fq2_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fq2> = (0..SAMPLES).map(|_| Fq2::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].inverse();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_inverse", |c| {
+        c.iter(|| {
+            let tmp = v[count].inverse();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq2_sqrt(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fq2_sqrt(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -138,9 +144,11 @@ fn bench_fq2_sqrt(b: &mut ::test::Bencher) {
     let v: Vec<Fq2> = (0..SAMPLES).map(|_| Fq2::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].sqrt();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fq2_sqrt", |c| {
+        c.iter(|| {
+            let tmp = v[count].sqrt();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }

--- a/curves/benches/bls12_377/fr.rs
+++ b/curves/benches/bls12_377/fr.rs
@@ -21,12 +21,12 @@ use snarkos_utilities::{
     rand::UniformRand,
 };
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_repr_add_nocarry(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -45,16 +45,17 @@ fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_nocarry(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_repr_add_nocarry", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_nocarry(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_sub_noborrow(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_repr_sub_noborrow(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -72,16 +73,17 @@ fn bench_fr_repr_sub_noborrow(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_noborrow(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_repr_sub_noborrow", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_noborrow(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_num_bits(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_repr_num_bits(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -89,15 +91,16 @@ fn bench_fr_repr_num_bits(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| FrRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].num_bits();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_repr_num_bits", |c| {
+        c.iter(|| {
+            let tmp = v[count].num_bits();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_mul2(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_repr_mul2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +108,17 @@ fn bench_fr_repr_mul2(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| FrRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.mul2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_repr_mul2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.mul2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_div2(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_repr_div2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,16 +126,17 @@ fn bench_fr_repr_div2(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| FrRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.div2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_repr_div2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.div2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_add_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -139,16 +144,17 @@ fn bench_fr_add_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fr, Fr)> = (0..SAMPLES).map(|_| (Fr::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_sub_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -156,16 +162,17 @@ fn bench_fr_sub_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fr, Fr)> = (0..SAMPLES).map(|_| (Fr::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_mul_assign(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -173,16 +180,17 @@ fn bench_fr_mul_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fr, Fr)> = (0..SAMPLES).map(|_| (Fr::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_double(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -190,16 +198,17 @@ fn bench_fr_double(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_square(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -207,16 +216,17 @@ fn bench_fr_square(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_inverse(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -224,14 +234,15 @@ fn bench_fr_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].inverse()
+    c.bench_function("bls12_377: fr_inverse", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].inverse()
+        })
     });
 }
 
-#[bench]
-fn bench_fr_negate(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_negate(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -239,16 +250,17 @@ fn bench_fr_negate(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp = -tmp;
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bls12_377: fr_negate", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp = -tmp;
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_sqrt(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_sqrt(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -262,14 +274,15 @@ fn bench_fr_sqrt(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].sqrt()
+    c.bench_function("bls12_377: fr_sqrt", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].sqrt()
+        })
     });
 }
 
-#[bench]
-fn bench_fr_into_repr(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_into_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -277,14 +290,15 @@ fn bench_fr_into_repr(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].into_repr()
+    c.bench_function("bls12_377: fr_into_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].into_repr()
+        })
     });
 }
 
-#[bench]
-fn bench_fr_from_repr(b: &mut ::test::Bencher) {
+pub(crate) fn bench_fr_from_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -292,8 +306,10 @@ fn bench_fr_from_repr(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng).into_repr()).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        Fr::from_repr(v[count])
+    c.bench_function("bls12_377: fr_from_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            Fr::from_repr(v[count])
+        })
     });
 }

--- a/curves/benches/bls12_377/mod.rs
+++ b/curves/benches/bls12_377/mod.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod ec;
-mod fq;
-mod fq12;
-mod fq2;
-mod fr;
-mod pairing;
+pub(crate) mod ec;
+pub(crate) mod fq;
+pub(crate) mod fq12;
+pub(crate) mod fq2;
+pub(crate) mod fr;
+pub(crate) mod pairing;

--- a/curves/benches/bls12_377/pairing.rs
+++ b/curves/benches/bls12_377/pairing.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod pairing {
+pub(crate) mod pairing {
     use snarkos_curves::{
         bls12_377::{Bls12_377, Bls12_377Parameters, Fq12, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2},
         templates::bls12::{G1Prepared, G2Prepared},
@@ -22,11 +22,11 @@ mod pairing {
     use snarkos_models::curves::{PairingCurve, PairingEngine};
     use snarkos_utilities::rand::UniformRand;
 
+    use criterion::Criterion;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
-    #[bench]
-    fn bench_pairing_miller_loop(b: &mut ::test::Bencher) {
+    pub fn bench_pairing_miller_loop(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -41,15 +41,16 @@ mod pairing {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let tmp = Bls12_377::miller_loop(&[(&v[count].0, &v[count].1)]);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: pairing_miller_loop", |c| {
+            c.iter(|| {
+                let tmp = Bls12_377::miller_loop(&[(&v[count].0, &v[count].1)]);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_pairing_final_exponentiation(b: &mut ::test::Bencher) {
+    pub fn bench_pairing_final_exponentiation(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -65,15 +66,16 @@ mod pairing {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let tmp = Bls12_377::final_exponentiation(&v[count]);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: pairing_final_exponentiation", |c| {
+            c.iter(|| {
+                let tmp = Bls12_377::final_exponentiation(&v[count]);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_pairing_full(b: &mut ::test::Bencher) {
+    pub fn bench_pairing_full(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -81,10 +83,12 @@ mod pairing {
         let v: Vec<(G1, G2)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G2::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let tmp = Bls12_377::pairing(v[count].0, v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bls12_377: pairing_full", |c| {
+            c.iter(|| {
+                let tmp = Bls12_377::pairing(v[count].0, v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 }

--- a/curves/benches/bw6_761/ec.rs
+++ b/curves/benches/bw6_761/ec.rs
@@ -14,23 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod g1 {
+pub(crate) mod g1 {
     use snarkos_curves::bw6_761::{Fr, G1Affine, G1Projective as G1};
     use snarkos_models::curves::ProjectiveCurve;
     use snarkos_utilities::rand::UniformRand;
 
+    use criterion::Criterion;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use std::ops::AddAssign;
 
-    #[bench]
-    fn bench_g1_rand(b: &mut ::test::Bencher) {
+    pub fn bench_g1_rand(c: &mut Criterion) {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
-        b.iter(|| G1::rand(&mut rng));
+        c.bench_function("bw6_761: g1_rand", |c| c.iter(|| G1::rand(&mut rng)));
     }
 
-    #[bench]
-    fn bench_g1_mul_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g1_mul_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -38,16 +37,17 @@ mod g1 {
         let v: Vec<(G1, Fr)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.mul_assign(v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g1_mul_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.mul_assign(v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g1_add_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g1_add_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -55,16 +55,17 @@ mod g1 {
         let v: Vec<(G1, G1)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G1::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g1_add_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g1_add_assign_mixed(b: &mut ::test::Bencher) {
+    pub fn bench_g1_add_assign_mixed(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -74,16 +75,17 @@ mod g1 {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign_mixed(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g1_add_assign_mixed", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign_mixed(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g1_double(b: &mut ::test::Bencher) {
+    pub fn bench_g1_double(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -91,32 +93,33 @@ mod g1 {
         let v: Vec<(G1, G1)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G1::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.double_in_place();
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g1_double", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.double_in_place();
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 }
 
-mod g2 {
+pub(crate) mod g2 {
     use snarkos_curves::bw6_761::{Fr, G2Affine, G2Projective as G2};
     use snarkos_models::curves::ProjectiveCurve;
     use snarkos_utilities::rand::UniformRand;
 
+    use criterion::Criterion;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use std::ops::AddAssign;
 
-    #[bench]
-    fn bench_g2_rand(b: &mut ::test::Bencher) {
+    pub fn bench_g2_rand(c: &mut Criterion) {
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
-        b.iter(|| G2::rand(&mut rng));
+        c.bench_function("bw6_761: g2_rand", |c| c.iter(|| G2::rand(&mut rng)));
     }
 
-    #[bench]
-    fn bench_g2_mul_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g2_mul_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -124,16 +127,17 @@ mod g2 {
         let v: Vec<(G2, Fr)> = (0..SAMPLES).map(|_| (G2::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.mul_assign(v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g2_mul_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.mul_assign(v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g2_add_assign(b: &mut ::test::Bencher) {
+    pub fn bench_g2_add_assign(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -141,16 +145,17 @@ mod g2 {
         let v: Vec<(G2, G2)> = (0..SAMPLES).map(|_| (G2::rand(&mut rng), G2::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g2_add_assign", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g2_add_assign_mixed(b: &mut ::test::Bencher) {
+    pub fn bench_g2_add_assign_mixed(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -160,16 +165,17 @@ mod g2 {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.add_assign_mixed(&v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g2_add_assign_mixed", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.add_assign_mixed(&v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_g2_double(b: &mut ::test::Bencher) {
+    pub fn bench_g2_double(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -177,11 +183,13 @@ mod g2 {
         let v: Vec<(G2, G2)> = (0..SAMPLES).map(|_| (G2::rand(&mut rng), G2::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let mut tmp = v[count].0;
-            tmp.double_in_place();
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: g2_double", |c| {
+            c.iter(|| {
+                let mut tmp = v[count].0;
+                tmp.double_in_place();
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 }

--- a/curves/benches/bw6_761/fq.rs
+++ b/curves/benches/bw6_761/fq.rs
@@ -21,12 +21,12 @@ use snarkos_utilities::{
     rand::UniformRand,
 };
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {
+pub fn bench_fq_repr_add_nocarry(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -45,16 +45,17 @@ fn bench_fq_repr_add_nocarry(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_nocarry(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_repr_add_nocarry", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_nocarry(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_sub_noborrow(b: &mut ::test::Bencher) {
+pub fn bench_fq_repr_sub_noborrow(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -72,16 +73,17 @@ fn bench_fq_repr_sub_noborrow(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_noborrow(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_repr_sub_noborrow", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_noborrow(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_num_bits(b: &mut ::test::Bencher) {
+pub fn bench_fq_repr_num_bits(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -89,15 +91,16 @@ fn bench_fq_repr_num_bits(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| FqRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].num_bits();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_repr_num_bits", |c| {
+        c.iter(|| {
+            let tmp = v[count].num_bits();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_mul2(b: &mut ::test::Bencher) {
+pub fn bench_fq_repr_mul2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +108,17 @@ fn bench_fq_repr_mul2(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| FqRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.mul2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_repr_mul2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.mul2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_repr_div2(b: &mut ::test::Bencher) {
+pub fn bench_fq_repr_div2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,16 +126,17 @@ fn bench_fq_repr_div2(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| FqRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.div2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_repr_div2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.div2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_add_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -139,16 +144,17 @@ fn bench_fq_add_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fq, Fq)> = (0..SAMPLES).map(|_| (Fq::rand(&mut rng), Fq::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_sub_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -156,16 +162,17 @@ fn bench_fq_sub_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fq, Fq)> = (0..SAMPLES).map(|_| (Fq::rand(&mut rng), Fq::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_mul_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -173,16 +180,17 @@ fn bench_fq_mul_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fq, Fq)> = (0..SAMPLES).map(|_| (Fq::rand(&mut rng), Fq::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_double(b: &mut ::test::Bencher) {
+pub fn bench_fq_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -190,16 +198,17 @@ fn bench_fq_double(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_square(b: &mut ::test::Bencher) {
+pub fn bench_fq_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -207,16 +216,17 @@ fn bench_fq_square(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_inverse(b: &mut ::test::Bencher) {
+pub fn bench_fq_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -224,14 +234,15 @@ fn bench_fq_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].inverse()
+    c.bench_function("bw6_761: fq_inverse", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].inverse()
+        })
     });
 }
 
-#[bench]
-fn bench_fq_negate(b: &mut ::test::Bencher) {
+pub fn bench_fq_negate(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -239,16 +250,17 @@ fn bench_fq_negate(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp = -tmp;
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq_negate", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp = -tmp;
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq_sqrt(b: &mut ::test::Bencher) {
+pub fn bench_fq_sqrt(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -262,14 +274,15 @@ fn bench_fq_sqrt(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].sqrt()
+    c.bench_function("bw6_761: fq_sqrt", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].sqrt()
+        })
     });
 }
 
-#[bench]
-fn bench_fq_into_repr(b: &mut ::test::Bencher) {
+pub fn bench_fq_into_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -277,14 +290,15 @@ fn bench_fq_into_repr(b: &mut ::test::Bencher) {
     let v: Vec<Fq> = (0..SAMPLES).map(|_| Fq::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].into_repr()
+    c.bench_function("bw6_761: fq_into_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].into_repr()
+        })
     });
 }
 
-#[bench]
-fn bench_fq_from_repr(b: &mut ::test::Bencher) {
+pub fn bench_fq_from_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -292,8 +306,10 @@ fn bench_fq_from_repr(b: &mut ::test::Bencher) {
     let v: Vec<FqRepr> = (0..SAMPLES).map(|_| Fq::rand(&mut rng).into_repr()).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        Fq::from_repr(v[count])
+    c.bench_function("bw6_761: fq_from_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            Fq::from_repr(v[count])
+        })
     });
 }

--- a/curves/benches/bw6_761/fq3.rs
+++ b/curves/benches/bw6_761/fq3.rs
@@ -18,12 +18,12 @@ use snarkos_curves::bw6_761::Fq3;
 use snarkos_models::curves::{Field, SquareRootField};
 use snarkos_utilities::rand::UniformRand;
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fq3_add_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq3_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -33,16 +33,17 @@ fn bench_fq3_add_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq3_sub_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq3_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -52,16 +53,17 @@ fn bench_fq3_sub_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq3_mul_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq3_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -71,16 +73,17 @@ fn bench_fq3_mul_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq3_double(b: &mut ::test::Bencher) {
+pub fn bench_fq3_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -88,16 +91,17 @@ fn bench_fq3_double(b: &mut ::test::Bencher) {
     let v: Vec<Fq3> = (0..SAMPLES).map(|_| Fq3::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq3_square(b: &mut ::test::Bencher) {
+pub fn bench_fq3_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +109,17 @@ fn bench_fq3_square(b: &mut ::test::Bencher) {
     let v: Vec<Fq3> = (0..SAMPLES).map(|_| Fq3::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq3_inverse(b: &mut ::test::Bencher) {
+pub fn bench_fq3_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,15 +127,16 @@ fn bench_fq3_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fq3> = (0..SAMPLES).map(|_| Fq3::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].inverse();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_inverse", |c| {
+        c.iter(|| {
+            let tmp = v[count].inverse();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq3_sqrt(b: &mut ::test::Bencher) {
+pub fn bench_fq3_sqrt(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -138,9 +144,11 @@ fn bench_fq3_sqrt(b: &mut ::test::Bencher) {
     let v: Vec<Fq3> = (0..SAMPLES).map(|_| Fq3::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].sqrt();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq3_sqrt", |c| {
+        c.iter(|| {
+            let tmp = v[count].sqrt();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }

--- a/curves/benches/bw6_761/fq6.rs
+++ b/curves/benches/bw6_761/fq6.rs
@@ -22,8 +22,8 @@ use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fq6_add_assign(b: &mut ::test::Bencher) {
+use criterion::Criterion;
+pub fn bench_fq6_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -33,16 +33,17 @@ fn bench_fq6_add_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq6_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq6_sub_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq6_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -52,16 +53,17 @@ fn bench_fq6_sub_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq6_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq6_mul_assign(b: &mut ::test::Bencher) {
+pub fn bench_fq6_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -71,16 +73,17 @@ fn bench_fq6_mul_assign(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq6_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq6_double(b: &mut ::test::Bencher) {
+pub fn bench_fq6_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -88,16 +91,17 @@ fn bench_fq6_double(b: &mut ::test::Bencher) {
     let v: Vec<Fq6> = (0..SAMPLES).map(|_| Fq6::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq6_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq6_square(b: &mut ::test::Bencher) {
+pub fn bench_fq6_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +109,17 @@ fn bench_fq6_square(b: &mut ::test::Bencher) {
     let v: Vec<Fq6> = (0..SAMPLES).map(|_| Fq6::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq6_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fq6_inverse(b: &mut ::test::Bencher) {
+pub fn bench_fq6_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,9 +127,11 @@ fn bench_fq6_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fq6> = (0..SAMPLES).map(|_| Fq6::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].inverse();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fq6_inverse", |c| {
+        c.iter(|| {
+            let tmp = v[count].inverse();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }

--- a/curves/benches/bw6_761/fr.rs
+++ b/curves/benches/bw6_761/fr.rs
@@ -21,12 +21,12 @@ use snarkos_utilities::{
     rand::UniformRand,
 };
 
+use criterion::Criterion;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 
-#[bench]
-fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {
+pub fn bench_fr_repr_add_nocarry(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -45,16 +45,17 @@ fn bench_fr_repr_add_nocarry(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_nocarry(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_repr_add_nocarry", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_nocarry(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_sub_noborrow(b: &mut ::test::Bencher) {
+pub fn bench_fr_repr_sub_noborrow(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -72,16 +73,17 @@ fn bench_fr_repr_sub_noborrow(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_noborrow(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_repr_sub_noborrow", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_noborrow(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_num_bits(b: &mut ::test::Bencher) {
+pub fn bench_fr_repr_num_bits(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -89,15 +91,16 @@ fn bench_fr_repr_num_bits(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| FrRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let tmp = v[count].num_bits();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_repr_num_bits", |c| {
+        c.iter(|| {
+            let tmp = v[count].num_bits();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_mul2(b: &mut ::test::Bencher) {
+pub fn bench_fr_repr_mul2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -105,16 +108,17 @@ fn bench_fr_repr_mul2(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| FrRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.mul2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_repr_mul2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.mul2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_repr_div2(b: &mut ::test::Bencher) {
+pub fn bench_fr_repr_div2(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -122,16 +126,17 @@ fn bench_fr_repr_div2(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| FrRepr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.div2();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_repr_div2", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.div2();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_add_assign(b: &mut ::test::Bencher) {
+pub fn bench_fr_add_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -139,16 +144,17 @@ fn bench_fr_add_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fr, Fr)> = (0..SAMPLES).map(|_| (Fr::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.add_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_add_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.add_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_sub_assign(b: &mut ::test::Bencher) {
+pub fn bench_fr_sub_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -156,16 +162,17 @@ fn bench_fr_sub_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fr, Fr)> = (0..SAMPLES).map(|_| (Fr::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.sub_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_sub_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.sub_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_mul_assign(b: &mut ::test::Bencher) {
+pub fn bench_fr_mul_assign(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -173,16 +180,17 @@ fn bench_fr_mul_assign(b: &mut ::test::Bencher) {
     let v: Vec<(Fr, Fr)> = (0..SAMPLES).map(|_| (Fr::rand(&mut rng), Fr::rand(&mut rng))).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count].0;
-        tmp.mul_assign(&v[count].1);
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_mul_assign", |c| {
+        c.iter(|| {
+            let mut tmp = v[count].0;
+            tmp.mul_assign(&v[count].1);
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_double(b: &mut ::test::Bencher) {
+pub fn bench_fr_double(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -190,16 +198,17 @@ fn bench_fr_double(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.double_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_double", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.double_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_square(b: &mut ::test::Bencher) {
+pub fn bench_fr_square(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -207,16 +216,17 @@ fn bench_fr_square(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp.square_in_place();
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_square", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp.square_in_place();
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_inverse(b: &mut ::test::Bencher) {
+pub fn bench_fr_inverse(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -224,14 +234,15 @@ fn bench_fr_inverse(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].inverse()
+    c.bench_function("bw6_761: fr_inverse", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].inverse()
+        })
     });
 }
 
-#[bench]
-fn bench_fr_negate(b: &mut ::test::Bencher) {
+pub fn bench_fr_negate(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -239,16 +250,17 @@ fn bench_fr_negate(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        let mut tmp = v[count];
-        tmp = -tmp;
-        count = (count + 1) % SAMPLES;
-        tmp
+    c.bench_function("bw6_761: fr_negate", |c| {
+        c.iter(|| {
+            let mut tmp = v[count];
+            tmp = -tmp;
+            count = (count + 1) % SAMPLES;
+            tmp
+        })
     });
 }
 
-#[bench]
-fn bench_fr_sqrt(b: &mut ::test::Bencher) {
+pub fn bench_fr_sqrt(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -262,14 +274,15 @@ fn bench_fr_sqrt(b: &mut ::test::Bencher) {
         .collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].sqrt()
+    c.bench_function("bw6_761: fr_sqrt", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].sqrt()
+        })
     });
 }
 
-#[bench]
-fn bench_fr_into_repr(b: &mut ::test::Bencher) {
+pub fn bench_fr_into_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -277,14 +290,15 @@ fn bench_fr_into_repr(b: &mut ::test::Bencher) {
     let v: Vec<Fr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng)).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        v[count].into_repr()
+    c.bench_function("bw6_761: fr_into_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            v[count].into_repr()
+        })
     });
 }
 
-#[bench]
-fn bench_fr_from_repr(b: &mut ::test::Bencher) {
+pub fn bench_fr_from_repr(c: &mut Criterion) {
     const SAMPLES: usize = 1000;
 
     let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -292,8 +306,10 @@ fn bench_fr_from_repr(b: &mut ::test::Bencher) {
     let v: Vec<FrRepr> = (0..SAMPLES).map(|_| Fr::rand(&mut rng).into_repr()).collect();
 
     let mut count = 0;
-    b.iter(|| {
-        count = (count + 1) % SAMPLES;
-        Fr::from_repr(v[count])
+    c.bench_function("bw6_761: fr_from_repr", |c| {
+        c.iter(|| {
+            count = (count + 1) % SAMPLES;
+            Fr::from_repr(v[count])
+        })
     });
 }

--- a/curves/benches/bw6_761/mod.rs
+++ b/curves/benches/bw6_761/mod.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod ec;
-mod fq;
-mod fq3;
-mod fq6;
-mod fr;
-mod pairing;
+pub(crate) mod ec;
+pub(crate) mod fq;
+pub(crate) mod fq3;
+pub(crate) mod fq6;
+pub(crate) mod fr;
+pub(crate) mod pairing;

--- a/curves/benches/bw6_761/pairing.rs
+++ b/curves/benches/bw6_761/pairing.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod pairing {
+pub(crate) mod pairing {
     use snarkos_curves::{
         bw6_761::{BW6_761Parameters, Fq6, G1Affine, G1Projective as G1, G2Affine, G2Projective as G2, BW6_761},
         templates::bw6::{G1Prepared, G2Prepared},
@@ -22,11 +22,11 @@ mod pairing {
     use snarkos_models::curves::{PairingCurve, PairingEngine};
     use snarkos_utilities::rand::UniformRand;
 
+    use criterion::Criterion;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
-    #[bench]
-    fn bench_pairing_miller_loop(b: &mut ::test::Bencher) {
+    pub fn bench_pairing_miller_loop(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -41,15 +41,16 @@ mod pairing {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let tmp = BW6_761::miller_loop(&[(&v[count].0, &v[count].1)]);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: pairing_miller_loop", |c| {
+            c.iter(|| {
+                let tmp = BW6_761::miller_loop(&[(&v[count].0, &v[count].1)]);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_pairing_final_exponentiation(b: &mut ::test::Bencher) {
+    pub fn bench_pairing_final_exponentiation(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -65,15 +66,16 @@ mod pairing {
             .collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let tmp = BW6_761::final_exponentiation(&v[count]);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: pairing_final_exponentiation", |c| {
+            c.iter(|| {
+                let tmp = BW6_761::final_exponentiation(&v[count]);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 
-    #[bench]
-    fn bench_pairing_full(b: &mut ::test::Bencher) {
+    pub fn bench_pairing_full(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
         let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
@@ -81,10 +83,12 @@ mod pairing {
         let v: Vec<(G1, G2)> = (0..SAMPLES).map(|_| (G1::rand(&mut rng), G2::rand(&mut rng))).collect();
 
         let mut count = 0;
-        b.iter(|| {
-            let tmp = BW6_761::pairing(v[count].0, v[count].1);
-            count = (count + 1) % SAMPLES;
-            tmp
+        c.bench_function("bw6_761: pairing_full", |c| {
+            c.iter(|| {
+                let tmp = BW6_761::pairing(v[count].0, v[count].1);
+                count = (count + 1) % SAMPLES;
+                tmp
+            })
         });
     }
 }

--- a/curves/benches/curve_and_field_benches.rs
+++ b/curves/benches/curve_and_field_benches.rs
@@ -14,10 +14,183 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#![feature(test)]
-
-extern crate test;
+use criterion::{criterion_group, criterion_main};
 
 mod bls12_377;
 mod bw6_761;
 // mod sw6;
+
+criterion_group!(
+    bls12_377_ec,
+    bls12_377::ec::g1::bench_g1_rand,
+    bls12_377::ec::g1::bench_g1_mul_assign,
+    bls12_377::ec::g1::bench_g1_add_assign,
+    bls12_377::ec::g1::bench_g1_add_assign_mixed,
+    bls12_377::ec::g1::bench_g1_double,
+    bls12_377::ec::g2::bench_g2_rand,
+    bls12_377::ec::g2::bench_g2_mul_assign,
+    bls12_377::ec::g2::bench_g2_add_assign,
+    bls12_377::ec::g2::bench_g2_add_assign_mixed,
+    bls12_377::ec::g2::bench_g2_double,
+);
+
+criterion_group!(
+    bls12_377_fq,
+    bls12_377::fq::bench_fq_repr_add_nocarry,
+    bls12_377::fq::bench_fq_repr_sub_noborrow,
+    bls12_377::fq::bench_fq_repr_num_bits,
+    bls12_377::fq::bench_fq_repr_mul2,
+    bls12_377::fq::bench_fq_repr_div2,
+    bls12_377::fq::bench_fq_add_assign,
+    bls12_377::fq::bench_fq_sub_assign,
+    bls12_377::fq::bench_fq_mul_assign,
+    bls12_377::fq::bench_fq_double,
+    bls12_377::fq::bench_fq_square,
+    bls12_377::fq::bench_fq_inverse,
+    bls12_377::fq::bench_fq_negate,
+    bls12_377::fq::bench_fq_sqrt,
+    bls12_377::fq::bench_fq_into_repr,
+    bls12_377::fq::bench_fq_from_repr,
+);
+
+criterion_group!(
+    bls12_377_fq12,
+    bls12_377::fq12::bench_fq12_add_assign,
+    bls12_377::fq12::bench_fq12_sub_assign,
+    bls12_377::fq12::bench_fq12_mul_assign,
+    bls12_377::fq12::bench_fq12_double,
+    bls12_377::fq12::bench_fq12_square,
+    bls12_377::fq12::bench_fq12_inverse,
+);
+
+criterion_group!(
+    bls12_377_fq2,
+    bls12_377::fq2::bench_fq2_add_assign,
+    bls12_377::fq2::bench_fq2_sub_assign,
+    bls12_377::fq2::bench_fq2_mul_assign,
+    bls12_377::fq2::bench_fq2_double,
+    bls12_377::fq2::bench_fq2_square,
+    bls12_377::fq2::bench_fq2_inverse,
+    bls12_377::fq2::bench_fq2_sqrt,
+);
+
+criterion_group!(
+    bls12_377_fr,
+    bls12_377::fr::bench_fr_repr_add_nocarry,
+    bls12_377::fr::bench_fr_repr_sub_noborrow,
+    bls12_377::fr::bench_fr_repr_num_bits,
+    bls12_377::fr::bench_fr_repr_mul2,
+    bls12_377::fr::bench_fr_repr_div2,
+    bls12_377::fr::bench_fr_add_assign,
+    bls12_377::fr::bench_fr_sub_assign,
+    bls12_377::fr::bench_fr_mul_assign,
+    bls12_377::fr::bench_fr_double,
+    bls12_377::fr::bench_fr_square,
+    bls12_377::fr::bench_fr_inverse,
+    bls12_377::fr::bench_fr_negate,
+    bls12_377::fr::bench_fr_sqrt,
+    bls12_377::fr::bench_fr_into_repr,
+    bls12_377::fr::bench_fr_from_repr,
+);
+
+criterion_group!(
+    bls12_377_pairing,
+    bls12_377::pairing::pairing::bench_pairing_miller_loop,
+    bls12_377::pairing::pairing::bench_pairing_final_exponentiation,
+    bls12_377::pairing::pairing::bench_pairing_full,
+);
+
+criterion_group!(
+    bw6_761_ec,
+    bw6_761::ec::g1::bench_g1_rand,
+    bw6_761::ec::g1::bench_g1_mul_assign,
+    bw6_761::ec::g1::bench_g1_add_assign,
+    bw6_761::ec::g1::bench_g1_add_assign_mixed,
+    bw6_761::ec::g1::bench_g1_double,
+    bw6_761::ec::g2::bench_g2_rand,
+    bw6_761::ec::g2::bench_g2_mul_assign,
+    bw6_761::ec::g2::bench_g2_add_assign,
+    bw6_761::ec::g2::bench_g2_add_assign_mixed,
+    bw6_761::ec::g2::bench_g2_double,
+);
+
+criterion_group!(
+    bw6_761_fq,
+    bw6_761::fq::bench_fq_repr_add_nocarry,
+    bw6_761::fq::bench_fq_repr_sub_noborrow,
+    bw6_761::fq::bench_fq_repr_num_bits,
+    bw6_761::fq::bench_fq_repr_mul2,
+    bw6_761::fq::bench_fq_repr_div2,
+    bw6_761::fq::bench_fq_add_assign,
+    bw6_761::fq::bench_fq_sub_assign,
+    bw6_761::fq::bench_fq_mul_assign,
+    bw6_761::fq::bench_fq_double,
+    bw6_761::fq::bench_fq_square,
+    bw6_761::fq::bench_fq_inverse,
+    bw6_761::fq::bench_fq_negate,
+    bw6_761::fq::bench_fq_sqrt,
+    bw6_761::fq::bench_fq_into_repr,
+    bw6_761::fq::bench_fq_from_repr,
+);
+
+criterion_group!(
+    bw6_761_fq3,
+    bw6_761::fq3::bench_fq3_add_assign,
+    bw6_761::fq3::bench_fq3_sub_assign,
+    bw6_761::fq3::bench_fq3_mul_assign,
+    bw6_761::fq3::bench_fq3_double,
+    bw6_761::fq3::bench_fq3_square,
+    bw6_761::fq3::bench_fq3_inverse,
+    bw6_761::fq3::bench_fq3_sqrt,
+);
+
+criterion_group!(
+    bw6_761_fq6,
+    bw6_761::fq6::bench_fq6_add_assign,
+    bw6_761::fq6::bench_fq6_sub_assign,
+    bw6_761::fq6::bench_fq6_mul_assign,
+    bw6_761::fq6::bench_fq6_double,
+    bw6_761::fq6::bench_fq6_square,
+    bw6_761::fq6::bench_fq6_inverse,
+);
+
+criterion_group!(
+    bw6_761_fr,
+    bw6_761::fr::bench_fr_repr_add_nocarry,
+    bw6_761::fr::bench_fr_repr_sub_noborrow,
+    bw6_761::fr::bench_fr_repr_num_bits,
+    bw6_761::fr::bench_fr_repr_mul2,
+    bw6_761::fr::bench_fr_repr_div2,
+    bw6_761::fr::bench_fr_add_assign,
+    bw6_761::fr::bench_fr_sub_assign,
+    bw6_761::fr::bench_fr_mul_assign,
+    bw6_761::fr::bench_fr_double,
+    bw6_761::fr::bench_fr_square,
+    bw6_761::fr::bench_fr_inverse,
+    bw6_761::fr::bench_fr_negate,
+    bw6_761::fr::bench_fr_sqrt,
+    bw6_761::fr::bench_fr_into_repr,
+    bw6_761::fr::bench_fr_from_repr,
+);
+
+criterion_group!(
+    bw6_761_pairing,
+    bw6_761::pairing::pairing::bench_pairing_miller_loop,
+    bw6_761::pairing::pairing::bench_pairing_final_exponentiation,
+    bw6_761::pairing::pairing::bench_pairing_full,
+);
+
+criterion_main!(
+    bls12_377_ec,
+    bls12_377_fq,
+    bls12_377_fq12,
+    bls12_377_fq2,
+    bls12_377_fr,
+    bls12_377_pairing,
+    bw6_761_ec,
+    bw6_761_fq,
+    bw6_761_fq3,
+    bw6_761_fq6,
+    bw6_761_fr,
+    bw6_761_pairing,
+);


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/481, only the second commit is new.

Changes the benchmarking setup in `curves::benches` from `bencher` to `criterion`, which is already widely used in `benchmarks` and provides superior functionalities.

Rationale: there is room for improvement in terms of memory handling across the codebase, and having good benchmarks will aid future changes in that field.