### PR TITLE
Introduce Ping and Pong messages, improve last_seen handling and peering

### DIFF
--- a/network/documentation/network_messages/ping.md
+++ b/network/documentation/network_messages/ping.md
@@ -6,6 +6,6 @@ A ping protocol request for a `Pong`.
 
 ### Payload
 
-| Parameter | Type   |            Description            |
-|:---------:|--------|:---------------------------------:|
-| `nonce`   | number | A unique ping protocol identifier |
+| Parameter        | Type   |            Description            |
+|:----------------:|--------|:---------------------------------:|
+| `block_height`   | number | The current height of the chain   |

--- a/network/documentation/network_messages/pong.md
+++ b/network/documentation/network_messages/pong.md
@@ -6,6 +6,4 @@ A response to a `Ping` request.
 
 ### Payload
 
-| Parameter | Type   |              Description              |
-|:---------:|--------|:-------------------------------------:|
-| `nonce`   | number | The received ping protocol identifier |
+`None`

--- a/network/documentation/network_messages/version.md
+++ b/network/documentation/network_messages/version.md
@@ -12,4 +12,3 @@ A handshake request for a `Verack` to establish a connection with a potential pe
 | `height`           | number | Latest block height of the node              |
 | `nonce`            | number | Random nonce to identify the version message |
 | `listening_port`   | number | The node's listening port                    |
-| `timestamp`        | number | Message timestamp                            |

--- a/network/src/external/message/message.rs
+++ b/network/src/external/message/message.rs
@@ -18,7 +18,6 @@ use crate::external::Version;
 use snarkos_storage::BlockHeight;
 use snarkvm_objects::BlockHeaderHash;
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use std::{fmt, net::SocketAddr};
@@ -67,8 +66,6 @@ impl fmt::Display for Message {
     }
 }
 
-pub type Peer = (SocketAddr, DateTime<Utc>);
-
 /// The actual message transmitted over the network.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum Payload {
@@ -85,7 +82,7 @@ pub enum Payload {
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/memory_pool.md"))]
     MemoryPool(Vec<Vec<u8>>),
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/peers.md"))]
-    Peers(Vec<Peer>),
+    Peers(Vec<SocketAddr>),
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/ping.md"))]
     Ping(BlockHeight),
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/pong.md"))]

--- a/network/src/external/message/message.rs
+++ b/network/src/external/message/message.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::external::Version;
+use snarkos_storage::BlockHeight;
 use snarkvm_objects::BlockHeaderHash;
 
 use chrono::{DateTime, Utc};
@@ -85,6 +86,10 @@ pub enum Payload {
     MemoryPool(Vec<Vec<u8>>),
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/peers.md"))]
     Peers(Vec<Peer>),
+    #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/ping.md"))]
+    Ping(BlockHeight),
+    #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/pong.md"))]
+    Pong,
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/sync.md"))]
     Sync(Vec<BlockHeaderHash>),
     #[cfg_attr(nightly, doc(include = "../../../documentation/network_messages/sync_block.md"))]
@@ -117,6 +122,8 @@ impl fmt::Display for Payload {
             Self::GetSync(..) => "getsync",
             Self::MemoryPool(..) => "memorypool",
             Self::Peers(..) => "peers",
+            Self::Ping(..) => "ping",
+            Self::Pong => "pong",
             Self::Sync(..) => "sync",
             Self::SyncBlock(..) => "syncblock",
             Self::Transaction(..) => "transaction",

--- a/network/src/external/message/version.rs
+++ b/network/src/external/message/version.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use chrono::Utc;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -27,8 +26,6 @@ pub struct Version {
     pub nonce: u64,
     /// The listening port of the sender.
     pub listening_port: u16,
-    /// The timestamp of this message.
-    pub timestamp: i64,
 }
 
 impl Version {
@@ -37,7 +34,6 @@ impl Version {
             version,
             nonce,
             listening_port,
-            timestamp: Utc::now().timestamp(),
         }
     }
 
@@ -50,7 +46,6 @@ impl Version {
             version,
             nonce: rng.gen::<u64>(),
             listening_port,
-            timestamp: Utc::now().timestamp(),
         }
     }
 }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -278,6 +278,8 @@ impl Inbound {
                 ))
                 .await?;
 
+            debug!("Successfully handshaken with {}", remote_address);
+
             Ok((writer, reader))
         } else {
             error!("{} didn't send their Version during the handshake", remote_address);

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -247,6 +247,14 @@ impl Server {
             Payload::Peers(peers) => {
                 self.peers.process_inbound_peers(peers)?;
             }
+            Payload::Ping(block_height) => {
+                self.outbound
+                    .send_request(Message::new(Direction::Outbound(source.unwrap()), Payload::Pong));
+                // TODO(ljedrz/niklas): perform a sync if needed
+            }
+            Payload::Pong => {
+                self.peers.received_pong(source.unwrap());
+            }
         }
 
         Ok(())

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -248,7 +248,7 @@ impl Server {
             Payload::Peers(peers) => {
                 self.peers.process_inbound_peers(peers);
             }
-            Payload::Ping(block_height) => {
+            Payload::Ping(_block_height) => {
                 self.outbound
                     .send_request(Message::new(Direction::Outbound(source.unwrap()), Payload::Pong));
                 // TODO(ljedrz/niklas): perform a sync if needed

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -185,6 +185,7 @@ impl Server {
         let Message { direction, payload } = receiver.recv().await.ok_or(NetworkError::ReceiverFailedToParse)?;
 
         let source = if let Direction::Inbound(addr) = direction {
+            self.peers.update_last_seen(addr);
             Some(addr)
         } else {
             None

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -243,7 +243,7 @@ impl Server {
                 }
             }
             Payload::GetPeers => {
-                self.peers.send_get_peers(source.unwrap());
+                self.peers.send_peers(source.unwrap());
             }
             Payload::Peers(peers) => {
                 self.peers.process_inbound_peers(peers)?;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -239,14 +239,14 @@ impl Server {
             }
             Payload::Disconnect(addr) => {
                 if direction == Direction::Internal {
-                    self.peers.disconnected_from_peer(&addr)?;
+                    self.peers.disconnected_from_peer(addr)?;
                 }
             }
             Payload::GetPeers => {
                 self.peers.send_peers(source.unwrap());
             }
             Payload::Peers(peers) => {
-                self.peers.process_inbound_peers(peers)?;
+                self.peers.process_inbound_peers(peers);
             }
             Payload::Ping(block_height) => {
                 self.outbound

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -160,7 +160,7 @@ impl Server {
         let mut receiver = self.inbound.take_receiver();
         task::spawn(async move {
             loop {
-                if let Err(e) = server.receive_response(&mut receiver).await {
+                if let Err(e) = server.process_incoming_messages(&mut receiver).await {
                     error!("Server error: {}", e);
                 }
             }
@@ -181,7 +181,7 @@ impl Server {
         self.environment.local_address()
     }
 
-    async fn receive_response(&self, receiver: &mut Receiver) -> Result<(), NetworkError> {
+    async fn process_incoming_messages(&self, receiver: &mut Receiver) -> Result<(), NetworkError> {
         let Message { direction, payload } = receiver.recv().await.ok_or(NetworkError::ReceiverFailedToParse)?;
 
         let source = if let Direction::Inbound(addr) = direction {

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -259,43 +259,19 @@ impl PeerBook {
     pub fn add_peer(&mut self, address: &SocketAddr) -> Result<(), NetworkError> {
         // Check if the peer is a connecting peer.
         if self.is_connecting(address) {
-            // Fetch the peer info of the given address.
-            let peer_info = self
-                .connecting_peers
-                .get_mut(address)
-                .ok_or(NetworkError::PeerBookMissingPeer)?;
-            // Update the `last_seen` timestamp in the peer info.
-            peer_info.set_last_seen()?;
-
-            error!("{} already exists in the peer book", address);
+            warn!("{} already exists in the peer book", address);
             return Err(NetworkError::PeerAlreadyExists);
         }
 
         // Check if the peer is a connected peer.
         if self.is_connected(address) {
-            // Fetch the peer info of the given address.
-            let peer_info = self
-                .connected_peers
-                .get_mut(address)
-                .ok_or(NetworkError::PeerBookMissingPeer)?;
-            // Update the `last_seen` timestamp in the peer info.
-            peer_info.set_last_seen()?;
-
-            error!("{} already exists in the peer book", address);
+            warn!("{} already exists in the peer book", address);
             return Err(NetworkError::PeerAlreadyExists);
         }
 
         // Check if the peer is a known disconnected peer.
         if self.is_disconnected(address) {
-            // Fetch the peer info of the given address.
-            let peer_info = self
-                .disconnected_peers
-                .get_mut(address)
-                .ok_or(NetworkError::PeerBookMissingPeer)?;
-            // Update the `last_seen` timestamp in the peer info.
-            peer_info.set_last_seen()?;
-
-            error!("{} already exists in the peer book", address);
+            warn!("{} already exists in the peer book", address);
             return Err(NetworkError::PeerAlreadyExists);
         }
 
@@ -346,6 +322,19 @@ impl PeerBook {
 
         error!("Missing {} in the peer book", address);
         Err(NetworkError::PeerBookMissingPeer)
+    }
+
+    ///
+    /// Updates the last seen timestamp of this peer to the current time.
+    ///
+    // TODO(ljedrz): use on Version reads
+    #[inline]
+    pub fn update_last_seen(&mut self, address: SocketAddr) {
+        if let Some(ref mut peer) = self.connected_peers.get_mut(&address) {
+            peer.last_seen = chrono::Utc::now();
+        } else {
+            warn!("Attempted to update state of a peer that's not connected: {}", address);
+        }
     }
 
     ///

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -269,13 +269,13 @@ impl PeerBook {
     ///
     /// Returns a reference to the peer info of the given address, if it exists.
     ///
-    pub fn get_peer(&mut self, address: &SocketAddr) -> Result<&PeerInfo, NetworkError> {
+    pub fn get_peer(&mut self, address: SocketAddr) -> Result<&PeerInfo, NetworkError> {
         // Check if the address is a connecting peer.
         if self.is_connecting(address) {
             // Fetch the peer info of the connecting peer.
             return self
                 .connecting_peers
-                .get(address)
+                .get(&address)
                 .ok_or(NetworkError::PeerBookMissingPeer);
         }
 
@@ -284,7 +284,7 @@ impl PeerBook {
             // Fetch the peer info of the connected peer.
             return self
                 .connected_peers
-                .get(address)
+                .get(&address)
                 .ok_or(NetworkError::PeerBookMissingPeer);
         }
 
@@ -293,7 +293,7 @@ impl PeerBook {
             // Fetch the peer info of the disconnected peer.
             return self
                 .disconnected_peers
-                .get(address)
+                .get(&address)
                 .ok_or(NetworkError::PeerBookMissingPeer);
         }
 

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -61,24 +61,24 @@ impl PeerBook {
     /// Returns `true` if a given address is a connecting peer in the `PeerBook`.
     ///
     #[inline]
-    pub fn is_connecting(&self, address: &SocketAddr) -> bool {
-        self.connecting_peers.contains_key(address)
+    pub fn is_connecting(&self, address: SocketAddr) -> bool {
+        self.connecting_peers.contains_key(&address)
     }
 
     ///
     /// Returns `true` if a given address is a connected peer in the `PeerBook`.
     ///
     #[inline]
-    pub fn is_connected(&self, address: &SocketAddr) -> bool {
-        self.connected_peers.contains_key(address)
+    pub fn is_connected(&self, address: SocketAddr) -> bool {
+        self.connected_peers.contains_key(&address)
     }
 
     ///
     /// Returns `true` if a given address is a disconnected peer in the `PeerBook`.
     ///
     #[inline]
-    pub fn is_disconnected(&self, address: &SocketAddr) -> bool {
-        self.disconnected_peers.contains_key(address)
+    pub fn is_disconnected(&self, address: SocketAddr) -> bool {
+        self.disconnected_peers.contains_key(&address)
     }
 
     ///
@@ -132,13 +132,13 @@ impl PeerBook {
     ///
     /// Returns the handshake nonce if the given address is a connecting or connected peer.
     ///
-    pub fn handshake_nonce(&self, address: &SocketAddr) -> Result<u64, NetworkError> {
+    pub fn handshake_nonce(&self, address: SocketAddr) -> Result<u64, NetworkError> {
         // Check if the address is a connecting peer.
         if self.is_connecting(address) {
             // Fetch the handshake nonce of the connecting peer.
             return match self
                 .connecting_peers
-                .get(address)
+                .get(&address)
                 .ok_or(NetworkError::PeerBookMissingPeer)?
                 .nonce()
             {
@@ -152,7 +152,7 @@ impl PeerBook {
             // Fetch the handshake nonce of the connected peer.
             return match self
                 .connected_peers
-                .get(address)
+                .get(&address)
                 .ok_or(NetworkError::PeerBookMissingPeer)?
                 .nonce()
             {
@@ -212,25 +212,25 @@ impl PeerBook {
     /// Removes the given address from the connecting and connected peers in this `PeerBook`,
     /// and adds the given address to the disconnected peers in this `PeerBook`.
     ///
-    pub fn set_disconnected(&mut self, address: &SocketAddr) -> Result<(), NetworkError> {
+    pub fn set_disconnected(&mut self, address: SocketAddr) -> Result<(), NetworkError> {
         // Case 1 - The given address is a connecting peer, attempt to disconnect.
-        if let Some(mut peer_info) = self.connecting_peers.remove(address) {
+        if let Some(mut peer_info) = self.connecting_peers.remove(&address) {
             // Update the peer info to disconnected.
             peer_info.set_disconnected()?;
 
             // Add the address into the disconnected peers.
-            self.disconnected_peers.insert(*address, peer_info);
+            self.disconnected_peers.insert(address, peer_info);
 
             return Ok(());
         }
 
         // Case 2 - The given address is a connected peer, attempt to disconnect.
-        if let Some(mut peer_info) = self.connected_peers.remove(address) {
+        if let Some(mut peer_info) = self.connected_peers.remove(&address) {
             // Update the peer info to disconnected.
             peer_info.set_disconnected()?;
 
             // Add the address into the disconnected peers.
-            let success = self.disconnected_peers.insert(*address, peer_info).is_none();
+            let success = self.disconnected_peers.insert(address, peer_info).is_none();
             // On success, decrement the connected peer count.
             connected_peers_dec!(success);
 
@@ -241,10 +241,10 @@ impl PeerBook {
         // Check if the peer is a known disconnected peer, and attempt to
         // add them to the disconnected peers if they are undiscovered.
         // Check if the peer is a known disconnected peer.
-        if !self.disconnected_peers.contains_key(address) {
+        if !self.disconnected_peers.contains_key(&address) {
             // If not, add the address into the disconnected peers.
-            warn!("Adding an undiscovered peer to the peer book - {}", address);
-            self.add_peer(address)?;
+            trace!("Adding an undiscovered peer to the peer book - {}", address);
+            self.add_peer(address);
         }
 
         Ok(())
@@ -253,40 +253,17 @@ impl PeerBook {
     ///
     /// Adds the given address to the disconnected peers in this `PeerBook`.
     ///
-    /// If the given address is a connecting, connected, or disconnected peer,
-    /// updates the last seen timestamp and returns a `NetworkError`.
-    ///
-    pub fn add_peer(&mut self, address: &SocketAddr) -> Result<(), NetworkError> {
-        // Check if the peer is a connecting peer.
-        if self.is_connecting(address) {
-            warn!("{} already exists in the peer book", address);
-            return Err(NetworkError::PeerAlreadyExists);
-        }
-
-        // Check if the peer is a connected peer.
-        if self.is_connected(address) {
-            warn!("{} already exists in the peer book", address);
-            return Err(NetworkError::PeerAlreadyExists);
-        }
-
-        // Check if the peer is a known disconnected peer.
-        if self.is_disconnected(address) {
-            warn!("{} already exists in the peer book", address);
-            return Err(NetworkError::PeerAlreadyExists);
+    pub fn add_peer(&mut self, address: SocketAddr) {
+        if self.is_connected(address) || self.is_disconnected(address) || self.is_connecting(address) {
+            return;
         }
 
         // Add the given address to the map of disconnected peers.
-        if self
-            .disconnected_peers
-            .insert(*address, PeerInfo::new(*address))
-            .is_some()
-        {
-            error!("{} already exists in the peer book", address);
-            return Err(NetworkError::PeerAlreadyExists);
-        }
+        self.disconnected_peers
+            .entry(address)
+            .or_insert_with(|| PeerInfo::new(address));
 
-        trace!("Added {} to the peer book", address);
-        Ok(())
+        debug!("Added {} to the peer book", address);
     }
 
     ///

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -142,7 +142,7 @@ impl PeerBook {
                 .ok_or(NetworkError::PeerBookMissingPeer)?
                 .nonce()
             {
-                Some(nonce) => Ok(*nonce),
+                Some(nonce) => Ok(nonce),
                 None => Err(NetworkError::PeerIsDisconnected),
             };
         }
@@ -156,7 +156,7 @@ impl PeerBook {
                 .ok_or(NetworkError::PeerBookMissingPeer)?
                 .nonce()
             {
-                Some(nonce) => Ok(*nonce),
+                Some(nonce) => Ok(nonce),
                 None => Err(NetworkError::PeerIsDisconnected),
             };
         }
@@ -322,19 +322,6 @@ impl PeerBook {
 
         error!("Missing {} in the peer book", address);
         Err(NetworkError::PeerBookMissingPeer)
-    }
-
-    ///
-    /// Updates the last seen timestamp of this peer to the current time.
-    ///
-    // TODO(ljedrz): use on Version reads
-    #[inline]
-    pub fn update_last_seen(&mut self, address: SocketAddr) {
-        if let Some(ref mut peer) = self.connected_peers.get_mut(&address) {
-            peer.last_seen = chrono::Utc::now();
-        } else {
-            warn!("Attempted to update state of a peer that's not connected: {}", address);
-        }
     }
 
     ///

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -64,7 +64,7 @@ pub struct PeerInfo {
     /// The timestamp of the first seen instance of this peer.
     first_seen: DateTime<Utc>,
     /// The timestamp of the last seen instance of this peer.
-    last_seen: DateTime<Utc>,
+    pub(crate) last_seen: DateTime<Utc>,
     /// The timestamp of the last connection to this peer.
     last_connected: DateTime<Utc>,
     /// The timestamp of the last disconnect from this peer.
@@ -172,26 +172,6 @@ impl PeerInfo {
     }
 
     ///
-    /// Updates the last seen timestamp of this peer to the current time.
-    ///
-    #[inline]
-    pub(crate) fn set_last_seen(&mut self) -> Result<(), NetworkError> {
-        // Fetch the current connection status with this peer.
-        match self.status() {
-            // Case 1 - The node server is connected to this peer, updates the last seen timestamp.
-            PeerStatus::Connected | PeerStatus::Connecting => {
-                self.last_seen = Utc::now();
-                Ok(())
-            }
-            // Case 2 - The node server is not connected to this peer, returns a `NetworkError`.
-            PeerStatus::Disconnected | PeerStatus::NeverConnected => {
-                error!("Attempting to update state of a disconnected peer - {}", self.address);
-                Err(NetworkError::PeerIsDisconnected)
-            }
-        }
-    }
-
-    ///
     /// Updates the peer to connecting and sets the handshake to the given nonce.
     ///
     /// If the peer is not transitioning from `PeerStatus::Disconnected` or `PeerStatus::NeverConnected`,
@@ -225,8 +205,7 @@ impl PeerInfo {
                 // Add the given nonce to the set of all handshake nonces.
                 self.handshakes.insert(nonce);
 
-                // Set the last seen timestamp of this peer.
-                self.set_last_seen()
+                Ok(())
             }
             PeerStatus::Connecting | PeerStatus::Connected => {
                 error!(

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -489,11 +489,11 @@ impl Peers {
         Ok(())
     }
 
-    pub(crate) fn send_get_peers(&self, remote_address: SocketAddr) {
+    pub(crate) fn send_peers(&self, remote_address: SocketAddr) {
         // TODO (howardwu): Simplify this and parallelize this with Rayon.
         // Broadcast the sanitized list of connected peers back to requesting peer.
         let mut peers = Vec::new();
-        for (peer_address, peer_info) in self.connected_peers() {
+        for peer_address in self.connected_peers().keys().copied() {
             // Skip the iteration if the requesting peer that we're sending the response to
             // appears in the list of peers.
             if peer_address == remote_address {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -328,7 +328,7 @@ impl Peers {
         // Iterate through each connected peer and attempts a connection request.
         for (remote_address, _) in self.disconnected_peers() {
             if let Err(e) = self.initiate_connection(remote_address).await {
-                warn!("Couldn't connect to the disconnected peer {}: {}", remote_address, e);
+                trace!("Couldn't connect to the disconnected peer {}: {}", remote_address, e);
             }
         }
     }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -279,7 +279,11 @@ impl Peers {
                 // save the outbound channel
                 self.outbound.channels.write().insert(remote_address, writer);
 
-                self.connected_to_peer(remote_address, version.nonce)
+                self.connected_to_peer(remote_address, version.nonce)?;
+
+                debug!("Successfully handshaken with {}", remote_address);
+
+                Ok(())
             } else {
                 Err(NetworkError::InvalidHandshake)
             }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -487,7 +487,7 @@ impl Peers {
             if peer_address == remote_address {
                 continue;
             }
-            peers.push((peer_address, *peer_info.last_seen()));
+            peers.push(peer_address);
         }
         self.outbound
             .send_request(Message::new(Direction::Outbound(remote_address), Payload::Peers(peers)));
@@ -496,7 +496,7 @@ impl Peers {
     /// A miner has sent their list of peer addresses.
     /// Add all new/updated addresses to our disconnected.
     /// The connection handler will be responsible for sending out handshake requests to them.
-    pub(crate) fn process_inbound_peers(&self, peers: Vec<Peer>) -> Result<(), NetworkError> {
+    pub(crate) fn process_inbound_peers(&self, peers: Vec<SocketAddr>) -> Result<(), NetworkError> {
         // TODO (howardwu): Simplify this and parallelize this with Rayon.
         // Process all of the peers sent in the message,
         // by informing the peer book of that we found peers.
@@ -511,7 +511,6 @@ impl Peers {
         for peer_address in peers
             .iter()
             .take(number_to_connect as usize)
-            .map(|(addr, _)| addr)
             .filter(|&peer_addr| *peer_addr != local_address)
         {
             // Inform the peer book that we found a peer.

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -24,7 +24,6 @@ use snarkvm_objects::block_header_hash::BlockHeaderHash;
 
 use std::time::Duration;
 
-use chrono::Utc;
 use tokio::{
     io::AsyncReadExt,
     net::{TcpListener, TcpStream},
@@ -53,7 +52,7 @@ async fn handshake_responder_side() {
 
     // at this point the node should have marked the peer as ' connecting'
     sleep(Duration::from_millis(200)).await;
-    assert!(node.peers.is_connecting(&peer_address));
+    assert!(node.peers.is_connecting(peer_address));
 
     // the buffer for peer's reads
     let mut peer_buf = [0u8; 64];
@@ -78,7 +77,7 @@ async fn handshake_responder_side() {
 
     // the node should now have register the peer as 'connected'
     sleep(Duration::from_millis(200)).await;
-    assert!(node.peers.is_connected(&peer_address));
+    assert!(node.peers.is_connected(peer_address));
     assert_eq!(node.peers.number_of_connected_peers(), 1);
 }
 
@@ -114,7 +113,7 @@ async fn handshake_initiator_side() {
     };
 
     // at this point the node should have marked the peer as 'connecting'
-    assert!(node.peers.is_connecting(&peer_address));
+    assert!(node.peers.is_connecting(peer_address));
 
     // the peer responds with a Verack acknowledging the Version message
     let verack = Payload::Verack(version.nonce);
@@ -126,7 +125,7 @@ async fn handshake_initiator_side() {
 
     // the node should now have registered the peer as 'connected'
     sleep(Duration::from_millis(200)).await;
-    assert!(node.peers.is_connected(&peer_address));
+    assert!(node.peers.is_connected(peer_address));
     assert_eq!(node.peers.number_of_connected_peers(), 1);
 }
 
@@ -143,7 +142,7 @@ async fn assert_node_rejected_message(node: &Server, peer_stream: &mut TcpStream
     assert!(buffer.is_empty());
 
     // check the node's state hasn't been altered by the message
-    assert!(!node.peers.is_connecting(&peer_stream.local_addr().unwrap()));
+    assert!(!node.peers.is_connecting(peer_stream.local_addr().unwrap()));
     assert_eq!(node.peers.number_of_connected_peers(), 0);
 }
 
@@ -186,7 +185,7 @@ async fn reject_non_version_messages_before_handshake() {
 
     // Peers
     let mut peer_stream = TcpStream::connect(node.local_address().unwrap()).await.unwrap();
-    let peers = vec![("127.0.0.1:0".parse().unwrap(), Utc::now())];
+    let peers = vec!["127.0.0.1:0".parse().unwrap()];
     write_message_to_stream(Payload::Peers(peers), &mut peer_stream).await;
     assert_node_rejected_message(&node, &mut peer_stream).await;
 

--- a/storage/src/objects/block.rs
+++ b/storage/src/objects/block.rs
@@ -20,6 +20,8 @@ use snarkvm_models::{algorithms::LoadableMerkleParameters, objects::Transaction}
 use snarkvm_objects::{Block, BlockHeaderHash, DPCTransactions};
 use snarkvm_utilities::{to_bytes, FromBytes, ToBytes};
 
+use std::sync::atomic::Ordering;
+
 impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
     /// Get the latest block in the chain.
     pub fn get_latest_block(&self) -> Result<Block<T>, StorageError> {
@@ -227,8 +229,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> Ledger<T, P> {
 
         self.storage.write(database_transaction)?;
 
-        let mut current_block_height = self.current_block_height.write();
-        *current_block_height -= 1;
+        self.current_block_height.fetch_sub(1, Ordering::SeqCst);
 
         self.update_merkle_tree()?;
 

--- a/storage/src/objects/ledger_scheme.rs
+++ b/storage/src/objects/ledger_scheme.rs
@@ -54,7 +54,7 @@ impl<T: Transaction, P: LoadableMerkleParameters> LedgerScheme for Ledger<T, P> 
         let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), &leaves)?;
 
         let ledger_storage = Self {
-            current_block_height: RwLock::new(0),
+            current_block_height: Default::default(),
             storage: Arc::new(storage),
             cm_merkle_tree: RwLock::new(empty_cm_merkle_tree),
             ledger_parameters: parameters,


### PR DESCRIPTION
Individual commits describe the specific changes; the notable ones are:
- introduce `Ping` and `Pong` messages and calculate RTT for peers; the `Ping` contains the `BlockHeight`, replacing the `Version` message in this functionality
- remove the timestamp from `Version` (unused)
- use an `AtomicU32` to store `BlockHeight`, add a related type alias
- introduce a `PeerQuality` member of `PeerInfo`: it contains objects related to RTT calculation and the number of peer-related failures
- remove the timestamps from `Peers` messages (unused and susceptible to manipulation)
- limit the number of disconnected peers being connected to at once to avoid breaching the peer limit