### PR TITLE
TestConstraintSystem interning improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,11 +1262,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2688,6 +2695,7 @@ dependencies = [
  "bincode",
  "criterion",
  "derivative",
+ "indexmap",
  "itertools",
  "rand",
  "rand_xorshift",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,6 +2702,7 @@ name = "snarkos-models"
 version = "1.1.4"
 dependencies = [
  "bincode",
+ "cfg-if 0.1.10",
  "criterion",
  "derivative",
  "fxhash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generator"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1727,12 @@ name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -2695,8 +2710,10 @@ dependencies = [
  "bincode",
  "criterion",
  "derivative",
+ "fxhash",
  "indexmap",
  "itertools",
+ "nohash-hasher",
  "rand",
  "rand_xorshift",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,7 +2710,6 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
- "smallvec 1.4.2",
  "snarkos-errors",
  "snarkos-utilities",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,12 +1729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,7 +2707,6 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools",
- "nohash-hasher",
  "rand",
  "rand_xorshift",
  "serde",

--- a/algorithms/src/snark/gm17/generator.rs
+++ b/algorithms/src/snark/gm17/generator.rs
@@ -61,7 +61,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         // There is no assignment, so we don't invoke the
         // function for obtaining one.
@@ -77,7 +77,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         // There is no assignment, so we don't invoke the
         // function for obtaining one.
@@ -91,7 +91,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
@@ -122,7 +122,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.

--- a/algorithms/src/snark/gm17/prover.rs
+++ b/algorithms/src/snark/gm17/prover.rs
@@ -103,7 +103,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.num_aux;
         self.num_aux += 1;
@@ -117,7 +117,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.num_inputs;
         self.num_inputs += 1;
@@ -130,7 +130,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
@@ -166,7 +166,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.

--- a/algorithms/src/snark/groth16/generator.rs
+++ b/algorithms/src/snark/groth16/generator.rs
@@ -64,7 +64,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         // There is no assignment, so we don't invoke the
         // function for obtaining one.
@@ -80,7 +80,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         // There is no assignment, so we don't invoke the
         // function for obtaining one.
@@ -95,7 +95,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
@@ -107,7 +107,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for KeypairAssembly<E> {
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.

--- a/algorithms/src/snark/groth16/prover.rs
+++ b/algorithms/src/snark/groth16/prover.rs
@@ -48,7 +48,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.aux_assignment.len();
         self.aux_assignment.push(f()?);
@@ -60,7 +60,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     where
         F: FnOnce() -> Result<E::Fr, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.input_assignment.len();
         self.input_assignment.push(f()?);
@@ -71,7 +71,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
@@ -83,7 +83,7 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for ProvingAssignment<E> {
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.

--- a/marlin/src/ahp/constraint_systems.rs
+++ b/marlin/src/ahp/constraint_systems.rs
@@ -20,7 +20,6 @@ use crate::{
     ahp::{indexer::Matrix, *},
     BTreeMap,
     Cow,
-    String,
     ToString,
 };
 use derivative::Derivative;
@@ -140,7 +139,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for IndexerConstraintSyst
     where
         F: FnOnce() -> Result<ConstraintF, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         // There is no assignment, so we don't invoke the
         // function for obtaining one.
@@ -156,7 +155,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for IndexerConstraintSyst
     where
         F: FnOnce() -> Result<ConstraintF, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         // There is no assignment, so we don't invoke the
         // function for obtaining one.
@@ -170,7 +169,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for IndexerConstraintSyst
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
         LB: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
         LC: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
@@ -184,7 +183,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for IndexerConstraintSyst
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.
@@ -442,7 +441,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ProverConstraintSyste
     where
         F: FnOnce() -> Result<ConstraintF, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.num_witness_variables;
         self.num_witness_variables += 1;
@@ -456,7 +455,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ProverConstraintSyste
     where
         F: FnOnce() -> Result<ConstraintF, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.num_input_variables;
         self.num_input_variables += 1;
@@ -469,7 +468,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ProverConstraintSyste
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, _: LA, _: LB, _: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
         LB: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
         LC: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
@@ -479,7 +478,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ProverConstraintSyste
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         // Do nothing; we don't care about namespaces in this context.

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -16,6 +16,7 @@ snarkos-errors = { path = "../errors", version = "1.1.4", default-features = fal
 snarkos-utilities = { path = "../utilities", version = "1.1.4", default-features = false }
 
 bincode = { version = "1.3.1" }
+cfg-if = { version = "0.1.10" }
 derivative = { version = "2" }
 fxhash = { version = "0.2.1" }
 indexmap = { version = "1.6.0" }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -17,6 +17,7 @@ snarkos-utilities = { path = "../utilities", version = "1.1.4", default-features
 
 bincode = { version = "1.3.1" }
 derivative = { version = "2" }
+indexmap = { version = "1.6.0" }
 itertools = { version = "0.9.0" }
 rand = { version = "0.7", default-features = false }
 rand_xorshift = { version = "0.2", default-features = false }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -19,6 +19,7 @@ bincode = { version = "1.3.1" }
 derivative = { version = "2" }
 indexmap = { version = "1.6.0" }
 itertools = { version = "0.9.0" }
+nohash-hasher = { version = "0.2.0" }
 rand = { version = "0.7", default-features = false }
 rand_xorshift = { version = "0.2", default-features = false }
 serde = { version = "1.0.117", default-features = false, features = ["derive"] }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -20,7 +20,6 @@ derivative = { version = "2" }
 fxhash = { version = "0.2.1" }
 indexmap = { version = "1.6.0" }
 itertools = { version = "0.9.0" }
-nohash-hasher = { version = "0.2.0" }
 rand = { version = "0.7", default-features = false }
 rand_xorshift = { version = "0.2", default-features = false }
 serde = { version = "1.0.117", default-features = false, features = ["derive"] }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -17,6 +17,7 @@ snarkos-utilities = { path = "../utilities", version = "1.1.4", default-features
 
 bincode = { version = "1.3.1" }
 derivative = { version = "2" }
+fxhash = { version = "0.2.1" }
 indexmap = { version = "1.6.0" }
 itertools = { version = "0.9.0" }
 nohash-hasher = { version = "0.2.0" }

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -23,7 +23,6 @@ itertools = { version = "0.9.0" }
 rand = { version = "0.7", default-features = false }
 rand_xorshift = { version = "0.2", default-features = false }
 serde = { version = "1.0.117", default-features = false, features = ["derive"] }
-smallvec = { version = "1.4" }
 
 [features]
 default = [ "snarkos-errors/default", "snarkos-utilities/default", ]

--- a/models/src/gadgets/r1cs/constraint_counter.rs
+++ b/models/src/gadgets/r1cs/constraint_counter.rs
@@ -41,7 +41,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ConstraintCounter {
     where
         F: FnOnce() -> Result<ConstraintF, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let var = Variable::new_unchecked(Index::Aux(self.num_aux));
         self.num_aux += 1;
@@ -52,7 +52,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ConstraintCounter {
     where
         F: FnOnce() -> Result<ConstraintF, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let var = Variable::new_unchecked(Index::Input(self.num_inputs));
         self.num_inputs += 1;
@@ -63,7 +63,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ConstraintCounter {
     fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, _: LA, _: LB, _: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
         LB: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
         LC: FnOnce(LinearCombination<ConstraintF>) -> LinearCombination<ConstraintF>,
@@ -73,7 +73,7 @@ impl<ConstraintF: Field> ConstraintSystem<ConstraintF> for ConstraintCounter {
 
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
     }

--- a/models/src/gadgets/r1cs/constraint_system.rs
+++ b/models/src/gadgets/r1cs/constraint_system.rs
@@ -42,7 +42,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     where
         FN: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>;
+        AR: AsRef<str>;
 
     /// Allocate a public variable in the constraint system. The provided
     /// function is used to determine the assignment of the variable.
@@ -50,7 +50,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     where
         FN: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>;
+        AR: AsRef<str>;
 
     /// Enforce that `A` * `B` = `C`. The `annotation` function is invoked in
     /// testing contexts in order to derive a unique name for the constraint
@@ -58,7 +58,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LB: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LC: FnOnce(LinearCombination<F>) -> LinearCombination<F>;
@@ -67,7 +67,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     /// for downstream use; use `namespace` instead.
     fn push_namespace<NR, N>(&mut self, name_fn: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR;
 
     /// Exit out of the existing namespace. Not intended for
@@ -81,7 +81,7 @@ pub trait ConstraintSystem<F: Field>: Sized {
     /// Begin a namespace for this constraint system.
     fn ns<NR, N>(&mut self, name_fn: N) -> Namespace<'_, F, Self::Root>
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         self.get_root().push_namespace(name_fn);
@@ -119,7 +119,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for Namespace<'_, F,
     where
         FN: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         self.0.alloc(annotation, f)
     }
@@ -129,7 +129,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for Namespace<'_, F,
     where
         FN: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         self.0.alloc_input(annotation, f)
     }
@@ -138,7 +138,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for Namespace<'_, F,
     fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LB: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LC: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
@@ -153,7 +153,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for Namespace<'_, F,
     #[inline]
     fn push_namespace<NR, N>(&mut self, _: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         panic!("only the root's push_namespace should be called");
@@ -197,7 +197,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for &mut CS {
     where
         FN: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         (**self).alloc(annotation, f)
     }
@@ -207,7 +207,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for &mut CS {
     where
         FN: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         (**self).alloc_input(annotation, f)
     }
@@ -216,7 +216,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for &mut CS {
     fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LB: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LC: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
@@ -227,7 +227,7 @@ impl<F: Field, CS: ConstraintSystem<F>> ConstraintSystem<F> for &mut CS {
     #[inline]
     fn push_namespace<NR, N>(&mut self, name_fn: N)
     where
-        NR: Into<String>,
+        NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
         (**self).push_namespace(name_fn)

--- a/models/src/gadgets/r1cs/impl_lc.rs
+++ b/models/src/gadgets/r1cs/impl_lc.rs
@@ -16,10 +16,9 @@
 
 use crate::{
     curves::Field,
-    gadgets::r1cs::{LinearCombination, SmallVec, Variable},
+    gadgets::r1cs::{LinearCombination, Variable},
 };
 
-use smallvec::smallvec;
 use std::{
     cmp::Ordering,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub},
@@ -35,14 +34,14 @@ impl<F: Field> AsRef<[(Variable, F)]> for LinearCombination<F> {
 impl<F: Field> From<(F, Variable)> for LinearCombination<F> {
     #[inline]
     fn from((coeff, var): (F, Variable)) -> Self {
-        LinearCombination(smallvec![(var, coeff)])
+        LinearCombination(vec![(var, coeff)])
     }
 }
 
 impl<F: Field> From<Variable> for LinearCombination<F> {
     #[inline]
     fn from(var: Variable) -> Self {
-        LinearCombination(smallvec![(var, F::one())])
+        LinearCombination(vec![(var, F::one())])
     }
 }
 
@@ -50,7 +49,7 @@ impl<F: Field> LinearCombination<F> {
     /// Outputs an empty linear combination.
     #[inline]
     pub fn zero() -> LinearCombination<F> {
-        LinearCombination(SmallVec::<F>::new())
+        LinearCombination(Vec::new())
     }
 
     /// Replaces the contents of `self` with those of `other`.
@@ -178,7 +177,7 @@ where
     F1: Fn(F) -> F,
     F2: Fn(F, F) -> F,
 {
-    let mut new_vec = SmallVec::<F>::new(); // with_capacity($self.0.len() + $other.0.len());
+    let mut new_vec = Vec::with_capacity(cur.0.len() + other.0.len());
     let mut i = 0;
     let mut j = 0;
     while i < cur.0.len() && j < other.0.len() {

--- a/models/src/gadgets/r1cs/mod.rs
+++ b/models/src/gadgets/r1cs/mod.rs
@@ -51,6 +51,12 @@ impl Variable {
     pub fn get_unchecked(&self) -> Index {
         self.0
     }
+
+    /// Mutably borrows the index underlying the variable.
+    /// Circuit implementations are not recommended to use this.
+    pub fn mut_unchecked(&mut self) -> &mut Index {
+        &mut self.0
+    }
 }
 
 /// Represents the index of either an input variable or auxiliary variable.

--- a/models/src/gadgets/r1cs/mod.rs
+++ b/models/src/gadgets/r1cs/mod.rs
@@ -39,7 +39,7 @@ use std::cmp::Ordering;
 type SmallVec<F> = StackVec<[(Variable, F); 16]>;
 
 /// Represents a variable in a constraint system.
-#[derive(PartialOrd, Ord, PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Copy, Clone, Debug, Hash)]
 pub struct Variable(Index);
 
 impl Variable {
@@ -57,7 +57,7 @@ impl Variable {
 }
 
 /// Represents the index of either an input variable or auxiliary variable.
-#[derive(Copy, Clone, PartialEq, Debug, Eq)]
+#[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
 pub enum Index {
     /// Index of an input variable.
     Input(usize),
@@ -128,7 +128,7 @@ impl CanonicalDeserialize for Index {
 /// in the field `F`.
 /// The `(coeff, var)` pairs in a `LinearCombination` are kept sorted according
 /// to the index of the variable in its constraint system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LinearCombination<F: Field>(pub SmallVec<F>);
 
 /// Either a `Variable` or a `LinearCombination`.

--- a/models/src/gadgets/r1cs/mod.rs
+++ b/models/src/gadgets/r1cs/mod.rs
@@ -31,12 +31,9 @@ pub use test_fr::*;
 
 use crate::curves::Field;
 
-use smallvec::SmallVec as StackVec;
 use snarkos_errors::serialization::SerializationError;
 use snarkos_utilities::serialize::*;
 use std::cmp::Ordering;
-
-type SmallVec<F> = StackVec<[(Variable, F); 16]>;
 
 /// Represents a variable in a constraint system.
 #[derive(PartialOrd, Ord, PartialEq, Eq, Copy, Clone, Debug, Hash)]
@@ -129,7 +126,7 @@ impl CanonicalDeserialize for Index {
 /// The `(coeff, var)` pairs in a `LinearCombination` are kept sorted according
 /// to the index of the variable in its constraint system.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct LinearCombination<F: Field>(pub SmallVec<F>);
+pub struct LinearCombination<F: Field>(pub Vec<(Variable, F)>);
 
 /// Either a `Variable` or a `LinearCombination`.
 #[derive(Clone, Debug)]

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -185,7 +185,7 @@ impl<F: Field> TestConstraintSystem<F> {
 
     pub fn set(&mut self, path: &str, to: F) {
         let interned_path = self.intern_path(path);
-        let interned_field = self.interned_fields.get_index_of(&to).unwrap();
+        let interned_field = self.interned_fields.insert_full(to).0;
 
         match self.named_objects.get(&interned_path) {
             Some(&NamedObject::Var(ref v)) => match v.get_unchecked() {

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -404,6 +404,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
             unreachable!()
         };
 
+        #[cfg(not(test))]
         for child_obj in named_object {
             match child_obj {
                 NamedObject::Var(var) => match var.get_unchecked() {

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -281,7 +281,6 @@ impl<F: Field> TestConstraintSystem<F> {
         match self.named_objects.entry(interned_path) {
             Entry::Vacant(e) => {
                 let ns_idx = e.index();
-                //println!("  set_named_obj {:?} : {}", &to, ns_idx);
                 e.insert(to);
                 ns_idx
             }
@@ -408,17 +407,13 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         let name = name_fn();
         let interned_path = self.compute_path(name.as_ref());
         let new_segment = *interned_path.0.last().unwrap();
-        let namespace_idx = self.set_named_obj(interned_path.clone(), NamedObject::Namespace(vec![])); // FIXME: remove this clone() after debugging
+        let namespace_idx = self.set_named_obj(interned_path, NamedObject::Namespace(vec![]));
 
-        //println!("pushed ns {} : {}", namespace_idx, self.unintern_path(&interned_path));
         self.current_namespace.0.push(new_segment);
         self.current_namespace.1 = namespace_idx;
-        //println!("  curr ns idx: {}", namespace_idx);
     }
 
     fn pop_namespace(&mut self) {
-        //println!("popping ns {} : {}", ns_idx, self.unintern_path(&current_ns.to_owned().into()));
-
         #[cfg(not(test))]
         let named_object = if let NamedObject::Namespace(no) = self
             .named_objects
@@ -437,16 +432,13 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
                 NamedObject::Var(var) => match var.get_unchecked() {
                     Index::Aux(idx) => {
                         self.aux.remove(idx);
-                        //println!("  removing Aux({})", idx);
                     }
                     Index::Input(idx) => {
                         self.inputs.remove(idx);
-                        //println!("  removing Input({})", idx);
                     }
                 },
                 NamedObject::Constraint(idx) => {
                     self.constraints.remove(idx);
-                    //println!("  removing Constraint({})", idx);
                 }
                 _ => {}
             }
@@ -455,11 +447,9 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         assert!(self.current_namespace.0.pop().is_some());
         if let Some(new_ns_idx) = self.named_objects.get_index_of(&self.current_namespace.0) {
             self.current_namespace.1 = new_ns_idx;
-            //println!("  curr ns idx: {}", new_ns_idx);
         } else {
             // we must be at the "bottom" namespace
             self.current_namespace.1 = 0;
-            //println!("  curr ns idx: 0");
         }
     }
 

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -298,9 +298,6 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         self.set_named_obj(interned_path.clone(), NamedObject::Constraint(index));
 
         let a = a(LinearCombination::zero());
-        let b = b(LinearCombination::zero());
-        let c = c(LinearCombination::zero());
-
         let a =
             a.0.into_iter()
                 .map(|(var, field)| {
@@ -308,6 +305,9 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
                     (var, interned_field)
                 })
                 .collect();
+        let a = self.interned_constraints.insert_full(a).0;
+
+        let b = b(LinearCombination::zero());
         let b =
             b.0.into_iter()
                 .map(|(var, field)| {
@@ -315,6 +315,9 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
                     (var, interned_field)
                 })
                 .collect();
+        let b = self.interned_constraints.insert_full(b).0;
+
+        let c = c(LinearCombination::zero());
         let c =
             c.0.into_iter()
                 .map(|(var, field)| {
@@ -322,9 +325,6 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
                     (var, interned_field)
                 })
                 .collect();
-
-        let a = self.interned_constraints.insert_full(a).0;
-        let b = self.interned_constraints.insert_full(b).0;
         let c = self.interned_constraints.insert_full(c).0;
 
         self.constraints.insert(interned_path, TestConstraint { a, b, c });

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -226,7 +226,7 @@ impl<F: Field> TestConstraintSystem<F> {
             }
             Entry::Occupied(e) => {
                 let mut path = String::new();
-                for interned_segment in e.remove_entry().0.0.borrow().iter() {
+                for interned_segment in (e.remove_entry().0).0.borrow().iter() {
                     path.push_str(self.interned_path_segments.get_index(*interned_segment).unwrap());
                 }
 

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -21,8 +21,9 @@ use crate::{
 use snarkos_errors::gadgets::SynthesisError;
 
 use indexmap::IndexSet;
+use nohash_hasher::IntMap;
 
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::collections::hash_map::Entry;
 
 #[derive(Debug)]
 enum NamedObject {
@@ -42,7 +43,7 @@ type TestConstraint<T> = (
 /// Constraint system for testing purposes.
 pub struct TestConstraintSystem<F: Field> {
     paths: IndexSet<String>,
-    named_objects: BTreeMap<PathIdx, NamedObject>,
+    named_objects: IntMap<PathIdx, NamedObject>,
     current_namespace: Vec<String>,
     pub constraints: Vec<TestConstraint<F>>,
     inputs: Vec<(F, PathIdx)>,
@@ -71,7 +72,7 @@ impl<F: Field> Default for TestConstraintSystem<F> {
     fn default() -> Self {
         let mut paths = IndexSet::new();
         let path_idx = paths.insert_full("ONE".into()).0;
-        let mut map = BTreeMap::new();
+        let mut map = IntMap::default();
         map.insert(path_idx, NamedObject::Var(TestConstraintSystem::<F>::one()));
 
         TestConstraintSystem {

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -127,7 +127,7 @@ impl<F: Field> TestConstraintSystem<F> {
 
     pub fn print_named_objects(&self) {
         let mut path = String::new();
-        for (interned_path, _constraint) in &self.constraints {
+        for interned_path in self.constraints.keys() {
             for interned_segment in interned_path.0.borrow().iter() {
                 path.push_str(self.interned_path_segments.get_index(*interned_segment).unwrap());
             }
@@ -332,7 +332,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     fn push_namespace<NR: AsRef<str>, N: FnOnce() -> NR>(&mut self, name_fn: N) {
         let name = name_fn();
         let interned_path = self.compute_path(name.as_ref());
-        let new_segment = interned_path.0.borrow().last().unwrap().clone();
+        let new_segment = *interned_path.0.borrow().last().unwrap();
         self.set_named_obj(interned_path, NamedObject::Namespace);
         self.current_namespace.0.borrow_mut().push(new_segment);
     }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -84,11 +84,11 @@ impl<T> std::ops::IndexMut<usize> for OptionalVec<T> {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct InternedPath(Rc<Vec<usize>>);
+pub struct InternedPath(Rc<[usize]>);
 
 impl From<Vec<usize>> for InternedPath {
     fn from(v: Vec<usize>) -> Self {
-        Self(Rc::new(v))
+        Self(Rc::from(v))
     }
 }
 
@@ -100,8 +100,8 @@ impl Deref for InternedPath {
     }
 }
 
-impl Borrow<Vec<usize>> for InternedPath {
-    fn borrow(&self) -> &Vec<usize> {
+impl Borrow<[usize]> for InternedPath {
+    fn borrow(&self) -> &[usize] {
         &self.0
     }
 }
@@ -444,7 +444,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         }
 
         assert!(self.current_namespace.0.pop().is_some());
-        if let Some(new_ns_idx) = self.named_objects.get_index_of(&self.current_namespace.0) {
+        if let Some(new_ns_idx) = self.named_objects.get_index_of(self.current_namespace.0.as_slice()) {
             self.current_namespace.1 = new_ns_idx;
         } else {
             // we must be at the "bottom" namespace
@@ -456,7 +456,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     fn pop_namespace(&mut self) {
         self.named_objects.swap_remove_index(self.current_namespace.1);
         assert!(self.current_namespace.0.pop().is_some());
-        if let Some(new_ns_idx) = self.named_objects.get_index_of(&self.current_namespace.0) {
+        if let Some(new_ns_idx) = self.named_objects.get_index_of(self.current_namespace.0.as_slice()) {
             self.current_namespace.1 = new_ns_idx;
         } else {
             // we must be at the "bottom" namespace

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -48,15 +48,13 @@ pub struct TestConstraint {
 
 impl Hash for TestConstraint {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.a.hash(state);
-        self.b.hash(state);
-        self.c.hash(state);
+        self.path_idx.hash(state); // TODO: double-check
     }
 }
 
 impl PartialEq for TestConstraint {
     fn eq(&self, other: &Self) -> bool {
-        self.a == other.a && self.b == other.b && self.c == other.c
+        self.path_idx == other.path_idx
     }
 }
 

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -430,32 +430,19 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         self.register_object_in_namespace(named_obj.clone());
         self.set_named_obj(interned_path.clone(), named_obj);
 
-        let a = a(LinearCombination::zero());
-        let a =
-            a.0.into_iter()
+        let mut intern_fields = |uninterned: Vec<(Variable, F)>| -> Vec<(Variable, InternedField)> {
+            uninterned
+                .into_iter()
                 .map(|(var, field)| {
                     let interned_field = self.interned_fields.insert_full(field).0;
                     (var, interned_field)
                 })
-                .collect();
+                .collect()
+        };
 
-        let b = b(LinearCombination::zero());
-        let b =
-            b.0.into_iter()
-                .map(|(var, field)| {
-                    let interned_field = self.interned_fields.insert_full(field).0;
-                    (var, interned_field)
-                })
-                .collect();
-
-        let c = c(LinearCombination::zero());
-        let c =
-            c.0.into_iter()
-                .map(|(var, field)| {
-                    let interned_field = self.interned_fields.insert_full(field).0;
-                    (var, interned_field)
-                })
-                .collect();
+        let a = intern_fields(a(LinearCombination::zero()).0);
+        let b = intern_fields(b(LinearCombination::zero()).0);
+        let c = intern_fields(c(LinearCombination::zero()).0);
 
         self.constraints.insert(TestConstraint { interned_path, a, b, c });
     }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -369,6 +369,14 @@ impl<F: Field> TestConstraintSystem<F> {
         // don't perform a full cleanup in test conditions, so that all the variables and
         // constraints remain available throughout the tests
     }
+
+    fn register_object_in_namespace(&mut self, named_obj: NamedObject) {
+        if let NamedObject::Namespace(ref mut ns) =
+            self.named_objects.get_index_mut(self.current_namespace.1).unwrap().1
+        {
+            ns.push(named_obj);
+        }
+    }
 }
 
 impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
@@ -385,11 +393,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         let index = self.aux.insert(interned_field);
         let var = Variable::new_unchecked(Index::Aux(index));
         let named_obj = NamedObject::Var(var);
-        if let NamedObject::Namespace(ref mut ns) =
-            self.named_objects.get_index_mut(self.current_namespace.1).unwrap().1
-        {
-            ns.push(named_obj.clone());
-        }
+        self.register_object_in_namespace(named_obj.clone());
         self.set_named_obj(interned_path, named_obj);
 
         Ok(var)
@@ -406,11 +410,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         let index = self.inputs.insert(interned_field);
         let var = Variable::new_unchecked(Index::Input(index));
         let named_obj = NamedObject::Var(var);
-        if let NamedObject::Namespace(ref mut ns) =
-            self.named_objects.get_index_mut(self.current_namespace.1).unwrap().1
-        {
-            ns.push(named_obj.clone());
-        }
+        self.register_object_in_namespace(named_obj.clone());
         self.set_named_obj(interned_path, named_obj);
 
         Ok(var)
@@ -427,11 +427,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         let interned_path = self.compute_path(annotation().as_ref());
         let index = self.constraints.next_idx();
         let named_obj = NamedObject::Constraint(index);
-        if let NamedObject::Namespace(ref mut ns) =
-            self.named_objects.get_index_mut(self.current_namespace.1).unwrap().1
-        {
-            ns.push(named_obj.clone());
-        }
+        self.register_object_in_namespace(named_obj.clone());
         self.set_named_obj(interned_path.clone(), named_obj);
 
         let a = a(LinearCombination::zero());

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use snarkos_errors::gadgets::SynthesisError;
 
+use fxhash::FxBuildHasher;
 use indexmap::IndexSet;
 use nohash_hasher::IntMap;
 
@@ -42,7 +43,7 @@ type TestConstraint<T> = (
 
 /// Constraint system for testing purposes.
 pub struct TestConstraintSystem<F: Field> {
-    paths: IndexSet<String>,
+    paths: IndexSet<String, FxBuildHasher>,
     named_objects: IntMap<PathIdx, NamedObject>,
     current_namespace: Vec<String>,
     pub constraints: Vec<TestConstraint<F>>,
@@ -70,7 +71,7 @@ impl<F: Field> TestConstraintSystem<F> {
 
 impl<F: Field> Default for TestConstraintSystem<F> {
     fn default() -> Self {
-        let mut paths = IndexSet::new();
+        let mut paths = IndexSet::with_hasher(FxBuildHasher::default());
         let path_idx = paths.insert_full("ONE".into()).0;
         let mut map = IntMap::default();
         map.insert(path_idx, NamedObject::Var(TestConstraintSystem::<F>::one()));

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -345,7 +345,11 @@ impl<F: Field> TestConstraintSystem<F> {
     fn compute_path(&mut self, new_segment: &str) -> InternedPath {
         let mut vec = Vec::with_capacity(self.current_namespace.0.len() + 1);
         vec.extend_from_slice(&self.current_namespace.0);
-        let (interned_segment, new) = self.interned_path_segments.insert_full(new_segment.to_owned());
+        let (interned_segment, new) = if let Some(index) = self.interned_path_segments.get_index_of(new_segment) {
+            (index, false)
+        } else {
+            self.interned_path_segments.insert_full(new_segment.to_owned())
+        };
 
         // only perform the check for segments not seen before
         assert!(!new || !new_segment.contains('/'), "'/' is not allowed in names");

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -322,7 +322,6 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
                 })
                 .collect();
 
-        self.interned_constraints.reserve(3);
         let a = self.interned_constraints.insert_full(a).0;
         let b = self.interned_constraints.insert_full(b).0;
         let c = self.interned_constraints.insert_full(c).0;

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -254,6 +254,7 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         b.0.shrink_to_fit();
         c.0.shrink_to_fit();
 
+        self.interned_constraints.reserve(3);
         let a = self.interned_constraints.insert_full(a).0;
         let b = self.interned_constraints.insert_full(b).0;
         let c = self.interned_constraints.insert_full(c).0;

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -22,7 +22,6 @@ use snarkos_errors::gadgets::SynthesisError;
 
 use fxhash::{FxBuildHasher, FxHashMap};
 use indexmap::IndexSet;
-use smallvec::SmallVec;
 
 use std::{
     cell::RefCell,
@@ -40,7 +39,7 @@ enum NamedObject {
 
 type InternedConstraint = usize;
 type InternedField = usize;
-type InternedLC = SmallVec<[(Variable, InternedField); 16]>;
+type InternedLC = Vec<(Variable, InternedField)>;
 type InternedPathSegment = usize;
 
 #[derive(Clone, PartialEq, Eq)]

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -160,23 +160,22 @@ impl<F: Field> TestConstraintSystem<F> {
         }
     }
 
+    #[inline]
     fn set_named_obj(&mut self, path_idx: PathIdx, to: NamedObject) {
         match self.named_objects.entry(path_idx) {
             Entry::Vacant(e) => {
                 e.insert(to);
             }
             Entry::Occupied(e) => {
-                let (path, _) = e.remove_entry();
-                panic!("tried to create object at existing path: {}", path);
+                panic!("tried to create object at existing path: {}", e.key());
             }
         }
     }
 }
 
+#[inline]
 fn compute_path(ns: &[String], this: &str) -> String {
-    if this.contains('/') {
-        panic!("'/' is not allowed in names");
-    }
+    assert!(!this.contains('/'), "'/' is not allowed in names");
 
     // preallocate the target path size, including the separators
     let len = ns.iter().map(|s| s.len()).sum::<usize>() + ns.len() + this.len();

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -120,9 +120,13 @@ impl<F: Field> TestConstraintSystem<F> {
 
     fn unintern_path(&self, interned_path: &InternedPath) -> String {
         let mut ret = String::new();
+        let mut iter = interned_path.iter().peekable();
 
-        for interned_segment in interned_path.iter() {
+        while let Some(interned_segment) = iter.next() {
             ret.push_str(self.interned_path_segments.get_index(*interned_segment).unwrap());
+            if iter.peek().is_some() {
+                ret.push('/');
+            }
         }
 
         ret

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -71,7 +71,7 @@ pub struct TestConstraintSystem<F: Field> {
     interned_constraints: IndexSet<InternedLC, FxBuildHasher>,
     named_objects: FxHashMap<InternedPath, NamedObject>,
     current_namespace: InternedPath,
-    pub constraints: FxHashMap<InternedPath, TestConstraint>,
+    constraints: FxHashMap<InternedPath, TestConstraint>,
     inputs: Vec<InternedField>,
     aux: Vec<InternedField>,
 }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -238,11 +238,13 @@ impl<F: Field> TestConstraintSystem<F> {
 
     #[inline]
     fn compute_path(&mut self, new_segment: &str) -> InternedPath {
-        assert!(!new_segment.contains('/'), "'/' is not allowed in names");
-
         let mut vec = Vec::with_capacity(self.current_namespace.len() + 1);
         vec.extend_from_slice(&self.current_namespace);
-        let interned_segment = self.interned_path_segments.insert_full(new_segment.to_owned()).0;
+        let (interned_segment, new) = self.interned_path_segments.insert_full(new_segment.to_owned());
+
+        // only perform the check for segments not seen before
+        assert!(!new || !new_segment.contains('/'), "'/' is not allowed in names");
+
         vec.push(interned_segment);
 
         vec.into()

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -49,7 +49,7 @@ pub struct TestConstraintSystem<F: Field> {
     interned_constraints: IndexSet<LinearCombination<F>, FxBuildHasher>,
     named_objects: IntMap<PathIdx, NamedObject>,
     current_namespace: Vec<String>,
-    pub constraints: IntMap<ConstraintIdx, TestConstraint>,
+    pub constraints: IntMap<PathIdx, TestConstraint>,
     inputs: Vec<(F, PathIdx)>,
     aux: Vec<(F, PathIdx)>,
 }

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -63,6 +63,7 @@ pub struct OptionalVec<T> {
 impl<T> OptionalVec<T> {
     // inserts a new value either into the first existing hole or extending the vector
     // of values, i.e. pushing it to its end
+    #[inline]
     pub fn insert(&mut self, elem: T) -> usize {
         let idx = self.holes.pop_front().unwrap_or_else(|| self.values.len());
         if idx < self.values.len() {
@@ -74,6 +75,7 @@ impl<T> OptionalVec<T> {
     }
 
     // returns the index of the next value inserted into the OptionalVec
+    #[inline]
     pub fn next_idx(&self) -> usize {
         self.holes.front().copied().unwrap_or_else(|| self.values.len())
     }
@@ -87,6 +89,7 @@ impl<T> OptionalVec<T> {
         val.unwrap()
     }
 
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.values.iter().filter(|v| v.is_some()).map(|v| v.as_ref().unwrap())
     }
@@ -195,6 +198,7 @@ impl<F: Field> TestConstraintSystem<F> {
         Self::default()
     }
 
+    #[inline]
     fn intern_path(&self, path: &str) -> InternedPath {
         let mut vec = vec![];
 
@@ -265,6 +269,7 @@ impl<F: Field> TestConstraintSystem<F> {
         None
     }
 
+    #[inline]
     pub fn is_satisfied(&self) -> bool {
         self.which_is_unsatisfied().is_none()
     }
@@ -365,11 +370,13 @@ impl<F: Field> TestConstraintSystem<F> {
     }
 
     #[cfg(debug_assertions)]
+    #[inline]
     fn purge_namespace(&mut self, _namespace: Namespace) {
         // don't perform a full cleanup in test conditions, so that all the variables and
         // constraints remain available throughout the tests
     }
 
+    #[inline]
     fn register_object_in_namespace(&mut self, named_obj: NamedObject) {
         if let NamedObject::Namespace(ref mut ns) =
             self.named_objects.get_index_mut(self.current_namespace.1).unwrap().1

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -179,10 +179,12 @@ impl<F: Field> Default for TestConstraintSystem<F> {
             last_segment: interned_path_segment,
         };
 
-        let mut interned_full_paths = FxHashMap::default();
         cfg_if! {
             if #[cfg(debug_assertions)] {
+                let mut interned_full_paths = FxHashMap::default();
                 interned_full_paths.insert(vec![interned_path_segment], interned_path);
+            } else {
+                let interned_full_paths = FxHashMap::default();
             }
         }
 

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -38,7 +38,7 @@ enum NamedObject {
     Namespace,
 }
 
-type ConstraintIdx = usize;
+type InternedConstraint = usize;
 type InternedField = usize;
 type InternedLC = SmallVec<[(Variable, InternedField); 16]>;
 
@@ -59,9 +59,9 @@ impl From<Vec<usize>> for InternedPath {
 
 #[derive(PartialEq, Eq, Hash)]
 pub struct TestConstraint {
-    a: ConstraintIdx,
-    b: ConstraintIdx,
-    c: ConstraintIdx,
+    a: InternedConstraint,
+    b: InternedConstraint,
+    c: InternedConstraint,
 }
 
 /// Constraint system for testing purposes.
@@ -80,8 +80,8 @@ impl<F: Field> Default for TestConstraintSystem<F> {
     fn default() -> Self {
         let mut interned_path_segments = IndexSet::with_hasher(FxBuildHasher::default());
         let path_segment = "ONE".to_owned();
-        let path_idx = interned_path_segments.insert_full(path_segment).0;
-        let interned_path: InternedPath = vec![path_idx].into();
+        let interned_path_segment = interned_path_segments.insert_full(path_segment).0;
+        let interned_path: InternedPath = vec![interned_path_segment].into();
         let mut named_objects = FxHashMap::default();
         named_objects.insert(interned_path, NamedObject::Var(TestConstraintSystem::<F>::one()));
         let mut interned_fields = IndexSet::with_hasher(FxBuildHasher::default());

--- a/models/src/gadgets/r1cs/test_constraint_system.rs
+++ b/models/src/gadgets/r1cs/test_constraint_system.rs
@@ -206,10 +206,10 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     where
         Fn: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.aux.len();
-        let path = compute_path(&self.current_namespace, &annotation().into());
+        let path = compute_path(&self.current_namespace, annotation().as_ref());
         let path_idx = self.interned_paths.insert_full(path).0;
         self.aux.push((f()?, path_idx));
         let var = Variable::new_unchecked(Index::Aux(index));
@@ -222,10 +222,10 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     where
         Fn: FnOnce() -> Result<F, SynthesisError>,
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
     {
         let index = self.inputs.len();
-        let path = compute_path(&self.current_namespace, &annotation().into());
+        let path = compute_path(&self.current_namespace, annotation().as_ref());
         let path_idx = self.interned_paths.insert_full(path).0;
         self.inputs.push((f()?, path_idx));
         let var = Variable::new_unchecked(Index::Input(index));
@@ -237,12 +237,12 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
     fn enforce<A, AR, LA, LB, LC>(&mut self, annotation: A, a: LA, b: LB, c: LC)
     where
         A: FnOnce() -> AR,
-        AR: Into<String>,
+        AR: AsRef<str>,
         LA: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LB: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
         LC: FnOnce(LinearCombination<F>) -> LinearCombination<F>,
     {
-        let path = compute_path(&self.current_namespace, &annotation().into());
+        let path = compute_path(&self.current_namespace, annotation().as_ref());
         let path_idx = self.interned_paths.insert_full(path).0;
         let index = self.constraints.len();
         self.set_named_obj(path_idx, NamedObject::Constraint(index));
@@ -262,12 +262,12 @@ impl<F: Field> ConstraintSystem<F> for TestConstraintSystem<F> {
         self.constraints.insert(path_idx, TestConstraint { a, b, c });
     }
 
-    fn push_namespace<NR: Into<String>, N: FnOnce() -> NR>(&mut self, name_fn: N) {
-        let name = name_fn().into();
-        let path = compute_path(&self.current_namespace, &name);
+    fn push_namespace<NR: AsRef<str>, N: FnOnce() -> NR>(&mut self, name_fn: N) {
+        let name = name_fn();
+        let path = compute_path(&self.current_namespace, name.as_ref());
         let path_idx = self.interned_paths.insert_full(path).0;
         self.set_named_obj(path_idx, NamedObject::Namespace);
-        self.current_namespace.push(name);
+        self.current_namespace.push(name.as_ref().to_owned());
     }
 
     fn pop_namespace(&mut self) {

--- a/models/src/gadgets/utilities/boolean.rs
+++ b/models/src/gadgets/utilities/boolean.rs
@@ -809,7 +809,7 @@ mod test {
         assert!(cs.is_satisfied());
         cs.set("boolean", Fr::from_str("2").unwrap());
         assert!(!cs.is_satisfied());
-        assert!(cs.which_is_unsatisfied() == Some("boolean constraint"));
+        assert!(cs.which_is_unsatisfied().as_deref() == Some("boolean constraint"));
     }
 
     #[test]


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/541, I'll rebase it once that one is merged.

After having accumulated a number of profiling results, I took a closer look at them and found room for further improvement; the most important changes are:
- `compute_path` now performs an extra lookup in order to avoid a potentially unnecessary `String` allocation
- `InternedPath`, instead of being a list of `InternedPathSegments`, now consists of its parent namespace index and the final segment; this removes a lot of allocations and improves lookup time in non-test scenarios; a side-effect of this change is that an additional map, `interned_full_paths`, needs to be maintained for test purposes
- the "holes" in the `OptionalVec` object are now contained in a plain `Vec` (as it doesn't matter which hole is being filled, as long as all are filled in before resizing)
- the `get`, `set`, and `intern_path` methods are built only for test purposes

A comparison of a memory profile of a relatively complex operation (`2i128 ** 2i128`) between https://github.com/AleoHQ/snarkOS/pull/541 and this PR shows its added performance improvements.

without these changes:
![massif_leo_2i128_pow_once](https://user-images.githubusercontent.com/3750347/101057827-c3b45100-358c-11eb-8a39-639f16534cc2.png)

with these changes (the runtime is decreased):
![massif_leo_2i128_pow_once_cont](https://user-images.githubusercontent.com/3750347/101060143-5950e000-358f-11eb-98f5-c1ecd879769e.png)
