### PR TITLE
Pass Circuit by reference

### DIFF
--- a/algorithms/examples/snark/constraints.rs
+++ b/algorithms/examples/snark/constraints.rs
@@ -37,7 +37,7 @@ impl<F: Field> Benchmark<F> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         let mut assignments = Vec::with_capacity(2 + self.num_constraints - 1);
 
         let mut a_val = F::one();

--- a/algorithms/src/snark/gm17/generator.rs
+++ b/algorithms/src/snark/gm17/generator.rs
@@ -27,7 +27,7 @@ use rand::Rng;
 
 /// Generates a random common reference string for
 /// a circuit.
-pub fn generate_random_parameters<E, C, R>(circuit: C, rng: &mut R) -> Result<Parameters<E>, SynthesisError>
+pub fn generate_random_parameters<E, C, R>(circuit: &C, rng: &mut R) -> Result<Parameters<E>, SynthesisError>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
@@ -144,7 +144,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 /// Create parameters for a circuit, given some toxic waste.
 #[allow(clippy::many_single_char_names)]
 pub fn generate_parameters<E, C, R>(
-    circuit: C,
+    circuit: &C,
     alpha: E::Fr,
     beta: E::Fr,
     gamma: E::Fr,

--- a/algorithms/src/snark/gm17/prover.rs
+++ b/algorithms/src/snark/gm17/prover.rs
@@ -185,7 +185,11 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     }
 }
 
-pub fn create_random_proof<E, C, R>(circuit: C, params: &Parameters<E>, rng: &mut R) -> Result<Proof<E>, SynthesisError>
+pub fn create_random_proof<E, C, R>(
+    circuit: &C,
+    params: &Parameters<E>,
+    rng: &mut R,
+) -> Result<Proof<E>, SynthesisError>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
@@ -199,7 +203,7 @@ where
 }
 
 pub fn create_proof<E, C>(
-    circuit: C,
+    circuit: &C,
     params: &Parameters<E>,
     d1: E::Fr,
     d2: E::Fr,

--- a/algorithms/src/snark/gm17/snark.rs
+++ b/algorithms/src/snark/gm17/snark.rs
@@ -53,7 +53,7 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
     type VerifierInput = V;
 
     fn setup<R: Rng>(
-        circuit: Self::Circuit,
+        circuit: &Self::Circuit,
         rng: &mut R,
     ) -> Result<(Self::ProvingParameters, Self::PreparedVerificationParameters), SNARKError> {
         let setup_time = start_timer!(|| "{Groth-Maller 2017}::Setup");
@@ -65,7 +65,7 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
 
     fn prove<R: Rng>(
         pp: &Self::ProvingParameters,
-        input_and_witness: Self::AssignedCircuit,
+        input_and_witness: &Self::AssignedCircuit,
         rng: &mut R,
     ) -> Result<Self::Proof, SNARKError> {
         let proof_time = start_timer!(|| "{Groth-Maller 2017}::Prove");

--- a/algorithms/src/snark/gm17/tests.rs
+++ b/algorithms/src/snark/gm17/tests.rs
@@ -26,7 +26,7 @@ struct MySillyCircuit<F: Field> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for MySillyCircuit<F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
         let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
         let c = cs.alloc_input(
@@ -58,7 +58,7 @@ mod bls12_377 {
     fn prove_and_verify() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<Bls12_377, _, _>(MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let pvk = prepare_verifying_key::<Bls12_377>(&params.vk);
 
@@ -68,7 +68,7 @@ mod bls12_377 {
             let mut c = a;
             c.mul_assign(&b);
 
-            let proof = create_random_proof(MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+            let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
 
             assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
             assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
@@ -86,7 +86,7 @@ mod bw6 {
     fn prove_and_verify() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<BW6_761, _, _>(MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let params = generate_random_parameters::<BW6_761, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let pvk = prepare_verifying_key::<BW6_761>(&params.vk);
 
@@ -94,7 +94,7 @@ mod bw6 {
         let b = BW6Fr::rand(rng);
         let c = a * &b;
 
-        let proof = create_random_proof(MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
 
         assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
         assert!(!verify_proof(&pvk, &proof, &[BW6Fr::zero()]).unwrap());
@@ -132,7 +132,7 @@ mod gm17 {
         }
 
         impl ConstraintSynthesizer<Fr> for R1CSCircuit {
-            fn generate_constraints<CS: ConstraintSystem<Fr>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+            fn generate_constraints<CS: ConstraintSystem<Fr>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
                 let input = cs.alloc_input(|| "x", || Ok(self.x.unwrap()))?;
                 let sum = cs.alloc_input(|| "sum", || Ok(self.sum.unwrap()))?;
                 let witness = cs.alloc(|| "w", || Ok(self.w.unwrap()))?;
@@ -153,9 +153,9 @@ mod gm17 {
 
         let rng = &mut thread_rng();
 
-        let parameters = GM17::<Bls12_377, R1CSCircuit, [Fr]>::setup(circuit, rng).unwrap();
+        let parameters = GM17::<Bls12_377, R1CSCircuit, [Fr]>::setup(&circuit, rng).unwrap();
 
-        let proof = GM17::<Bls12_377, R1CSCircuit, [Fr]>::prove(&parameters.0, circuit, rng).unwrap();
+        let proof = GM17::<Bls12_377, R1CSCircuit, [Fr]>::prove(&parameters.0, &circuit, rng).unwrap();
 
         let result = GM17::<Bls12_377, R1CSCircuit, [Fr]>::verify(&parameters.1, &[Fr::one(), sum], &proof).unwrap();
         assert!(result);
@@ -181,12 +181,12 @@ mod serialization {
         let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
 
         let parameters =
-            generate_random_parameters::<Bls12_377, _, _>(MySillyCircuit { a: None, b: None }, rng).unwrap();
+            generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let a = Fr::rand(rng);
         let b = Fr::rand(rng);
 
-        let proof = create_random_proof(MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
+        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &parameters, rng).unwrap();
 
         let proof_bytes = to_bytes![proof].unwrap();
         let recovered_proof: Proof<Bls12_377> = FromBytes::read(&proof_bytes[..]).unwrap();
@@ -199,7 +199,7 @@ mod serialization {
         let rng = &mut XorShiftRng::seed_from_u64(1231275789u64);
 
         let parameters =
-            generate_random_parameters::<Bls12_377, _, _>(MySillyCircuit { a: None, b: None }, rng).unwrap();
+            generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
         let vk = parameters.vk.clone();
 
         let parameter_bytes = to_bytes![&parameters].unwrap();

--- a/algorithms/src/snark/groth16/generator.rs
+++ b/algorithms/src/snark/groth16/generator.rs
@@ -31,7 +31,7 @@ use rayon::prelude::*;
 
 /// Generates a random common reference string for
 /// a circuit.
-pub fn generate_random_parameters<E, C, R>(circuit: C, rng: &mut R) -> Result<Parameters<E>, SynthesisError>
+pub fn generate_random_parameters<E, C, R>(circuit: &C, rng: &mut R) -> Result<Parameters<E>, SynthesisError>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
@@ -135,7 +135,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 /// Create parameters for a circuit, given some toxic waste.
 #[allow(clippy::many_single_char_names)]
 pub fn generate_parameters<E, C, R>(
-    circuit: C,
+    circuit: &C,
     alpha: E::Fr,
     beta: E::Fr,
     gamma: E::Fr,

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -110,7 +110,11 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     }
 }
 
-pub fn create_random_proof<E, C, R>(circuit: C, params: &Parameters<E>, rng: &mut R) -> Result<Proof<E>, SynthesisError>
+pub fn create_random_proof<E, C, R>(
+    circuit: &C,
+    params: &Parameters<E>,
+    rng: &mut R,
+) -> Result<Proof<E>, SynthesisError>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
@@ -122,7 +126,7 @@ where
     create_proof::<E, C>(circuit, params, r, s)
 }
 
-pub fn create_proof_no_zk<E, C>(circuit: C, params: &Parameters<E>) -> Result<Proof<E>, SynthesisError>
+pub fn create_proof_no_zk<E, C>(circuit: &C, params: &Parameters<E>) -> Result<Proof<E>, SynthesisError>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,
@@ -130,7 +134,7 @@ where
     create_proof::<E, C>(circuit, params, E::Fr::zero(), E::Fr::zero())
 }
 
-pub fn create_proof<E, C>(circuit: C, params: &Parameters<E>, r: E::Fr, s: E::Fr) -> Result<Proof<E>, SynthesisError>
+pub fn create_proof<E, C>(circuit: &C, params: &Parameters<E>, r: E::Fr, s: E::Fr) -> Result<Proof<E>, SynthesisError>
 where
     E: PairingEngine,
     C: ConstraintSynthesizer<E::Fr>,

--- a/algorithms/src/snark/groth16/snark.rs
+++ b/algorithms/src/snark/groth16/snark.rs
@@ -55,7 +55,7 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
     type VerifierInput = V;
 
     fn setup<R: Rng>(
-        circuit: Self::Circuit,
+        circuit: &Self::Circuit,
         rng: &mut R,
     ) -> Result<(Self::ProvingParameters, Self::PreparedVerificationParameters), SNARKError> {
         let setup_time = start_timer!(|| "{Groth 2016}::Setup");
@@ -67,7 +67,7 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
 
     fn prove<R: Rng>(
         pp: &Self::ProvingParameters,
-        input_and_witness: Self::AssignedCircuit,
+        input_and_witness: &Self::AssignedCircuit,
         rng: &mut R,
     ) -> Result<Self::Proof, SNARKError> {
         let proof_time = start_timer!(|| "{Groth 2016}::Prove");

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -26,7 +26,7 @@ struct MySillyCircuit<F: Field> {
 }
 
 impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for MySillyCircuit<ConstraintF> {
-    fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
         let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
         let c = cs.alloc_input(
@@ -62,7 +62,7 @@ mod bls12_377 {
     fn prove_and_verify() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<Bls12_377, _, _>(MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let pvk = prepare_verifying_key::<Bls12_377>(&params.vk);
 
@@ -72,7 +72,7 @@ mod bls12_377 {
             let mut c = a;
             c.mul_assign(&b);
 
-            let proof = create_random_proof(MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+            let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
 
             assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
             assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
@@ -91,7 +91,7 @@ mod bw6_761 {
     fn prove_and_verify() {
         let rng = &mut test_rng();
 
-        let params = generate_random_parameters::<BW6_761, _, _>(MySillyCircuit { a: None, b: None }, rng).unwrap();
+        let params = generate_random_parameters::<BW6_761, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
         let pvk = prepare_verifying_key::<BW6_761>(&params.vk);
 
@@ -99,7 +99,7 @@ mod bw6_761 {
         let b = Fr::rand(rng);
         let c = a * &b;
 
-        let proof = create_random_proof(MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+        let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
 
         assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
         assert!(!verify_proof(&pvk, &proof, &[Fr::zero()]).unwrap());

--- a/algorithms/tests/snark/mimc.rs
+++ b/algorithms/tests/snark/mimc.rs
@@ -85,7 +85,7 @@ struct MiMCDemo<'a, F: Field> {
 /// is used during paramgen and proving in order to
 /// synthesize the constraint system.
 impl<'a, F: Field> ConstraintSynthesizer<F> for MiMCDemo<'a, F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         assert_eq!(self.constants.len(), MIMC_ROUNDS);
 
         // Allocate the first component of the preimage.
@@ -180,7 +180,7 @@ fn test_mimc_groth_16() {
             constants: &constants,
         };
 
-        generate_random_parameters::<Bls12_377, _, _>(c, rng).unwrap()
+        generate_random_parameters::<Bls12_377, _, _>(&c, rng).unwrap()
     };
 
     // Prepare the verification key (for proof verification)
@@ -216,7 +216,7 @@ fn test_mimc_groth_16() {
             };
 
             // Create a groth16 proof with our parameters.
-            let proof = create_random_proof(c, &params, rng).unwrap();
+            let proof = create_random_proof(&c, &params, rng).unwrap();
             assert!(verify_proof(&pvk, &proof, &[image]).unwrap());
 
             // proof.write(&mut proof_vec).unwrap();
@@ -267,7 +267,7 @@ fn test_mimc_groth_maller_17() {
             constants: &constants,
         };
 
-        generate_random_parameters::<Bls12_377, _, _>(c, rng).unwrap()
+        generate_random_parameters::<Bls12_377, _, _>(&c, rng).unwrap()
     };
 
     // Prepare the verification key (for proof verification)
@@ -303,7 +303,7 @@ fn test_mimc_groth_maller_17() {
             };
 
             // Create a groth16 proof with our parameters.
-            let proof = create_random_proof(c, &params, rng).unwrap();
+            let proof = create_random_proof(&c, &params, rng).unwrap();
             assert!(verify_proof(&pvk, &proof, &[image]).unwrap());
 
             // proof.write(&mut proof_vec).unwrap();

--- a/benchmarks/algorithms/snark/snark.rs
+++ b/benchmarks/algorithms/snark/snark.rs
@@ -37,12 +37,12 @@ struct Benchmark<F: Field> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         assert!(self.inputs.len() >= 2);
         assert!(self.num_constraints >= self.inputs.len());
 
         let mut variables: Vec<_> = Vec::with_capacity(self.inputs.len());
-        for (i, input) in self.inputs.into_iter().enumerate() {
+        for (i, input) in self.inputs.iter().cloned().enumerate() {
             let input_var = cs.alloc_input(
                 || format!("input_{}", i),
                 || input.ok_or(SynthesisError::AssignmentMissing),

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit.rs
@@ -253,7 +253,7 @@ impl<C: BaseDPCComponents> InnerCircuit<C> {
 }
 
 impl<C: BaseDPCComponents> ConstraintSynthesizer<C::InnerField> for InnerCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::InnerField>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<C::InnerField>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_inner_proof_gadget::<C, CS>(
             cs,
             // Parameters

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit.rs
@@ -219,7 +219,7 @@ where
     <<C::MerkleParameters as MerkleParameters>::H as CRH>::Parameters: ToConstraintField<C::InnerField>,
     MerkleTreeDigest<C::MerkleParameters>: ToConstraintField<C::InnerField>,
 {
-    fn generate_constraints<CS: ConstraintSystem<C::OuterField>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<C::OuterField>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_outer_proof_gadget::<C, CS>(
             cs,
             self.system_parameters.get()?,

--- a/dpc/src/base_dpc/program/noop_program.rs
+++ b/dpc/src/base_dpc/program/noop_program.rs
@@ -82,7 +82,7 @@ where
 
         let circuit = NoopCircuit::<C>::new(&local_data.system_parameters, &local_data_root, position);
 
-        let proof = S::prove(proving_key, circuit, rng)?;
+        let proof = S::prove(proving_key, &circuit, rng)?;
 
         {
             let program_snark_pvk: <S as SNARK>::PreparedVerificationParameters = verification_key.clone().into();

--- a/dpc/src/base_dpc/program/noop_program_circuit.rs
+++ b/dpc/src/base_dpc/program/noop_program_circuit.rs
@@ -65,7 +65,7 @@ impl<C: BaseDPCComponents> NoopCircuit<C> {
 }
 
 impl<C: BaseDPCComponents> ConstraintSynthesizer<C::InnerField> for NoopCircuit<C> {
-    fn generate_constraints<CS: ConstraintSystem<C::InnerField>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<C::InnerField>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         execute_noop_gadget(
             cs,
             self.system_parameters.get()?,

--- a/dpc/src/base_dpc/test.rs
+++ b/dpc/src/base_dpc/test.rs
@@ -313,7 +313,7 @@ fn test_execute_base_dpc_constraints() {
 
     // Generate inner snark parameters and proof for verification in the outer snark
     let inner_snark_parameters = <Components as BaseDPCComponents>::InnerSNARK::setup(
-        InnerCircuit::blank(&system_parameters, ledger.parameters()),
+        &InnerCircuit::blank(&system_parameters, ledger.parameters()),
         &mut rng,
     )
     .unwrap();
@@ -329,7 +329,7 @@ fn test_execute_base_dpc_constraints() {
 
     let inner_snark_proof = <Components as BaseDPCComponents>::InnerSNARK::prove(
         &inner_snark_parameters.0,
-        InnerCircuit::new(
+        &InnerCircuit::new(
             &system_parameters,
             ledger.parameters(),
             &ledger_digest,

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -444,12 +444,12 @@ mod test {
     }
 
     impl<F: Field> ConstraintSynthesizer<F> for Bench<F> {
-        fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+        fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
             assert!(self.inputs.len() >= 2);
             assert!(self.num_constraints >= self.inputs.len());
 
             let mut variables: Vec<_> = Vec::with_capacity(self.inputs.len());
-            for (i, input) in self.inputs.into_iter().enumerate() {
+            for (i, input) in self.inputs.iter().cloned().enumerate() {
                 let input_var = cs.alloc_input(
                     || format!("Input {}", i),
                     || input.ok_or(SynthesisError::AssignmentMissing),
@@ -495,7 +495,7 @@ mod test {
                 num_constraints,
             };
 
-            generate_random_parameters(c, rng).unwrap()
+            generate_random_parameters(&c, rng).unwrap()
         };
 
         {
@@ -507,7 +507,7 @@ mod test {
                     num_constraints,
                 };
                 // Create a groth16 proof with our parameters.
-                create_random_proof(c, &params, rng).unwrap()
+                create_random_proof(&c, &params, rng).unwrap()
             };
 
             // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
@@ -566,7 +566,7 @@ mod test {
                 num_constraints,
             };
 
-            generate_random_parameters::<Bls12_377, _, _>(c, rng).unwrap()
+            generate_random_parameters::<Bls12_377, _, _>(&c, rng).unwrap()
         };
 
         {
@@ -578,7 +578,7 @@ mod test {
                     num_constraints,
                 };
                 // Create a groth16 proof with our parameters.
-                create_random_proof(c, &params, rng).unwrap()
+                create_random_proof(&c, &params, rng).unwrap()
             };
 
             // assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());

--- a/gadgets/src/algorithms/snark/tests.rs
+++ b/gadgets/src/algorithms/snark/tests.rs
@@ -44,12 +44,12 @@ struct Bench<F: Field> {
 }
 
 impl<F: Field> ConstraintSynthesizer<F> for Bench<F> {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         assert!(self.inputs.len() >= 2);
         assert!(self.num_constraints >= self.inputs.len());
 
         let mut variables: Vec<_> = Vec::with_capacity(self.inputs.len());
-        for (i, input) in self.inputs.into_iter().enumerate() {
+        for (i, input) in self.inputs.iter().cloned().enumerate() {
             let input_var = cs.alloc_input(
                 || format!("Input {}", i),
                 || input.ok_or(SynthesisError::AssignmentMissing),
@@ -90,7 +90,7 @@ fn gm17_verifier_test() {
         inputs.push(Some(rng.gen()));
     }
     let params = generate_random_parameters(
-        Bench::<Fr> {
+        &Bench::<Fr> {
             inputs: vec![None; num_inputs],
             num_constraints,
         },
@@ -103,7 +103,7 @@ fn gm17_verifier_test() {
             // Create an instance of our circuit (with the witness).
             // Create a gm17 proof with our parameters.
             create_random_proof(
-                Bench {
+                &Bench {
                     inputs: inputs.clone(),
                     num_constraints,
                 },
@@ -163,7 +163,7 @@ fn gm17_verifier_bytes_test() {
         inputs.push(Some(rng.gen()));
     }
     let params = generate_random_parameters::<Bls12_377, _, _>(
-        Bench::<Fr> {
+        &Bench::<Fr> {
             inputs: vec![None; num_inputs],
             num_constraints,
         },
@@ -176,7 +176,7 @@ fn gm17_verifier_bytes_test() {
             // Create an instance of our circuit (with the witness).
             // Create a gm17 proof with our parameters.
             create_random_proof(
-                Bench {
+                &Bench {
                     inputs: inputs.clone(),
                     num_constraints,
                 },

--- a/marlin/src/ahp/indexer.rs
+++ b/marlin/src/ahp/indexer.rs
@@ -121,7 +121,7 @@ impl<'a, F: PrimeField, C: ConstraintSynthesizer<F>> Index<'a, F, C> {
 
 impl<F: PrimeField> AHPForR1CS<F> {
     /// Generate the index for this constraint system.
-    pub fn index<'a, C: ConstraintSynthesizer<F>>(c: C) -> Result<Index<'a, F, C>, Error> {
+    pub fn index<'a, C: ConstraintSynthesizer<F>>(c: &C) -> Result<Index<'a, F, C>, Error> {
         let index_time = start_timer!(|| "AHP::Index");
 
         let constraint_time = start_timer!(|| "Generating constraints");

--- a/marlin/src/ahp/prover.rs
+++ b/marlin/src/ahp/prover.rs
@@ -148,7 +148,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     /// Initialize the AHP prover.
     pub fn prover_init<'a, 'b, C: ConstraintSynthesizer<F>>(
         index: &'a Index<F, C>,
-        c: C,
+        c: &C,
     ) -> Result<ProverState<'a, 'b, F, C>, Error> {
         let init_time = start_timer!(|| "AHP::Prover::Init");
 

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -125,8 +125,8 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
     /// keys. This is a deterministic algorithm that anyone can rerun.
     #[allow(clippy::type_complexity)]
     pub fn index<'a, C: ConstraintSynthesizer<F>>(
-        srs: UniversalSRS<F, PC>,
-        c: C,
+        srs: &UniversalSRS<F, PC>,
+        c: &C,
     ) -> Result<(IndexProverKey<'a, F, PC, C>, IndexVerifierKey<F, PC, C>), Error<PC::Error>> {
         let index_time = start_timer!(|| "Marlin::Index");
 
@@ -170,7 +170,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
     /// Create a zkSNARK asserting that the constraint system is satisfied.
     pub fn prove<C: ConstraintSynthesizer<F>, R: RngCore>(
         index_pk: &IndexProverKey<F, PC, C>,
-        c: C,
+        c: &C,
         zk_rng: &mut R,
     ) -> Result<Proof<F, PC, C>, Error<PC::Error>> {
         let prover_time = start_timer!(|| "Marlin::Prover");

--- a/marlin/src/snark.rs
+++ b/marlin/src/snark.rs
@@ -100,7 +100,7 @@ where
     C: ConstraintSynthesizer<E::Fr>,
 {
     /// Creates a new Parameters instance from a previously computed universal SRS
-    pub fn new(circuit: C, universal_srs: SRS<E>) -> Result<Self, SNARKError> {
+    pub fn new(circuit: &C, universal_srs: &SRS<E>) -> Result<Self, SNARKError> {
         let (prover_key, verifier_key) = Marlin::index(universal_srs, circuit)
             .map_err(|_| SNARKError::Crate("marlin", "could not index".to_owned()))?;
         Ok(Self {
@@ -136,7 +136,7 @@ where
     type VerifierInput = V;
 
     fn setup<R: RngCore>(
-        (circuit, srs): Self::Circuit,
+        (circuit, srs): &Self::Circuit,
         _rng: &mut R, // The Marlin Setup is deterministic
     ) -> Result<(Self::ProvingParameters, Self::PreparedVerificationParameters), SNARKError> {
         let setup_time = start_timer!(|| "{Marlin}::Setup");
@@ -148,7 +148,7 @@ where
 
     fn prove<R: RngCore>(
         pp: &Self::ProvingParameters,
-        circuit: Self::AssignedCircuit,
+        circuit: &Self::AssignedCircuit,
         rng: &mut R,
     ) -> Result<Self::Proof, SNARKError> {
         let proving_time = start_timer!(|| "{Marlin}::Proving");

--- a/marlin/src/test.rs
+++ b/marlin/src/test.rs
@@ -29,7 +29,7 @@ struct Circuit<F: Field> {
 }
 
 impl<ConstraintF: Field> ConstraintSynthesizer<ConstraintF> for Circuit<ConstraintF> {
-    fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<ConstraintF>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         let a = cs.alloc(|| "a", || self.a.ok_or(SynthesisError::AssignmentMissing))?;
         let b = cs.alloc(|| "b", || self.b.ok_or(SynthesisError::AssignmentMissing))?;
         let c = cs.alloc_input(
@@ -95,10 +95,10 @@ mod marlin {
                             num_variables,
                         };
 
-                        let (index_pk, index_vk) = $marlin_inst::index(universal_srs.clone(), circ.clone()).unwrap();
+                        let (index_pk, index_vk) = $marlin_inst::index(&universal_srs, &circ).unwrap();
                         println!("Called index");
 
-                        let proof = $marlin_inst::prove(&index_pk, circ, rng).unwrap();
+                        let proof = $marlin_inst::prove(&index_pk, &circ, rng).unwrap();
                         println!("Called prover");
 
                         assert!($marlin_inst::verify(&index_vk, &[c], &proof, rng).unwrap());

--- a/models/src/algorithms/snark.rs
+++ b/models/src/algorithms/snark.rs
@@ -34,13 +34,13 @@ pub trait SNARK {
     type VerifierInput: ?Sized;
 
     fn setup<R: Rng>(
-        circuit: Self::Circuit,
+        circuit: &Self::Circuit,
         rng: &mut R,
     ) -> Result<(Self::ProvingParameters, Self::PreparedVerificationParameters), SNARKError>;
 
     fn prove<R: Rng>(
         parameter: &Self::ProvingParameters,
-        input_and_witness: Self::AssignedCircuit,
+        input_and_witness: &Self::AssignedCircuit,
         rng: &mut R,
     ) -> Result<Self::Proof, SNARKError>;
 

--- a/models/src/gadgets/r1cs/constraint_system.rs
+++ b/models/src/gadgets/r1cs/constraint_system.rs
@@ -103,7 +103,7 @@ pub struct Namespace<'a, F: Field, CS: ConstraintSystem<F>>(&'a mut CS, PhantomD
 /// both CRS generation and for proving.
 pub trait ConstraintSynthesizer<F: Field> {
     /// Drives generation of new constraints inside `CS`.
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError>;
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError>;
 }
 
 impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for Namespace<'_, F, CS> {

--- a/parameters/examples/inner_snark.rs
+++ b/parameters/examples/inner_snark.rs
@@ -48,7 +48,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 
     let system_parameters = SystemParameters::<C>::load()?;
     let inner_snark_parameters = C::InnerSNARK::setup(
-        InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
+        &InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
         rng,
     )?;
     let inner_snark_pk = to_bytes![inner_snark_parameters.0]?;

--- a/parameters/examples/outer_snark.rs
+++ b/parameters/examples/outer_snark.rs
@@ -56,7 +56,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 
     let inner_snark_proof = C::InnerSNARK::prove(
         &inner_snark_pk,
-        InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
+        &InnerCircuit::blank(&system_parameters, &ledger_merkle_tree_parameters),
         rng,
     )?;
 
@@ -65,7 +65,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
 
     let program_snark_proof = C::NoopProgramSNARK::prove(
         &noop_program_snark_parameters.proving_key,
-        NoopCircuit::blank(&system_parameters),
+        &NoopCircuit::blank(&system_parameters),
         rng,
     )?;
     let private_program_input = PrivateProgramInput {
@@ -74,7 +74,7 @@ pub fn setup<C: BaseDPCComponents>() -> Result<(Vec<u8>, Vec<u8>), DPCError> {
     };
 
     let outer_snark_parameters = C::OuterSNARK::setup(
-        OuterCircuit::blank(
+        &OuterCircuit::blank(
             &system_parameters,
             &ledger_merkle_tree_parameters,
             &inner_snark_vk,

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -56,7 +56,7 @@ pub struct POSWCircuit<
 impl<F: PrimeField, M: MaskedMerkleParameters, HG: MaskedCRHGadget<M::H, F>, CP: POSWCircuitParameters>
     ConstraintSynthesizer<F> for POSWCircuit<F, M, HG, CP>
 {
-    fn generate_constraints<CS: ConstraintSystem<F>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+    fn generate_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<(), SynthesisError> {
         // Compute the mask if it exists.
         let mask = self.mask.clone().unwrap_or_else(|| vec![0; CP::MASK_LENGTH]);
         if mask.len() != CP::MASK_LENGTH {
@@ -105,7 +105,8 @@ impl<F: PrimeField, M: MaskedMerkleParameters, HG: MaskedCRHGadget<M::H, F>, CP:
         )?;
 
         // Enforce the input root is the same as the computed root.
-        let public_computed_root = HG::OutputGadget::alloc_input(cs.ns(|| "public computed root"), || self.root.get())?;
+        let public_computed_root =
+            HG::OutputGadget::alloc_input(cs.ns(|| "public computed root"), || self.root.as_ref().get())?;
         computed_root.enforce_equal(cs.ns(|| "inputize computed root"), &public_computed_root)?;
 
         Ok(())
@@ -157,7 +158,7 @@ mod test {
 
         let parameters = EdwardsMaskedMerkleParameters::setup(&mut rng);
         let params = generate_random_parameters::<Bls12_377, _, _>(
-            POSWCircuit::<_, EdwardsMaskedMerkleParameters, HashGadget, TestPOSWCircuitParameters> {
+            &POSWCircuit::<_, EdwardsMaskedMerkleParameters, HashGadget, TestPOSWCircuitParameters> {
                 leaves: vec![None; 7],
                 merkle_parameters: parameters.clone(),
                 mask: None,
@@ -184,7 +185,7 @@ mod test {
 
         let snark_leaves = tree.hashed_leaves().into_iter().map(Some).collect();
         let proof = create_random_proof(
-            POSWCircuit::<_, EdwardsMaskedMerkleParameters, HashGadget, TestPOSWCircuitParameters> {
+            &POSWCircuit::<_, EdwardsMaskedMerkleParameters, HashGadget, TestPOSWCircuitParameters> {
                 leaves: snark_leaves,
                 merkle_parameters: parameters,
                 mask: Some(mask.clone()),

--- a/posw/src/consensus.rs
+++ b/posw/src/consensus.rs
@@ -142,7 +142,7 @@ where
         S: SNARK<Circuit = POSWCircuit<F, M, HG, CP>>,
     {
         let params = S::setup(
-            POSWCircuit {
+            &POSWCircuit {
                 // the circuit will be padded internally
                 leaves: vec![None; 0],
                 merkle_parameters: PARAMS.clone(),
@@ -169,7 +169,7 @@ where
         S: SNARK<Circuit = (POSWCircuit<F, M, HG, CP>, SRS<E>)>,
     {
         let params = S::setup(
-            (
+            &(
                 POSWCircuit {
                     // the circuit will be padded internally
                     leaves: vec![None; 0],
@@ -233,7 +233,7 @@ where
 
         // generate the proof
         let proof_timer = start_timer!(|| "POSW proof");
-        let proof = S::prove(pk, circuit, rng)?;
+        let proof = S::prove(pk, &circuit, rng)?;
         end_timer!(proof_timer);
 
         Ok(proof)


### PR DESCRIPTION
This PR will allow Leo `Program`s to not require costly cloning during the build process and remove the need to derive `Clone` for them and the related objects that are not practical to clone.