### PR TITLE
Clippy compliance 1.47

### DIFF
--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 [[example]]
 name = "gm17"
 path = "examples/snark/gm17.rs"
-required-features = ["rand", "snarkos-curves/bls12_377", "snarkos-models/gadgets"]
 
 [dependencies]
 snarkos-errors = { path = "../errors", version = "1.1.4", default-features = false }

--- a/algorithms/examples/snark/constraints.rs
+++ b/algorithms/examples/snark/constraints.rs
@@ -91,7 +91,7 @@ impl<F: Field> ConstraintSynthesizer<F> for Benchmark<F> {
         for (val, var) in assignments {
             a_lc = a_lc + var;
             b_lc = b_lc + var;
-            c_val = c_val + &val;
+            c_val += &val;
         }
         c_val = c_val.square();
 

--- a/algorithms/examples/snark/gm17.rs
+++ b/algorithms/examples/snark/gm17.rs
@@ -25,8 +25,6 @@
 #![deny(renamed_and_removed_lints, stable_features, unused_allocation, unused_comparisons)]
 #![deny(unused_must_use, unused_mut, unused_unsafe, private_in_public, unsafe_code)]
 
-use csv;
-
 // For randomness (during paramgen and proof generation)
 use rand::thread_rng;
 
@@ -39,7 +37,7 @@ use std::{
 // Bring in some tools for using pairing-friendly curves
 // We're going to use the BLS12-377 pairing-friendly elliptic curve.
 use snarkos_curves::bls12_377::{Bls12_377, Fr};
-use snarkos_models::curves::Field;
+use snarkos_models::curves::One;
 
 // We're going to use the Groth-Maller 17 proving system.
 use snarkos_algorithms::snark::gm17::{

--- a/algorithms/examples/snark/gm17.rs
+++ b/algorithms/examples/snark/gm17.rs
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let start = Instant::now();
         let params = {
             let c = Benchmark::<Fr>::new(num_constraints);
-            generate_random_parameters::<Bls12_377, _, _>(c, rng)?
+            generate_random_parameters::<Bls12_377, _, _>(&c, rng)?
         };
 
         // Prepare the verification key (for proof verification)
@@ -111,7 +111,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Create an instance of our circuit (with the witness)
             let c = Benchmark::new(num_constraints);
             // Create a proof with our parameters.
-            create_random_proof(c, &params, rng)?
+            create_random_proof(&c, &params, rng)?
         };
 
         total_proving += start.elapsed();

--- a/algorithms/src/crh/bowe_hopwood_pedersen.rs
+++ b/algorithms/src/crh/bowe_hopwood_pedersen.rs
@@ -138,9 +138,7 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
         let mut padded_input_bytes = vec![];
         if (input.len() * 8) < S::WINDOW_SIZE * S::NUM_WINDOWS {
             padded_input_bytes.extend_from_slice(input_bytes);
-            for _ in input.len()..((S::WINDOW_SIZE * S::NUM_WINDOWS) / 8) {
-                padded_input_bytes.push(0u8);
-            }
+            padded_input_bytes.resize((S::WINDOW_SIZE * S::NUM_WINDOWS) / 8, 0u8);
             input_bytes = padded_input_bytes.as_slice();
         }
 
@@ -151,9 +149,10 @@ impl<G: Group, S: PedersenSize> CRH for BoweHopwoodPedersenCRH<G, S> {
         padded_input.extend(input);
         if input_len % BOWE_HOPWOOD_CHUNK_SIZE != 0 {
             let current_length = input_len;
-            for _ in 0..(BOWE_HOPWOOD_CHUNK_SIZE - current_length % BOWE_HOPWOOD_CHUNK_SIZE) {
-                padded_input.push(false);
-            }
+            padded_input.resize(
+                current_length + BOWE_HOPWOOD_CHUNK_SIZE - current_length % BOWE_HOPWOOD_CHUNK_SIZE,
+                false,
+            );
         }
 
         assert_eq!(padded_input.len() % BOWE_HOPWOOD_CHUNK_SIZE, 0);

--- a/algorithms/src/crh/pedersen.rs
+++ b/algorithms/src/crh/pedersen.rs
@@ -58,9 +58,7 @@ impl<G: Group, S: PedersenSize> CRH for PedersenCRH<G, S> {
         let mut padded_input = vec![];
         if (input.len() * 8) < S::WINDOW_SIZE * S::NUM_WINDOWS {
             padded_input.extend_from_slice(input);
-            for _ in input.len()..((S::WINDOW_SIZE * S::NUM_WINDOWS) / 8) {
-                padded_input.push(0u8);
-            }
+            padded_input.resize((S::WINDOW_SIZE * S::NUM_WINDOWS) / 8, 0u8);
             input = padded_input.as_slice();
         }
 

--- a/algorithms/src/fft/polynomial/mod.rs
+++ b/algorithms/src/fft/polynomial/mod.rs
@@ -128,11 +128,11 @@ impl<F: Field> DenseOrSparsePolynomial<'_, F> {
 
                 if let SPolynomial(p) = divisor {
                     for (i, div_coeff) in &p.coeffs {
-                        remainder[cur_q_degree + i] -= &(cur_q_coeff * &div_coeff);
+                        remainder[cur_q_degree + i] -= &(cur_q_coeff * div_coeff);
                     }
                 } else if let DPolynomial(p) = divisor {
                     for (i, div_coeff) in p.iter().enumerate() {
-                        remainder[cur_q_degree + i] -= &(cur_q_coeff * &div_coeff);
+                        remainder[cur_q_degree + i] -= &(cur_q_coeff * div_coeff);
                     }
                 }
 

--- a/models/src/curves/tests_field.rs
+++ b/models/src/curves/tests_field.rs
@@ -436,21 +436,15 @@ pub fn field_serialization_test<F: Field>() {
         use snarkos_errors::serialization::SerializationError;
         {
             let mut serialized = vec![0; buf_size];
-            assert!(if let SerializationError::NotEnoughSpace = a
-                .serialize_with_flags(&mut &mut serialized[..], DummyFlags)
-                .unwrap_err()
-            {
-                true
-            } else {
-                false
-            });
-            assert!(if let SerializationError::NotEnoughSpace =
-                F::deserialize_with_flags::<_, DummyFlags>(&mut &serialized[..]).unwrap_err()
-            {
-                true
-            } else {
-                false
-            });
+            assert!(matches!(
+                a.serialize_with_flags(&mut &mut serialized[..], DummyFlags)
+                    .unwrap_err(),
+                SerializationError::NotEnoughSpace
+            ));
+            assert!(matches!(
+                F::deserialize_with_flags::<_, DummyFlags>(&mut &serialized[..]).unwrap_err(),
+                SerializationError::NotEnoughSpace
+            ));
         }
 
         {

--- a/models/src/curves/to_field_vec.rs
+++ b/models/src/curves/to_field_vec.rs
@@ -72,10 +72,7 @@ impl<F: PrimeField> ToConstraintField<F> for [u8] {
             .chunks(max_size)
             .map(|chunk| {
                 let mut chunk = chunk.to_vec();
-                let len = chunk.len();
-                for _ in len..(max_size + 1) {
-                    chunk.push(0u8);
-                }
+                chunk.resize(max_size + 1, 0u8);
                 F::read(chunk.as_slice())
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/models/src/gadgets/curves/group.rs
+++ b/models/src/gadgets/curves/group.rs
@@ -74,7 +74,7 @@ pub trait GroupGadget<G: Group, F: Field>:
     /// Inputs must be specified in *little-endian* form.
     /// If the addition law is incomplete for the identity element,
     /// `result` must not be the identity element.
-    fn mul_bits<'a, CS: ConstraintSystem<F>>(
+    fn mul_bits<CS: ConstraintSystem<F>>(
         &self,
         mut cs: CS,
         result: &Self,

--- a/models/src/gadgets/utilities/uint/uint128.rs
+++ b/models/src/gadgets/utilities/uint/uint128.rs
@@ -706,7 +706,7 @@ impl<F: PrimeField> CondSelectGadget<F> for UInt128 {
                 }
             });
 
-            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || result_val.get().map(|v| v))?;
+            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || result_val.get())?;
 
             result.negated = is_negated;
 

--- a/network/src/server.rs
+++ b/network/src/server.rs
@@ -212,7 +212,7 @@ impl Server {
         mut channel: Arc<Channel>,
         mut message_handler_sender: mpsc::Sender<(oneshot::Sender<Arc<Channel>>, MessageName, Vec<u8>, Arc<Channel>)>,
     ) {
-        let peer_address = channel.address.clone();
+        let peer_address = channel.address;
         let future = async move {
             // Determines the criteria for disconnecting from a peer.
             fn should_disconnect(failure_count: &u8) -> bool {

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -329,6 +329,7 @@ impl<'a, F: Field> AddAssign<(F, &'a LinearCombination<F>)> for LinearCombinatio
 }
 
 impl<'a, F: Field> SubAssign<(F, &'a LinearCombination<F>)> for LinearCombination<F> {
+    #[allow(clippy::suspicious_op_assign_impl)]
     fn sub_assign(&mut self, (coeff, other): (F, &'a LinearCombination<F>)) {
         self.terms
             .extend(other.terms.iter().map(|(c, t)| (-coeff * c, t.clone())));

--- a/polycommit/src/data_structures.rs
+++ b/polycommit/src/data_structures.rs
@@ -228,7 +228,7 @@ impl LCTerm {
     /// Returns `true` if `self == LCTerm::One`
     #[inline]
     pub fn is_one(&self) -> bool {
-        if let LCTerm::One = self { true } else { false }
+        matches!(self, LCTerm::One)
     }
 }
 

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -216,7 +216,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for MarlinKZG10<E> {
 
         let enforced_degree_bounds = enforced_degree_bounds.map(|v| {
             let mut v = v.to_vec();
-            v.sort();
+            v.sort_unstable();
             v.dedup();
             v
         });

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -169,7 +169,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
 
         let enforced_degree_bounds = enforced_degree_bounds.map(|bounds| {
             let mut v = bounds.to_vec();
-            v.sort();
+            v.sort_unstable();
             v.dedup();
             v
         });

--- a/utilities/src/bititerator.rs
+++ b/utilities/src/bititerator.rs
@@ -20,6 +20,7 @@ pub struct BitIterator<E> {
     n: usize,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl<E: AsRef<[u64]>> BitIterator<E> {
     pub fn new(t: E) -> Self {
         let n = t.as_ref().len() * 64;

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -345,9 +345,7 @@ pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
     let mut bits = std::borrow::Cow::from(bits);
     if bits.len() % 8 != 0 {
         let current_length = bits.len();
-        for _ in 0..(8 - (current_length % 8)) {
-            bits.to_mut().push(false);
-        }
+        bits.resize(current_length + 8 - (current_length % 8), false);
     }
 
     let mut bytes = Vec::with_capacity(bits.len() / 8);

--- a/utilities/src/bytes.rs
+++ b/utilities/src/bytes.rs
@@ -345,7 +345,7 @@ pub fn bits_to_bytes(bits: &[bool]) -> Vec<u8> {
     let mut bits = std::borrow::Cow::from(bits);
     if bits.len() % 8 != 0 {
         let current_length = bits.len();
-        bits.resize(current_length + 8 - (current_length % 8), false);
+        bits.to_mut().resize(current_length + 8 - (current_length % 8), false);
     }
 
     let mut bytes = Vec::with_capacity(bits.len() / 8);

--- a/utilities/src/serialize/flags.rs
+++ b/utilities/src/serialize/flags.rs
@@ -76,10 +76,7 @@ impl SWFlags {
 
     #[inline]
     pub fn is_infinity(&self) -> bool {
-        match self {
-            SWFlags::Infinity => true,
-            _ => false,
-        }
+        matches!(self, SWFlags::Infinity)
     }
 
     #[inline]


### PR DESCRIPTION
The new version of the compiler is bundled with an updated `clippy`, which was able to find some new issues in the codebase. There are also some new lints, 2 of which can yield performance improvements:
- `match_like_matches_macro`, fixed in https://github.com/AleoHQ/snarkOS/commit/54efd538171028741b5bdd0532d0d55967e1207e
- `stable_sort_primitive`, handled in https://github.com/AleoHQ/snarkOS/commit/3b1585c948b98227ece9a4e5cf3eaee3c5ee62ef
- `same_item_push` (commit https://github.com/AleoHQ/snarkOS/commit/30a1d76325a7ac358e6ebeabfed1ba1248acc0a6)