### PR TITLE
Update CI to recent Rust versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: snark-cache-main
+        default: snarkos-stable-cache
     steps:
       - run: set -e
       - setup_remote_docker
@@ -31,7 +31,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: snark-main
+        default: snarkos-stable-cache
     steps:
       - run: (sccache -s||true)
       - run: set +e
@@ -43,12 +43,12 @@ commands:
 jobs:
   rust_stable:
     docker:
-      - image: cimg/rust:1.43.0
+      - image: cimg/rust:1.46.0
     resource_class: xlarge
     steps:
       - checkout
       - setup_environment:
-          cache_key: snark-main
+          cache_key: snarkos-stable-cache
       - run:
           name: Build and run tests
           command: >
@@ -58,7 +58,7 @@ jobs:
           root: ~/
           paths: project/
       - clear_environment:
-          cache_key: snark-main
+          cache_key: snarkos-stable-cache
   analyse_and_store_coverage:
     machine:
       image: ubuntu-1604:202004-01
@@ -72,23 +72,23 @@ jobs:
           command: >
             cd ~/project/project/ &&
             docker run --security-opt seccomp=unconfined -v ~/project/project/:/home/circleci/project/
-            daniilr/kcov bash /home/circleci/project/ci/kcov.sh
+            howardwu/snarkos-codecov bash /home/circleci/project/ci/kcov.sh
       - run: cd ./project/ && bash <(curl -s https://codecov.io/bash)
   rust_nightly:
     docker:
-      - image: daniilr/rust-nightly:2020-05-15
+      - image: howardwu/snarkos-ci:2020-08-27
     resource_class: xlarge
     steps:
       - checkout
       - setup_environment:
-          cache_key: snark-cache-nighty
+          cache_key: snarkos-nightly-cache
       - run: rustup component add rustfmt
       - run: cargo fmt -- --check
       - run:
           name: Build and test
           command: RUST_MIN_STACK=8388608 cargo test --all -- --skip dpc --skip dpc_integration_test --skip startup_handshake_stored_peers --skip test_rpc_create_raw_transaction
       - clear_environment:
-          cache_key: snark-cache-nighty
+          cache_key: snarkos-nightly-cache
 workflows:
   version: 2
   main-workflow:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,48 +29,48 @@ jobs:
           command: fmt
           args: --all -- --check
 
-#  clippy:
-#    name: Clippy
-#    runs-on: ubuntu-latest
-#    env:
-#      RUSTFLAGS: -Dwarnings
-#    strategy:
-#      matrix:
-#        rust:
-#          - stable
-#          - nightly
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Install Rust (${{ matrix.rust }})
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          override: true
-#          components: clippy
-#
-#      - name: Check examples
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: clippy
-#          args: --examples --all
-#
-#      - name: Check examples with all features on stable
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: clippy
-#          args: --examples --all-features --all
-#        if: matrix.rust == 'stable'
-#
-#      - name: Check benchmarks on nightly
-#        uses: actions-rs/cargo@v1
-#        with:
-#          command: clippy
-#          args: --all-features --examples --all --benches
-#        if: matrix.rust == 'nightly'
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Dwarnings
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Rust (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: clippy
+
+      - name: Check examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --examples --all
+
+      - name: Check examples with all features on stable
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --examples --all-features --all
+        if: matrix.rust == 'stable'
+
+      - name: Check benchmarks on nightly
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --examples --all --benches
+        if: matrix.rust == 'nightly'
 
   test:
     name: Check Tests (Simple)

--- a/ci/docker-kcov/Dockerfile
+++ b/ci/docker-kcov/Dockerfile
@@ -31,5 +31,4 @@ RUN curl -LO https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&  \
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-
 CMD ["/usr/local/bin/kcov"]

--- a/ci/docker-kcov/README.md
+++ b/ci/docker-kcov/README.md
@@ -1,9 +1,10 @@
-1. Go to [Rustup components availability page](https://rust-lang.github.io/rustup-components-history/)
-2. Find out latest version that supports `rustfmt` component (e.g. 2020-05-15)
-3. Edit Dockerfile. Change `RUST_VERSION` to the target version e.g. nightly-2020-05-15.
-4. Build and push:
+# To Update
 
+1. Go to [Rustup components availability page](https://rust-lang.github.io/rustup-components-history/)
+2. Find the latest version that supports `rustfmt` component (e.g. 2020-08-27)
+3. Update the Dockerfile by changing `RUST_VERSION` to the target version (e.g. nightly-2020-08-27)
+4. Build and push:
 ```bash
-docker build -t daniilr/rust-nightly:2020-05-15 .
-docker push daniilr/rust-nightly:2020-05-15 
+docker build -t howardwu/snarkos-codecov:2020-08-27 .
+docker push howardwu/snarkos-codecov:2020-08-27
 ```

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,10 +1,8 @@
 FROM buildpack-deps:buster
 
+FROM cimg/base:2020.09
 
-FROM cimg/base:2020.05
-
-
-ENV RUST_VERSION=nightly-2020-05-15 \
+ENV RUST_VERSION=nightly-2020-08-27 \
 	PATH=/home/circleci/.cargo/bin:$PATH
 
 RUN curl -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \

--- a/ci/docker-rust/README.md
+++ b/ci/docker-rust/README.md
@@ -1,9 +1,9 @@
 1. Go to [Rustup components availability page](https://rust-lang.github.io/rustup-components-history/)
-2. Find out latest version that supports `rustfmt` component (e.g. 2020-05-15)
-3. Edit Dockerfile. Change `RUST_VERSION` to the target version e.g. nightly-2020-05-15.
+2. Find out latest version that supports `rustfmt` component (e.g. 2020-08-27)
+3. Edit Dockerfile. Change `RUST_VERSION` to the target version e.g. nightly-2020-08-27.
 4. Build and push:
 
 ```bash
-docker build -t daniilr/rust-nightly:2020-05-15 .
-docker push daniilr/rust-nightly:2020-05-15 
+docker build -t howardwu/snarkos-ci:2020-08-27 .
+docker push howardwu/snarkos-ci:2020-08-27
 ```

--- a/network/src/internal/message_handler.rs
+++ b/network/src/internal/message_handler.rs
@@ -282,10 +282,8 @@ impl Server {
                 transaction,
             };
 
-            if let Ok(inserted) = memory_pool.insert(&self.storage, entry) {
-                if let Some(txid) = inserted {
-                    debug!("Transaction added to memory pool with txid: {:?}", hex::encode(&txid));
-                }
+            if let Ok(Some(txid)) = memory_pool.insert(&self.storage, entry) {
+                debug!("Transaction added to memory pool with txid: {:?}", hex::encode(&txid));
             }
         }
 

--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -28,7 +28,7 @@ pub trait CLI {
     const SUBCOMMANDS: &'static [SubCommandType];
 
     #[cfg_attr(tarpaulin, skip)]
-    fn new<'a>() -> ArgMatches<'a> {
+    fn args<'a>() -> ArgMatches<'a> {
         let flags = &Self::FLAGS
             .iter()
             .map(|a| Arg::from_usage(a))

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -165,7 +165,7 @@ async fn start_server(config: Config) -> Result<(), NodeError> {
 }
 
 fn main() -> Result<(), NodeError> {
-    let arguments = ConfigCli::new();
+    let arguments = ConfigCli::args();
 
     let config: Config = ConfigCli::parse(&arguments)?;
 

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -122,7 +122,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
 
                 let mut cm_and_indices = vec![];
 
-                for (commitment_key, index_value) in storage.get_iter(COL_COMMITMENT)? {
+                for (commitment_key, index_value) in storage.get_iter(COL_COMMITMENT) {
                     let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
                     let index = bytes_to_u32(index_value.to_vec()) as usize;
 

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -60,7 +60,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     /// Get the set of past ledger digests
     pub fn past_digests(&self) -> Result<HashSet<Vec<u8>>, StorageError> {
         let mut digests = HashSet::new();
-        for (key, _value) in self.storage.get_iter(COL_DIGEST)? {
+        for (key, _value) in self.storage.get_iter(COL_DIGEST) {
             digests.insert(key.to_vec());
         }
 
@@ -114,7 +114,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
         // TODO (raychu86) make this more efficient
         let mut cm_and_indices = additional_cms;
 
-        for (commitment_key, index_value) in self.storage.get_iter(COL_COMMITMENT)? {
+        for (commitment_key, index_value) in self.storage.get_iter(COL_COMMITMENT) {
             let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
             let index = bytes_to_u32(index_value.to_vec()) as usize;
 

--- a/storage/src/objects/records.rs
+++ b/storage/src/objects/records.rs
@@ -28,7 +28,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     pub fn get_record_commitments(&self, limit: Option<usize>) -> Result<Vec<Vec<u8>>, StorageError> {
         let mut record_commitments = vec![];
 
-        for (commitment_key, _record) in self.storage.get_iter(COL_RECORDS)? {
+        for (commitment_key, _record) in self.storage.get_iter(COL_RECORDS) {
             if let Some(limit) = limit {
                 if record_commitments.len() >= limit {
                     break;

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -103,8 +103,8 @@ impl Storage {
 
     /// Returns the iterator from a given col.
     /// If the given key does not exist, returns [StorageError](snarkvm_errors::storage::StorageError).
-    pub(crate) fn get_iter(&self, col: u32) -> Result<DBIterator, StorageError> {
-        Ok(self.db.iterator_cf(self.get_cf_ref(col), IteratorMode::Start))
+    pub(crate) fn get_iter(&self, col: u32) -> DBIterator {
+        self.db.iterator_cf(self.get_cf_ref(col), IteratorMode::Start)
     }
 
     /// Returns `Ok(())` after executing a database transaction


### PR DESCRIPTION
This updates the CI to more recent Rust versions, namely: 
- stable: `1.46.0`
- nightly: `2020-08-27`

The Clippy lint has also been added (resolves #514). 
