### PR TITLE
Hotfix: Revert RPC server listener to 0.0.0.0, update bootnode

### DIFF
--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -49,7 +49,7 @@ pub async fn start_rpc_server(
     username: Option<String>,
     password: Option<String>,
 ) {
-    let rpc_server: SocketAddr = format!("127.0.0.1:{}", rpc_port).parse().unwrap();
+    let rpc_server: SocketAddr = format!("0.0.0.0:{}", rpc_port).parse().unwrap();
 
     let credentials = match (username, password) {
         (Some(username), Some(password)) => Some(RpcCredentials { username, password }),

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -33,7 +33,7 @@ use std::{
 /// A node should try and connect to these first after coming online.
 pub const MAINNET_BOOTNODES: &[&str] = &[]; // "192.168.0.1:4130"
 pub const TESTNET_BOOTNODES: &[&str] = &[
-        "0.0.0.0:4141"
+    "50.18.246.201:4131",
     // "138.197.232.178:4131",
     // "64.225.91.42:4131",
     // "64.225.91.43:4131",


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Hotfix: Revert RPC server listener to 0.0.0.0, update bootnode

