### PR TITLE
A range of perf improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2561,6 +2561,7 @@ version = "1.1.4"
 dependencies = [
  "bincode",
  "chrono",
+ "criterion",
  "futures-await-test",
  "hex",
  "rand",

--- a/algorithms/examples/snark/gm17.rs
+++ b/algorithms/examples/snark/gm17.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         };
 
         // Prepare the verification key (for proof verification)
-        let pvk = prepare_verifying_key(&params.vk);
+        let pvk = prepare_verifying_key(params.vk.clone());
         total_setup += start.elapsed();
 
         // proof_vec.clear();

--- a/algorithms/src/crh/sha256.rs
+++ b/algorithms/src/crh/sha256.rs
@@ -16,12 +16,20 @@
 
 use sha2::{Digest, Sha256};
 
-pub fn sha256(data: &[u8]) -> Vec<u8> {
-    Sha256::digest(&data).to_vec()
+pub fn sha256(data: &[u8]) -> [u8; 32] {
+    let digest = Sha256::digest(&data);
+    let mut ret = [0u8; 32];
+    ret.copy_from_slice(&digest);
+
+    ret
 }
 
-pub fn double_sha256(data: &[u8]) -> Vec<u8> {
-    Sha256::digest(&Sha256::digest(&data)).to_vec()
+pub fn double_sha256(data: &[u8]) -> [u8; 32] {
+    let digest = Sha256::digest(&Sha256::digest(&data));
+    let mut ret = [0u8; 32];
+    ret.copy_from_slice(&digest);
+
+    ret
 }
 
 pub fn sha256d_to_u64(data: &[u8]) -> u64 {

--- a/algorithms/src/merkle_tree/merkle_tree.rs
+++ b/algorithms/src/merkle_tree/merkle_tree.rs
@@ -53,11 +53,8 @@ impl<P: MerkleParameters> MerkleTree<P> {
         }
 
         // Initialize the Merkle tree.
-        let mut tree = Vec::with_capacity(tree_size);
         let empty_hash = parameters.hash_empty()?;
-        for _ in 0..tree_size {
-            tree.push(empty_hash.clone());
-        }
+        let mut tree = vec![empty_hash.clone(); tree_size];
 
         // Compute the starting index (on the left) for each level of the tree.
         let mut index = 0;

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -244,7 +244,7 @@ impl<E: PairingEngine> From<Parameters<E>> for VerifyingKey<E> {
 
 impl<E: PairingEngine> From<Parameters<E>> for PreparedVerifyingKey<E> {
     fn from(other: Parameters<E>) -> Self {
-        prepare_verifying_key(&other.vk)
+        prepare_verifying_key(other.vk)
     }
 }
 
@@ -396,7 +396,7 @@ impl<E: PairingEngine> From<PreparedVerifyingKey<E>> for VerifyingKey<E> {
 
 impl<E: PairingEngine> From<VerifyingKey<E>> for PreparedVerifyingKey<E> {
     fn from(other: VerifyingKey<E>) -> Self {
-        prepare_verifying_key(&other)
+        prepare_verifying_key(other)
     }
 }
 

--- a/algorithms/src/snark/gm17/mod.rs
+++ b/algorithms/src/snark/gm17/mod.rs
@@ -380,7 +380,12 @@ pub struct PreparedVerifyingKey<E: PairingEngine> {
     pub g_gamma_pc: <E::G1Affine as PairingCurve>::Prepared,
     pub h_gamma_pc: <E::G2Affine as PairingCurve>::Prepared,
     pub h_pc: <E::G2Affine as PairingCurve>::Prepared,
-    pub query: Vec<E::G1Affine>,
+}
+
+impl<E: PairingEngine> PreparedVerifyingKey<E> {
+    fn query(&self) -> &[E::G1Affine] {
+        &self.vk.query
+    }
 }
 
 impl<E: PairingEngine> From<PreparedVerifyingKey<E>> for VerifyingKey<E> {
@@ -405,7 +410,6 @@ impl<E: PairingEngine> Default for PreparedVerifyingKey<E> {
             g_gamma_pc: <E::G1Affine as PairingCurve>::Prepared::default(),
             h_gamma_pc: <E::G2Affine as PairingCurve>::Prepared::default(),
             h_pc: <E::G2Affine as PairingCurve>::Prepared::default(),
-            query: Vec::new(),
         }
     }
 }
@@ -419,7 +423,7 @@ impl<E: PairingEngine> ToBytes for PreparedVerifyingKey<E> {
         self.g_gamma_pc.write(&mut writer)?;
         self.h_gamma_pc.write(&mut writer)?;
         self.h_pc.write(&mut writer)?;
-        for q in &self.query {
+        for q in self.query() {
             q.write(&mut writer)?;
         }
         Ok(())

--- a/algorithms/src/snark/gm17/snark.rs
+++ b/algorithms/src/snark/gm17/snark.rs
@@ -58,7 +58,7 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
     ) -> Result<(Self::ProvingParameters, Self::PreparedVerificationParameters), SNARKError> {
         let setup_time = start_timer!(|| "{Groth-Maller 2017}::Setup");
         let pp = generate_random_parameters::<E, Self::Circuit, R>(circuit, rng)?;
-        let vk = prepare_verifying_key(&pp.vk);
+        let vk = prepare_verifying_key(pp.vk.clone());
         end_timer!(setup_time);
         Ok((pp, vk))
     }

--- a/algorithms/src/snark/gm17/tests.rs
+++ b/algorithms/src/snark/gm17/tests.rs
@@ -60,7 +60,7 @@ mod bls12_377 {
 
         let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
-        let pvk = prepare_verifying_key::<Bls12_377>(&params.vk);
+        let pvk = prepare_verifying_key::<Bls12_377>(params.vk.clone());
 
         for _ in 0..10 {
             let a = Fr::rand(rng);
@@ -88,13 +88,12 @@ mod bw6 {
 
         let params = generate_random_parameters::<BW6_761, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
-        let pvk = prepare_verifying_key::<BW6_761>(&params.vk);
-
         let a = BW6Fr::rand(rng);
         let b = BW6Fr::rand(rng);
         let c = a * &b;
 
         let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+        let pvk = prepare_verifying_key::<BW6_761>(params.vk);
 
         assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
         assert!(!verify_proof(&pvk, &proof, &[BW6Fr::zero()]).unwrap());

--- a/algorithms/src/snark/gm17/verifier.rs
+++ b/algorithms/src/snark/gm17/verifier.rs
@@ -23,15 +23,22 @@ use std::{
     ops::{AddAssign, MulAssign, Neg},
 };
 
-pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
+pub fn prepare_verifying_key<E: PairingEngine>(vk: VerifyingKey<E>) -> PreparedVerifyingKey<E> {
+    let g_alpha = vk.g_alpha_g1;
+    let h_beta = vk.h_beta_g2;
+    let g_alpha_h_beta_ml = E::miller_loop(iter::once((&g_alpha.prepare(), &h_beta.prepare())));
+    let g_gamma_pc = vk.g_gamma_g1.prepare();
+    let h_gamma_pc = vk.h_gamma_g2.prepare();
+    let h_pc = vk.h_g2.prepare();
+
     PreparedVerifyingKey {
-        vk: vk.clone(),
-        g_alpha: vk.g_alpha_g1,
-        h_beta: vk.h_beta_g2,
-        g_alpha_h_beta_ml: E::miller_loop(iter::once((&vk.g_alpha_g1.prepare(), &vk.h_beta_g2.prepare()))),
-        g_gamma_pc: vk.g_gamma_g1.prepare(),
-        h_gamma_pc: vk.h_gamma_g2.prepare(),
-        h_pc: vk.h_g2.prepare(),
+        vk,
+        g_alpha,
+        h_beta,
+        g_alpha_h_beta_ml,
+        g_gamma_pc,
+        h_gamma_pc,
+        h_pc,
     }
 }
 

--- a/algorithms/src/snark/gm17/verifier.rs
+++ b/algorithms/src/snark/gm17/verifier.rs
@@ -32,7 +32,6 @@ pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> Prepared
         g_gamma_pc: vk.g_gamma_g1.prepare(),
         h_gamma_pc: vk.h_gamma_g2.prepare(),
         h_pc: vk.h_g2.prepare(),
-        query: vk.query.clone(),
     }
 }
 
@@ -41,15 +40,15 @@ pub fn verify_proof<E: PairingEngine>(
     proof: &Proof<E>,
     public_inputs: &[E::Fr],
 ) -> Result<bool, SynthesisError> {
-    if (public_inputs.len() + 1) != pvk.query.len() {
+    if (public_inputs.len() + 1) != pvk.query().len() {
         return Err(SynthesisError::MalformedVerifyingKey);
     }
 
     // e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma}) *
     // e(C, H) where psi = \sum_{i=0}^l input_i pvk.query[i]
 
-    let mut g_psi = pvk.query[0].into_projective();
-    for (i, b) in public_inputs.iter().zip(pvk.query.iter().skip(1)) {
+    let mut g_psi = pvk.query()[0].into_projective();
+    for (i, b) in public_inputs.iter().zip(pvk.query().iter().skip(1)) {
         g_psi.add_assign(&b.mul(i.into_repr()));
     }
 

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -351,13 +351,13 @@ impl<E: PairingEngine> PreparedVerifyingKey<E> {
 
 impl<E: PairingEngine> From<Parameters<E>> for PreparedVerifyingKey<E> {
     fn from(other: Parameters<E>) -> Self {
-        prepare_verifying_key(&other.vk)
+        prepare_verifying_key(other.vk)
     }
 }
 
 impl<E: PairingEngine> From<VerifyingKey<E>> for PreparedVerifyingKey<E> {
     fn from(other: VerifyingKey<E>) -> Self {
-        prepare_verifying_key(&other)
+        prepare_verifying_key(other)
     }
 }
 

--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -341,7 +341,12 @@ pub struct PreparedVerifyingKey<E: PairingEngine> {
     pub alpha_g1_beta_g2: E::Fqk,
     pub gamma_g2_neg_pc: <E::G2Affine as PairingCurve>::Prepared,
     pub delta_g2_neg_pc: <E::G2Affine as PairingCurve>::Prepared,
-    pub gamma_abc_g1: Vec<E::G1Affine>,
+}
+
+impl<E: PairingEngine> PreparedVerifyingKey<E> {
+    fn gamma_abc_g1(&self) -> &[E::G1Affine] {
+        &self.vk.gamma_abc_g1
+    }
 }
 
 impl<E: PairingEngine> From<Parameters<E>> for PreparedVerifyingKey<E> {

--- a/algorithms/src/snark/groth16/snark.rs
+++ b/algorithms/src/snark/groth16/snark.rs
@@ -60,7 +60,7 @@ impl<E: PairingEngine, C: ConstraintSynthesizer<E::Fr>, V: ToConstraintField<E::
     ) -> Result<(Self::ProvingParameters, Self::PreparedVerificationParameters), SNARKError> {
         let setup_time = start_timer!(|| "{Groth 2016}::Setup");
         let pp = generate_random_parameters::<E, Self::Circuit, R>(circuit, rng)?;
-        let vk = prepare_verifying_key(&pp.vk);
+        let vk = prepare_verifying_key(pp.vk.clone());
         end_timer!(setup_time);
         Ok((pp, vk))
     }

--- a/algorithms/src/snark/groth16/tests.rs
+++ b/algorithms/src/snark/groth16/tests.rs
@@ -64,8 +64,6 @@ mod bls12_377 {
 
         let params = generate_random_parameters::<Bls12_377, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
-        let pvk = prepare_verifying_key::<Bls12_377>(&params.vk);
-
         for _ in 0..100 {
             let a = Fr::rand(rng);
             let b = Fr::rand(rng);
@@ -73,6 +71,7 @@ mod bls12_377 {
             c.mul_assign(&b);
 
             let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+            let pvk = prepare_verifying_key::<Bls12_377>(params.vk.clone());
 
             assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
             assert!(!verify_proof(&pvk, &proof, &[a]).unwrap());
@@ -93,13 +92,12 @@ mod bw6_761 {
 
         let params = generate_random_parameters::<BW6_761, _, _>(&MySillyCircuit { a: None, b: None }, rng).unwrap();
 
-        let pvk = prepare_verifying_key::<BW6_761>(&params.vk);
-
         let a = Fr::rand(rng);
         let b = Fr::rand(rng);
         let c = a * &b;
 
         let proof = create_random_proof(&MySillyCircuit { a: Some(a), b: Some(b) }, &params, rng).unwrap();
+        let pvk = prepare_verifying_key::<BW6_761>(params.vk);
 
         assert!(verify_proof(&pvk, &proof, &[c]).unwrap());
         assert!(!verify_proof(&pvk, &proof, &[Fr::zero()]).unwrap());

--- a/algorithms/src/snark/groth16/verifier.rs
+++ b/algorithms/src/snark/groth16/verifier.rs
@@ -20,12 +20,16 @@ use snarkos_models::curves::{AffineCurve, PairingCurve, PairingEngine, PrimeFiel
 
 use core::ops::{AddAssign, Neg};
 
-pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> PreparedVerifyingKey<E> {
+pub fn prepare_verifying_key<E: PairingEngine>(vk: VerifyingKey<E>) -> PreparedVerifyingKey<E> {
+    let alpha_g1_beta_g2 = E::pairing(vk.alpha_g1, vk.beta_g2);
+    let gamma_g2_neg_pc = vk.gamma_g2.neg().prepare();
+    let delta_g2_neg_pc = vk.delta_g2.neg().prepare();
+
     PreparedVerifyingKey {
-        vk: vk.clone(),
-        alpha_g1_beta_g2: E::pairing(vk.alpha_g1, vk.beta_g2),
-        gamma_g2_neg_pc: vk.gamma_g2.neg().prepare(),
-        delta_g2_neg_pc: vk.delta_g2.neg().prepare(),
+        vk,
+        alpha_g1_beta_g2,
+        gamma_g2_neg_pc,
+        delta_g2_neg_pc,
     }
 }
 

--- a/algorithms/src/snark/groth16/verifier.rs
+++ b/algorithms/src/snark/groth16/verifier.rs
@@ -26,7 +26,6 @@ pub fn prepare_verifying_key<E: PairingEngine>(vk: &VerifyingKey<E>) -> Prepared
         alpha_g1_beta_g2: E::pairing(vk.alpha_g1, vk.beta_g2),
         gamma_g2_neg_pc: vk.gamma_g2.neg().prepare(),
         delta_g2_neg_pc: vk.delta_g2.neg().prepare(),
-        gamma_abc_g1: vk.gamma_abc_g1.clone(),
     }
 }
 
@@ -35,12 +34,12 @@ pub fn verify_proof<E: PairingEngine>(
     proof: &Proof<E>,
     public_inputs: &[E::Fr],
 ) -> Result<bool, SynthesisError> {
-    if (public_inputs.len() + 1) != pvk.gamma_abc_g1.len() {
+    if (public_inputs.len() + 1) != pvk.gamma_abc_g1().len() {
         return Err(SynthesisError::MalformedVerifyingKey);
     }
 
-    let mut g_ic = pvk.gamma_abc_g1[0].into_projective();
-    for (i, b) in public_inputs.iter().zip(pvk.gamma_abc_g1.iter().skip(1)) {
+    let mut g_ic = pvk.gamma_abc_g1()[0].into_projective();
+    for (i, b) in public_inputs.iter().zip(pvk.gamma_abc_g1().iter().skip(1)) {
         g_ic.add_assign(&b.mul(i.into_repr()));
     }
 

--- a/algorithms/tests/snark/mimc.rs
+++ b/algorithms/tests/snark/mimc.rs
@@ -184,7 +184,7 @@ fn test_mimc_groth_16() {
     };
 
     // Prepare the verification key (for proof verification)
-    let pvk = prepare_verifying_key(&params.vk);
+    let pvk = prepare_verifying_key(params.vk.clone());
 
     println!("Creating proofs...");
 
@@ -271,7 +271,7 @@ fn test_mimc_groth_maller_17() {
     };
 
     // Prepare the verification key (for proof verification)
-    let pvk = prepare_verifying_key(&params.vk);
+    let pvk = prepare_verifying_key(params.vk.clone());
 
     println!("Creating proofs...");
 

--- a/benchmarks/algorithms/snark/snark.rs
+++ b/benchmarks/algorithms/snark/snark.rs
@@ -85,7 +85,7 @@ fn snark_setup(c: &mut Criterion) {
     c.bench_function("snark_setup", move |b| {
         b.iter(|| {
             GM17SNARK::setup(
-                Benchmark::<Fr> {
+                &Benchmark::<Fr> {
                     inputs: vec![None; num_inputs],
                     num_constraints,
                 },
@@ -106,7 +106,7 @@ fn snark_prove(c: &mut Criterion) {
     }
 
     let params = GM17SNARK::setup(
-        Benchmark::<Fr> {
+        &Benchmark::<Fr> {
             inputs: vec![None; num_inputs],
             num_constraints,
         },
@@ -118,7 +118,7 @@ fn snark_prove(c: &mut Criterion) {
         b.iter(|| {
             GM17SNARK::prove(
                 &params.0,
-                Benchmark {
+                &Benchmark {
                     inputs: inputs.clone(),
                     num_constraints,
                 },

--- a/benchmarks/posw/posw.rs
+++ b/benchmarks/posw/posw.rs
@@ -34,7 +34,7 @@ fn gm17_bench(c: &mut Criterion) {
     let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
 
     // Can we test for different tx id sizes?
-    let transaction_ids = vec![vec![1u8; 32]; 8];
+    let transaction_ids = vec![[1u8; 32]; 8];
     let (_, pedersen_merkle_root, subroots) = txids_to_roots(&transaction_ids);
 
     // Proof Generation Bench
@@ -64,7 +64,7 @@ fn marlin_bench(c: &mut Criterion) {
 
     let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
 
-    let transaction_ids = vec![vec![1u8; 32]; 8];
+    let transaction_ids = vec![[1u8; 32]; 8];
     let (_, pedersen_merkle_root, subroots) = txids_to_roots(&transaction_ids);
 
     // Proof Generation Bench

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -34,5 +34,11 @@ tracing = { default-features = false, features = ["log"], version = "0.1" }
 [dev-dependencies]
 snarkos-testing = { path = "../testing" }
 
+criterion = { version = "0.3" }
 futures-await-test = { version = "0.3.0" }
 rand_xorshift = { version = "0.2" }
+
+[[bench]]
+name = "transactions"
+path = "benches/transactions.rs"
+harness = false

--- a/consensus/benches/transactions.rs
+++ b/consensus/benches/transactions.rs
@@ -1,0 +1,56 @@
+// Copyright (C) 2019-2020 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkos_objects::{dpc::DPCTransactions, merkle_root};
+use snarkos_posw::txids_to_roots;
+use snarkos_testing::consensus::*;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_txids_to_roots(c: &mut Criterion) {
+    let transactions = DPCTransactions(vec![TestTx; 200]);
+
+    c.bench_function("txids_to_roots", |b| {
+        b.iter(|| txids_to_roots(&transactions.to_transaction_ids().unwrap()))
+    });
+}
+
+fn bench_merkle_root(c: &mut Criterion) {
+    use std::convert::TryInto;
+
+    let mut txs: Vec<[u8; 32]> = Vec::with_capacity(5);
+
+    for hash in &[
+        "c06fbab289f723c6261d3030ddb6be121f7d2508d77862bb1e484f5cd7f92b25",
+        "5a4ebf66822b0b2d56bd9dc64ece0bc38ee7844a23ff1d7320a88c5fdb2ad3e2",
+        "513507fa209db823541caf7b9742bb9999b4a399cf604ba8da7037f3acced649",
+        "6bf5d2e02b8432d825c5dff692d435b6c5f685d94efa6b3d8fb818f2ecdcfb66",
+        "8a5ad423bc54fb7c76718371fd5a73b8c42bf27beaf2ad448761b13bcafb8895",
+    ] {
+        txs.push(hex::decode(hash).unwrap().as_slice().try_into().unwrap())
+    }
+
+    c.bench_function("merkle_root", |b| b.iter(|| merkle_root(&txs)));
+}
+
+criterion_group!(
+    name = benches_transactions;
+    config = Criterion::default();
+    targets = bench_txids_to_roots,
+    bench_merkle_root,
+);
+
+criterion_main!(benches_transactions);

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -203,7 +203,7 @@ impl ConsensusParameters {
         block: &Block<Tx>,
         ledger: &MerkleTreeLedger,
     ) -> Result<bool, ConsensusError> {
-        let transaction_ids: Vec<Vec<u8>> = block.transactions.to_transaction_ids()?;
+        let transaction_ids: Vec<_> = block.transactions.to_transaction_ids()?;
         let (merkle_root, pedersen_merkle_root, _) = txids_to_roots(&transaction_ids);
 
         // Verify the block header

--- a/curves/benches/bls12_377/pairing.rs
+++ b/curves/benches/bls12_377/pairing.rs
@@ -26,6 +26,8 @@ pub(crate) mod pairing {
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
+    use std::iter;
+
     pub fn bench_pairing_miller_loop(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
@@ -43,7 +45,7 @@ pub(crate) mod pairing {
         let mut count = 0;
         c.bench_function("bls12_377: pairing_miller_loop", |c| {
             c.iter(|| {
-                let tmp = Bls12_377::miller_loop(&[(&v[count].0, &v[count].1)]);
+                let tmp = Bls12_377::miller_loop(iter::once((&v[count].0, &v[count].1)));
                 count = (count + 1) % SAMPLES;
                 tmp
             })

--- a/curves/benches/bw6_761/pairing.rs
+++ b/curves/benches/bw6_761/pairing.rs
@@ -26,6 +26,8 @@ pub(crate) mod pairing {
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
+    use std::iter;
+
     pub fn bench_pairing_miller_loop(c: &mut Criterion) {
         const SAMPLES: usize = 1000;
 
@@ -43,7 +45,7 @@ pub(crate) mod pairing {
         let mut count = 0;
         c.bench_function("bw6_761: pairing_miller_loop", |c| {
             c.iter(|| {
-                let tmp = BW6_761::miller_loop(&[(&v[count].0, &v[count].1)]);
+                let tmp = BW6_761::miller_loop(iter::once((&v[count].0, &v[count].1)));
                 count = (count + 1) % SAMPLES;
                 tmp
             })

--- a/dpc/tests/base_dpc.rs
+++ b/dpc/tests/base_dpc.rs
@@ -225,12 +225,7 @@ fn base_dpc_integration_test() {
     let mut transactions = DPCTransactions::new();
     transactions.push(transaction);
 
-    let transaction_ids: Vec<Vec<u8>> = transactions
-        .to_transaction_ids()
-        .unwrap()
-        .iter()
-        .map(|id| id.to_vec())
-        .collect();
+    let transaction_ids = transactions.to_transaction_ids().unwrap();
 
     let mut merkle_root_bytes = [0u8; 32];
     merkle_root_bytes[..].copy_from_slice(&merkle_root(&transaction_ids));

--- a/gadgets/src/algorithms/snark/gm17.rs
+++ b/gadgets/src/algorithms/snark/gm17.rs
@@ -61,11 +61,11 @@ impl<Pairing: PairingEngine, F: Field, P: PairingGadget<Pairing, F>> GM17Verifyi
         mut cs: CS,
     ) -> Result<GM17PreparedVerifyingKeyGadget<Pairing, F, P>, SynthesisError> {
         let mut cs = cs.ns(|| "Preparing verifying key");
-        let g_alpha_pc = P::prepare_g1(&mut cs.ns(|| "Prepare g_alpha_g1"), &self.g_alpha_g1)?;
-        let h_beta_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_beta_g2"), &self.h_beta_g2)?;
-        let g_gamma_pc = P::prepare_g1(&mut cs.ns(|| "Prepare g_gamma_pc"), &self.g_gamma_g1)?;
-        let h_gamma_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_gamma_pc"), &self.h_gamma_g2)?;
-        let h_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_pc"), &self.h_g2)?;
+        let g_alpha_pc = P::prepare_g1(&mut cs.ns(|| "Prepare g_alpha_g1"), self.g_alpha_g1.clone())?;
+        let h_beta_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_beta_g2"), self.h_beta_g2.clone())?;
+        let g_gamma_pc = P::prepare_g1(&mut cs.ns(|| "Prepare g_gamma_pc"), self.g_gamma_g1.clone())?;
+        let h_gamma_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_gamma_pc"), self.h_gamma_g2.clone())?;
+        let h_pc = P::prepare_g2(&mut cs.ns(|| "Prepare h_pc"), self.h_g2.clone())?;
         Ok(GM17PreparedVerifyingKeyGadget {
             g_alpha: self.g_alpha_g1.clone(),
             h_beta: self.h_beta_g2.clone(),
@@ -140,12 +140,12 @@ impl<
 
         let test1_exp = {
             test1_a_g_alpha = test1_a_g_alpha.negate(cs.ns(|| "neg 1"))?;
-            let test1_a_g_alpha_prep = P::prepare_g1(cs.ns(|| "First prep"), &test1_a_g_alpha)?;
-            let test1_b_h_beta_prep = P::prepare_g2(cs.ns(|| "Second prep"), &test1_b_h_beta)?;
+            let test1_a_g_alpha_prep = P::prepare_g1(cs.ns(|| "First prep"), test1_a_g_alpha)?;
+            let test1_b_h_beta_prep = P::prepare_g2(cs.ns(|| "Second prep"), test1_b_h_beta)?;
 
-            let g_psi_prep = P::prepare_g1(cs.ns(|| "Third prep"), &g_psi)?;
+            let g_psi_prep = P::prepare_g1(cs.ns(|| "Third prep"), g_psi)?;
 
-            let c_prep = P::prepare_g1(cs.ns(|| "Fourth prep"), &proof.c)?;
+            let c_prep = P::prepare_g1(cs.ns(|| "Fourth prep"), proof.c.clone())?;
 
             P::miller_loop(
                 cs.ns(|| "Miller loop 1"),
@@ -163,11 +163,11 @@ impl<
 
         // e(A, H^{gamma}) = e(G^{gamma}, B)
         let test2_exp = {
-            let a_prep = P::prepare_g1(cs.ns(|| "Fifth prep"), &proof.a)?;
+            let a_prep = P::prepare_g1(cs.ns(|| "Fifth prep"), proof.a.clone())?;
             // pvk.h_gamma_pc
             //&pvk.g_gamma_pc
             let proof_b = proof.b.negate(cs.ns(|| "Negate b"))?;
-            let b_prep = P::prepare_g2(cs.ns(|| "Sixth prep"), &proof_b)?;
+            let b_prep = P::prepare_g2(cs.ns(|| "Sixth prep"), proof_b)?;
             P::miller_loop(cs.ns(|| "Miller loop 4"), &[a_prep, pvk.g_gamma_pc.clone()], &[
                 pvk.h_gamma_pc,
                 b_prep,

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -62,8 +62,8 @@ impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, Con
         mut cs: CS,
     ) -> Result<PreparedVerifyingKeyGadget<PairingE, ConstraintF, P>, SynthesisError> {
         let mut cs = cs.ns(|| "Preparing verifying key");
-        let alpha_g1_pc = P::prepare_g1(&mut cs.ns(|| "Prepare alpha_g1"), &self.alpha_g1)?;
-        let beta_g2_pc = P::prepare_g2(&mut cs.ns(|| "Prepare beta_g2"), &self.beta_g2)?;
+        let alpha_g1_pc = P::prepare_g1(&mut cs.ns(|| "Prepare alpha_g1"), self.alpha_g1.clone())?;
+        let beta_g2_pc = P::prepare_g2(&mut cs.ns(|| "Prepare beta_g2"), self.beta_g2.clone())?;
 
         let alpha_g1_beta_g2 = P::pairing(
             &mut cs.ns(|| "Precompute e(alpha_g1, beta_g2)"),
@@ -72,10 +72,10 @@ impl<PairingE: PairingEngine, ConstraintF: Field, P: PairingGadget<PairingE, Con
         )?;
 
         let gamma_g2_neg = self.gamma_g2.negate(&mut cs.ns(|| "Negate gamma_g2"))?;
-        let gamma_g2_neg_pc = P::prepare_g2(&mut cs.ns(|| "Prepare gamma_g2_neg"), &gamma_g2_neg)?;
+        let gamma_g2_neg_pc = P::prepare_g2(&mut cs.ns(|| "Prepare gamma_g2_neg"), gamma_g2_neg)?;
 
         let delta_g2_neg = self.delta_g2.negate(&mut cs.ns(|| "Negate delta_g2"))?;
-        let delta_g2_neg_pc = P::prepare_g2(&mut cs.ns(|| "Prepare delta_g2_neg"), &delta_g2_neg)?;
+        let delta_g2_neg_pc = P::prepare_g2(&mut cs.ns(|| "Prepare delta_g2_neg"), delta_g2_neg)?;
 
         Ok(PreparedVerifyingKeyGadget {
             alpha_g1_beta_g2,
@@ -153,11 +153,11 @@ where
         };
 
         let test_exp = {
-            let proof_a_prep = P::prepare_g1(cs.ns(|| "Prepare proof a"), &proof.a)?;
-            let proof_b_prep = P::prepare_g2(cs.ns(|| "Prepare proof b"), &proof.b)?;
-            let proof_c_prep = P::prepare_g1(cs.ns(|| "Prepare proof c"), &proof.c)?;
+            let proof_a_prep = P::prepare_g1(cs.ns(|| "Prepare proof a"), proof.a.clone())?;
+            let proof_b_prep = P::prepare_g2(cs.ns(|| "Prepare proof b"), proof.b.clone())?;
+            let proof_c_prep = P::prepare_g1(cs.ns(|| "Prepare proof c"), proof.c.clone())?;
 
-            let g_ic_prep = P::prepare_g1(cs.ns(|| "Prepare g_ic"), &g_ic)?;
+            let g_ic_prep = P::prepare_g1(cs.ns(|| "Prepare g_ic"), g_ic)?;
 
             P::miller_loop(cs.ns(|| "Miller loop 1"), &[proof_a_prep, g_ic_prep, proof_c_prep], &[
                 proof_b_prep,

--- a/gadgets/src/curves/templates/bls12/g1.rs
+++ b/gadgets/src/curves/templates/bls12/g1.rs
@@ -43,8 +43,8 @@ impl<P: Bls12Parameters> G1PreparedGadget<P> {
         Some(G1Prepared::from_affine(self.0.get_value().unwrap().into_affine()))
     }
 
-    pub fn from_affine<CS: ConstraintSystem<P::Fp>>(_cs: CS, q: &G1Gadget<P>) -> Result<Self, SynthesisError> {
-        Ok(G1PreparedGadget(q.clone()))
+    pub fn from_affine<CS: ConstraintSystem<P::Fp>>(_cs: CS, q: G1Gadget<P>) -> Result<Self, SynthesisError> {
+        Ok(G1PreparedGadget(q))
     }
 }
 

--- a/gadgets/src/curves/templates/bls12/g2.rs
+++ b/gadgets/src/curves/templates/bls12/g2.rs
@@ -60,7 +60,7 @@ impl<P: Bls12Parameters> ToBytesGadget<P::Fp> for G2PreparedGadget<P> {
 }
 
 impl<P: Bls12Parameters> G2PreparedGadget<P> {
-    pub fn from_affine<CS: ConstraintSystem<P::Fp>>(mut cs: CS, q: &G2Gadget<P>) -> Result<Self, SynthesisError> {
+    pub fn from_affine<CS: ConstraintSystem<P::Fp>>(mut cs: CS, q: G2Gadget<P>) -> Result<Self, SynthesisError> {
         let two_inv = P::Fp::one().double().inverse().unwrap();
         let zero = G2Gadget::<P>::zero(cs.ns(|| "zero"))?;
         q.enforce_not_equal(cs.ns(|| "enforce not zero"), &zero)?;

--- a/gadgets/src/curves/templates/bls12/pairing.rs
+++ b/gadgets/src/curves/templates/bls12/pairing.rs
@@ -209,14 +209,14 @@ where
 
     fn prepare_g1<CS: ConstraintSystem<P::Fp>>(
         cs: CS,
-        p: &Self::G1Gadget,
+        p: Self::G1Gadget,
     ) -> Result<Self::G1PreparedGadget, SynthesisError> {
         Self::G1PreparedGadget::from_affine(cs, p)
     }
 
     fn prepare_g2<CS: ConstraintSystem<P::Fp>>(
         cs: CS,
-        q: &Self::G2Gadget,
+        q: Self::G2Gadget,
     ) -> Result<Self::G2PreparedGadget, SynthesisError> {
         Self::G2PreparedGadget::from_affine(cs, q)
     }

--- a/gadgets/src/curves/tests_curve.rs
+++ b/gadgets/src/curves/tests_curve.rs
@@ -51,11 +51,11 @@ fn bls12_377_gadget_bilinearity_test() {
     let sa_g = G1Gadget::alloc(&mut cs.ns(|| "sa"), || Ok(sa)).unwrap();
     let sb_g = G2Gadget::alloc(&mut cs.ns(|| "sb"), || Ok(sb)).unwrap();
 
-    let a_prep_g = G1PreparedGadget::from_affine(&mut cs.ns(|| "a_prep"), &a_g).unwrap();
-    let b_prep_g = G2PreparedGadget::from_affine(&mut cs.ns(|| "b_prep"), &b_g).unwrap();
+    let a_prep_g = G1PreparedGadget::from_affine(&mut cs.ns(|| "a_prep"), a_g).unwrap();
+    let b_prep_g = G2PreparedGadget::from_affine(&mut cs.ns(|| "b_prep"), b_g).unwrap();
 
-    let sa_prep_g = G1PreparedGadget::from_affine(&mut cs.ns(|| "sa_prep"), &sa_g).unwrap();
-    let sb_prep_g = G2PreparedGadget::from_affine(&mut cs.ns(|| "sb_prep"), &sb_g).unwrap();
+    let sa_prep_g = G1PreparedGadget::from_affine(&mut cs.ns(|| "sa_prep"), sa_g).unwrap();
+    let sb_prep_g = G2PreparedGadget::from_affine(&mut cs.ns(|| "sb_prep"), sb_g).unwrap();
 
     let (ans1_g, ans1_n) = {
         let ans_g = Bls12PairingGadget::pairing(cs.ns(|| "pair(sa, b)"), sa_prep_g, b_prep_g.clone()).unwrap();

--- a/marlin/src/lib.rs
+++ b/marlin/src/lib.rs
@@ -357,8 +357,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, D: Digest> Marlin<F, PC, D> {
             .into_iter()
             .chain(AHPForR1CS::prover_first_round_degree_bounds(&index_info))
             .chain(AHPForR1CS::prover_second_round_degree_bounds(&index_info))
-            .chain(AHPForR1CS::prover_third_round_degree_bounds(&index_info))
-            .collect::<Vec<_>>();
+            .chain(AHPForR1CS::prover_third_round_degree_bounds(&index_info));
 
         // Gather commitments in one vector.
         let commitments = index_vk

--- a/models/src/curves/pairing_engine.rs
+++ b/models/src/curves/pairing_engine.rs
@@ -148,8 +148,7 @@ pub trait ProjectiveCurve:
 
     /// Normalizes a slice of projective elements and outputs a vector
     /// containing the affine equivalents.
-    fn batch_normalization_into_affine(v: &[Self]) -> Vec<Self::Affine> {
-        let mut v = v.to_vec();
+    fn batch_normalization_into_affine(mut v: Vec<Self>) -> Vec<Self::Affine> {
         Self::batch_normalization(&mut v);
         v.into_iter().map(|v| v.into()).collect()
     }

--- a/models/src/gadgets/curves/pairing.rs
+++ b/models/src/gadgets/curves/pairing.rs
@@ -63,13 +63,9 @@ pub trait PairingGadget<Pairing: PairingEngine, F: Field> {
         Self::final_exponentiation(&mut cs.ns(|| "Final Exp"), &miller_result)
     }
 
-    fn prepare_g1<CS: ConstraintSystem<F>>(
-        cs: CS,
-        q: &Self::G1Gadget,
-    ) -> Result<Self::G1PreparedGadget, SynthesisError>;
+    fn prepare_g1<CS: ConstraintSystem<F>>(cs: CS, q: Self::G1Gadget)
+    -> Result<Self::G1PreparedGadget, SynthesisError>;
 
-    fn prepare_g2<CS: ConstraintSystem<F>>(
-        cs: CS,
-        q: &Self::G2Gadget,
-    ) -> Result<Self::G2PreparedGadget, SynthesisError>;
+    fn prepare_g2<CS: ConstraintSystem<F>>(cs: CS, q: Self::G2Gadget)
+    -> Result<Self::G2PreparedGadget, SynthesisError>;
 }

--- a/objects/src/dpc/transactions.rs
+++ b/objects/src/dpc/transactions.rs
@@ -48,13 +48,8 @@ impl<T: Transaction> DPCTransactions<T> {
     }
 
     /// Returns the transaction ids.
-    pub fn to_transaction_ids(&self) -> Result<Vec<Vec<u8>>, TransactionError> {
-        self.0
-            .iter()
-            .map(|transaction| -> Result<Vec<u8>, TransactionError> {
-                transaction.transaction_id().map(|tx_id| tx_id.to_vec())
-            })
-            .collect::<Result<Vec<Vec<u8>>, TransactionError>>()
+    pub fn to_transaction_ids(&self) -> Result<Vec<[u8; 32]>, TransactionError> {
+        self.0.iter().map(|tx| tx.transaction_id()).collect()
     }
 
     /// Serializes the transactions into byte vectors.

--- a/objects/src/merkle_tree.rs
+++ b/objects/src/merkle_tree.rs
@@ -20,21 +20,22 @@ use snarkos_algorithms::crh::double_sha256;
 pub struct MerkleTreeRootHash([u8; 32]);
 
 fn merkle_round(hashes: &[Vec<u8>]) -> Vec<Vec<u8>> {
-    let mut pairs = Vec::with_capacity(hashes.len() / 2);
-
-    for i in (0..hashes.len() - 1).step_by(2) {
-        pairs.push((&hashes[i], &hashes[i + 1]));
-    }
-
-    // Duplicate the last element if there are an odd number of leaves
+    let mut ret_len = hashes.len() / 2;
     if hashes.len() % 2 == 1 {
-        let last = &hashes[hashes.len() - 1];
-        pairs.push((last, last));
+        ret_len += 1;
+    };
+    let mut ret = Vec::with_capacity(ret_len);
+
+    // Duplicates the last element if there are an odd number of leaves
+    for arr in hashes.chunks(2) {
+        match arr {
+            [h1, h2] => ret.push(merkle_hash(&h1, &h2)),
+            [h] => ret.push(merkle_hash(&h, &h)),
+            _ => unreachable!(),
+        }
     }
 
-    let result: Vec<Vec<u8>> = pairs.iter().map(|x| merkle_hash(x.0, x.1)).collect();
-
-    result
+    ret
 }
 
 /// Calculates a Merkle root and also returns the subroots at a desired depth. If the tree is too

--- a/objects/src/pedersen_merkle_tree.rs
+++ b/objects/src/pedersen_merkle_tree.rs
@@ -66,19 +66,19 @@ impl Display for PedersenMerkleRootHash {
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG
 /// and returns it serialized
-pub fn pedersen_merkle_root(hashes: &[Vec<u8>]) -> PedersenMerkleRootHash {
+pub fn pedersen_merkle_root(hashes: &[[u8; 32]]) -> PedersenMerkleRootHash {
     pedersen_merkle_root_hash(hashes).into()
 }
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG
-pub fn pedersen_merkle_root_hash(hashes: &[Vec<u8>]) -> Fr {
+pub fn pedersen_merkle_root_hash(hashes: &[[u8; 32]]) -> Fr {
     let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes).expect("could not create merkle tree");
     tree.root()
 }
 
 /// Calculates the root of the Merkle tree using a Pedersen Hash instantiated with a PRNG and the
 /// base layer hashes leaved
-pub fn pedersen_merkle_root_hash_with_leaves(hashes: &[Vec<u8>]) -> (Fr, Vec<Fr>) {
+pub fn pedersen_merkle_root_hash_with_leaves(hashes: &[[u8; 32]]) -> (Fr, Vec<Fr>) {
     let tree = EdwardsMaskedMerkleTree::new(PARAMS.clone(), hashes).expect("could not create merkle tree");
     (tree.root(), tree.hashed_leaves())
 }

--- a/parameters/src/params.rs
+++ b/parameters/src/params.rs
@@ -159,10 +159,8 @@ macro_rules! impl_params_remote {
                 // Attempt to write the parameter buffer to a file.
                 if let Ok(mut file) = File::create(relative_path) {
                     file.write_all(&buffer)?;
-                    drop(file);
                 } else if let Ok(mut file) = File::create(absolute_path) {
                     file.write_all(&buffer)?;
-                    drop(file);
                 }
                 Ok(())
             }

--- a/parameters/src/params.rs
+++ b/parameters/src/params.rs
@@ -84,10 +84,10 @@ macro_rules! impl_params_remote {
 
                 let buffer = if relative_path.exists() {
                     // Attempts to load the parameter file locally with a relative path.
-                    fs::read(relative_path)?.to_vec()
+                    fs::read(relative_path)?
                 } else if absolute_path.exists() {
                     // Attempts to load the parameter file locally with an absolute path.
-                    fs::read(absolute_path)?.to_vec()
+                    fs::read(absolute_path)?
                 } else {
                     // Downloads the missing parameters and stores it in the local directory for use.
                     eprintln!(

--- a/parameters/src/params.rs
+++ b/parameters/src/params.rs
@@ -21,7 +21,7 @@ use snarkos_models::parameters::Parameters;
 use std::{
     fs::{self, File},
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 #[cfg(any(test, feature = "remote"))]
@@ -76,7 +76,7 @@ macro_rules! impl_params_remote {
                 file_path.push(&filename);
 
                 // Compute the relative path.
-                let relative_path = file_path.strip_prefix("parameters")?.to_path_buf();
+                let relative_path = file_path.strip_prefix("parameters")?;
 
                 // Compute the absolute path.
                 let mut absolute_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -151,9 +151,9 @@ macro_rules! impl_params_remote {
 
             fn store_bytes(
                 buffer: &[u8],
-                relative_path: &PathBuf,
-                absolute_path: &PathBuf,
-                file_path: &PathBuf,
+                relative_path: &Path,
+                absolute_path: &Path,
+                file_path: &Path,
             ) -> Result<(), ParametersError> {
                 println!("{} - Storing parameters ({:?})", module_path!(), file_path);
                 // Attempt to write the parameter buffer to a file.

--- a/polycommit/src/kzg10/mod.rs
+++ b/polycommit/src/kzg10/mod.rs
@@ -93,8 +93,8 @@ impl<E: PairingEngine> KZG10<E> {
         powers_of_gamma_g.push(powers_of_gamma_g.last().unwrap().mul(&beta));
         end_timer!(gamma_g_time);
 
-        let powers_of_g = E::G1Projective::batch_normalization_into_affine(&powers_of_g);
-        let powers_of_gamma_g = E::G1Projective::batch_normalization_into_affine(&powers_of_gamma_g)
+        let powers_of_g = E::G1Projective::batch_normalization_into_affine(powers_of_g);
+        let powers_of_gamma_g = E::G1Projective::batch_normalization_into_affine(powers_of_gamma_g)
             .into_iter()
             .enumerate()
             .collect();
@@ -116,7 +116,7 @@ impl<E: PairingEngine> KZG10<E> {
                 &neg_powers_of_beta,
             );
 
-            let affines = E::G2Projective::batch_normalization_into_affine(&neg_powers_of_h);
+            let affines = E::G2Projective::batch_normalization_into_affine(neg_powers_of_h);
             let mut affines_map = BTreeMap::new();
             affines
                 .into_iter()
@@ -347,7 +347,7 @@ impl<E: PairingEngine> KZG10<E> {
         end_timer!(combination_time);
 
         let to_affine_time = start_timer!(|| "Converting results to affine for pairing");
-        let affine_points = E::G1Projective::batch_normalization_into_affine(&[-total_w, total_c]);
+        let affine_points = E::G1Projective::batch_normalization_into_affine(vec![-total_w, total_c]);
         let (total_w, total_c) = (affine_points[0], affine_points[1]);
         end_timer!(to_affine_time);
 

--- a/polycommit/src/marlin_pc/mod.rs
+++ b/polycommit/src/marlin_pc/mod.rs
@@ -117,8 +117,8 @@ impl<E: PairingEngine> MarlinKZG10<E> {
                 s_flags.push(false);
             }
         }
-        let comms = E::G1Projective::batch_normalization_into_affine(&comms);
-        let s_comms = E::G1Projective::batch_normalization_into_affine(&s_comms);
+        let comms = E::G1Projective::batch_normalization_into_affine(comms);
+        let s_comms = E::G1Projective::batch_normalization_into_affine(s_comms);
         comms.into_iter().zip(s_comms).zip(s_flags).map(|((c, s_c), flag)| {
             let shifted_comm = if flag { Some(kzg10::Commitment(s_c)) } else { None };
             Commitment {

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -602,10 +602,9 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
             lc_info.push((lc_label, degree_bound));
         }
 
-        let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(lc_commitments)
+        let comms = E::G1Projective::batch_normalization_into_affine(lc_commitments)
             .into_iter()
-            .map(kzg10::Commitment)
-            .collect();
+            .map(kzg10::Commitment);
 
         let lc_commitments = lc_info
             .into_iter()

--- a/polycommit/src/sonic_pc/mod.rs
+++ b/polycommit/src/sonic_pc/mod.rs
@@ -128,7 +128,7 @@ impl<E: PairingEngine> SonicKZG10<E> {
         g1_projective_elems.push(-combined_witness);
         g2_prepared_elems.push(vk.prepared_beta_h.clone());
 
-        let g1_prepared_elems_iter = E::G1Projective::batch_normalization_into_affine(g1_projective_elems.as_slice())
+        let g1_prepared_elems_iter = E::G1Projective::batch_normalization_into_affine(g1_projective_elems)
             .into_iter()
             .map(|a| a.prepare())
             .collect::<Vec<_>>();
@@ -521,7 +521,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
             lc_info.push((lc_label, degree_bound));
         }
 
-        let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(&lc_commitments)
+        let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(lc_commitments)
             .into_iter()
             .map(kzg10::Commitment::<E>)
             .collect();
@@ -602,7 +602,7 @@ impl<E: PairingEngine> PolynomialCommitment<E::Fr> for SonicKZG10<E> {
             lc_info.push((lc_label, degree_bound));
         }
 
-        let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(&lc_commitments)
+        let comms: Vec<Self::Commitment> = E::G1Projective::batch_normalization_into_affine(lc_commitments)
             .into_iter()
             .map(kzg10::Commitment)
             .collect();

--- a/posw/src/circuit.rs
+++ b/posw/src/circuit.rs
@@ -204,6 +204,6 @@ mod test {
         ]]
         .concat();
 
-        assert!(verify_proof(&prepare_verifying_key(&params.vk), &proof, &inputs,).unwrap());
+        assert!(verify_proof(&prepare_verifying_key(params.vk), &proof, &inputs,).unwrap());
     }
 }

--- a/posw/src/consensus.rs
+++ b/posw/src/consensus.rs
@@ -103,7 +103,7 @@ where
     }
 
     /// Creates a POSW circuit from the provided transaction ids and nonce.
-    fn circuit_from(nonce: u32, leaves: &[Vec<u8>]) -> POSWCircuit<F, M, HG, CP> {
+    fn circuit_from(nonce: u32, leaves: &[[u8; 32]]) -> POSWCircuit<F, M, HG, CP> {
         let (root, leaves) = pedersen_merkle_root_hash_with_leaves(leaves);
 
         // Generate the mask by committing to the nonce and the root
@@ -197,7 +197,7 @@ where
     /// under the difficulty target. These can then be used in the block header's field.
     pub fn mine<R: Rng>(
         &self,
-        subroots: &[Vec<u8>],
+        subroots: &[[u8; 32]],
         difficulty_target: u64, // TODO: Change to Bignum?
         rng: &mut R,
         max_nonce: u32,
@@ -225,7 +225,7 @@ where
     fn prove<R: Rng>(
         pk: &S::ProvingParameters,
         nonce: u32,
-        subroots: &[Vec<u8>],
+        subroots: &[[u8; 32]],
         rng: &mut R,
     ) -> Result<S::Proof, PoswError> {
         // instantiate the circuit with the nonce

--- a/posw/src/lib.rs
+++ b/posw/src/lib.rs
@@ -58,7 +58,7 @@ mod params {
 }
 
 /// Subtree calculation
-pub fn txids_to_roots(transaction_ids: &[Vec<u8>]) -> (MerkleRootHash, PedersenMerkleRootHash, Vec<Vec<u8>>) {
+pub fn txids_to_roots(transaction_ids: &[[u8; 32]]) -> (MerkleRootHash, PedersenMerkleRootHash, Vec<[u8; 32]>) {
     let (root, subroots) = merkle_root_with_subroots(transaction_ids, MASKED_TREE_DEPTH);
     let mut merkle_root_bytes = [0u8; 32];
     merkle_root_bytes[..].copy_from_slice(&root);
@@ -97,7 +97,7 @@ mod tests {
         // super low difficulty so we find a solution immediately
         let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
 
-        let transaction_ids = vec![vec![1u8; 32]; 8];
+        let transaction_ids = vec![[1u8; 32]; 8];
         let (_, pedersen_merkle_root, subroots) = txids_to_roots(&transaction_ids);
 
         // generate the proof
@@ -124,7 +124,7 @@ mod tests {
         // super low difficulty so we find a solution immediately
         let difficulty_target = 0xFFFF_FFFF_FFFF_FFFF_u64;
 
-        let transaction_ids = vec![vec![1u8; 32]; 8];
+        let transaction_ids = vec![[1u8; 32]; 8];
         let (_, pedersen_merkle_root, subroots) = txids_to_roots(&transaction_ids);
 
         // generate the proof

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -92,8 +92,9 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
 
     match ast.data {
         Data::Struct(ref data_struct) => {
+            let mut idents = Vec::<IdentOrIndex>::new();
+
             for (i, field) in data_struct.fields.iter().enumerate() {
-                let mut idents = Vec::<IdentOrIndex>::new();
                 match field.ident {
                     None => {
                         let index = Index::from(i);
@@ -112,6 +113,8 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
                     &mut idents,
                     &field.ty,
                 );
+
+                idents.clear();
             }
         }
         _ => panic!("Serialize can only be derived for structs, {} is not a struct", name),

--- a/utilities/derives/src/lib.rs
+++ b/utilities/derives/src/lib.rs
@@ -65,10 +65,16 @@ fn impl_canonical_serialize(ast: &syn::DeriveInput) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-    let mut serialize_body = Vec::<TokenStream>::new();
-    let mut serialized_size_body = Vec::<TokenStream>::new();
-    let mut serialize_uncompressed_body = Vec::<TokenStream>::new();
-    let mut uncompressed_size_body = Vec::<TokenStream>::new();
+    let len = if let Data::Struct(ref data_struct) = ast.data {
+        data_struct.fields.len()
+    } else {
+        panic!("Serialize can only be derived for structs, {} is not a struct", name);
+    };
+
+    let mut serialize_body = Vec::<TokenStream>::with_capacity(len);
+    let mut serialized_size_body = Vec::<TokenStream>::with_capacity(len);
+    let mut serialize_uncompressed_body = Vec::<TokenStream>::with_capacity(len);
+    let mut uncompressed_size_body = Vec::<TokenStream>::with_capacity(len);
 
     match ast.data {
         Data::Struct(ref data_struct) => {
@@ -166,8 +172,8 @@ fn impl_canonical_deserialize(ast: &syn::DeriveInput) -> TokenStream {
     match ast.data {
         Data::Struct(ref data_struct) => {
             let mut tuple = false;
-            let mut compressed_field_cases = Vec::<TokenStream>::new();
-            let mut uncompressed_field_cases = Vec::<TokenStream>::new();
+            let mut compressed_field_cases = Vec::<TokenStream>::with_capacity(data_struct.fields.len());
+            let mut uncompressed_field_cases = Vec::<TokenStream>::with_capacity(data_struct.fields.len());
             for field in data_struct.fields.iter() {
                 match &field.ident {
                     None => {

--- a/utilities/src/biginteger/biginteger.rs
+++ b/utilities/src/biginteger/biginteger.rs
@@ -94,7 +94,7 @@ pub trait BigInteger:
 
     /// Returns the big integer representation of a given big endian boolean
     /// array.
-    fn from_bits(bits: &[bool]) -> Self;
+    fn from_bits(bits: Vec<bool>) -> Self;
 
     /// Returns the bit representation in a big endian boolean array, without
     /// leading zeros.

--- a/utilities/src/biginteger/macros.rs
+++ b/utilities/src/biginteger/macros.rs
@@ -165,11 +165,10 @@ macro_rules! bigint_impl {
             /// Constructs a `BigInteger` by parsing a vector of bits in big endian format
             /// and transforms it into a vector of little endian u64 elements.
             #[inline]
-            fn from_bits(bits: &[bool]) -> Self {
+            fn from_bits(mut bits: Vec<bool>) -> Self {
                 let mut res = Self::default();
                 let mut acc: u64 = 0;
 
-                let mut bits = bits.to_vec();
                 bits.reverse();
                 for (i, bits64) in bits.chunks(64).enumerate() {
                     for bit in bits64.iter().rev() {


### PR DESCRIPTION
A host of perf improvements concentrating on the slow bits in the longest tests; a few of them were easily benchmarkable and thus got some `criterion` benches (they're in the first commit and can be removed if desired); the results on my machine were:
- `txids_to_roots`: ~6% improvement
- `merkle_root`: ~14% improvement

These changes are mostly concentrated on avoidable allocations, including:
- using (stack-bound) arrays instead of `Vec`s for some hashes
- removing child objects that seem to just be duplicates not need to exist at all
- better `Vec` initialization
- removing redundant conversions
- passing more arguments by value (i.e. consuming them)

Since this PR is still moderate in length, it might get extended until it's reviewed/merged, but it can be merged at any point in time.