### PR TITLE
More efficient iterator utilization

### DIFF
--- a/algorithms/src/snark/gm17/verifier.rs
+++ b/algorithms/src/snark/gm17/verifier.rs
@@ -18,14 +18,17 @@ use crate::snark::gm17::{PreparedVerifyingKey, Proof, VerifyingKey};
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::curves::{AffineCurve, One, PairingCurve, PairingEngine, PrimeField, ProjectiveCurve};
 
-use std::ops::{AddAssign, MulAssign, Neg};
+use std::{
+    iter,
+    ops::{AddAssign, MulAssign, Neg},
+};
 
 pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
     PreparedVerifyingKey {
         vk: vk.clone(),
         g_alpha: vk.g_alpha_g1,
         h_beta: vk.h_beta_g2,
-        g_alpha_h_beta_ml: E::miller_loop([(&vk.g_alpha_g1.prepare(), &vk.h_beta_g2.prepare())].iter()),
+        g_alpha_h_beta_ml: E::miller_loop(iter::once((&vk.g_alpha_g1.prepare(), &vk.h_beta_g2.prepare()))),
         g_gamma_pc: vk.g_gamma_g1.prepare(),
         h_gamma_pc: vk.h_gamma_g2.prepare(),
         h_pc: vk.h_g2.prepare(),
@@ -65,7 +68,8 @@ pub fn verify_proof<E: PairingEngine>(
             (&g_psi.into_affine().prepare(), &pvk.h_gamma_pc),
             (&proof.c.prepare(), &pvk.h_pc),
         ]
-        .iter(),
+        .iter()
+        .copied(),
     );
     let mut test1_exp = test1_r2;
     test1_exp.mul_assign(&test1_r1);
@@ -79,7 +83,8 @@ pub fn verify_proof<E: PairingEngine>(
             (&proof.a.prepare(), &pvk.h_gamma_pc),
             (&pvk.g_gamma_pc, &proof.b.neg().prepare()),
         ]
-        .iter(),
+        .iter()
+        .copied(),
     );
 
     let test2 = E::final_exponentiation(&test2_exp).unwrap();

--- a/algorithms/src/snark/groth16/verifier.rs
+++ b/algorithms/src/snark/groth16/verifier.rs
@@ -50,7 +50,8 @@ pub fn verify_proof<E: PairingEngine>(
             (&g_ic.into_affine().prepare(), &pvk.gamma_g2_neg_pc),
             (&proof.c.prepare(), &pvk.delta_g2_neg_pc),
         ]
-        .iter(),
+        .iter()
+        .copied(),
     );
 
     let test = E::final_exponentiation(&qap).ok_or(SynthesisError::UnexpectedIdentity)?;

--- a/curves/benches/bls12_377/pairing.rs
+++ b/curves/benches/bls12_377/pairing.rs
@@ -42,7 +42,7 @@ mod pairing {
 
         let mut count = 0;
         b.iter(|| {
-            let tmp = Bls12_377::miller_loop(&[(&v[count].0, &v[count].1)]);
+            let tmp = Bls12_377::miller_loop([(&v[count].0, &v[count].1)].iter().copied());
             count = (count + 1) % SAMPLES;
             tmp
         });
@@ -61,7 +61,7 @@ mod pairing {
                     G2Affine::from(G2::rand(&mut rng)).prepare(),
                 )
             })
-            .map(|(ref p, ref q)| Bls12_377::miller_loop(&[(p, q)]))
+            .map(|(ref p, ref q)| Bls12_377::miller_loop([(p, q)].iter().copied()))
             .collect();
 
         let mut count = 0;

--- a/curves/benches/bw6_761/pairing.rs
+++ b/curves/benches/bw6_761/pairing.rs
@@ -42,7 +42,7 @@ mod pairing {
 
         let mut count = 0;
         b.iter(|| {
-            let tmp = BW6_761::miller_loop(&[(&v[count].0, &v[count].1)]);
+            let tmp = BW6_761::miller_loop([(&v[count].0, &v[count].1)].iter().copied());
             count = (count + 1) % SAMPLES;
             tmp
         });
@@ -61,7 +61,7 @@ mod pairing {
                     G2Affine::from(G2::rand(&mut rng)).prepare(),
                 )
             })
-            .map(|(ref p, ref q)| BW6_761::miller_loop(&[(p, q)]))
+            .map(|(ref p, ref q)| BW6_761::miller_loop([(p, q)].iter().copied()))
             .collect();
 
         let mut count = 0;

--- a/curves/src/templates/bls12/bls12.rs
+++ b/curves/src/templates/bls12/bls12.rs
@@ -123,15 +123,15 @@ where
 
     fn miller_loop<'a, I>(i: I) -> Self::Fqk
     where
-        I: IntoIterator<
-            Item = &'a (
+        I: Iterator<
+            Item = (
                 &'a <Self::G1Affine as PairingCurve>::Prepared,
                 &'a <Self::G2Affine as PairingCurve>::Prepared,
             ),
         >,
     {
         let mut pairs = vec![];
-        for &(p, q) in i {
+        for (p, q) in i {
             if !p.is_zero() && !q.is_zero() {
                 pairs.push((p, q.ell_coeffs.iter()));
             }

--- a/curves/src/templates/bw6/bw6.rs
+++ b/curves/src/templates/bw6/bw6.rs
@@ -247,8 +247,8 @@ where
 
     fn miller_loop<'a, I>(i: I) -> Self::Fqk
     where
-        I: IntoIterator<
-            Item = &'a (
+        I: Iterator<
+            Item = (
                 &'a <Self::G1Affine as PairingCurve>::Prepared,
                 &'a <Self::G2Affine as PairingCurve>::Prepared,
             ),

--- a/gadgets/src/algorithms/commitment/pedersen.rs
+++ b/gadgets/src/algorithms/commitment/pedersen.rs
@@ -150,10 +150,10 @@ impl<F: PrimeField, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> Commitment
             GG::precomputed_base_multiscalar_mul(cs.ns(|| "msm"), &parameters.parameters.bases, input_in_bits)?;
 
         // Compute h^r
-        let rand_bits: Vec<_> = randomness.0.iter().flat_map(|byte| byte.to_bits_le()).collect();
+        let rand_bits = randomness.0.iter().flat_map(|byte| byte.to_bits_le());
         result.precomputed_base_scalar_mul(
             cs.ns(|| "randomizer"),
-            rand_bits.iter().zip(&parameters.parameters.random_base),
+            rand_bits.zip(&parameters.parameters.random_base),
         )?;
 
         Ok(result)

--- a/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
+++ b/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
@@ -62,7 +62,6 @@ impl<F: Field, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> CRHGadget<BoweH
 
         // Pad the input bits if it is not the current length.
         let mut input_in_bits: Vec<_> = padded_input_bytes
-            .to_vec()
             .into_iter()
             .flat_map(|byte| byte.to_bits_le())
             .collect();

--- a/gadgets/src/algorithms/encryption/group.rs
+++ b/gadgets/src/algorithms/encryption/group.rs
@@ -532,11 +532,11 @@ impl<G: Group + ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>>
         let record_view_key_gadget =
             public_key
                 .public_key
-                .mul_bits(cs.ns(|| "record_view_key"), &zero, randomness_bits.iter())?;
+                .mul_bits(cs.ns(|| "record_view_key"), &zero, randomness_bits.into_iter())?;
 
         let z = record_view_key_gadget.to_x_coordinate();
         let z_bytes = z.to_bytes(&mut cs.ns(|| "z_to_bytes"))?;
-        let z_bits: Vec<_> = z_bytes.iter().flat_map(|byte| byte.clone().to_bits_le()).collect();
+        let z_bits: Vec<_> = z_bytes.into_iter().flat_map(|byte| byte.clone().to_bits_le()).collect();
 
         let mut ciphertext = vec![c_0];
 
@@ -545,15 +545,12 @@ impl<G: Group + ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>>
 
             let cs = &mut cs.ns(|| format!("c_{}", j));
 
-            let blinding_exponent_bits: Vec<_> = blinding_exponent
-                .iter()
-                .flat_map(|byte| byte.clone().to_bits_le())
-                .collect();
+            let blinding_exponent_bits = blinding_exponent.iter().flat_map(|byte| byte.clone().to_bits_le());
 
-            let h = record_view_key_gadget.mul_bits(cs.ns(|| "h"), &zero, blinding_exponent_bits.iter())?;
+            let h = record_view_key_gadget.mul_bits(cs.ns(|| "h"), &zero, blinding_exponent_bits)?;
 
             // z * h
-            let h_z = h.mul_bits(cs.ns(|| "z * h"), &zero, z_bits.iter())?;
+            let h_z = h.mul_bits(cs.ns(|| "z * h"), &zero, z_bits.iter().copied())?;
 
             // j * h
             let h_j = {

--- a/gadgets/src/algorithms/encryption/group.rs
+++ b/gadgets/src/algorithms/encryption/group.rs
@@ -521,7 +521,7 @@ impl<G: Group + ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>>
     ) -> Result<Self::CiphertextGadget, SynthesisError> {
         let zero = GG::zero(&mut cs.ns(|| "zero")).unwrap();
 
-        let randomness_bits: Vec<_> = randomness.0.iter().flat_map(|byte| byte.clone().to_bits_le()).collect();
+        let randomness_bits: Vec<_> = randomness.0.iter().flat_map(|byte| byte.to_bits_le()).collect();
 
         let mut c_0 = zero.clone();
         c_0.precomputed_base_scalar_mul(
@@ -536,7 +536,7 @@ impl<G: Group + ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>>
 
         let z = record_view_key_gadget.to_x_coordinate();
         let z_bytes = z.to_bytes(&mut cs.ns(|| "z_to_bytes"))?;
-        let z_bits: Vec<_> = z_bytes.into_iter().flat_map(|byte| byte.clone().to_bits_le()).collect();
+        let z_bits: Vec<_> = z_bytes.into_iter().flat_map(|byte| byte.to_bits_le()).collect();
 
         let mut ciphertext = vec![c_0];
 
@@ -545,7 +545,7 @@ impl<G: Group + ProjectiveCurve, F: PrimeField, GG: CompressedGroupGadget<G, F>>
 
             let cs = &mut cs.ns(|| format!("c_{}", j));
 
-            let blinding_exponent_bits = blinding_exponent.iter().flat_map(|byte| byte.clone().to_bits_le());
+            let blinding_exponent_bits = blinding_exponent.iter().flat_map(|byte| byte.to_bits_le());
 
             let h = record_view_key_gadget.mul_bits(cs.ns(|| "h"), &zero, blinding_exponent_bits)?;
 

--- a/gadgets/src/algorithms/snark/gm17.rs
+++ b/gadgets/src/algorithms/snark/gm17.rs
@@ -126,7 +126,7 @@ impl<
             let mut input_len = 1;
             for (i, (input, b)) in public_inputs.by_ref().zip(pvk.query.iter().skip(1)).enumerate() {
                 let input_bits = input.to_bits(cs.ns(|| format!("Input {}", i)))?;
-                g_psi = b.mul_bits(cs.ns(|| format!("Mul {}", i)), &g_psi, input_bits.iter())?;
+                g_psi = b.mul_bits(cs.ns(|| format!("Mul {}", i)), &g_psi, input_bits.into_iter())?;
                 input_len += 1;
             }
             // Check that the input and the query in the verification are of the

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -143,7 +143,7 @@ where
             let mut input_len = 1;
             for (i, (input, b)) in public_inputs.by_ref().zip(pvk.gamma_abc_g1.iter().skip(1)).enumerate() {
                 let input_bits = input.to_bits(cs.ns(|| format!("Input {}", i)))?;
-                g_ic = b.mul_bits(cs.ns(|| format!("Mul {}", i)), &g_ic, input_bits.iter())?;
+                g_ic = b.mul_bits(cs.ns(|| format!("Mul {}", i)), &g_ic, input_bits.into_iter())?;
                 input_len += 1;
             }
             // Check that the input and the query in the verification are of the

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -513,12 +513,12 @@ mod test {
             // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
             let mut cs = TestConstraintSystem::<Fq>::new();
 
-            let inputs: Vec<_> = inputs.into_iter().map(|input| input.unwrap()).collect();
+            let inputs = inputs.into_iter().map(|input| input.unwrap());
             let mut input_gadgets = Vec::new();
 
             {
                 let mut cs = cs.ns(|| "Allocate Input");
-                for (i, input) in inputs.into_iter().enumerate() {
+                for (i, input) in inputs.enumerate() {
                     let mut input_bits = BitIterator::new(input.into_repr()).collect::<Vec<_>>();
                     // Input must be in little-endian, but BitIterator outputs in big-endian.
                     input_bits.reverse();

--- a/gadgets/src/curves/bls12_377.rs
+++ b/gadgets/src/curves/bls12_377.rs
@@ -152,7 +152,7 @@ mod test {
         scalar.reverse();
         let input = Vec::<Boolean>::alloc(cs.ns(|| "Input"), || Ok(scalar)).unwrap();
         let result = gadget_a
-            .mul_bits(cs.ns(|| "mul_bits"), &gadget_b, input.iter())
+            .mul_bits(cs.ns(|| "mul_bits"), &gadget_b, input.into_iter())
             .unwrap();
         let result_val = result.get_value().unwrap().into_affine();
         assert_eq!(

--- a/gadgets/src/curves/templates/twisted_edwards/test.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/test.rs
@@ -56,7 +56,9 @@ where
     scalar.reverse();
     let input = Vec::<Boolean>::alloc(cs.ns(|| "Input"), || Ok(scalar)).unwrap();
     let zero = GG::zero(cs.ns(|| "zero")).unwrap();
-    let result = gadget_a.mul_bits(cs.ns(|| "mul_bits"), &zero, input.iter()).unwrap();
+    let result = gadget_a
+        .mul_bits(cs.ns(|| "mul_bits"), &zero, input.into_iter())
+        .unwrap();
     let gadget_value = result.get_value().expect("Gadget_result failed");
     assert_eq!(native_result, gadget_value);
 }

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -244,9 +244,9 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
         // Gather commitments in one vector.
         #[rustfmt::skip]
         let commitments = vec![
-            first_comms.iter().map(|p| p.commitment().clone()).collect(),
-            second_comms.iter().map(|p| p.commitment().clone()).collect(),
-            third_comms.iter().map(|p| p.commitment().clone()).collect(),
+            first_comms.iter().map(|p| p.commitment()).cloned().collect(),
+            second_comms.iter().map(|p| p.commitment()).cloned().collect(),
+            third_comms.iter().map(|p| p.commitment()).cloned().collect(),
         ];
         let labeled_comms: Vec<_> = index_pk
             .index_vk
@@ -254,9 +254,9 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
             .cloned()
             .zip(&AHPForR1CS::<F>::INDEXER_POLYNOMIALS)
             .map(|(c, l)| LabeledCommitment::new(l.to_string(), c, None))
-            .chain(first_comms.iter().cloned())
-            .chain(second_comms.iter().cloned())
-            .chain(third_comms.iter().cloned())
+            .chain(first_comms.into_iter())
+            .chain(second_comms.into_iter())
+            .chain(third_comms.into_iter())
             .collect();
 
         // Gather commitment randomness together.

--- a/models/src/curves/pairing_engine.rs
+++ b/models/src/curves/pairing_engine.rs
@@ -25,6 +25,7 @@ use snarkos_utilities::{
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
+    iter,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 
@@ -65,8 +66,8 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     #[must_use]
     fn miller_loop<'a, I>(i: I) -> Self::Fqk
     where
-        I: IntoIterator<
-            Item = &'a (
+        I: Iterator<
+            Item = (
                 &'a <Self::G1Affine as PairingCurve>::Prepared,
                 &'a <Self::G2Affine as PairingCurve>::Prepared,
             ),
@@ -80,8 +81,8 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
     #[must_use]
     fn product_of_pairings<'a, I>(i: I) -> Self::Fqk
     where
-        I: IntoIterator<
-            Item = &'a (
+        I: Iterator<
+            Item = (
                 &'a <Self::G1Affine as PairingCurve>::Prepared,
                 &'a <Self::G2Affine as PairingCurve>::Prepared,
             ),
@@ -97,9 +98,10 @@ pub trait PairingEngine: Sized + 'static + Copy + Debug + Sync + Send {
         G1: Into<Self::G1Affine>,
         G2: Into<Self::G2Affine>,
     {
-        Self::final_exponentiation(&Self::miller_loop(
-            [(&(p.into().prepare()), &(q.into().prepare()))].iter(),
-        ))
+        Self::final_exponentiation(&Self::miller_loop(iter::once((
+            &p.into().prepare(),
+            &q.into().prepare(),
+        ))))
         .unwrap()
     }
 }

--- a/models/src/gadgets/curves/group.rs
+++ b/models/src/gadgets/curves/group.rs
@@ -78,7 +78,7 @@ pub trait GroupGadget<G: Group, F: Field>:
         &self,
         mut cs: CS,
         result: &Self,
-        bits: impl Iterator<Item = &'a Boolean>,
+        bits: impl Iterator<Item = Boolean>,
     ) -> Result<Self, SynthesisError> {
         let mut base = self.clone();
         let mut result = result.clone();

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -352,10 +352,14 @@ impl<E: PairingEngine> KZG10<E> {
         end_timer!(to_affine_time);
 
         let pairing_time = start_timer!(|| "Performing product of pairings");
-        let result = E::product_of_pairings(&[
-            (&total_w.prepare(), &vk.prepared_beta_h),
-            (&total_c.prepare(), &vk.prepared_h),
-        ])
+        let result = E::product_of_pairings(
+            [
+                (&total_w.prepare(), &vk.prepared_beta_h),
+                (&total_c.prepare(), &vk.prepared_h),
+            ]
+            .iter()
+            .copied(),
+        )
         .is_one();
         end_timer!(pairing_time);
         end_timer!(check_time, || format!("Result: {}", result));

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -133,11 +133,8 @@ impl<E: PairingEngine> SonicKZG10<E> {
             .map(|a| a.prepare())
             .collect::<Vec<_>>();
 
-        let g1_g2_prepared: Vec<(
-            &<E::G1Affine as PairingCurve>::Prepared,
-            &<E::G2Affine as PairingCurve>::Prepared,
-        )> = g1_prepared_elems_iter.iter().zip(g2_prepared_elems.iter()).collect();
-        let is_one: bool = E::product_of_pairings(g1_g2_prepared.iter()).is_one();
+        let g1_g2_prepared = g1_prepared_elems_iter.iter().zip(g2_prepared_elems.iter());
+        let is_one: bool = E::product_of_pairings(g1_g2_prepared).is_one();
         end_timer!(check_time);
         Ok(is_one)
     }


### PR DESCRIPTION
Another round of memory-handling improvements aimed at improving performance across the board. This time the changes are mostly targeting iterators being `collect()`ed, and the PR is best read in a commit-by-commit fashion, as a single change can span several files.

A positive side effect of some of these changes is reducing indirection when using iterators, making the code easier to reason about and potentially a bit faster, too.