### PR TITLE
Fewer Vec return values

### DIFF
--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -146,10 +146,11 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
 
         let mut padded_input = Vec::with_capacity(input_bytes.len());
         let input = bytes_to_bits(input_bytes);
+        let input_len = input_bytes.len() * 8;
         // Pad the input if it is not the current length.
-        padded_input.extend_from_slice(&input);
-        if input.len() % BOWE_HOPWOOD_CHUNK_SIZE != 0 {
-            let current_length = input.len();
+        padded_input.extend(input);
+        if input_len % BOWE_HOPWOOD_CHUNK_SIZE != 0 {
+            let current_length = input_len;
             for _ in 0..(BOWE_HOPWOOD_CHUNK_SIZE - current_length % BOWE_HOPWOOD_CHUNK_SIZE) {
                 padded_input.push(false);
             }

--- a/algorithms/src/crh/pedersen.rs
+++ b/algorithms/src/crh/pedersen.rs
@@ -78,6 +78,7 @@ impl<G: Group, S: PedersenSize> CRH for PedersenCRH<G, S> {
             #[cfg(feature = "pedersen-parallel")]
             {
                 bytes_to_bits(input)
+                    .collect::<Vec<_>>()
                     .par_chunks(S::WINDOW_SIZE)
                     .zip(&self.parameters.bases)
                     .map(|(bits, powers)| {

--- a/algorithms/src/encryption/group.rs
+++ b/algorithms/src/encryption/group.rs
@@ -98,11 +98,8 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
         let keygen_time = start_timer!(|| "GroupEncryption::generate_public_key");
 
         let mut public_key = G::zero();
-        for (bit, base_power) in bytes_to_bits(&to_bytes![private_key]?)
-            .iter()
-            .zip_eq(&self.parameters.generator_powers)
-        {
-            if *bit {
+        for (bit, base_power) in bytes_to_bits(&to_bytes![private_key]?).zip_eq(&self.parameters.generator_powers) {
+            if bit {
                 public_key += &base_power;
             }
         }
@@ -170,11 +167,8 @@ impl<G: Group + ProjectiveCurve> EncryptionScheme for GroupEncryption<G> {
         let record_view_key = public_key.0.mul(&randomness);
 
         let mut c_0 = G::zero();
-        for (bit, base_power) in bytes_to_bits(&to_bytes![randomness]?)
-            .iter()
-            .zip_eq(&self.parameters.generator_powers)
-        {
-            if *bit {
+        for (bit, base_power) in bytes_to_bits(&to_bytes![randomness]?).zip_eq(&self.parameters.generator_powers) {
+            if bit {
                 c_0 += &base_power;
             }
         }

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -107,14 +107,6 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
         }
     }
 
-    #[inline]
-    fn iter_with_index(&self) -> Vec<(usize, F)> {
-        match self {
-            SPolynomial(p) => p.coeffs.to_vec(),
-            DPolynomial(p) => p.iter().cloned().enumerate().collect(),
-        }
-    }
-
     /// Divide self by another (sparse or dense) polynomial, and returns the quotient and remainder.
     pub fn divide_with_q_and_r(&self, divisor: &Self) -> Option<(DensePolynomial<F>, DensePolynomial<F>)> {
         if self.is_zero() {
@@ -134,9 +126,16 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
                 let cur_q_degree = remainder.degree() - divisor.degree();
                 quotient[cur_q_degree] = cur_q_coeff;
 
-                for (i, div_coeff) in divisor.iter_with_index() {
-                    remainder[cur_q_degree + i] -= &(cur_q_coeff * &div_coeff);
+                if let SPolynomial(p) = divisor {
+                    for (i, div_coeff) in &p.coeffs {
+                        remainder[cur_q_degree + i] -= &(cur_q_coeff * &div_coeff);
+                    }
+                } else if let DPolynomial(p) = divisor {
+                    for (i, div_coeff) in p.iter().enumerate() {
+                        remainder[cur_q_degree + i] -= &(cur_q_coeff * &div_coeff);
+                    }
                 }
+
                 while let Some(true) = remainder.coeffs.last().map(|c| c.is_zero()) {
                     remainder.coeffs.pop();
                 }

--- a/algorithms/src/signature/schnorr.rs
+++ b/algorithms/src/signature/schnorr.rs
@@ -142,11 +142,8 @@ where
         let keygen_time = start_timer!(|| "SchnorrSignature::generate_public_key");
 
         let mut public_key = G::zero();
-        for (bit, base_power) in bytes_to_bits(&to_bytes![private_key]?)
-            .iter()
-            .zip_eq(&self.parameters.generator_powers)
-        {
-            if *bit {
+        for (bit, base_power) in bytes_to_bits(&to_bytes![private_key]?).zip_eq(&self.parameters.generator_powers) {
+            if bit {
                 public_key += &base_power;
             }
         }
@@ -169,11 +166,9 @@ where
             // Commit to the random scalar via r := k · g.
             // This is the prover's first msg in the Sigma protocol.
             let mut prover_commitment = G::zero();
-            for (bit, base_power) in bytes_to_bits(&to_bytes![random_scalar]?)
-                .iter()
-                .zip_eq(&self.parameters.generator_powers)
+            for (bit, base_power) in bytes_to_bits(&to_bytes![random_scalar]?).zip_eq(&self.parameters.generator_powers)
             {
-                if *bit {
+                if bit {
                     prover_commitment += &base_power;
                 }
             }
@@ -215,11 +210,8 @@ where
         } = signature;
 
         let mut claimed_prover_commitment = G::zero();
-        for (bit, base_power) in bytes_to_bits(&to_bytes![prover_response]?)
-            .iter()
-            .zip_eq(&self.parameters.generator_powers)
-        {
-            if *bit {
+        for (bit, base_power) in bytes_to_bits(&to_bytes![prover_response]?).zip_eq(&self.parameters.generator_powers) {
+            if bit {
                 claimed_prover_commitment += &base_power;
             }
         }
@@ -253,11 +245,8 @@ where
         let mut randomized_pk = public_key.0;
 
         let mut encoded = G::zero();
-        for (bit, base_power) in bytes_to_bits(&to_bytes![randomness]?)
-            .iter()
-            .zip_eq(&self.parameters.generator_powers)
-        {
-            if *bit {
+        for (bit, base_power) in bytes_to_bits(&to_bytes![randomness]?).zip_eq(&self.parameters.generator_powers) {
+            if bit {
                 encoded += &base_power;
             }
         }

--- a/dpc/src/base_dpc/record/record_encryption.rs
+++ b/dpc/src/base_dpc/record/record_encryption.rs
@@ -275,7 +275,10 @@ impl<C: BaseDPCComponents> RecordEncryption<C> {
             )?;
             let final_element_bits = bytes_to_bits(&final_element_bytes);
             [
-                &final_element_bits[1..serialized_record.len()],
+                &final_element_bits
+                    .skip(1)
+                    .take(serialized_record.len().saturating_sub(1))
+                    .collect::<Vec<_>>(),
                 &[final_fq_high_selector][..],
             ]
             .concat()

--- a/dpc/src/base_dpc/record/record_payload.rs
+++ b/dpc/src/base_dpc/record/record_payload.rs
@@ -28,8 +28,8 @@ impl Default for RecordPayload {
 }
 
 impl RecordPayload {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_vec()
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.0[..]
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Self {

--- a/dpc/src/base_dpc/record/record_serializer.rs
+++ b/dpc/src/base_dpc/record/record_serializer.rs
@@ -191,10 +191,14 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
 
         // Process payload.
 
+        let payload_bytes = to_bytes![payload]?;
+        let payload_bits_count = payload_bytes.len() * 8;
+        let payload_bits = bytes_to_bits(&payload_bytes);
+
         let mut payload_field_bits = Vec::with_capacity(Self::PAYLOAD_ELEMENT_BITSIZE + 1);
 
-        for (i, bit) in payload_bits.iter().enumerate() {
-            payload_field_bits.push(*bit);
+        for (i, bit) in payload_bits.enumerate() {
+            payload_field_bits.push(bit);
 
             if (i > 0) && ((i + 1) % Self::PAYLOAD_ELEMENT_BITSIZE == 0) {
                 // (Assumption 4)
@@ -209,6 +213,7 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
             }
         }
 
+        let num_payload_elements = payload_bits_count / Self::PAYLOAD_ELEMENT_BITSIZE;
         assert_eq!(data_elements.len(), 5 + num_payload_elements);
         assert_eq!(data_high_bits.len(), 5 + num_payload_elements);
 
@@ -238,7 +243,7 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
         );
 
         // Append the value bits and create the final base element.
-        let value_bits = bytes_to_bits(&to_bytes![value]?);
+        let value_bits = bytes_to_bits(&to_bytes![value]?).collect();
 
         // (Assumption 4)
         let final_element = [vec![true], data_high_bits, value_bits, payload_field_bits].concat();
@@ -273,7 +278,7 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
         let final_element = &serialized_record[serialized_record.len() - 1];
         let final_element_bytes =
             decode_from_group::<Self::Parameters, Self::Group>(final_element.into_affine(), final_sign_high)?;
-        let final_element_bits = bytes_to_bits(&final_element_bytes);
+        let final_element_bits = bytes_to_bits(&final_element_bytes).collect::<Vec<_>>();
 
         let fq_high_bits = &final_element_bits[1..serialized_record.len()];
 
@@ -290,7 +295,9 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
             commitment_randomness.into_affine(),
             *commitment_randomness_fq_high,
         )?;
-        let commitment_randomness_bits = &bytes_to_bits(&commitment_randomness_bytes)[0..Self::DATA_ELEMENT_BITSIZE];
+        let commitment_randomness_bits = &bytes_to_bits(&commitment_randomness_bytes)
+            .take(Self::DATA_ELEMENT_BITSIZE)
+            .collect::<Vec<_>>();
         let commitment_randomness = <C::RecordCommitment as CommitmentScheme>::Randomness::read(
             &bits_to_bytes(commitment_randomness_bits)[..],
         )?;
@@ -315,12 +322,16 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
             *program_id_sign_high,
         )?;
 
-        let mut birth_program_id_bits = bytes_to_bits(&birth_program_id_bytes)[0..Self::DATA_ELEMENT_BITSIZE].to_vec();
-        let mut death_program_id_bits = bytes_to_bits(&death_program_id_bytes)[0..Self::DATA_ELEMENT_BITSIZE].to_vec();
+        let mut birth_program_id_bits = bytes_to_bits(&birth_program_id_bytes)
+            .take(Self::DATA_ELEMENT_BITSIZE)
+            .collect::<Vec<_>>();
+        let mut death_program_id_bits = bytes_to_bits(&death_program_id_bytes)
+            .take(Self::DATA_ELEMENT_BITSIZE)
+            .collect::<Vec<_>>();
 
-        let program_id_remainder_bits = bytes_to_bits(&program_id_remainder_bytes);
-        birth_program_id_bits.extend(&program_id_remainder_bits[0..remainder_size]);
-        death_program_id_bits.extend(&program_id_remainder_bits[remainder_size..remainder_size * 2]);
+        let mut program_id_remainder_bits = bytes_to_bits(&program_id_remainder_bytes);
+        birth_program_id_bits.extend(program_id_remainder_bits.by_ref().take(remainder_size));
+        death_program_id_bits.extend(program_id_remainder_bits.take(remainder_size));
 
         let birth_program_id = bits_to_bytes(&birth_program_id_bits);
         let death_program_id = bits_to_bytes(&death_program_id_bits);
@@ -340,7 +351,7 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
             .zip_eq(&fq_high_bits[5..])
         {
             let element_bytes = decode_from_group::<Self::Parameters, Self::Group>(element.into_affine(), *fq_high)?;
-            payload_bits.extend_from_slice(&bytes_to_bits(&element_bytes)[..Self::PAYLOAD_ELEMENT_BITSIZE]);
+            payload_bits.extend(bytes_to_bits(&element_bytes).take(Self::PAYLOAD_ELEMENT_BITSIZE));
         }
         payload_bits.extend_from_slice(&final_element_bits[value_end..]);
 

--- a/dpc/src/base_dpc/record/record_serializer.rs
+++ b/dpc/src/base_dpc/record/record_serializer.rs
@@ -107,8 +107,10 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
         // This element needs to be represented in the constraint field; its bits and the number of elements
         // are calculated early, so that the storage vectors can be pre-allocated.
         let payload = record.payload();
-        let payload_bits = bytes_to_bits(&to_bytes![payload]?);
-        let num_payload_elements = payload_bits.len() / Self::PAYLOAD_ELEMENT_BITSIZE;
+        let payload_bytes = to_bytes![payload]?;
+        let payload_bits_count = payload_bytes.len() * 8;
+        let payload_bits = bytes_to_bits(&payload_bytes);
+        let num_payload_elements = payload_bits_count / Self::PAYLOAD_ELEMENT_BITSIZE;
 
         // Create the vector for storing data elements.
 
@@ -191,10 +193,6 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
 
         // Process payload.
 
-        let payload_bytes = to_bytes![payload]?;
-        let payload_bits_count = payload_bytes.len() * 8;
-        let payload_bits = bytes_to_bits(&payload_bytes);
-
         let mut payload_field_bits = Vec::with_capacity(Self::PAYLOAD_ELEMENT_BITSIZE + 1);
 
         for (i, bit) in payload_bits.enumerate() {
@@ -213,7 +211,6 @@ impl<C: BaseDPCComponents, P: MontgomeryModelParameters + TEModelParameters, G: 
             }
         }
 
-        let num_payload_elements = payload_bits_count / Self::PAYLOAD_ELEMENT_BITSIZE;
         assert_eq!(data_elements.len(), 5 + num_payload_elements);
         assert_eq!(data_high_bits.len(), 5 + num_payload_elements);
 

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -361,7 +361,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
             .collect::<Vec<_>>();
 
         // Gather commitments in one vector.
-        let commitments: Vec<_> = index_vk
+        let commitments = index_vk
             .iter()
             .chain(first_comms)
             .chain(second_comms)
@@ -369,8 +369,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
             .cloned()
             .zip(AHPForR1CS::<F>::polynomial_labels())
             .zip(degree_bounds)
-            .map(|((c, l), d)| LabeledCommitment::new(l, c, d))
-            .collect();
+            .map(|((c, l), d)| LabeledCommitment::new(l, c, d));
 
         let (query_set, verifier_state) = AHPForR1CS::verifier_query_set(verifier_state, &mut fs_rng);
 
@@ -392,7 +391,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
         let evaluations_are_correct = PC::check_combinations(
             &index_vk.verifier_key,
             &lc_s,
-            &commitments,
+            commitments,
             &query_set,
             &evaluations,
             &proof.pc_proof,

--- a/models/src/gadgets/utilities/uint/macros.rs
+++ b/models/src/gadgets/utilities/uint/macros.rs
@@ -73,7 +73,7 @@ macro_rules! uint_impl {
             }
 
             fn to_bits_le(&self) -> Vec<Boolean> {
-                self.bits.iter().cloned().collect()
+                self.bits.clone()
             }
 
             fn from_bits_le(bits: &[Boolean]) -> Self {

--- a/objects/src/account/account_private_key.rs
+++ b/objects/src/account/account_private_key.rs
@@ -191,7 +191,7 @@ impl<C: DPCComponents> AccountPrivateKey<C> {
         // to the scalar field in the `inner_snark`, we additionally enforce
         // that the MSB bit of the scalar field is also set to 0.
         if !self.is_dummy {
-            let account_decryption_key_bits = bytes_to_bits(&decryption_key_bytes[..]);
+            let account_decryption_key_bits = bytes_to_bits(&decryption_key_bytes[..]).collect::<Vec<_>>();
             let account_decryption_key_length = account_decryption_key_bits.len();
 
             let decryption_private_key_length = C::AccountEncryption::private_key_size_in_bits();

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -308,7 +308,7 @@ impl<E: PairingEngine> KZG10<E> {
     /// `commitment_i` at `point_i`.
     pub fn batch_check<R: RngCore>(
         vk: &VerifierKey<E>,
-        commitments: &[Commitment<E>],
+        commitments: impl ExactSizeIterator<Item = Commitment<E>>,
         points: &[E::Fr],
         values: &[E::Fr],
         proofs: &[Proof<E>],
@@ -327,7 +327,7 @@ impl<E: PairingEngine> KZG10<E> {
         // their coefficients and perform a final multiplication at the end.
         let mut g_multiplier = E::Fr::zero();
         let mut gamma_g_multiplier = E::Fr::zero();
-        for (((c, z), v), proof) in commitments.iter().zip(points).zip(values).zip(proofs) {
+        for (((c, z), v), proof) in commitments.zip(points).zip(values).zip(proofs) {
             let w = proof.w;
             let mut temp = w.mul(*z);
             temp.add_assign_mixed(&c.0);
@@ -583,7 +583,14 @@ mod tests {
                 points.push(point);
                 proofs.push(proof);
             }
-            assert!(KZG10::<E>::batch_check(&vk, &comms, &points, &values, &proofs, rng)?);
+            assert!(KZG10::<E>::batch_check(
+                &vk,
+                comms.into_iter(),
+                &points,
+                &values,
+                &proofs,
+                rng
+            )?);
         }
         Ok(())
     }

--- a/polycommit/src/lib.rs
+++ b/polycommit/src/lib.rs
@@ -302,7 +302,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     /// committed in `labeled_commitments`.
     fn batch_check<'a, R: RngCore>(
         vk: &Self::VerifierKey,
-        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
+        commitments: impl Iterator<Item = LabeledCommitment<Self::Commitment>>,
         query_set: &QuerySet<F>,
         evaluations: &Evaluations<F>,
         proof: &Self::BatchProof,
@@ -312,7 +312,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     where
         Self::Commitment: 'a,
     {
-        let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
+        let commitments: BTreeMap<_, _> = commitments.map(|c| (c.label().to_owned(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
         for (label, point) in query_set.iter() {
             let labels = query_to_labels_map.entry(point).or_insert_with(BTreeSet::new);
@@ -393,7 +393,7 @@ pub trait PolynomialCommitment<F: Field>: Sized + Clone + Debug {
     fn check_combinations<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         linear_combinations: impl IntoIterator<Item = &'a LinearCombination<F>>,
-        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
+        commitments: impl Iterator<Item = LabeledCommitment<Self::Commitment>>,
         eqn_query_set: &QuerySet<F>,
         eqn_evaluations: &Evaluations<F>,
         proof: &BatchLCProof<F, Self>,
@@ -567,7 +567,15 @@ pub mod tests {
                 &rands,
                 Some(rng),
             )?;
-            let result = PC::batch_check(&vk, &comms, &query_set, &values, &proof, opening_challenge, rng)?;
+            let result = PC::batch_check(
+                &vk,
+                comms.into_iter(),
+                &query_set,
+                &values,
+                &proof,
+                opening_challenge,
+                rng,
+            )?;
             assert!(result, "proof was incorrect, Query set: {:#?}", query_set);
         }
         Ok(())
@@ -668,7 +676,15 @@ pub mod tests {
                 &rands,
                 Some(rng),
             )?;
-            let result = PC::batch_check(&vk, &comms, &query_set, &values, &proof, opening_challenge, rng)?;
+            let result = PC::batch_check(
+                &vk,
+                comms.into_iter(),
+                &query_set,
+                &values,
+                &proof,
+                opening_challenge,
+                rng,
+            )?;
             if !result {
                 println!(
                     "Failed with {} polynomials, num_points_in_query_set: {:?}",
@@ -821,7 +837,7 @@ pub mod tests {
             let result = PC::check_combinations(
                 &vk,
                 &linear_combinations,
-                &comms,
+                comms.into_iter(),
                 &query_set,
                 &values,
                 &proof,

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -469,7 +469,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
                     label: label.to_string(),
                 })?;
 
-                comms_to_combine.push(*commitment);
+                comms_to_combine.push(commitment);
                 values_to_combine.push(*v_i);
             }
             let (c, v) =

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -101,7 +101,9 @@ impl<E: PairingEngine> MarlinKZG10<E> {
         (combined_comm, combined_shifted_comm)
     }
 
-    fn normalize_commitments(commitments: Vec<(E::G1Projective, Option<E::G1Projective>)>) -> Vec<Commitment<E>> {
+    fn normalize_commitments(
+        commitments: Vec<(E::G1Projective, Option<E::G1Projective>)>,
+    ) -> impl Iterator<Item = Commitment<E>> {
         let mut comms = Vec::with_capacity(commitments.len());
         let mut s_comms = Vec::with_capacity(commitments.len());
         let mut s_flags = Vec::with_capacity(commitments.len());
@@ -117,18 +119,13 @@ impl<E: PairingEngine> MarlinKZG10<E> {
         }
         let comms = E::G1Projective::batch_normalization_into_affine(&comms);
         let s_comms = E::G1Projective::batch_normalization_into_affine(&s_comms);
-        comms
-            .into_iter()
-            .zip(s_comms)
-            .zip(s_flags)
-            .map(|((c, s_c), flag)| {
-                let shifted_comm = if flag { Some(kzg10::Commitment(s_c)) } else { None };
-                Commitment {
-                    comm: kzg10::Commitment(c),
-                    shifted_comm,
-                }
-            })
-            .collect()
+        comms.into_iter().zip(s_comms).zip(s_flags).map(|((c, s_c), flag)| {
+            let shifted_comm = if flag { Some(kzg10::Commitment(s_c)) } else { None };
+            Commitment {
+                comm: kzg10::Commitment(c),
+                shifted_comm,
+            }
+        })
     }
 
     /// Accumulate `commitments` and `values` according to `opening_challenge`.

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -333,15 +333,11 @@ impl<'a, T: 'a + ToBytes> ToBytes for &'a T {
     }
 }
 
-pub fn bytes_to_bits(bytes: &[u8]) -> Vec<bool> {
-    let mut bits = Vec::with_capacity(bytes.len() * 8);
-    for byte in bytes {
-        for i in 0..8 {
-            let bit = (*byte >> i) & 1;
-            bits.push(bit == 1);
-        }
-    }
-    bits
+pub fn bytes_to_bits(bytes: &[u8]) -> impl Iterator<Item = bool> + '_ {
+    bytes
+        .iter()
+        .map(|byte| (0..8).map(move |i| (*byte >> i) & 1 == 1))
+        .flatten()
 }
 
 pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
@@ -406,7 +402,7 @@ mod test {
         for _ in 0..ITERATIONS {
             let given_bytes: [u8; 32] = rng.gen();
 
-            let bits = bytes_to_bits(&given_bytes);
+            let bits = bytes_to_bits(&given_bytes).collect::<Vec<_>>();
             let recovered_bytes = bits_to_bytes(&bits);
 
             assert_eq!(given_bytes.to_vec(), recovered_bytes);

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -342,11 +342,11 @@ pub fn bytes_to_bits(bytes: &[u8]) -> impl Iterator<Item = bool> + '_ {
 
 pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
     // Pad the bits if it not a correct size
-    let mut bits = bits.to_vec();
+    let mut bits = std::borrow::Cow::from(bits);
     if bits.len() % 8 != 0 {
         let current_length = bits.len();
         for _ in 0..(8 - (current_length % 8)) {
-            bits.push(false);
+            bits.to_mut().push(false);
         }
     }
 

--- a/utilities/src/variable_length_integer.rs
+++ b/utilities/src/variable_length_integer.rs
@@ -26,11 +26,11 @@ pub fn variable_length_integer(value: u64) -> Vec<u8> {
         // bounded by u8::max_value()
         0..=252 => vec![value as u8],
         // bounded by u16::max_value()
-        253..=65535 => [vec![0xfd], (value as u16).to_le_bytes().to_vec()].concat(),
+        253..=65535 => [&[0xfd], &(value as u16).to_le_bytes()[..]].concat(),
         // bounded by u32::max_value()
-        65536..=4_294_967_295 => [vec![0xfe], (value as u32).to_le_bytes().to_vec()].concat(),
+        65536..=4_294_967_295 => [&[0xfe], &(value as u32).to_le_bytes()[..]].concat(),
         // bounded by u64::max_value()
-        _ => [vec![0xff], value.to_le_bytes().to_vec()].concat(),
+        _ => [&[0xff], &value.to_le_bytes()[..]].concat(),
     }
 }
 


### PR DESCRIPTION
Another round of memory-handling improvements aimed at improving performance across the board. This time the changes are mostly targeting functions that return vectors, and the PR is best read in a commit-by-commit fashion, as a single change can span several files.

Another positive side effect of these changes is, in some of the cases (where slicing is replaced with `Iterator` methods), removing the need for bound checking, which has additional potential for improving runtime performance.