### PR TITLE
Speed up TestConstraintSystem's set_named_obj

### DIFF
--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -149,7 +149,7 @@ impl<F: Field> TestConstraintSystem<F> {
     }
 }
 
-fn compute_path(ns: &[String], this: String) -> String {
+fn compute_path(ns: &[String], this: &str) -> String {
     if this.chars().any(|a| a == '/') {
         panic!("'/' is not allowed in names");
     }
@@ -157,7 +157,7 @@ fn compute_path(ns: &[String], this: String) -> String {
     let mut name = String::new();
 
     let mut needs_separation = false;
-    for ns in ns.iter().chain(Some(&this).into_iter()) {
+    for ns in ns.iter().map(|s| s.as_str()).chain(Some(this)) {
         if needs_separation {
             name += "/";
         }
@@ -179,7 +179,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         AR: Into<String>,
     {
         let index = self.aux.len();
-        let path = compute_path(&self.current_namespace, annotation().into());
+        let path = compute_path(&self.current_namespace, &annotation().into());
         self.aux.push((f()?, path.clone()));
         let var = Variable::new_unchecked(Index::Aux(index));
         self.set_named_obj(path, NamedObject::Var(var));
@@ -194,7 +194,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         AR: Into<String>,
     {
         let index = self.inputs.len();
-        let path = compute_path(&self.current_namespace, annotation().into());
+        let path = compute_path(&self.current_namespace, &annotation().into());
         self.inputs.push((f()?, path.clone()));
         let var = Variable::new_unchecked(Index::Input(index));
         self.set_named_obj(path, NamedObject::Var(var));
@@ -210,7 +210,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         LB: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LC: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
     {
-        let path = compute_path(&self.current_namespace, annotation().into());
+        let path = compute_path(&self.current_namespace, &annotation().into());
         let index = self.constraints.len();
         self.set_named_obj(path.clone(), NamedObject::Constraint(index));
 
@@ -226,7 +226,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
 
     fn push_namespace<NR: Into<String>, N: FnOnce() -> NR>(&mut self, name_fn: N) {
         let name = name_fn().into();
-        let path = compute_path(&self.current_namespace, name.clone());
+        let path = compute_path(&self.current_namespace, &name);
         self.set_named_obj(path, NamedObject::Namespace);
         self.current_namespace.push(name);
     }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use snarkos_errors::gadgets::SynthesisError;
 
-use std::collections::BTreeMap;
+use std::collections::{btree_map::Entry, BTreeMap};
 
 #[derive(Debug)]
 enum NamedObject {
@@ -137,11 +137,15 @@ impl<F: Field> TestConstraintSystem<F> {
     }
 
     fn set_named_obj(&mut self, path: String, to: NamedObject) {
-        if self.named_objects.get(&path).is_some() {
-            panic!("tried to create object at existing path: {}", path);
+        match self.named_objects.entry(path) {
+            Entry::Vacant(e) => {
+                e.insert(to);
+            }
+            Entry::Occupied(e) => {
+                let (path, _) = e.remove_entry();
+                panic!("tried to create object at existing path: {}", path);
+            }
         }
-
-        self.named_objects.insert(path, to);
     }
 }
 


### PR DESCRIPTION
This change reduces the number of `BTreeMap` lookups by 1 in every call to the (very popular) `ns` method, improving the results of non-const benchmarks introduced in https://github.com/AleoHQ/snarkOS/pull/501 by **15-20%**.

Update: in addition there is a commit reducing the number of allocations in the `push_namespace` method, improving the results further.