### PR TITLE
more DPC-related perf improvements

### DIFF
--- a/algorithms/src/snark/groth16/mod.rs
+++ b/algorithms/src/snark/groth16/mod.rs
@@ -356,11 +356,15 @@ impl<E: PairingEngine> From<VerifyingKey<E>> for PreparedVerifyingKey<E> {
     }
 }
 
-fn push_constraints<F: Field>(l: LinearCombination<F>, constraints: &mut [Vec<(F, Index)>], this_constraint: usize) {
-    for (var, coeff) in l.as_ref() {
+fn push_constraints<F: Field>(l: LinearCombination<F>, constraints: &mut Vec<Vec<(F, Index)>>) {
+    let vars_and_coeffs = l.as_ref();
+    let mut vec = Vec::with_capacity(vars_and_coeffs.len());
+
+    for (var, coeff) in vars_and_coeffs {
         match var.get_unchecked() {
-            Index::Input(i) => constraints[this_constraint].push((*coeff, Index::Input(i))),
-            Index::Aux(i) => constraints[this_constraint].push((*coeff, Index::Aux(i))),
+            Index::Input(i) => vec.push((*coeff, Index::Input(i))),
+            Index::Aux(i) => vec.push((*coeff, Index::Aux(i))),
         }
     }
+    constraints.push(vec);
 }

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -76,17 +76,9 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
     {
-        let num_constraints = self.num_constraints();
-
-        self.at.push(Vec::new());
-        self.bt.push(Vec::new());
-        self.ct.push(Vec::new());
-
-        push_constraints(a(LinearCombination::zero()), &mut self.at, num_constraints);
-
-        push_constraints(b(LinearCombination::zero()), &mut self.bt, num_constraints);
-
-        push_constraints(c(LinearCombination::zero()), &mut self.ct, num_constraints);
+        push_constraints(a(LinearCombination::zero()), &mut self.at);
+        push_constraints(b(LinearCombination::zero()), &mut self.bt);
+        push_constraints(c(LinearCombination::zero()), &mut self.ct);
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)

--- a/algorithms/src/snark/groth16/r1cs_to_qap.rs
+++ b/algorithms/src/snark/groth16/r1cs_to_qap.rs
@@ -47,7 +47,7 @@ impl R1CStoQAP {
         assembly: &KeypairAssembly<E>,
         t: &E::Fr,
     ) -> SynthesisResult<(Vec<E::Fr>, Vec<E::Fr>, Vec<E::Fr>, E::Fr, usize, usize)> {
-        let domain_size = assembly.num_constraints + (assembly.num_inputs - 1) + 1;
+        let domain_size = assembly.num_constraints() + (assembly.num_inputs - 1) + 1;
         let domain = EvaluationDomain::<E::Fr>::new(domain_size).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
         let domain_size = domain.size();
 
@@ -65,10 +65,10 @@ impl R1CStoQAP {
         let mut c = vec![E::Fr::zero(); qap_num_variables + 1];
 
         for i in 0..assembly.num_inputs {
-            a[i] = u[assembly.num_constraints + i];
+            a[i] = u[assembly.num_constraints() + i];
         }
 
-        for (i, x) in u.iter().enumerate().take(assembly.num_constraints) {
+        for (i, x) in u.iter().enumerate().take(assembly.num_constraints()) {
             for &(ref coeff, index) in assembly.at[i].iter() {
                 let index = match index {
                     Index::Input(i) => i,

--- a/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
+++ b/dpc/src/base_dpc/inner_circuit/inner_circuit_gadget.rs
@@ -763,7 +763,7 @@ where
             let candidate_sn_nonce = SerialNumberNonceCRHGadget::check_evaluation_gadget(
                 &mut sn_cs.ns(|| "Compute serial number nonce"),
                 &serial_number_nonce_crh_parameters,
-                &sn_nonce_input,
+                sn_nonce_input,
             )?;
             candidate_sn_nonce.enforce_equal(
                 &mut sn_cs.ns(|| "Check that computed nonce matches provided nonce"),
@@ -1206,7 +1206,7 @@ where
             let candidate_encrypted_record_hash = EncryptedRecordCRHGadget::check_evaluation_gadget(
                 &mut encryption_cs.ns(|| format!("Compute encrypted record hash {}", j)),
                 &encrypted_record_crh_parameters,
-                &encrypted_record_hash_input,
+                encrypted_record_hash_input,
             )?;
 
             encrypted_record_hash_gadget.enforce_equal(
@@ -1330,13 +1330,13 @@ where
         let inner1_commitment_hash = LocalDataCRHGadget::check_evaluation_gadget(
             cs.ns(|| "Compute to local data commitment inner1 hash"),
             &local_data_crh_parameters,
-            &old_record_commitment_bytes,
+            old_record_commitment_bytes,
         )?;
 
         let inner2_commitment_hash = LocalDataCRHGadget::check_evaluation_gadget(
             cs.ns(|| "Compute to local data commitment inner2 hash"),
             &local_data_crh_parameters,
-            &new_record_commitment_bytes,
+            new_record_commitment_bytes,
         )?;
 
         let mut inner_commitment_hash_bytes = Vec::new();
@@ -1348,7 +1348,7 @@ where
         let candidate_local_data_root = LocalDataCRHGadget::check_evaluation_gadget(
             cs.ns(|| "Compute to local data commitment root"),
             &local_data_crh_parameters,
-            &inner_commitment_hash_bytes,
+            inner_commitment_hash_bytes,
         )?;
 
         let declared_local_data_root =

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -345,7 +345,9 @@ where
             .iter()
             .flat_map(|byte| byte.to_bits_le())
             .collect::<Vec<_>>();
-        program_input_bits.push(input_bits);
+        if !input_bits.is_empty() {
+            program_input_bits.push(input_bits);
+        }
     }
 
     // ************************************************************************
@@ -389,9 +391,7 @@ where
         C::ProgramSNARKGadget::check_verify(
             &mut cs.ns(|| "Check that proof is satisfied"),
             &death_program_vk,
-            ([position].iter())
-                .chain(program_input_bits.iter())
-                .filter(|inp| !inp.is_empty()),
+            ([position].iter()).chain(program_input_bits.iter()),
             &death_program_proof,
         )?;
     }
@@ -432,9 +432,7 @@ where
         C::ProgramSNARKGadget::check_verify(
             &mut cs.ns(|| "Check that proof is satisfied"),
             &birth_program_vk,
-            ([position].iter())
-                .chain(program_input_bits.iter())
-                .filter(|inp| !inp.is_empty()),
+            ([position].iter()).chain(program_input_bits.iter()),
             &birth_program_proof,
         )?;
     }

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -237,7 +237,7 @@ where
 
         serial_number_fe_bytes.extend(field_element_to_bytes::<C, _>(
             cs,
-            &serial_number_fe,
+            serial_number_fe,
             &format!("Allocate serial number {:?}", index),
         )?);
     }
@@ -255,13 +255,13 @@ where
 
         commitment_and_encrypted_record_hash_fe_bytes.extend(field_element_to_bytes::<C, _>(
             cs,
-            &commitment_fe,
+            commitment_fe,
             &format!("Allocate record commitment {:?}", index),
         )?);
 
         commitment_and_encrypted_record_hash_fe_bytes.extend(field_element_to_bytes::<C, _>(
             cs,
-            &encrypted_record_hash_fe,
+            encrypted_record_hash_fe,
             &format!("Allocate encrypted record hash {:?}", index),
         )?);
     }

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -378,7 +378,7 @@ where
         let claimed_death_program_id = C::ProgramVerificationKeyCRHGadget::check_evaluation_gadget(
             &mut cs.ns(|| "Compute death program vk hash"),
             &program_vk_crh_parameters,
-            &death_program_vk_bytes,
+            death_program_vk_bytes,
         )?;
 
         let claimed_death_program_id_bytes =
@@ -419,7 +419,7 @@ where
         let claimed_birth_program_id = C::ProgramVerificationKeyCRHGadget::check_evaluation_gadget(
             &mut cs.ns(|| "Compute birth program vk hash"),
             &program_vk_crh_parameters,
-            &birth_program_vk_bytes,
+            birth_program_vk_bytes,
         )?;
 
         let claimed_birth_program_id_bytes =
@@ -495,7 +495,7 @@ where
     let candidate_inner_snark_id = C::InnerSNARKVerificationKeyCRHGadget::check_evaluation_gadget(
         &mut cs.ns(|| "Compute inner snark vk hash"),
         &inner_snark_vk_crh_parameters,
-        &inner_snark_vk_bytes,
+        inner_snark_vk_bytes,
     )?;
 
     candidate_inner_snark_id.enforce_equal(

--- a/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
+++ b/dpc/src/base_dpc/outer_circuit/outer_circuit_gadget.rs
@@ -38,7 +38,7 @@ use itertools::Itertools;
 
 fn field_element_to_bytes<C: BaseDPCComponents, CS: ConstraintSystem<C::OuterField>>(
     cs: &mut CS,
-    field_elements: &[C::InnerField],
+    field_elements: Vec<C::InnerField>,
     name: &str,
 ) -> Result<Vec<Vec<UInt8>>, SynthesisError> {
     if field_elements.len() <= 1 {
@@ -211,24 +211,24 @@ where
     // Allocate field element bytes
 
     let account_commitment_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &account_commitment_parameters_fe, "account commitment pp")?;
+        field_element_to_bytes::<C, _>(cs, account_commitment_parameters_fe, "account commitment pp")?;
 
     let account_encryption_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &account_encryption_parameters_fe, "account encryption pp")?;
+        field_element_to_bytes::<C, _>(cs, account_encryption_parameters_fe, "account encryption pp")?;
 
-    let account_signature_fe_bytes = field_element_to_bytes::<C, _>(cs, &account_signature_fe, "account signature pp")?;
+    let account_signature_fe_bytes = field_element_to_bytes::<C, _>(cs, account_signature_fe, "account signature pp")?;
     let record_commitment_parameters_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &record_commitment_parameters_fe, "record commitment pp")?;
+        field_element_to_bytes::<C, _>(cs, record_commitment_parameters_fe, "record commitment pp")?;
     let encrypted_record_crh_parameters_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &encrypted_record_crh_parameters_fe, "encrypted record crh pp")?;
+        field_element_to_bytes::<C, _>(cs, encrypted_record_crh_parameters_fe, "encrypted record crh pp")?;
     let program_vk_commitment_parameters_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &program_vk_commitment_parameters_fe, "program vk commitment pp")?;
+        field_element_to_bytes::<C, _>(cs, program_vk_commitment_parameters_fe, "program vk commitment pp")?;
     let local_data_commitment_parameters_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &local_data_crh_parameters_fe, "local data commitment pp")?;
+        field_element_to_bytes::<C, _>(cs, local_data_crh_parameters_fe, "local data commitment pp")?;
     let serial_number_nonce_crh_parameters_fe_bytes =
-        field_element_to_bytes::<C, _>(cs, &serial_number_nonce_crh_parameters_fe, "serial number nonce crh pp")?;
-    let ledger_parameters_fe_bytes = field_element_to_bytes::<C, _>(cs, &ledger_parameters_fe, "ledger pp")?;
-    let ledger_digest_fe_bytes = field_element_to_bytes::<C, _>(cs, &ledger_digest_fe, "ledger digest")?;
+        field_element_to_bytes::<C, _>(cs, serial_number_nonce_crh_parameters_fe, "serial number nonce crh pp")?;
+    let ledger_parameters_fe_bytes = field_element_to_bytes::<C, _>(cs, ledger_parameters_fe, "ledger pp")?;
+    let ledger_digest_fe_bytes = field_element_to_bytes::<C, _>(cs, ledger_digest_fe, "ledger digest")?;
 
     let mut serial_number_fe_bytes = vec![];
     for (index, sn) in old_serial_numbers.iter().enumerate() {
@@ -266,11 +266,11 @@ where
         )?);
     }
 
-    let program_commitment_fe_bytes = field_element_to_bytes::<C, _>(cs, &program_commitment_fe, "program commitment")?;
-    let memo_fe_bytes = field_element_to_bytes::<C, _>(cs, &memo_fe, "memo")?;
-    let network_id_fe_bytes = field_element_to_bytes::<C, _>(cs, &network_id_fe, "network id")?;
-    let local_data_root_fe_bytes = field_element_to_bytes::<C, _>(cs, &local_data_root_fe, "local data root")?;
-    let value_balance_fe_bytes = field_element_to_bytes::<C, _>(cs, &value_balance_fe, "value balance")?;
+    let program_commitment_fe_bytes = field_element_to_bytes::<C, _>(cs, program_commitment_fe, "program commitment")?;
+    let memo_fe_bytes = field_element_to_bytes::<C, _>(cs, memo_fe, "memo")?;
+    let network_id_fe_bytes = field_element_to_bytes::<C, _>(cs, network_id_fe, "network id")?;
+    let local_data_root_fe_bytes = field_element_to_bytes::<C, _>(cs, local_data_root_fe, "local data root")?;
+    let value_balance_fe_bytes = field_element_to_bytes::<C, _>(cs, value_balance_fe, "value balance")?;
 
     // Construct inner snark input as bytes
 

--- a/gadgets/src/algorithms/commitment_tree/merkle_path.rs
+++ b/gadgets/src/algorithms/commitment_tree/merkle_path.rs
@@ -83,7 +83,7 @@ impl<C: CommitmentScheme, H: CRH, CG: CommitmentGadget<C, F>, HG: CRHGadget<H, F
         let mut leaf_bytes = left_leaf_bytes;
         leaf_bytes.extend_from_slice(&right_leaf_bytes);
 
-        let inner_hash = HG::check_evaluation_gadget(cs.ns(|| "inner_hash"), parameters, &leaf_bytes)?;
+        let inner_hash = HG::check_evaluation_gadget(cs.ns(|| "inner_hash"), parameters, leaf_bytes)?;
 
         let left_inner_hash = &self.inner_hashes.0;
         let right_inner_hash = &self.inner_hashes.1;
@@ -105,7 +105,7 @@ impl<C: CommitmentScheme, H: CRH, CG: CommitmentGadget<C, F>, HG: CRHGadget<H, F
         let mut inner_hash_bytes = left_inner_hash_bytes;
         inner_hash_bytes.extend_from_slice(&right_inner_hash_bytes);
 
-        let declared_root = HG::check_evaluation_gadget(cs.ns(|| "root_hash"), parameters, &inner_hash_bytes)?;
+        let declared_root = HG::check_evaluation_gadget(cs.ns(|| "root_hash"), parameters, inner_hash_bytes)?;
 
         root.conditional_enforce_equal(&mut cs.ns(|| "check_root_is_valid"), &declared_root, should_enforce)?;
 

--- a/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
+++ b/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
@@ -79,10 +79,10 @@ impl<F: Field, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> CRHGadget<BoweH
         // Allocate new variable for the result.
         let input_in_bits = input_in_bits
             .chunks(S::WINDOW_SIZE * BOWE_HOPWOOD_CHUNK_SIZE)
-            .map(|x| x.chunks(BOWE_HOPWOOD_CHUNK_SIZE).collect::<Vec<_>>())
-            .collect::<Vec<_>>();
+            .map(|x| x.chunks(BOWE_HOPWOOD_CHUNK_SIZE).collect::<Vec<_>>());
+
         let result =
-            GG::precomputed_base_3_bit_signed_digit_scalar_mul(cs, &parameters.parameters.bases, &input_in_bits)?;
+            GG::precomputed_base_3_bit_signed_digit_scalar_mul(cs, &parameters.parameters.bases, input_in_bits)?;
 
         Ok(result)
     }

--- a/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
+++ b/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
@@ -53,10 +53,10 @@ impl<F: Field, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> CRHGadget<BoweH
     fn check_evaluation_gadget<CS: ConstraintSystem<F>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
-        input: &[UInt8],
+        input: Vec<UInt8>,
     ) -> Result<Self::OutputGadget, SynthesisError> {
         // Pad the input bytes
-        let mut padded_input_bytes = input.to_vec();
+        let mut padded_input_bytes = input;
         padded_input_bytes.resize(S::WINDOW_SIZE * S::NUM_WINDOWS / 8, UInt8::constant(0u8));
         assert_eq!(padded_input_bytes.len() * 8, S::WINDOW_SIZE * S::NUM_WINDOWS);
 
@@ -105,7 +105,7 @@ impl<F: Field, G: Group + ProjectiveCurve, GG: CompressedGroupGadget<G, F>, S: P
     fn check_evaluation_gadget<CS: ConstraintSystem<F>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
-        input: &[UInt8],
+        input: Vec<UInt8>,
     ) -> Result<Self::OutputGadget, SynthesisError> {
         let output = BoweHopwoodPedersenCRHGadget::<G, F, GG>::check_evaluation_gadget(cs, parameters, input)?;
         Ok(output.to_x_coordinate())

--- a/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
+++ b/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
@@ -79,7 +79,7 @@ impl<F: Field, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> CRHGadget<BoweH
         // Allocate new variable for the result.
         let input_in_bits = input_in_bits
             .chunks(S::WINDOW_SIZE * BOWE_HOPWOOD_CHUNK_SIZE)
-            .map(|x| x.chunks(BOWE_HOPWOOD_CHUNK_SIZE).collect::<Vec<_>>());
+            .map(|x| x.chunks(BOWE_HOPWOOD_CHUNK_SIZE));
 
         let result =
             GG::precomputed_base_3_bit_signed_digit_scalar_mul(cs, &parameters.parameters.bases, input_in_bits)?;

--- a/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
+++ b/gadgets/src/algorithms/crh/bowe_hopwood_pedersen.rs
@@ -67,9 +67,8 @@ impl<F: Field, G: Group, GG: GroupGadget<G, F>, S: PedersenSize> CRHGadget<BoweH
             .collect();
         if (input_in_bits.len()) % BOWE_HOPWOOD_CHUNK_SIZE != 0 {
             let current_length = input_in_bits.len();
-            for _ in 0..(BOWE_HOPWOOD_CHUNK_SIZE - current_length % BOWE_HOPWOOD_CHUNK_SIZE) {
-                input_in_bits.push(Boolean::constant(false));
-            }
+            let target_length = current_length + BOWE_HOPWOOD_CHUNK_SIZE - current_length % BOWE_HOPWOOD_CHUNK_SIZE;
+            input_in_bits.resize(target_length, Boolean::constant(false));
         }
         assert!(input_in_bits.len() % BOWE_HOPWOOD_CHUNK_SIZE == 0);
         assert_eq!(parameters.parameters.bases.len(), S::NUM_WINDOWS);

--- a/gadgets/src/algorithms/crh/tests.rs
+++ b/gadgets/src/algorithms/crh/tests.rs
@@ -108,7 +108,7 @@ fn primitive_crh_gadget_test<F: Field, H: CRH, CG: CRHGadget<H, F>>(hash_constra
     let output_gadget = <CG as CRHGadget<_, _>>::check_evaluation_gadget(
         &mut cs.ns(|| "gadget_evaluation"),
         &parameters_gadget,
-        &input_bytes,
+        input_bytes,
     )
     .unwrap();
     assert_eq!(cs.num_constraints(), hash_constraints);
@@ -152,9 +152,9 @@ fn masked_crh_gadget_test<F: PrimeField, H: CRH, CG: MaskedCRHGadget<H, F>>() {
     let masked_output_gadget = <CG as MaskedCRHGadget<_, _>>::check_evaluation_gadget_masked(
         &mut cs.ns(|| "masked_gadget_evaluation"),
         &parameters_gadget,
-        &input_bytes,
+        input_bytes,
         &mask_parameters_gadget,
-        &mask_bytes,
+        mask_bytes,
     )
     .unwrap();
     assert_eq!(cs.num_constraints(), 17932);

--- a/gadgets/src/algorithms/merkle_tree/masked_tree.rs
+++ b/gadgets/src/algorithms/merkle_tree/masked_tree.rs
@@ -54,7 +54,7 @@ pub fn compute_root<H: CRH, HG: MaskedCRHGadget<H, F>, F: PrimeField, TB: ToByte
                     &left_right[0],
                     &left_right[1],
                     mask_parameters,
-                    &mask_bytes,
+                    mask_bytes.clone(),
                 );
                 inner_hash
             })
@@ -73,7 +73,7 @@ pub(crate) fn hash_inner_node_gadget<H, HG, F, TB, CS>(
     left_child: &TB,
     right_child: &TB,
     mask_parameters: &HG::ParametersGadget,
-    mask: &[UInt8],
+    mask: Vec<UInt8>,
 ) -> Result<HG::OutputGadget, SynthesisError>
 where
     F: PrimeField,
@@ -86,5 +86,5 @@ where
     let right_bytes = right_child.to_bytes(&mut cs.ns(|| "right_to_bytes"))?;
     let bytes = [left_bytes, right_bytes].concat();
 
-    HG::check_evaluation_gadget_masked(cs, parameters, &bytes, mask_parameters, &mask)
+    HG::check_evaluation_gadget_masked(cs, parameters, bytes, mask_parameters, mask)
 }

--- a/gadgets/src/algorithms/merkle_tree/merkle_path.rs
+++ b/gadgets/src/algorithms/merkle_tree/merkle_path.rs
@@ -60,7 +60,7 @@ impl<P: MerkleParameters, HG: CRHGadget<P::H, F>, F: Field> MerklePathGadget<P, 
         // Check that the hash of the given leaf matches the leaf hash in the membership
         // proof.
         let leaf_bits = leaf.to_bytes(&mut cs.ns(|| "leaf_to_bytes"))?;
-        let leaf_hash = HG::check_evaluation_gadget(cs.ns(|| "check_evaluation_gadget"), parameters, &leaf_bits)?;
+        let leaf_hash = HG::check_evaluation_gadget(cs.ns(|| "check_evaluation_gadget"), parameters, leaf_bits)?;
 
         // Check if leaf is one of the bottom-most siblings.
         let leaf_is_left =
@@ -121,7 +121,7 @@ where
     let mut bytes = left_bytes;
     bytes.extend_from_slice(&right_bytes);
 
-    HG::check_evaluation_gadget(cs, parameters, &bytes)
+    HG::check_evaluation_gadget(cs, parameters, bytes)
 }
 
 impl<P, HGadget, F> AllocGadget<MerklePath<P>, F> for MerklePathGadget<P, HGadget, F>

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -202,7 +202,7 @@ where
                 gamma_g2,
                 delta_g2,
                 gamma_abc_g1,
-            } = vk.borrow().clone();
+            } = vk.borrow();
             let alpha_g1 = P::G1Gadget::alloc(cs.ns(|| "alpha_g1"), || Ok(alpha_g1.into_projective()))?;
             let beta_g2 = P::G2Gadget::alloc(cs.ns(|| "beta_g2"), || Ok(beta_g2.into_projective()))?;
             let gamma_g2 = P::G2Gadget::alloc(cs.ns(|| "gamma_g2"), || Ok(gamma_g2.into_projective()))?;
@@ -216,9 +216,7 @@ where
                         Ok(gamma_abc_i.into_projective())
                     })
                 })
-                .collect::<Vec<_>>()
-                .into_iter()
-                .collect::<Result<_, _>>()?;
+                .collect::<Result<Vec<_>, _>>()?;
             Ok(Self {
                 alpha_g1,
                 beta_g2,
@@ -242,7 +240,7 @@ where
                 gamma_g2,
                 delta_g2,
                 gamma_abc_g1,
-            } = vk.borrow().clone();
+            } = vk.borrow();
             let alpha_g1 = P::G1Gadget::alloc_input(cs.ns(|| "alpha_g1"), || Ok(alpha_g1.into_projective()))?;
             let beta_g2 = P::G2Gadget::alloc_input(cs.ns(|| "beta_g2"), || Ok(beta_g2.into_projective()))?;
             let gamma_g2 = P::G2Gadget::alloc_input(cs.ns(|| "gamma_g2"), || Ok(gamma_g2.into_projective()))?;
@@ -256,7 +254,7 @@ where
                         Ok(gamma_abc_i.into_projective())
                     })
                 })
-                .collect::<Result<_, _>>()?;
+                .collect::<Result<Vec<_>, _>>()?;
 
             Ok(Self {
                 alpha_g1,
@@ -282,7 +280,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let vk: VerifyingKey<PairingE> = FromBytes::read(&vk_bytes.borrow().clone()[..])?;
+            let vk: VerifyingKey<PairingE> = FromBytes::read(&vk_bytes.borrow()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(vk))
         })
@@ -298,7 +296,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|vk_bytes| {
-            let vk: VerifyingKey<PairingE> = FromBytes::read(&vk_bytes.borrow().clone()[..])?;
+            let vk: VerifyingKey<PairingE> = FromBytes::read(&vk_bytes.borrow()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(vk))
         })
@@ -318,7 +316,7 @@ where
         T: Borrow<Proof<PairingE>>,
     {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c } = proof.borrow().clone();
+            let Proof { a, b, c } = proof.borrow();
             let a = P::G1Gadget::alloc_checked(cs.ns(|| "a"), || Ok(a.into_projective()))?;
             let b = P::G2Gadget::alloc_checked(cs.ns(|| "b"), || Ok(b.into_projective()))?;
             let c = P::G1Gadget::alloc_checked(cs.ns(|| "c"), || Ok(c.into_projective()))?;
@@ -333,7 +331,7 @@ where
         T: Borrow<Proof<PairingE>>,
     {
         value_gen().and_then(|proof| {
-            let Proof { a, b, c } = proof.borrow().clone();
+            let Proof { a, b, c } = proof.borrow();
             // We don't need to check here because the prime order check can be performed
             // in plain.
             let a = P::G1Gadget::alloc_input(cs.ns(|| "a"), || Ok(a.into_projective()))?;
@@ -357,7 +355,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<PairingE> = FromBytes::read(&proof_bytes.borrow().clone()[..])?;
+            let proof: Proof<PairingE> = FromBytes::read(&proof_bytes.borrow()[..])?;
 
             Self::alloc(cs.ns(|| "alloc_bytes"), || Ok(proof))
         })
@@ -373,7 +371,7 @@ where
         T: Borrow<Vec<u8>>,
     {
         value_gen().and_then(|proof_bytes| {
-            let proof: Proof<PairingE> = FromBytes::read(&proof_bytes.borrow().clone()[..])?;
+            let proof: Proof<PairingE> = FromBytes::read(&proof_bytes.borrow()[..])?;
 
             Self::alloc_input(cs.ns(|| "alloc_input_bytes"), || Ok(proof))
         })

--- a/gadgets/src/algorithms/snark/groth16.rs
+++ b/gadgets/src/algorithms/snark/groth16.rs
@@ -247,8 +247,6 @@ where
                         Ok(gamma_abc_i.into_projective())
                     })
                 })
-                .collect::<Vec<_>>()
-                .into_iter()
                 .collect::<Result<_, _>>()?;
 
             Ok(Self {

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -945,15 +945,16 @@ mod projective_impl {
             Ok(())
         }
 
-        fn precomputed_base_3_bit_signed_digit_scalar_mul<'a, CS, I, J, B>(
+        fn precomputed_base_3_bit_signed_digit_scalar_mul<'a, CS, I, J, K, B>(
             mut cs: CS,
             bases: &[B],
-            scalars: &[J],
+            scalars: K,
         ) -> Result<Self, SynthesisError>
         where
             CS: ConstraintSystem<F>,
             I: Borrow<[Boolean]>,
             J: Borrow<[I]>,
+            K: Iterator<Item = J>,
             B: Borrow<[TEProjective<P>]>,
         {
             const CHUNK_SIZE: usize = 3;
@@ -984,7 +985,7 @@ mod projective_impl {
             let mut coords2 = Vec::with_capacity(4);
             let mut x_coeffs = Vec::with_capacity(4);
             let mut y_coeffs = Vec::with_capacity(4);
-            for (segment_i, (segment_bits_chunks, segment_powers)) in scalars.iter().zip(bases.iter()).enumerate() {
+            for (segment_i, (segment_bits_chunks, segment_powers)) in scalars.zip(bases.iter()).enumerate() {
                 for (i, (bits, base_power)) in segment_bits_chunks
                     .borrow()
                     .iter()

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -981,19 +981,11 @@ mod projective_impl {
                 };
 
             // Compute ∏(h_i^{m_i}) for all i.
-            let mut coords1 = Vec::with_capacity(4);
-            let mut coords2 = Vec::with_capacity(4);
             let mut x_coeffs = Vec::with_capacity(4);
             let mut y_coeffs = Vec::with_capacity(4);
             for (segment_i, (segment_bits_chunks, segment_powers)) in scalars.zip(bases.iter()).enumerate() {
                 for (i, (bits, base_power)) in segment_bits_chunks.zip(segment_powers.borrow().iter()).enumerate() {
                     let base_power = base_power.borrow();
-                    let mut acc_power = *base_power;
-                    coords1.clear();
-                    for _ in 0..4 {
-                        coords1.push(acc_power);
-                        acc_power += base_power;
-                    }
 
                     let bits = bits
                         .borrow()
@@ -1002,18 +994,16 @@ mod projective_impl {
                         return Err(SynthesisError::Unsatisfiable);
                     }
 
-                    coords2.clear();
-                    for p in &coords1 {
-                        coords2.push(
-                            MontgomeryAffineGadget::<P, F, FG>::from_edwards_to_coords(&p.into_affine()).unwrap(),
-                        );
-                    }
-
                     x_coeffs.clear();
                     y_coeffs.clear();
-                    for (x, y) in &coords2 {
-                        x_coeffs.push(*x);
-                        y_coeffs.push(*y);
+                    let mut acc_power = *base_power;
+                    for _ in 0..4 {
+                        let p = acc_power;
+                        let (x, y) =
+                            MontgomeryAffineGadget::<P, F, FG>::from_edwards_to_coords(&p.into_affine()).unwrap();
+                        x_coeffs.push(x);
+                        y_coeffs.push(y);
+                        acc_power += base_power;
                     }
 
                     let precomp = Boolean::and(

--- a/gadgets/src/curves/templates/twisted_edwards/mod.rs
+++ b/gadgets/src/curves/templates/twisted_edwards/mod.rs
@@ -953,7 +953,7 @@ mod projective_impl {
         where
             CS: ConstraintSystem<F>,
             I: Borrow<[Boolean]>,
-            J: Borrow<[I]>,
+            J: Iterator<Item = I>,
             K: Iterator<Item = J>,
             B: Borrow<[TEProjective<P>]>,
         {
@@ -986,12 +986,7 @@ mod projective_impl {
             let mut x_coeffs = Vec::with_capacity(4);
             let mut y_coeffs = Vec::with_capacity(4);
             for (segment_i, (segment_bits_chunks, segment_powers)) in scalars.zip(bases.iter()).enumerate() {
-                for (i, (bits, base_power)) in segment_bits_chunks
-                    .borrow()
-                    .iter()
-                    .zip(segment_powers.borrow().iter())
-                    .enumerate()
-                {
+                for (i, (bits, base_power)) in segment_bits_chunks.zip(segment_powers.borrow().iter()).enumerate() {
                     let base_power = base_power.borrow();
                     let mut acc_power = *base_power;
                     coords1.clear();

--- a/models/src/gadgets/algorithms/crh.rs
+++ b/models/src/gadgets/algorithms/crh.rs
@@ -46,7 +46,7 @@ pub trait CRHGadget<H: CRH, F: Field>: Sized + Clone {
     fn check_evaluation_gadget<CS: ConstraintSystem<F>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
-        input: &[UInt8],
+        input: Vec<UInt8>,
     ) -> Result<Self::OutputGadget, SynthesisError>;
 }
 
@@ -72,8 +72,8 @@ pub trait MaskedCRHGadget<H: CRH, F: PrimeField>: CRHGadget<H, F> {
     fn check_evaluation_gadget_masked<CS: ConstraintSystem<F>>(
         cs: CS,
         parameters: &Self::ParametersGadget,
-        input: &[UInt8],
+        input: Vec<UInt8>,
         mask_parameters: &Self::ParametersGadget,
-        mask: &[UInt8],
+        mask: Vec<UInt8>,
     ) -> Result<Self::OutputGadget, SynthesisError>;
 }

--- a/models/src/gadgets/curves/group.rs
+++ b/models/src/gadgets/curves/group.rs
@@ -156,15 +156,16 @@ pub trait GroupGadget<G: Group, F: Field>:
         Err(SynthesisError::AssignmentMissing)
     }
 
-    fn precomputed_base_3_bit_signed_digit_scalar_mul<CS, I, J, B>(
+    fn precomputed_base_3_bit_signed_digit_scalar_mul<CS, I, J, K, B>(
         _: CS,
         _: &[B],
-        _: &[J],
+        _: K,
     ) -> Result<Self, SynthesisError>
     where
         CS: ConstraintSystem<F>,
         I: Borrow<[Boolean]>,
         J: Borrow<[I]>,
+        K: Iterator<Item = J>,
         B: Borrow<[G]>,
     {
         Err(SynthesisError::AssignmentMissing)

--- a/models/src/gadgets/curves/group.rs
+++ b/models/src/gadgets/curves/group.rs
@@ -164,7 +164,7 @@ pub trait GroupGadget<G: Group, F: Field>:
     where
         CS: ConstraintSystem<F>,
         I: Borrow<[Boolean]>,
-        J: Borrow<[I]>,
+        J: Iterator<Item = I>,
         K: Iterator<Item = J>,
         B: Borrow<[G]>,
     {

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -149,7 +149,7 @@ impl<F: Field> TestConstraintSystem<F> {
     }
 }
 
-fn compute_path(ns: &[String], this: String) -> String {
+fn compute_path(ns: &[String], this: &str) -> String {
     if this.contains('/') {
         panic!("'/' is not allowed in names");
     }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -149,8 +149,8 @@ impl<F: Field> TestConstraintSystem<F> {
     }
 }
 
-fn compute_path(ns: &[String], this: &str) -> String {
-    if this.chars().any(|a| a == '/') {
+fn compute_path(ns: &[String], this: String) -> String {
+    if this.contains('/') {
         panic!("'/' is not allowed in names");
     }
 


### PR DESCRIPTION
A range of mostly allocation-related performance improvements around DPC: more aggressive iterator utilization, fewer intermediate vectors and more eager vector consumption.

These changes, compared to the branch with https://github.com/AleoHQ/snarkOS/pull/510, result in further wins confirmed by running the `base_dpc_multiple_transactions` test, primarily:
- a reduction in running time, from 193s to 180s (-7%)
- a reduction in RAM usage spikes from 4.3GB to 3.3GB (verified with `massif`)
- profiling with `valgrind --tools=massif` (when running that same test) now takes orders of magnitude less time, making it a viable option for taking repeated measurements