### PR TITLE
Default to the unspecified IP for the node's listener

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -75,7 +75,7 @@ impl Inbound {
             let listener = TcpListener::bind(&addr).await?;
             (addr, listener)
         } else {
-            let listener = TcpListener::bind("127.0.0.1:0").await?;
+            let listener = TcpListener::bind("0.0.0.0:0").await?;
             let listener_address = listener.local_addr()?;
             environment.set_local_address(listener_address);
             (listener_address, listener)

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -33,7 +33,7 @@ use std::{
 /// A node should try and connect to these first after coming online.
 pub const MAINNET_BOOTNODES: &[&str] = &[]; // "192.168.0.1:4130"
 pub const TESTNET_BOOTNODES: &[&str] = &[
-        "127.0.0.1:4141"
+        "0.0.0.0:4141"
     // "138.197.232.178:4131",
     // "64.225.91.42:4131",
     // "64.225.91.43:4131",
@@ -102,7 +102,7 @@ impl Default for Config {
                 dir: Self::snarkos_dir(),
                 db: "snarkos_testnet1".into(),
                 is_bootnode: false,
-                ip: "127.0.0.1".into(),
+                ip: "0.0.0.0".into(),
                 port: 4131,
                 verbose: 3,
             },


### PR DESCRIPTION
While it has been practical to default to a concrete address during local tests, it is probably simpler for users to have the node's listener IP address set to the unspecified one, i.e. `0.0.0.0`, back again.