### PR TITLE
Extend connection on-failure dropping rules, fix an error name

### DIFF
--- a/network/src/errors/connect.rs
+++ b/network/src/errors/connect.rs
@@ -38,15 +38,17 @@ pub enum ConnectError {
 
 impl ConnectError {
     pub fn is_fatal(&self) -> bool {
-        if let Self::MessageHeaderError(MessageHeaderError::StreamReadError(StreamReadError::Io(err))) = self {
-            [
+        match self {
+            Self::MessageError(MessageError::StreamReadError(StreamReadError::Io(err)))
+            | Self::MessageHeaderError(MessageHeaderError::StreamReadError(StreamReadError::Io(err)))
+            | Self::MessageHeaderError(MessageHeaderError::Io(err))
+            | Self::Std(err) => [
                 ErrorKind::BrokenPipe,
                 ErrorKind::ConnectionReset,
                 ErrorKind::UnexpectedEof,
             ]
-            .contains(&err.kind())
-        } else {
-            false
+            .contains(&err.kind()),
+            _ => false,
         }
     }
 }

--- a/network/src/errors/message/message.rs
+++ b/network/src/errors/message/message.rs
@@ -31,7 +31,7 @@ pub enum MessageError {
     MessageHeaderError(MessageHeaderError),
 
     #[error("Stream error: {}", _0)]
-    SteamReadError(StreamReadError),
+    StreamReadError(StreamReadError),
 }
 
 impl From<MessageHeaderError> for MessageError {
@@ -42,7 +42,7 @@ impl From<MessageHeaderError> for MessageError {
 
 impl From<StreamReadError> for MessageError {
     fn from(error: StreamReadError) -> Self {
-        MessageError::SteamReadError(error)
+        MessageError::StreamReadError(error)
     }
 }
 


### PR DESCRIPTION
There are more read-related errors that should cause a connection to be dropped; include them and fix the name of one of them.