### PR TITLE
Speed up compute_path

### DIFF
--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -154,16 +154,15 @@ fn compute_path(ns: &[String], this: &str) -> String {
         panic!("'/' is not allowed in names");
     }
 
-    let mut name = String::new();
+    // preallocate the target path size, including the separators
+    let len = ns.iter().map(|s| s.len()).sum::<usize>() + ns.len() + this.len();
+    let mut name = String::with_capacity(len);
 
-    let mut needs_separation = false;
-    for ns in ns.iter().map(|s| s.as_str()).chain(Some(this)) {
-        if needs_separation {
-            name += "/";
+    for (i, ns) in ns.iter().map(|s| s.as_str()).chain(Some(this)).enumerate() {
+        if i != 0 {
+            name.push('/');
         }
-
-        name += ns;
-        needs_separation = true;
+        name.push_str(ns);
     }
 
     name


### PR DESCRIPTION
I was looking into https://github.com/AleoHQ/leo/issues/450, and `models::gadgets::test_constraint_system::compute_path` was pretty prominent in profiling, showing **a lot** of related allocations. This PR reduces their number by pre-allocating the final path. In addition, slightly simpler operations are used to create it too.

The positive impact of this PR was verified with criterion benchmarks, showing large runtime improvements for the function, ranging from around -30% to as much as -70% depending on the number of segments and their length. The existing arithmetic benchmarks also show an improvement of between -5% and -26%.