### PR TITLE
Remove the RwLock over storage (MerkleTreeLedger)

### DIFF
--- a/benchmarks/syncing/syncing.rs
+++ b/benchmarks/syncing/syncing.rs
@@ -36,7 +36,7 @@ fn providing_sync_blocks(c: &mut Criterion) {
             .consensus_parameters()
             .receive_block(
                 provider.consensus().dpc_parameters(),
-                &provider.consensus().storage().read(),
+                &provider.consensus().storage(),
                 &mut provider.consensus().memory_pool().lock(),
                 &block,
             )

--- a/consensus/src/miner.rs
+++ b/consensus/src/miner.rs
@@ -27,7 +27,7 @@ use snarkvm_objects::{dpc::DPCTransactions, AccountAddress, Block, BlockHeader};
 use snarkvm_utilities::{bytes::ToBytes, to_bytes};
 
 use chrono::Utc;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use rand::{thread_rng, Rng};
 use std::sync::Arc;
 
@@ -56,12 +56,12 @@ impl Miner {
 
     /// Fetches new transactions from the memory pool.
     pub async fn fetch_memory_pool_transactions<T: Transaction, P: LoadableMerkleParameters>(
-        storage: &RwLock<Ledger<T, P>>,
+        storage: &Ledger<T, P>,
         memory_pool: &Mutex<MemoryPool<T>>,
         max_size: usize,
     ) -> Result<DPCTransactions<T>, ConsensusError> {
         let memory_pool = memory_pool.lock();
-        Ok(memory_pool.get_candidates(&storage.read(), max_size)?)
+        Ok(memory_pool.get_candidates(&storage, max_size)?)
     }
 
     /// Add a coinbase transaction to a list of candidate block transactions
@@ -166,20 +166,17 @@ impl Miner {
     pub async fn mine_block(
         &self,
         parameters: &PublicParameters<Components>,
-        storage: &Arc<RwLock<MerkleTreeLedger>>,
+        storage: &Arc<MerkleTreeLedger>,
         memory_pool: &Arc<Mutex<MemoryPool<Tx>>>,
     ) -> Result<(Block<Tx>, Vec<DPCRecord<Components>>), ConsensusError> {
-        let candidate_transactions = Self::fetch_memory_pool_transactions(
-            &storage.clone(),
-            memory_pool,
-            self.consensus_parameters.max_block_size,
-        )
-        .await?;
+        let candidate_transactions =
+            Self::fetch_memory_pool_transactions(&storage, memory_pool, self.consensus_parameters.max_block_size)
+                .await?;
 
         debug!("The miner is creating a block");
 
         let (previous_block_header, transactions, coinbase_records) =
-            self.establish_block(parameters, &storage.read(), &candidate_transactions)?;
+            self.establish_block(parameters, storage, &candidate_transactions)?;
 
         debug!("The miner generated a coinbase transaction");
 
@@ -195,7 +192,7 @@ impl Miner {
         let block = Block { header, transactions };
 
         self.consensus_parameters
-            .receive_block(parameters, &storage.read(), &mut memory_pool.lock(), &block)?;
+            .receive_block(parameters, storage, &mut memory_pool.lock(), &block)?;
 
         // Store the non-dummy coinbase records.
         let mut records_to_store = vec![];
@@ -204,7 +201,7 @@ impl Miner {
                 records_to_store.push(record.clone());
             }
         }
-        storage.read().store_records(&records_to_store)?;
+        storage.store_records(&records_to_store)?;
 
         Ok((block, coinbase_records))
     }

--- a/network/src/consensus/consensus.rs
+++ b/network/src/consensus/consensus.rs
@@ -35,7 +35,7 @@ pub struct Consensus {
     /// The node this consensus is bound to.
     node: Node,
     /// The storage system of this node.
-    storage: Arc<RwLock<MerkleTreeLedger>>,
+    storage: Arc<MerkleTreeLedger>,
     /// The memory pool of this node.
     memory_pool: Arc<Mutex<MemoryPool<Tx>>>,
     /// The consensus parameters for the associated network ID.
@@ -58,7 +58,7 @@ impl Consensus {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         node: Node,
-        storage: Arc<RwLock<MerkleTreeLedger>>,
+        storage: Arc<MerkleTreeLedger>,
         memory_pool: Arc<Mutex<MemoryPool<Tx>>>,
         consensus_parameters: Arc<ConsensusParameters>,
         dpc_parameters: Arc<PublicParameters<Components>>,
@@ -87,7 +87,7 @@ impl Consensus {
 
     /// Returns a reference to the storage system of this node.
     #[inline]
-    pub fn storage(&self) -> &Arc<RwLock<MerkleTreeLedger>> {
+    pub fn storage(&self) -> &Arc<MerkleTreeLedger> {
         &self.storage
     }
 
@@ -128,7 +128,7 @@ impl Consensus {
     /// Returns the current block height of the ledger from storage.
     #[inline]
     pub fn current_block_height(&self) -> u32 {
-        self.storage.read().get_current_block_height()
+        self.storage.get_current_block_height()
     }
 
     /// Checks whether enough time has elapsed for the node to attempt another block sync.

--- a/network/src/consensus/transactions.rs
+++ b/network/src/consensus/transactions.rs
@@ -75,11 +75,11 @@ impl Consensus {
     ) -> Result<(), NetworkError> {
         if let Ok(tx) = Tx::read(&*transaction) {
             let insertion = {
-                let parameters = &self.dpc_parameters();
-                let storage = self.storage().read();
-                let consensus = &self.consensus_parameters();
+                let parameters = self.dpc_parameters();
+                let storage = self.storage();
+                let consensus = self.consensus_parameters();
 
-                if !consensus.verify_transaction(&parameters, &tx, &storage)? {
+                if !consensus.verify_transaction(parameters, &tx, storage)? {
                     error!("Received a transaction that was invalid");
                     return Ok(());
                 }
@@ -94,7 +94,7 @@ impl Consensus {
                     transaction: tx,
                 };
 
-                self.memory_pool().lock().insert(&storage, entry)
+                self.memory_pool().lock().insert(storage, entry)
             };
 
             if let Ok(inserted) = insertion {
@@ -142,7 +142,7 @@ impl Consensus {
     /// A peer has sent us their memory pool transactions.
     pub(crate) fn received_memory_pool(&self, transactions: Vec<Vec<u8>>) -> Result<(), NetworkError> {
         let mut memory_pool = self.memory_pool().lock();
-        let storage = self.storage().read();
+        let storage = self.storage();
 
         for transaction_bytes in transactions {
             let transaction: Tx = Tx::read(&transaction_bytes[..])?;

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -267,7 +267,6 @@ impl Node {
         // Save the serialized peer book to storage.
         self.consensus()
             .storage()
-            .write()
             .save_peer_book_to_storage(serialized_peer_book)?;
 
         Ok(())

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -88,8 +88,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     let mut path = config.node.dir;
     path.push(&config.node.db);
-    let storage = MerkleTreeLedger::open_at_path(path.clone())?;
-    // let storage = Arc::new(MerkleTreeLedger::open_at_path(path.clone())?);
+    let storage = Arc::new(MerkleTreeLedger::open_at_path(path.clone())?);
 
     let memory_pool = Arc::new(Mutex::new(MemoryPool::from_storage(&storage)?));
 
@@ -135,7 +134,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // Construct the consensus instance and set it on the node instance.
     let consensus = Consensus::new(
         node.clone(),
-        Arc::new(RwLock::new(storage)),
+        storage,
         memory_pool.clone(),
         consensus_params.clone(),
         dpc_parameters.clone(),

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -36,7 +36,7 @@ use snarkos_network::{
     MAX_MESSAGE_SIZE,
 };
 
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
@@ -146,7 +146,7 @@ impl Default for TestSetup {
 pub fn test_consensus(setup: ConsensusSetup, node: Node) -> Consensus {
     Consensus::new(
         node,
-        Arc::new(RwLock::new(FIXTURE_VK.ledger())),
+        Arc::new(FIXTURE_VK.ledger()),
         Arc::new(Mutex::new(snarkos_consensus::MemoryPool::new())),
         Arc::new(TEST_CONSENSUS.clone()),
         Arc::new(FIXTURE.parameters.clone()),

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -87,20 +87,8 @@ async fn block_initiator_side() {
     peer.write_message(&block_2).await;
 
     // check the blocks have been added to the node's chain
-    wait_until!(
-        1,
-        node.consensus()
-            .storage()
-            .read()
-            .block_hash_exists(&block_1_header_hash)
-    );
-    wait_until!(
-        1,
-        node.consensus()
-            .storage()
-            .read()
-            .block_hash_exists(&block_2_header_hash)
-    );
+    wait_until!(1, node.consensus().storage().block_hash_exists(&block_1_header_hash));
+    wait_until!(1, node.consensus().storage().block_hash_exists(&block_2_header_hash));
 }
 
 #[tokio::test]
@@ -114,7 +102,7 @@ async fn block_responder_side() {
         .consensus_parameters()
         .receive_block(
             node.consensus().dpc_parameters(),
-            &node.consensus().storage().read(),
+            &node.consensus().storage(),
             &mut node.consensus().memory_pool().lock(),
             &block_struct_1,
         )
@@ -174,7 +162,7 @@ async fn block_two_node() {
             .consensus_parameters()
             .receive_block(
                 node_alice.consensus().dpc_parameters(),
-                &node_alice.consensus().storage().read(),
+                &node_alice.consensus().storage(),
                 &mut node_alice.consensus().memory_pool().lock(),
                 &block,
             )
@@ -239,7 +227,7 @@ async fn transaction_responder_side() {
 
     // insert transaction into node
     let mut memory_pool = node.consensus().memory_pool().lock();
-    let storage = node.consensus().storage().read();
+    let storage = node.consensus().storage();
 
     let entry_1 = Entry {
         size_in_bytes: TRANSACTION_1.len(),
@@ -286,7 +274,7 @@ async fn transaction_two_node() {
 
     // insert transaction into node_alice
     let mut memory_pool = node_alice.consensus().memory_pool().lock();
-    let storage = node_alice.consensus().storage().read();
+    let storage = node_alice.consensus().storage();
 
     let transaction = Tx::read(&TRANSACTION_1[..]).unwrap();
     let size = TRANSACTION_1.len();

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -244,7 +244,6 @@ async fn transaction_responder_side() {
 
     // drop the locks to avoid deadlocks
     drop(memory_pool);
-    drop(storage);
 
     // send a GetMemoryPool message
     let get_memory_pool = Payload::GetMemoryPool;
@@ -287,7 +286,6 @@ async fn transaction_two_node() {
 
     // drop the locks to avoid deadlocks
     drop(memory_pool);
-    drop(storage);
 
     let setup = TestSetup {
         consensus_setup: Some(ConsensusSetup {


### PR DESCRIPTION
[Noticed](https://github.com/AleoHQ/snarkOS/pull/617#discussion_r572118710) while going over https://github.com/AleoHQ/snarkOS/pull/617; we can actually remove the `RwLock` over `storage`, simplifying the associated APIs and improving performance.

This is a very simple removal, so it can be rebased after the aforementioned PR goes in.