### PR TITLE
Fix a debug-mode block-baking stack overflow

### DIFF
--- a/models/src/gadgets/curves/fp6_3over2.rs
+++ b/models/src/gadgets/curves/fp6_3over2.rs
@@ -317,11 +317,14 @@ where
         // v4 = a(∞)b(∞)   = a2 * b2
         let v4 = self.c2.mul(cs.ns(|| "v2: a2 * b2"), &other.c2)?;
 
-        let two = <P::Fp2Params as Fp2Parameters>::Fp::one().double();
-        let six = two.double() + &two;
-        let mut two_and_six = [two, six];
-        batch_inversion(&mut two_and_six);
-        let (two_inverse, six_inverse) = (two_and_six[0], two_and_six[1]);
+        let (two_inverse, six_inverse) = {
+            let two = <P::Fp2Params as Fp2Parameters>::Fp::one().double();
+            let six = two.double() + &two;
+            let mut two_and_six = [two, six];
+            batch_inversion(&mut two_and_six);
+
+            (two_and_six[0], two_and_six[1])
+        };
 
         let half_v0 = v0.mul_by_fp_constant(cs.ns(|| "half_v0"), &two_inverse)?;
         let half_v1 = v1.mul_by_fp_constant(cs.ns(|| "half_v1"), &two_inverse)?;
@@ -418,11 +421,14 @@ where
         // v4 = a(∞)^2 = a2^2
         let v4 = self.c2.square(&mut cs.ns(|| "a2^2"))?;
 
-        let two = <P::Fp2Params as Fp2Parameters>::Fp::one().double();
-        let six = two.double() + &two;
-        let mut two_and_six = [two, six];
-        batch_inversion(&mut two_and_six);
-        let (two_inverse, six_inverse) = (two_and_six[0], two_and_six[1]);
+        let (two_inverse, six_inverse) = {
+            let two = <P::Fp2Params as Fp2Parameters>::Fp::one().double();
+            let six = two.double() + &two;
+            let mut two_and_six = [two, six];
+            batch_inversion(&mut two_and_six);
+
+            (two_and_six[0], two_and_six[1])
+        };
 
         let half_v0 = v0.mul_by_fp_constant(cs.ns(|| "half_v0"), &two_inverse)?;
         let half_v1 = v1.mul_by_fp_constant(cs.ns(|| "half_v1"), &two_inverse)?;
@@ -566,11 +572,14 @@ where
         // v4 = a(∞)b(∞)   = a2 * b2
         let v4 = self.c2.mul_by_constant(cs.ns(|| "v4"), &other.c2)?;
 
-        let two = <P::Fp2Params as Fp2Parameters>::Fp::one().double();
-        let six = two.double() + &two;
-        let mut two_and_six = [two, six];
-        batch_inversion(&mut two_and_six);
-        let (two_inverse, six_inverse) = (two_and_six[0], two_and_six[1]);
+        let (two_inverse, six_inverse) = {
+            let two = <P::Fp2Params as Fp2Parameters>::Fp::one().double();
+            let six = two.double() + &two;
+            let mut two_and_six = [two, six];
+            batch_inversion(&mut two_and_six);
+
+            (two_and_six[0], two_and_six[1])
+        };
 
         let mut half_v0 = v0.mul_by_fp_constant(cs.ns(|| "half_v0"), &two_inverse)?;
         let half_v1 = v1.mul_by_fp_constant(cs.ns(|| "half_v1"), &two_inverse)?;

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -34,7 +34,7 @@ use snarkos_rpc::start_rpc_server;
 use snarkos_utilities::{to_bytes, ToBytes};
 
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
-use tokio::{runtime::Runtime, sync::Mutex};
+use tokio::{runtime::Builder, sync::Mutex};
 use tracing_futures::Instrument;
 use tracing_subscriber::EnvFilter;
 
@@ -194,7 +194,12 @@ fn main() -> Result<(), NodeError> {
     // create a tracing span dedicated to the entire node
     let node_span = debug_span!("node");
 
-    Runtime::new()?.block_on(start_server(config).instrument(node_span))?;
+    Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .thread_stack_size(4 * 1024 * 1024)
+        .build()?
+        .block_on(start_server(config).instrument(node_span))?;
 
     Ok(())
 }


### PR DESCRIPTION
`gdb` analysis revealed that the stack overflow reported in https://github.com/AleoHQ/snarkOS/issues/523 occurred while performing one of the `groth16`-related multiplication operations; other than a slight reduction of stack use in the related `mul` function and a few others (https://github.com/AleoHQ/snarkOS/commit/699561aaf06b04c215737e9730174841360e005c), there are 2 possible solutions to this issue:
1. increasing `tokio` worker thread stack size from the default 2MiB to a greater value
2. changing the stack-bound `SmallVec` used in `gadgets::r1cs::LinearCombination` to the heap-bound `Vec`

I've confirmed that the same issue applies with `tokio` updated to the current `0.3` version, and that either of the options above causes the stack overflow to not occur while baking the first block. Since 2MiB is pretty modest and since it's faster to work with the stack whenever possible, I'd recommend going with the first solution and to increase the stack size to 4MiB - and also for `release` builds - for added safety.

fixes https://github.com/AleoHQ/snarkOS/issues/523