### PR TITLE
More vector pre-allocations

### DIFF
--- a/algorithms/examples/snark/constraints.rs
+++ b/algorithms/examples/snark/constraints.rs
@@ -38,7 +38,7 @@ impl<F: Field> Benchmark<F> {
 
 impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
     fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
-        let mut assignments = Vec::new();
+        let mut assignments = Vec::with_capacity(2 + self.num_constraints - 1);
 
         let mut a_val = F::one();
         let mut a_var = cs.alloc_input(|| "a", || Ok(a_val))?;

--- a/algorithms/src/commitment/pedersen_parameters.rs
+++ b/algorithms/src/commitment/pedersen_parameters.rs
@@ -48,7 +48,7 @@ impl<G: Group, S: PedersenSize> PedersenCommitmentParameters<G, S> {
     }
 
     fn base<R: Rng>(num_powers: usize, rng: &mut R) -> Vec<G> {
-        let mut powers = vec![];
+        let mut powers = Vec::with_capacity(num_powers);
         let mut base = G::rand(rng);
         for _ in 0..num_powers {
             powers.push(base);
@@ -91,13 +91,13 @@ impl<G: Group, S: PedersenSize> ToBytes for PedersenCommitmentParameters<G, S> {
 impl<G: Group, S: PedersenSize> FromBytes for PedersenCommitmentParameters<G, S> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let mut bases = vec![];
-
         let num_bases: u32 = FromBytes::read(&mut reader)?;
-        for _ in 0..num_bases {
-            let mut base = vec![];
+        let mut bases = Vec::with_capacity(num_bases as usize);
 
+        for _ in 0..num_bases {
             let base_len: u32 = FromBytes::read(&mut reader)?;
+            let mut base = Vec::with_capacity(base_len as usize);
+
             for _ in 0..base_len {
                 let g: G = FromBytes::read(&mut reader)?;
                 base.push(g);
@@ -105,9 +105,9 @@ impl<G: Group, S: PedersenSize> FromBytes for PedersenCommitmentParameters<G, S>
             bases.push(base);
         }
 
-        let mut random_base = vec![];
-
         let random_base_len: u32 = FromBytes::read(&mut reader)?;
+        let mut random_base = Vec::with_capacity(random_base_len as usize);
+
         for _ in 0..random_base_len {
             let g: G = FromBytes::read(&mut reader)?;
             random_base.push(g);

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -65,9 +65,9 @@ pub struct BoweHopwoodPedersenCRH<G: Group, S: PedersenSize> {
 
 impl<G: Group, S: PedersenSize> BoweHopwoodPedersenCRH<G, S> {
     pub fn create_generators<R: Rng>(rng: &mut R) -> Vec<Vec<G>> {
-        let mut generators = Vec::new();
+        let mut generators = Vec::with_capacity(S::NUM_WINDOWS);
         for _ in 0..S::NUM_WINDOWS {
-            let mut generators_for_segment = Vec::new();
+            let mut generators_for_segment = Vec::with_capacity(S::WINDOW_SIZE);
             let mut base = G::rand(rng);
             for _ in 0..S::WINDOW_SIZE {
                 generators_for_segment.push(base);

--- a/algorithms/src/crh/pedersen_parameters.rs
+++ b/algorithms/src/crh/pedersen_parameters.rs
@@ -58,7 +58,7 @@ impl<G: Group, S: PedersenSize> PedersenCRHParameters<G, S> {
     }
 
     fn base<R: Rng>(num_powers: usize, rng: &mut R) -> Vec<G> {
-        let mut powers = vec![];
+        let mut powers = Vec::with_capacity(num_powers);
         let mut base = G::rand(rng);
         for _ in 0..num_powers {
             powers.push(base);
@@ -85,13 +85,13 @@ impl<G: Group, S: PedersenSize> ToBytes for PedersenCRHParameters<G, S> {
 impl<G: Group, S: PedersenSize> FromBytes for PedersenCRHParameters<G, S> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let mut bases = vec![];
-
         let num_bases: u32 = FromBytes::read(&mut reader)?;
-        for _ in 0..num_bases {
-            let mut base = vec![];
+        let mut bases = Vec::with_capacity(num_bases as usize);
 
+        for _ in 0..num_bases {
             let base_len: u32 = FromBytes::read(&mut reader)?;
+            let mut base = Vec::with_capacity(base_len as usize);
+
             for _ in 0..base_len {
                 let g: G = FromBytes::read(&mut reader)?;
                 base.push(g);

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -216,7 +216,7 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
         let z = Self::Randomness::read(&z_bytes[..])?;
 
         let one = Self::Randomness::one();
-        let mut plaintext = vec![];
+        let mut plaintext = Vec::with_capacity(ciphertext.len().saturating_sub(1));
         let mut i = Self::Randomness::one();
 
         for c_i in ciphertext.iter().skip(1) {

--- a/algorithms/src/encryption/group_parameters.rs
+++ b/algorithms/src/encryption/group_parameters.rs
@@ -66,8 +66,8 @@ impl<G: Group> ToBytes for GroupEncryptionParameters<G> {
 impl<G: Group> FromBytes for GroupEncryptionParameters<G> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let mut generator_powers = vec![];
         let generator_powers_length: u32 = FromBytes::read(&mut reader)?;
+        let mut generator_powers = Vec::with_capacity(generator_powers_length as usize);
         for _ in 0..generator_powers_length {
             let g: G = FromBytes::read(&mut reader)?;
             generator_powers.push(g);

--- a/algorithms/src/encryption/tests.rs
+++ b/algorithms/src/encryption/tests.rs
@@ -30,12 +30,7 @@ type TestEncryptionScheme = GroupEncryption<EdwardsProjective>;
 pub const ITERATIONS: usize = 1000;
 
 fn generate_input<G: Group + ProjectiveCurve, R: Rng>(input_size: usize, rng: &mut R) -> Vec<G> {
-    let mut input = vec![];
-    for _ in 0..input_size {
-        input.push(G::rand(rng))
-    }
-
-    input
+    (0..input_size).map(|_| G::rand(rng)).collect()
 }
 
 #[test]

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -140,10 +140,7 @@ impl<F: Field> DensePolynomial<F> {
     /// Outputs a polynomial of degree `d` where each coefficient is sampled uniformly at random
     /// from the field `F`.
     pub fn rand<R: Rng>(d: usize, rng: &mut R) -> Self {
-        let mut random_coeffs = Vec::new();
-        for _ in 0..(d + 1) {
-            random_coeffs.push(F::rand(rng));
-        }
+        let random_coeffs = (0..(d + 1)).map(|_| F::rand(rng)).collect();
         Self::from_coefficients_vec(random_coeffs)
     }
 }

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -19,6 +19,7 @@ use snarkos_errors::algorithms::MerkleError;
 use snarkos_models::algorithms::{MerkleParameters, CRH};
 use snarkos_utilities::ToBytes;
 
+#[derive(Default)]
 pub struct MerkleTree<P: MerkleParameters> {
     /// The computed root of the full Merkle tree.
     root: Option<MerkleTreeDigest<P>>,
@@ -180,18 +181,6 @@ impl<P: MerkleParameters> MerkleTree<P> {
                 parameters: self.parameters.clone(),
                 path,
             })
-        }
-    }
-}
-
-impl<P: MerkleParameters> Default for MerkleTree<P> {
-    fn default() -> Self {
-        MerkleTree {
-            tree: vec![],
-            padding_tree: vec![],
-            hashed_leaves: vec![],
-            root: None,
-            parameters: P::default(),
         }
     }
 }

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -93,7 +93,7 @@ impl<P: MerkleParameters> MerkleTree<P> {
         // Finished computing actual tree.
         // Now, we compute the dummy nodes until we hit our DEPTH goal.
         let mut current_depth = tree_depth;
-        let mut padding_tree = vec![];
+        let mut padding_tree = Vec::with_capacity((Self::DEPTH as usize).saturating_sub(current_depth + 1));
         let mut current_hash = tree[0].clone();
         while current_depth < Self::DEPTH as usize {
             current_hash = parameters.hash_inner_node(&current_hash, &empty_hash, &mut buffer)?;

--- a/algorithms/src/signature/schnorr_parameters.rs
+++ b/algorithms/src/signature/schnorr_parameters.rs
@@ -74,8 +74,8 @@ impl<G: Group, D: Digest> ToBytes for SchnorrParameters<G, D> {
 impl<G: Group, D: Digest> FromBytes for SchnorrParameters<G, D> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
-        let mut generator_powers = vec![];
         let generator_powers_length: u32 = FromBytes::read(&mut reader)?;
+        let mut generator_powers = Vec::with_capacity(generator_powers_length as usize);
         for _ in 0..generator_powers_length {
             let g: G = FromBytes::read(&mut reader)?;
             generator_powers.push(g);

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -176,7 +176,7 @@ impl<E: PairingEngine> VerifyingKey<E> {
         let h_gamma_g2: E::G2Affine = FromBytes::read(&mut reader)?;
 
         let query_len: u32 = FromBytes::read(&mut reader)?;
-        let mut query: Vec<E::G1Affine> = vec![];
+        let mut query: Vec<E::G1Affine> = Vec::with_capacity(query_len as usize);
         for _ in 0..query_len {
             let query_element: E::G1Affine = FromBytes::read(&mut reader)?;
             query.push(query_element);
@@ -319,28 +319,26 @@ impl<E: PairingEngine> Parameters<E> {
 
         let vk = VerifyingKey::<E>::read(&mut reader)?;
 
-        let mut a_query: Vec<E::G1Affine> = vec![];
-        let mut b_query: Vec<E::G2Affine> = vec![];
-        let mut c_query_1: Vec<E::G1Affine> = vec![];
-        let mut c_query_2: Vec<E::G1Affine> = vec![];
-        let mut g_gamma2_z_t: Vec<E::G1Affine> = vec![];
-
         let a_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut a_query = Vec::with_capacity(a_query_len as usize);
         for _ in 0..a_query_len {
             a_query.push(read_g1_affine(&mut reader)?);
         }
 
         let b_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut b_query = Vec::with_capacity(b_query_len as usize);
         for _ in 0..b_query_len {
             b_query.push(read_g2_affine(&mut reader)?);
         }
 
         let c_query_1_len: u32 = FromBytes::read(&mut reader)?;
+        let mut c_query_1 = Vec::with_capacity(c_query_1_len as usize);
         for _ in 0..c_query_1_len {
             c_query_1.push(read_g1_affine(&mut reader)?);
         }
 
         let c_query_2_len: u32 = FromBytes::read(&mut reader)?;
+        let mut c_query_2 = Vec::with_capacity(c_query_2_len as usize);
         for _ in 0..c_query_2_len {
             c_query_2.push(read_g1_affine(&mut reader)?);
         }
@@ -351,6 +349,7 @@ impl<E: PairingEngine> Parameters<E> {
         let g_gamma2_z2: E::G1Affine = FromBytes::read(&mut reader)?;
 
         let g_gamma2_z_t_len: u32 = FromBytes::read(&mut reader)?;
+        let mut g_gamma2_z_t = Vec::with_capacity(g_gamma2_z_t_len as usize);
         for _ in 0..g_gamma2_z_t_len {
             g_gamma2_z_t.push(read_g1_affine(&mut reader)?);
         }

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -177,7 +177,7 @@ impl<E: PairingEngine> VerifyingKey<E> {
         let delta_g2: E::G2Affine = FromBytes::read(&mut reader)?;
 
         let gamma_abc_g1_len: u32 = FromBytes::read(&mut reader)?;
-        let mut gamma_abc_g1: Vec<E::G1Affine> = vec![];
+        let mut gamma_abc_g1: Vec<E::G1Affine> = Vec::with_capacity(gamma_abc_g1_len as usize);
         for _ in 0..gamma_abc_g1_len {
             let gamma_abc_g1_element: E::G1Affine = FromBytes::read(&mut reader)?;
             gamma_abc_g1.push(gamma_abc_g1_element);
@@ -290,33 +290,32 @@ impl<E: PairingEngine> Parameters<E> {
 
         let delta_g1: E::G1Affine = FromBytes::read(&mut reader)?;
 
-        let mut a_query: Vec<E::G1Affine> = vec![];
-        let mut b_g1_query: Vec<E::G1Affine> = vec![];
-        let mut b_g2_query: Vec<E::G2Affine> = vec![];
-        let mut h_query: Vec<E::G1Affine> = vec![];
-        let mut l_query: Vec<E::G1Affine> = vec![];
-
         let a_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut a_query = Vec::with_capacity(a_query_len as usize);
         for _ in 0..a_query_len {
             a_query.push(read_g1_affine(&mut reader)?);
         }
 
         let b_g1_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut b_g1_query = Vec::with_capacity(b_g1_query_len as usize);
         for _ in 0..b_g1_query_len {
             b_g1_query.push(read_g1_affine(&mut reader)?);
         }
 
         let b_g2_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut b_g2_query = Vec::with_capacity(b_g2_query_len as usize);
         for _ in 0..b_g2_query_len {
             b_g2_query.push(read_g2_affine(&mut reader)?);
         }
 
         let h_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut h_query = Vec::with_capacity(h_query_len as usize);
         for _ in 0..h_query_len {
             h_query.push(read_g1_affine(&mut reader)?);
         }
 
         let l_query_len: u32 = FromBytes::read(&mut reader)?;
+        let mut l_query = Vec::with_capacity(l_query_len as usize);
         for _ in 0..l_query_len {
             l_query.push(read_g1_affine(&mut reader)?);
         }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -399,7 +399,7 @@ impl ConsensusParameters {
 
         // Generate dummy input records having as address the genesis address.
         let old_account_private_keys = vec![new_account.private_key.clone(); Components::NUM_INPUT_RECORDS];
-        let mut old_records = vec![];
+        let mut old_records = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
         for _ in 0..Components::NUM_INPUT_RECORDS {
             let sn_nonce_input: [u8; 4] = rng.gen();
 
@@ -495,7 +495,7 @@ impl ConsensusParameters {
         let dpc_program =
             NoopProgram::<_, <Components as BaseDPCComponents>::NoopProgramSNARK>::new(noop_program_snark_id);
 
-        let mut old_death_program_proofs = vec![];
+        let mut old_death_program_proofs = Vec::with_capacity(NUM_INPUT_RECORDS);
         for i in 0..NUM_INPUT_RECORDS {
             let private_input = dpc_program.execute(
                 &parameters.noop_program_snark_parameters.proving_key,
@@ -508,7 +508,7 @@ impl ConsensusParameters {
             old_death_program_proofs.push(private_input);
         }
 
-        let mut new_birth_program_proofs = vec![];
+        let mut new_birth_program_proofs = Vec::with_capacity(NUM_OUTPUT_RECORDS);
         for j in 0..NUM_OUTPUT_RECORDS {
             let private_input = dpc_program.execute(
                 &parameters.noop_program_snark_parameters.proving_key,

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -114,7 +114,7 @@ impl<T: Transaction> MemoryPool<T> {
 
         let mut holding_serial_numbers = vec![];
         let mut holding_commitments = vec![];
-        let mut holding_memos = vec![];
+        let mut holding_memos = Vec::with_capacity(self.transactions.len());
 
         for (_, tx) in self.transactions.iter() {
             holding_serial_numbers.extend(tx.transaction.old_serial_numbers());

--- a/curves/src/templates/bls12/g2.rs
+++ b/curves/src/templates/bls12/g2.rs
@@ -85,14 +85,16 @@ impl<P: Bls12Parameters> G2Prepared<P> {
             };
         }
 
-        let mut ell_coeffs = vec![];
         let mut r = G2HomProjective {
             x: q.x,
             y: q.y,
             z: Fp2::one(),
         };
 
-        for i in BitIterator::new(P::X).skip(1) {
+        let bit_iterator = BitIterator::new(P::X);
+        let mut ell_coeffs = Vec::with_capacity(bit_iterator.len());
+
+        for i in bit_iterator.skip(1) {
             ell_coeffs.push(doubling_step::<P>(&mut r, &two_inv));
 
             if i {

--- a/curves/src/templates/bw6/g2.rs
+++ b/curves/src/templates/bw6/g2.rs
@@ -90,14 +90,16 @@ impl<P: BW6Parameters> From<G2Affine<P>> for G2Prepared<P> {
         }
 
         // f_{u+1,Q}(P)
-        let mut ell_coeffs_1 = vec![];
         let mut r = G2HomProjective {
             x: q.x,
             y: q.y,
             z: P::Fp::one(),
         };
 
-        for i in BitIterator::new(P::ATE_LOOP_COUNT_1).skip(1) {
+        let bit_iterator = BitIterator::new(P::ATE_LOOP_COUNT_1);
+        let mut ell_coeffs_1 = Vec::with_capacity(bit_iterator.len());
+
+        for i in bit_iterator.skip(1) {
             ell_coeffs_1.push(doubling_step::<P>(&mut r));
 
             if i {
@@ -106,7 +108,7 @@ impl<P: BW6Parameters> From<G2Affine<P>> for G2Prepared<P> {
         }
 
         // f_{u^3-u^2-u,Q}(P)
-        let mut ell_coeffs_2 = vec![];
+        let mut ell_coeffs_2 = Vec::with_capacity(P::ATE_LOOP_COUNT_2.len());
         let mut r = G2HomProjective {
             x: q.x,
             y: q.y,

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
@@ -845,7 +845,7 @@ where
                 given_death_program_id.to_bits(&mut encryption_cs.ns(|| "Convert given_death_program_id to bits"))?;
             let value_bits = given_value.to_bits(&mut encryption_cs.ns(|| "Convert given_value to bits"))?;
             let payload_bits = given_payload.to_bits(&mut encryption_cs.ns(|| "Convert given_payload to bits"))?;
-            let mut fq_high_bits = vec![];
+            let mut fq_high_bits = Vec::with_capacity(fq_high_selectors.len() - 1);
 
             for (i, fq_high_bit) in fq_high_selectors[0..(fq_high_selectors.len() - 1)].iter().enumerate() {
                 let boolean = Boolean::alloc(

--- a/dpc/src/base_dpc/mod.rs
+++ b/dpc/src/base_dpc/mod.rs
@@ -465,7 +465,7 @@ where
         let mut old_serial_numbers = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
         let mut old_randomizers = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
         let mut joint_serial_numbers = Vec::new();
-        let mut old_death_program_ids = Vec::new();
+        let mut old_death_program_ids = Vec::with_capacity(old_records.len());
 
         let mut value_balance = AleoAmount::ZERO;
 
@@ -529,7 +529,7 @@ where
         // TODO (raychu86) Add index and program register inputs + outputs to local data commitment leaves
         let local_data_merkle_tree_timer = start_timer!(|| "Compute local data merkle tree");
 
-        let mut local_data_commitment_randomizers = vec![];
+        let mut local_data_commitment_randomizers = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
 
         let mut old_record_commitments = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
         for i in 0..Components::NUM_INPUT_RECORDS {

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -47,7 +47,7 @@ fn field_element_to_bytes<C: BaseDPCComponents, CS: ConstraintSystem<C::OuterFie
             &to_bytes![field_elements].map_err(|_| SynthesisError::AssignmentMissing)?,
         )?])
     } else {
-        let mut fe_bytes = vec![];
+        let mut fe_bytes = Vec::with_capacity(field_elements.len());
         for (index, field_element) in field_elements.iter().enumerate() {
             fe_bytes.push(UInt8::alloc_input_vec(
                 cs.ns(|| format!("Allocate {} - index {} ", name, index)),
@@ -193,7 +193,7 @@ where
     let ledger_digest_fe = ToConstraintField::<C::InnerField>::to_field_elements(ledger_digest)
         .map_err(|_| SynthesisError::AssignmentMissing)?;
 
-    let mut serial_numbers_fe = vec![];
+    let mut serial_numbers_fe = Vec::with_capacity(old_serial_numbers.len());
     for sn in old_serial_numbers {
         let serial_number_fe =
             ToConstraintField::<C::InnerField>::to_field_elements(sn).map_err(|_| SynthesisError::AssignmentMissing)?;
@@ -201,7 +201,7 @@ where
         serial_numbers_fe.push(serial_number_fe);
     }
 
-    let mut commitments_fe = vec![];
+    let mut commitments_fe = Vec::with_capacity(new_commitments.len());
     for cm in new_commitments {
         let commitment_fe =
             ToConstraintField::<C::InnerField>::to_field_elements(cm).map_err(|_| SynthesisError::AssignmentMissing)?;
@@ -209,7 +209,7 @@ where
         commitments_fe.push(commitment_fe);
     }
 
-    let mut encrypted_record_hashes_fe = vec![];
+    let mut encrypted_record_hashes_fe = Vec::with_capacity(new_encrypted_record_hashes.len());
     for encrypted_record_hash in new_encrypted_record_hashes {
         let encrypted_record_hash_fe = ToConstraintField::<C::InnerField>::to_field_elements(encrypted_record_hash)
             .map_err(|_| SynthesisError::AssignmentMissing)?;
@@ -309,7 +309,7 @@ where
 
     // Convert inner snark input bytes to bits
 
-    let mut inner_snark_input_bits = vec![];
+    let mut inner_snark_input_bits = Vec::with_capacity(inner_snark_input_bytes.len());
     for input_bytes in inner_snark_input_bytes {
         let input_bits = input_bytes
             .iter()
@@ -350,7 +350,7 @@ where
     program_input_bytes.extend(local_data_commitment_parameters_fe_bytes);
     program_input_bytes.extend(local_data_root_fe_bytes);
 
-    let mut program_input_bits = vec![];
+    let mut program_input_bits = Vec::with_capacity(program_input_bytes.len());
 
     for input_bytes in program_input_bytes {
         let input_bits = input_bytes
@@ -363,8 +363,8 @@ where
     // ************************************************************************
     // ************************************************************************
 
-    let mut old_death_program_ids = Vec::new();
-    let mut new_birth_program_ids = Vec::new();
+    let mut old_death_program_ids = Vec::with_capacity(C::NUM_INPUT_RECORDS);
+    let mut new_birth_program_ids = Vec::with_capacity(C::NUM_OUTPUT_RECORDS);
     for (i, input) in old_death_program_verification_inputs
         .iter()
         .enumerate()

--- a/dpc/src/base_dpc/record/encrypted_record.rs
+++ b/dpc/src/base_dpc/record/encrypted_record.rs
@@ -40,7 +40,7 @@ pub struct EncryptedRecord<C: BaseDPCComponents> {
 impl<C: BaseDPCComponents> ToBytes for EncryptedRecord<C> {
     #[inline]
     fn write<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        let mut ciphertext_selectors = vec![];
+        let mut ciphertext_selectors = Vec::with_capacity(self.encrypted_record.len() + 1);
 
         // Write the encrypted record
         variable_length_integer(self.encrypted_record.len() as u64).write(&mut writer)?;
@@ -78,8 +78,8 @@ impl<C: BaseDPCComponents> FromBytes for EncryptedRecord<C> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the ciphertext x coordinates
-        let mut ciphertext_x_coordinates = vec![];
         let num_ciphertext_elements = read_variable_length_integer(&mut reader)?;
+        let mut ciphertext_x_coordinates = Vec::with_capacity(num_ciphertext_elements);
         for _ in 0..num_ciphertext_elements {
             let ciphertext_element_x_coordinate: <<<C as BaseDPCComponents>::EncryptionGroup as ProjectiveCurve>::Affine as AffineCurve>::BaseField =
                 FromBytes::read(&mut reader)?;
@@ -97,7 +97,7 @@ impl<C: BaseDPCComponents> FromBytes for EncryptedRecord<C> {
         let final_fq_high_selector = selector_bits[num_ciphertext_elements];
 
         // Recover the ciphertext
-        let mut ciphertext = vec![];
+        let mut ciphertext = Vec::with_capacity(ciphertext_x_coordinates.len());
         for (x_coordinate, ciphertext_selector_bit) in ciphertext_x_coordinates.iter().zip_eq(ciphertext_selectors) {
             let ciphertext_element_affine =
                 match <<C as BaseDPCComponents>::EncryptionGroup as ProjectiveCurve>::Affine::from_x_coordinate(

--- a/dpc/src/base_dpc/record/record.rs
+++ b/dpc/src/base_dpc/record/record.rs
@@ -140,7 +140,7 @@ impl<C: BaseDPCComponents> FromBytes for DPCRecord<C> {
 
         let birth_program_id_size: usize = read_variable_length_integer(&mut reader)?;
 
-        let mut birth_program_id = vec![];
+        let mut birth_program_id = Vec::with_capacity(birth_program_id_size);
         for _ in 0..birth_program_id_size {
             let byte: u8 = FromBytes::read(&mut reader)?;
             birth_program_id.push(byte);
@@ -148,7 +148,7 @@ impl<C: BaseDPCComponents> FromBytes for DPCRecord<C> {
 
         let death_program_id_size: usize = read_variable_length_integer(&mut reader)?;
 
-        let mut death_program_id = vec![];
+        let mut death_program_id = Vec::with_capacity(death_program_id_size);
         for _ in 0..death_program_id_size {
             let byte: u8 = FromBytes::read(&mut reader)?;
             death_program_id.push(byte);

--- a/dpc/src/base_dpc/record/record_encryption.rs
+++ b/dpc/src/base_dpc/record/record_encryption.rs
@@ -102,7 +102,7 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
         let (serialized_record, final_fq_high_selector) =
             RecordSerializer::<C, C::EncryptionModelParameters, C::EncryptionGroup>::serialize(&record)?;
 
-        let mut record_plaintexts = vec![];
+        let mut record_plaintexts = Vec::with_capacity(serialized_record.len());
         for element in serialized_record.iter() {
             // Construct the plaintext element from the serialized group elements
             // This value will be used in the inner circuit to validate the encryption
@@ -144,7 +144,7 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
             &encrypted_record.encrypted_record,
         )?;
 
-        let mut plaintext = vec![];
+        let mut plaintext = Vec::with_capacity(plaintext_elements.len());
         for element in plaintext_elements {
             let plaintext_element = <C as BaseDPCComponents>::EncryptionGroup::read(&to_bytes![element]?[..])?;
 
@@ -219,8 +219,8 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
         system_parameters: &SystemParameters<C>,
         encrypted_record: &EncryptedRecord<C>,
     ) -> Result<<<C as DPCComponents>::EncryptedRecordCRH as CRH>::Output, DPCError> {
-        let mut ciphertext_affine_x = vec![];
-        let mut selector_bits = vec![];
+        let mut ciphertext_affine_x = Vec::with_capacity(encrypted_record.encrypted_record.len());
+        let mut selector_bits = Vec::with_capacity(encrypted_record.encrypted_record.len() + 1);
         for ciphertext_element in &encrypted_record.encrypted_record {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =
@@ -281,9 +281,9 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
             .concat()
         };
 
-        let mut record_field_elements = vec![];
-        let mut record_group_encoding = vec![];
-        let mut record_plaintexts = vec![];
+        let mut record_field_elements = Vec::with_capacity(serialized_record.len());
+        let mut record_group_encoding = Vec::with_capacity(serialized_record.len());
+        let mut record_plaintexts = Vec::with_capacity(serialized_record.len());
 
         for (i, (element, fq_high)) in serialized_record.iter().zip_eq(&fq_high_selectors).enumerate() {
             let element_affine = element.into_affine();
@@ -340,7 +340,7 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
         )?;
 
         // Compute the compressed ciphertext selector bits
-        let mut ciphertext_selectors = vec![];
+        let mut ciphertext_selectors = Vec::with_capacity(encrypted_record.len());
         for ciphertext_element in encrypted_record.iter() {
             // Compress the ciphertext element to the affine x coordinate
             let ciphertext_element_affine =

--- a/dpc/src/base_dpc/record/record_serializer.rs
+++ b/dpc/src/base_dpc/record/record_serializer.rs
@@ -104,7 +104,7 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
         // reserve the MSB of the data field element's valid bitsize and set the bit to 1.
         assert_eq!(Self::PAYLOAD_ELEMENT_BITSIZE, Self::DATA_ELEMENT_BITSIZE - 1);
 
-        // This element needs to be represented in the contraint field; its bits and the number of elements
+        // This element needs to be represented in the constraint field; its bits and the number of elements
         // are calculated early, so that the storage vectors can be pre-allocated.
         let payload = record.payload();
         let payload_bits = bytes_to_bits(&to_bytes![payload]?);

--- a/dpc/src/base_dpc/transaction.rs
+++ b/dpc/src/base_dpc/transaction.rs
@@ -236,7 +236,7 @@ impl<C: BaseDPCComponents> FromBytes for DPCTransaction<C> {
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the old serial numbers
         let num_old_serial_numbers = C::NUM_INPUT_RECORDS;
-        let mut old_serial_numbers = vec![];
+        let mut old_serial_numbers = Vec::with_capacity(num_old_serial_numbers);
         for _ in 0..num_old_serial_numbers {
             let old_serial_number: <C::AccountSignature as SignatureScheme>::PublicKey =
                 CanonicalDeserialize::deserialize(&mut reader).unwrap();
@@ -246,7 +246,7 @@ impl<C: BaseDPCComponents> FromBytes for DPCTransaction<C> {
 
         // Read the new commitments
         let num_new_commitments = C::NUM_OUTPUT_RECORDS;
-        let mut new_commitments = vec![];
+        let mut new_commitments = Vec::with_capacity(num_new_commitments);
         for _ in 0..num_new_commitments {
             let new_commitment: <C::RecordCommitment as CommitmentScheme>::Output = FromBytes::read(&mut reader)?;
             new_commitments.push(new_commitment);
@@ -266,7 +266,7 @@ impl<C: BaseDPCComponents> FromBytes for DPCTransaction<C> {
 
         // Read the signatures
         let num_signatures = C::NUM_INPUT_RECORDS;
-        let mut signatures = vec![];
+        let mut signatures = Vec::with_capacity(num_signatures);
         for _ in 0..num_signatures {
             let signature: <C::AccountSignature as SignatureScheme>::Output = FromBytes::read(&mut reader)?;
             signatures.push(signature);
@@ -274,7 +274,7 @@ impl<C: BaseDPCComponents> FromBytes for DPCTransaction<C> {
 
         // Read the encrypted records
         let num_encrypted_records = C::NUM_OUTPUT_RECORDS;
-        let mut encrypted_records = vec![];
+        let mut encrypted_records = Vec::with_capacity(num_encrypted_records);
         for _ in 0..num_encrypted_records {
             let encrypted_record: EncryptedRecord<C> = FromBytes::read(&mut reader)?;
 

--- a/gadgets/src/algorithms/prf/blake2s.rs
+++ b/gadgets/src/algorithms/prf/blake2s.rs
@@ -335,7 +335,7 @@ pub fn blake2s_gadget<F: PrimeField, CS: ConstraintSystem<F>>(
     h.push(UInt32::constant(0x1F83D9AB));
     h.push(UInt32::constant(0x5BE0CD19));
 
-    let mut blocks: Vec<Vec<UInt32>> = vec![];
+    let mut blocks: Vec<Vec<UInt32>> = Vec::with_capacity(input.len() / 512);
 
     for block in input.chunks(512) {
         let mut this_block = Vec::with_capacity(16);

--- a/gadgets/src/curves/templates/bls12/g2.rs
+++ b/gadgets/src/curves/templates/bls12/g2.rs
@@ -64,10 +64,11 @@ impl<P: Bls12Parameters> G2PreparedGadget<P> {
         let two_inv = P::Fp::one().double().inverse().unwrap();
         let zero = G2Gadget::<P>::zero(cs.ns(|| "zero"))?;
         q.enforce_not_equal(cs.ns(|| "enforce not zero"), &zero)?;
-        let mut ell_coeffs = vec![];
+        let bit_iterator = BitIterator::new(P::X);
+        let mut ell_coeffs = Vec::with_capacity(bit_iterator.len());
         let mut r = q.clone();
 
-        for (j, i) in BitIterator::new(P::X).skip(1).enumerate() {
+        for (j, i) in bit_iterator.skip(1).enumerate() {
             let mut cs = cs.ns(|| format!("Iteration {}", j));
             ell_coeffs.push(Self::double(cs.ns(|| "double"), &mut r, &two_inv)?);
 

--- a/gadgets/src/curves/templates/bls12/pairing.rs
+++ b/gadgets/src/curves/templates/bls12/pairing.rs
@@ -118,7 +118,7 @@ where
         ps: &[Self::G1PreparedGadget],
         qs: &[Self::G2PreparedGadget],
     ) -> Result<Self::GTGadget, SynthesisError> {
-        let mut pairs = vec![];
+        let mut pairs = Vec::with_capacity(ps.len());
         for (p, q) in ps.iter().zip(qs.iter()) {
             pairs.push((p, q.ell_coeffs.iter()));
         }

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -989,7 +989,7 @@ mod projective_impl {
                 {
                     let base_power = base_power.borrow();
                     let mut acc_power = *base_power;
-                    let mut coords = vec![];
+                    let mut coords = Vec::with_capacity(4);
                     for _ in 0..4 {
                         coords.push(acc_power);
                         acc_power += base_power;

--- a/marlin/src/ahp/constraint_systems.rs
+++ b/marlin/src/ahp/constraint_systems.rs
@@ -281,9 +281,10 @@ pub(crate) fn arithmetize_matrix<'a, F: PrimeField>(
 
     let elems: Vec<_> = output_domain.elements().collect();
 
-    let mut row_vec = Vec::new();
-    let mut col_vec = Vec::new();
-    let mut val_vec = Vec::new();
+    let vec_len: usize = matrix.iter().map(|row| row.len()).sum();
+    let mut row_vec = Vec::with_capacity(vec_len);
+    let mut col_vec = Vec::with_capacity(vec_len);
+    let mut val_vec = Vec::with_capacity(vec_len);
 
     let eq_poly_vals_time = start_timer!(|| "Precomputing eq_poly_vals");
     let eq_poly_vals: BTreeMap<F, F> = output_domain
@@ -293,7 +294,7 @@ pub(crate) fn arithmetize_matrix<'a, F: PrimeField>(
     end_timer!(eq_poly_vals_time);
 
     let lde_evals_time = start_timer!(|| "Computing row, col and val evals");
-    let mut inverses = Vec::new();
+    let mut inverses = Vec::with_capacity(vec_len);
 
     let mut count = 0;
 

--- a/marlin/src/ahp/mod.rs
+++ b/marlin/src/ahp/mod.rs
@@ -147,7 +147,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         let beta = state.second_round_msg.unwrap().beta;
         let gamma = state.gamma.unwrap();
 
-        let mut linear_combinations = Vec::new();
+        let mut linear_combinations = Vec::with_capacity(9);
 
         // Outer sumchecK:
         let z_b = LinearCombination::new("z_b", vec![(F::one(), "z_b")]);

--- a/marlin/src/ahp/prover.rs
+++ b/marlin/src/ahp/prover.rs
@@ -81,7 +81,7 @@ impl<'a, 'b, F: PrimeField, C> ProverState<'a, 'b, F, C> {
 
 /// Each prover message that is not a list of oracles is a list of field elements.
 #[repr(transparent)]
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ProverMsg<F: Field> {
     /// The field elements that make up the message
     pub field_elements: Vec<F>,
@@ -297,7 +297,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         mask_poly[0] -= &scaled_sigma_1;
         end_timer!(mask_poly_time);
 
-        let msg = ProverMsg { field_elements: vec![] };
+        let msg = ProverMsg::default();
 
         assert!(w_poly.degree() < domain_h.size() - domain_x.size() + zk_bound);
         assert!(z_a_poly.degree() < domain_h.size() + zk_bound);
@@ -613,7 +613,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
             .0;
         end_timer!(h_2_poly_time);
 
-        let msg = ProverMsg { field_elements: vec![] };
+        let msg = ProverMsg::default();
 
         assert!(g_2.degree() <= domain_k.size() - 2);
         let oracles = ProverThirdOracles {

--- a/models/src/gadgets/curves/fp.rs
+++ b/models/src/gadgets/curves/fp.rs
@@ -349,7 +349,7 @@ impl<F: PrimeField> ToBitsGadget<F> for FpGadget<F> {
             None => vec![None; num_bits as usize],
         };
 
-        let mut bits = vec![];
+        let mut bits = Vec::with_capacity(bit_values.len());
         for (i, b) in bit_values.into_iter().enumerate() {
             bits.push(AllocatedBit::alloc(cs.ns(|| format!("bit {}", i)), || b.get())?);
         }

--- a/models/src/gadgets/utilities/alloc.rs
+++ b/models/src/gadgets/utilities/alloc.rs
@@ -79,8 +79,9 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
-        let mut vec = vec![];
-        for (i, value) in f()?.borrow().iter().enumerate() {
+        let f = f()?;
+        let mut vec = Vec::with_capacity(f.borrow().len());
+        for (i, value) in f.borrow().iter().enumerate() {
             vec.push(A::alloc(&mut cs.ns(|| format!("alloc_{}", i)), || Ok(value))?);
         }
         Ok(vec)
@@ -90,8 +91,9 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
-        let mut vec = vec![];
-        for (i, value) in f()?.borrow().iter().enumerate() {
+        let f = f()?;
+        let mut vec = Vec::with_capacity(f.borrow().len());
+        for (i, value) in f.borrow().iter().enumerate() {
             vec.push(A::alloc_checked(&mut cs.ns(|| format!("alloc_checked_{}", i)), || {
                 Ok(value)
             })?);
@@ -103,8 +105,9 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
-        let mut vec = vec![];
-        for (i, value) in f()?.borrow().iter().enumerate() {
+        let f = f()?;
+        let mut vec = Vec::with_capacity(f.borrow().len());
+        for (i, value) in f.borrow().iter().enumerate() {
             vec.push(A::alloc_input(&mut cs.ns(|| format!("alloc_input_{}", i)), || {
                 Ok(value)
             })?);
@@ -116,8 +119,9 @@ impl<I, F: Field, A: AllocGadget<I, F>> AllocGadget<[I], F> for Vec<A> {
         mut cs: CS,
         f: Fn,
     ) -> Result<Self, SynthesisError> {
-        let mut vec = vec![];
-        for (i, value) in f()?.borrow().iter().enumerate() {
+        let f = f()?;
+        let mut vec = Vec::with_capacity(f.borrow().len());
+        for (i, value) in f.borrow().iter().enumerate() {
             vec.push(A::alloc_input_checked(
                 &mut cs.ns(|| format!("alloc_input_checked_{}", i)),
                 || Ok(value),

--- a/models/src/gadgets/utilities/bits/rca.rs
+++ b/models/src/gadgets/utilities/bits/rca.rs
@@ -34,7 +34,7 @@ where
 // Generic impl
 impl<F: Field> RippleCarryAdder<F> for Vec<Boolean> {
     fn add_bits<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut result = vec![];
+        let mut result = Vec::with_capacity(self.len() + 1);
         let mut carry = Boolean::constant(false);
         for (i, (a, b)) in self.iter().zip(other.iter()).enumerate() {
             let (sum, next) = Boolean::add(cs.ns(|| format!("rpc {}", i)), a, b, &carry)?;

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -407,7 +407,7 @@ impl Boolean {
 
     /// Construct a boolean vector from a vector of u8
     pub fn constant_u8_vec<F: Field, CS: ConstraintSystem<F>>(cs: &mut CS, values: &[u8]) -> Vec<Self> {
-        let mut input_bits = vec![];
+        let mut input_bits = Vec::with_capacity(values.len() * 8);
         for (byte_i, input_byte) in values.iter().enumerate() {
             for bit_i in (0..8).rev() {
                 let cs = cs.ns(|| format!("input_bit_gadget {} {}", byte_i, bit_i));

--- a/models/src/gadgets/utilities/int/arithmetic/add.rs
+++ b/models/src/gadgets/utilities/int/arithmetic/add.rs
@@ -109,7 +109,7 @@ macro_rules! add_int_impl {
                 }
 
                 // Storage area for the resulting bits
-                let mut result_bits = vec![];
+                let mut result_bits = Vec::with_capacity(max_bits);
 
                 // Allocate each bit_gadget of the result
                 let mut coeff = F::one();

--- a/models/src/gadgets/utilities/uint/macros.rs
+++ b/models/src/gadgets/utilities/uint/macros.rs
@@ -318,7 +318,7 @@ macro_rules! uint_impl {
                                 let modular_value = result_value.map(|v| v as $_type);
 
                                 // Storage area for the resulting bits
-                                let mut result_bits = vec![];
+                                let mut result_bits = Vec::with_capacity($size);
 
                                 // This is a linear combination that we will enforce to be "zero"
                                 let mut lc = LinearCombination::zero();

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -357,7 +357,7 @@ impl UInt for UInt128 {
                         let modular_value = result_value.map(|v| v as u128);
 
                         // Storage area for the resulting bits
-                        let mut result_bits = vec![];
+                        let mut result_bits = Vec::with_capacity(128);
 
                         // This is a linear combination that we will enforce to be "zero"
                         let mut lc = LinearCombination::zero();

--- a/models/src/gadgets/utilities/uint/unsigned_integer.rs
+++ b/models/src/gadgets/utilities/uint/unsigned_integer.rs
@@ -100,11 +100,7 @@ pub trait UInt: Debug + Clone + PartialOrd + Eq + PartialEq {
 impl UInt8 {
     /// Construct a constant vector of `UInt8` from a vector of `u8`
     pub fn constant_vec(values: &[u8]) -> Vec<Self> {
-        let mut result = Vec::new();
-        for value in values {
-            result.push(UInt8::constant(*value));
-        }
-        result
+        values.iter().copied().map(UInt8::constant).collect()
     }
 
     pub fn alloc_vec<F, CS, T>(mut cs: CS, values: &[T]) -> Result<Vec<Self>, SynthesisError>

--- a/network/src/external/message/message_header.rs
+++ b/network/src/external/message/message_header.rs
@@ -33,13 +33,9 @@ impl MessageHeader {
     }
 
     pub fn serialize(&self) -> Result<Vec<u8>, MessageHeaderError> {
-        let mut result = vec![];
+        let mut result = Vec::with_capacity(self.name.len() + 4);
         result.extend_from_slice(&self.name.as_bytes());
-
-        let mut wtr = vec![];
-        wtr.write_u32::<BigEndian>(self.len)?;
-
-        result.extend_from_slice(&wtr);
+        result.write_u32::<BigEndian>(self.len)?;
 
         Ok(result)
     }

--- a/network/src/external/message_types/ping.rs
+++ b/network/src/external/message_types/ping.rs
@@ -61,7 +61,7 @@ impl Message for Ping {
     }
 
     fn serialize(&self) -> Result<Vec<u8>, MessageError> {
-        let mut writer = vec![];
+        let mut writer = Vec::with_capacity(8);
         writer.write_u64::<BigEndian>(self.nonce)?;
 
         Ok(writer)

--- a/network/src/external/message_types/pong.rs
+++ b/network/src/external/message_types/pong.rs
@@ -54,7 +54,7 @@ impl Message for Pong {
     }
 
     fn serialize(&self) -> Result<Vec<u8>, MessageError> {
-        let mut writer = vec![];
+        let mut writer = Vec::with_capacity(8);
         writer.write_u64::<BigEndian>(self.nonce)?;
 
         Ok(writer)

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -29,7 +29,7 @@ use crate::{
 use snarkos_consensus::memory_pool::Entry;
 use snarkos_dpc::base_dpc::instantiated::Tx;
 use snarkos_errors::network::ServerError;
-use snarkos_objects::{Block as BlockStruct, BlockHeaderHash};
+use snarkos_objects::Block as BlockStruct;
 use snarkos_utilities::{
     bytes::{FromBytes, ToBytes},
     to_bytes,
@@ -381,7 +381,7 @@ impl Server {
                     max_height = height + 4000;
                 }
 
-                let mut block_hashes: Vec<BlockHeaderHash> = vec![];
+                let mut block_hashes = Vec::with_capacity(max_height.saturating_sub(height + 1) as usize);
 
                 for block_num in height + 1..=max_height {
                     block_hashes.push(self.storage.get_block_hash(block_num)?);

--- a/objects/src/dpc/transactions.rs
+++ b/objects/src/dpc/transactions.rs
@@ -76,7 +76,7 @@ impl<T: Transaction> DPCTransactions<T> {
     pub fn conflicts(&self, transaction: &T) -> bool {
         let mut holding_serial_numbers = vec![];
         let mut holding_commitments = vec![];
-        let mut holding_memos = vec![];
+        let mut holding_memos = Vec::with_capacity(self.0.len());
 
         for tx in &self.0 {
             if tx.network_id() != transaction.network_id() {
@@ -139,7 +139,7 @@ impl<T: Transaction> FromBytes for DPCTransactions<T> {
     #[inline]
     fn read<R: Read>(mut reader: R) -> IoResult<Self> {
         let num_transactions = read_variable_length_integer(&mut reader)?;
-        let mut transactions = vec![];
+        let mut transactions = Vec::with_capacity(num_transactions);
         for _ in 0..num_transactions {
             let transaction: T = FromBytes::read(&mut reader)?;
             transactions.push(transaction);

--- a/objects/src/merkle_tree.rs
+++ b/objects/src/merkle_tree.rs
@@ -20,7 +20,7 @@ use snarkos_algorithms::crh::double_sha256;
 pub struct MerkleTreeRootHash([u8; 32]);
 
 fn merkle_round(hashes: &[Vec<u8>]) -> Vec<Vec<u8>> {
-    let mut pairs = vec![];
+    let mut pairs = Vec::with_capacity(hashes.len() / 2);
 
     for i in (0..hashes.len() - 1).step_by(2) {
         pairs.push((&hashes[i], &hashes[i + 1]));

--- a/parameters/examples/generate_transaction.rs
+++ b/parameters/examples/generate_transaction.rs
@@ -106,7 +106,7 @@ pub fn generate(recipient: &String, value: u64, network_id: u8, file_name: &Stri
     // Generate dummy input records
 
     let old_account_private_keys = vec![dummy_account.private_key.clone(); Components::NUM_INPUT_RECORDS];
-    let mut old_records = vec![];
+    let mut old_records = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
     for i in 0..Components::NUM_INPUT_RECORDS {
         let old_sn_nonce = &parameters
             .system_parameters

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -248,20 +248,20 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
             labels.insert(label);
         }
 
-        let mut proofs = Vec::new();
+        let mut proofs = Vec::with_capacity(query_to_labels_map.len());
         for (query, labels) in query_to_labels_map.into_iter() {
-            let mut query_polys: Vec<&'a LabeledPolynomial<'a, _>> = Vec::new();
-            let mut query_rands: Vec<&'a Self::Randomness> = Vec::new();
-            let mut query_comms: Vec<&'a LabeledCommitment<Self::Commitment>> = Vec::new();
+            let mut query_polys = Vec::with_capacity(labels.len());
+            let mut query_rands = Vec::with_capacity(labels.len());
+            let mut query_comms = Vec::with_capacity(labels.len());
 
             for label in labels {
                 let (polynomial, rand, comm) = poly_rand_comm.get(label).ok_or(Error::MissingPolynomial {
                     label: label.to_string(),
                 })?;
 
-                query_polys.push(polynomial);
-                query_rands.push(rand);
-                query_comms.push(comm);
+                query_polys.push(*polynomial);
+                query_rands.push(*rand);
+                query_comms.push(*comm);
             }
 
             let proof_time = start_timer!(|| "Creating proof");
@@ -326,8 +326,8 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
 
         let mut result = true;
         for ((query, labels), proof) in query_to_labels_map.into_iter().zip(proofs) {
-            let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::new();
-            let mut values = Vec::new();
+            let mut comms: Vec<&'_ LabeledCommitment<_>> = Vec::with_capacity(labels.len());
+            let mut values = Vec::with_capacity(labels.len());
             for label in labels.into_iter() {
                 let commitment = commitments.get(label).ok_or(Error::MissingPolynomial {
                     label: label.to_string(),

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -454,13 +454,13 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
         }
         assert_eq!(proof.len(), query_to_labels_map.len());
 
-        let mut combined_comms = Vec::new();
-        let mut combined_queries = Vec::new();
-        let mut combined_evals = Vec::new();
+        let mut combined_comms = Vec::with_capacity(query_to_labels_map.len());
+        let mut combined_queries = Vec::with_capacity(query_to_labels_map.len());
+        let mut combined_evals = Vec::with_capacity(query_to_labels_map.len());
         for (query, labels) in query_to_labels_map.into_iter() {
             let lc_time = start_timer!(|| format!("Randomly combining {} commitments", labels.len()));
-            let mut comms_to_combine: Vec<&'_ LabeledCommitment<_>> = Vec::new();
-            let mut values_to_combine = Vec::new();
+            let mut comms_to_combine = Vec::with_capacity(labels.len());
+            let mut values_to_combine = Vec::with_capacity(labels.len());
             for label in labels.into_iter() {
                 let commitment = commitments.get(label).ok_or(Error::MissingPolynomial {
                     label: label.to_string(),
@@ -472,7 +472,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
                     label: label.to_string(),
                 })?;
 
-                comms_to_combine.push(commitment);
+                comms_to_combine.push(*commitment);
                 values_to_combine.push(*v_i);
             }
             let (c, v) =

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -107,8 +107,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
         vk: &VerifierKey<E>,
     ) -> Result<bool, Error> {
         let check_time = start_timer!(|| "Checking elems");
-        let mut g1_projective_elems: Vec<E::G1Projective> = Vec::new();
-        let mut g2_prepared_elems: Vec<<E::G2Affine as PairingCurve>::Prepared> = Vec::new();
+        let mut g1_projective_elems = Vec::with_capacity(combined_comms.len() + 2);
+        let mut g2_prepared_elems = Vec::with_capacity(combined_comms.len() + 2);
 
         for (degree_bound, comm) in combined_comms.into_iter() {
             let shift_power = if let Some(degree_bound) = degree_bound {
@@ -200,7 +200,8 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
                     let _max_gamma_g = pp.powers_of_gamma_g.keys().last().unwrap();
                     for degree_bound in enforced_degree_bounds {
                         let shift_degree = max_degree - degree_bound;
-                        let mut powers_for_degree_bound = vec![];
+                        let mut powers_for_degree_bound =
+                            Vec::with_capacity((max_degree + 2).saturating_sub(shift_degree));
                         for i in 0..=supported_hiding_bound + 1 {
                             // We have an additional degree in `powers_of_gamma_g` beyond `powers_of_g`.
                             if shift_degree + i < max_degree + 2 {

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -305,11 +305,7 @@ impl RpcFunctions for RpcImpl {
         // Create a temporary tokio runtime to make an asynchronous function call
         let peer_book = Runtime::new()?.block_on(self.server_context.peer_book.read());
 
-        let mut peers = vec![];
-
-        for peer in peer_book.get_connected().keys() {
-            peers.push(*peer);
-        }
+        let peers = peer_book.get_connected().keys().cloned().collect();
 
         Ok(PeerInfo { peers })
     }

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -124,7 +124,7 @@ impl RpcFunctions for RpcImpl {
         };
 
         if let Ok(block) = self.storage.get_block(&block_header_hash) {
-            let mut transactions = vec![];
+            let mut transactions = Vec::with_capacity(block.transactions.len());
 
             for transaction in block.transactions.iter() {
                 transactions.push(hex::encode(&transaction.transaction_id()?));
@@ -191,7 +191,7 @@ impl RpcFunctions for RpcImpl {
         let transaction_bytes = hex::decode(transaction_bytes)?;
         let transaction = Tx::read(&transaction_bytes[..])?;
 
-        let mut old_serial_numbers = vec![];
+        let mut old_serial_numbers = Vec::with_capacity(transaction.old_serial_numbers().len());
 
         for sn in transaction.old_serial_numbers() {
             let mut serial_number: Vec<u8> = vec![];
@@ -199,7 +199,7 @@ impl RpcFunctions for RpcImpl {
             old_serial_numbers.push(hex::encode(serial_number));
         }
 
-        let mut new_commitments = vec![];
+        let mut new_commitments = Vec::with_capacity(transaction.new_commitments().len());
 
         for cm in transaction.new_commitments() {
             new_commitments.push(hex::encode(to_bytes![cm]?));
@@ -207,12 +207,12 @@ impl RpcFunctions for RpcImpl {
 
         let memo = hex::encode(to_bytes![transaction.memorandum()]?);
 
-        let mut signatures = vec![];
+        let mut signatures = Vec::with_capacity(transaction.signatures.len());
         for sig in &transaction.signatures {
             signatures.push(hex::encode(to_bytes![sig]?));
         }
 
-        let mut encrypted_records = vec![];
+        let mut encrypted_records = Vec::with_capacity(transaction.encrypted_records.len());
 
         for encrypted_record in &transaction.encrypted_records {
             encrypted_records.push(hex::encode(to_bytes![encrypted_record]?));

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -258,13 +258,13 @@ impl ProtectedRpcFunctions for RpcImpl {
         let new_death_program_ids = vec![program_id.clone(); Components::NUM_OUTPUT_RECORDS];
 
         // Decode old records
-        let mut old_records = vec![];
+        let mut old_records = Vec::with_capacity(transaction_input.old_records.len());
         for record_string in transaction_input.old_records {
             let record_bytes = hex::decode(record_string)?;
             old_records.push(DPCRecord::<Components>::read(&record_bytes[..])?);
         }
 
-        let mut old_account_private_keys = vec![];
+        let mut old_account_private_keys = Vec::with_capacity(transaction_input.old_account_private_keys.len());
         for private_key_string in transaction_input.old_account_private_keys {
             old_account_private_keys.push(AccountPrivateKey::<Components>::from_str(&private_key_string)?);
         }
@@ -306,9 +306,9 @@ impl ProtectedRpcFunctions for RpcImpl {
         assert_eq!(old_account_private_keys.len(), Components::NUM_INPUT_RECORDS);
 
         // Decode new recipient data
-        let mut new_record_owners = vec![];
-        let mut new_is_dummy_flags = vec![];
-        let mut new_values = vec![];
+        let mut new_record_owners = Vec::with_capacity(Components::NUM_OUTPUT_RECORDS);
+        let mut new_is_dummy_flags = Vec::with_capacity(Components::NUM_OUTPUT_RECORDS);
+        let mut new_values = Vec::with_capacity(Components::NUM_OUTPUT_RECORDS);
         for recipient in transaction_input.recipients {
             new_record_owners.push(AccountAddress::<Components>::from_str(&recipient.address)?);
             new_is_dummy_flags.push(false);
@@ -363,7 +363,7 @@ impl ProtectedRpcFunctions for RpcImpl {
         )?;
 
         let encoded_transaction = hex::encode(to_bytes![transaction]?);
-        let mut encoded_records = vec![];
+        let mut encoded_records = Vec::with_capacity(records.len());
         for record in records {
             encoded_records.push(hex::encode(to_bytes![record]?));
         }

--- a/storage/src/objects/block_path.rs
+++ b/storage/src/objects/block_path.rs
@@ -101,7 +101,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         if children.is_empty() {
             Ok((1, final_path))
         } else {
-            let mut paths = vec![];
+            let mut paths = Vec::with_capacity(children.len());
             for child in children {
                 paths.push(self.longest_child_path(child)?);
             }

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -138,13 +138,11 @@ fn impl_deserialize_field(ty: &Type) -> (TokenStream, TokenStream) {
     // Check if type is a tuple.
     match ty {
         Type::Tuple(tuple) => {
-            let mut compressed_fields = Vec::new();
-            let mut uncompressed_fields = Vec::new();
-            for elem_ty in tuple.elems.iter() {
-                let (compressed, uncompressed) = impl_deserialize_field(elem_ty);
-                compressed_fields.push(compressed);
-                uncompressed_fields.push(uncompressed);
-            }
+            let (compressed_fields, uncompressed_fields): (Vec<_>, Vec<_>) = tuple
+                .elems
+                .iter()
+                .map(|elem_ty| impl_deserialize_field(elem_ty))
+                .unzip();
             (
                 quote! { (#(#compressed_fields)*), },
                 quote! { (#(#uncompressed_fields)*), },

--- a/utilities/src/bititerator.rs
+++ b/utilities/src/bititerator.rs
@@ -26,6 +26,10 @@ impl<E: AsRef<[u64]>> BitIterator<E> {
 
         BitIterator { t, n }
     }
+
+    pub fn len(&self) -> usize {
+        self.n
+    }
 }
 
 impl<E: AsRef<[u64]>> Iterator for BitIterator<E> {


### PR DESCRIPTION
A sweep of mostly straightforward memory-handling tweaks targeting `Vec::new` and `vec![]` that are followed by `.push()` loops; pre-allocating the expected vector capacity allows to perform fewer re-allocations during runtime, leading to potential performance and memory use (possibly reducing over-allocations) improvements.
notes:
- in some places the final vector length could be greater than the specified value; in those cases the minimal/conservative scenario is assumed, possibly including an extra `1` or `2` elements that might be pushed in the related conditionals
- in cases where the loop contains early returns (e.g. via `?`), the "happy path" (i.e. no errors) is assumed
- capacity calculations where the calculation was already present in some form (e.g. in a loop range) are preserved verbatim; new ones, especially subtractions, are using the `saturating` methods in order not to cause overflow panics
- a few explicit types were removed, as they could be inferred by the compiler

Some of the more noteworthy related adjustments are:
- adding a `len` method to `BitIterator` allowing to pre-allocate in `push()`-loops using it
- deriving `Default` for more objects, limiting the number of `vec![]` groups in the code (improving future memory-handling tweaks and readability)
- optimizing the was `MessageHandler::serialize` performs its writes