### PR TITLE
Introduce miner testing setup and resource management testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.3",
  "rand_xorshift",
+ "snarkos",
  "snarkos-consensus",
  "snarkos-network",
  "snarkos-parameters",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peak_alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae5ca2a4f36e9bba393e6711350dde5d11f5aacca3660fcca7877fe6b6e9d98"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2729,7 @@ dependencies = [
  "hex",
  "log",
  "parking_lot",
+ "peak_alloc",
  "rand 0.8.3",
  "rustc_version 0.2.3",
  "serde",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -111,5 +111,8 @@ version = "0.2"
 [dev-dependencies.snarkos-testing]
 path = "../testing"
 
+[dev-dependencies.peak_alloc]
+version = "0.1.0"
+
 [build-dependencies]
 rustc_version = "0.2"

--- a/network/tests/cleanup.rs
+++ b/network/tests/cleanup.rs
@@ -42,11 +42,11 @@ async fn check_node_cleanup() {
     for i in 0u16..4096 {
         // Connect a peer.
         let peer = handshaken_peer(node.local_address().unwrap()).await;
-        wait_until!(5, node.peers.number_of_connected_peers() == 1);
+        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 1);
 
         // Drop the peer stream.
         drop(peer);
-        wait_until!(5, node.peers.number_of_connected_peers() == 0);
+        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 0);
 
         // Register heap bump after the connection was dropped.
         let curr_peak = PEAK_ALLOC.peak_usage();

--- a/network/tests/cleanup.rs
+++ b/network/tests/cleanup.rs
@@ -1,0 +1,79 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkos_testing::{
+    network::{handshaken_peer, test_node, TestSetup},
+    wait_until,
+};
+
+use peak_alloc::PeakAlloc;
+
+#[ignore]
+#[tokio::test]
+async fn check_node_cleanup() {
+    #[global_allocator]
+    static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+    // Start a node without consensus.
+    let setup = TestSetup {
+        consensus_setup: None,
+        ..Default::default()
+    };
+    let node = test_node(setup).await;
+
+    // Keep track of peak heap throughout the iterations.
+    let mut peak_heap = PEAK_ALLOC.peak_usage();
+    let mut peak_heap_post_1st_conn = 0;
+
+    // Note: `ulimit` will be a limiting factor in how many peer connections can be opened.
+    for i in 0u16..4096 {
+        // Connect a peer.
+        let peer = handshaken_peer(node.local_address().unwrap()).await;
+        wait_until!(5, node.peers.number_of_connected_peers() == 1);
+
+        // Drop the peer stream.
+        drop(peer);
+        wait_until!(5, node.peers.number_of_connected_peers() == 0);
+
+        // Register heap bump after the connection was dropped.
+        let curr_peak = PEAK_ALLOC.peak_usage();
+
+        // println!(
+        //     "heap bump: {}B at i={} (+{}%)",
+        //     curr_peak,
+        //     i,
+        //     (curr_peak as f64 / peak_heap as f64 - 1.0) * 100.0
+        // );
+
+        if curr_peak > peak_heap {
+            peak_heap = curr_peak;
+        }
+
+        // Register first peak heap for growth evaluation.
+        if i == 0 {
+            peak_heap_post_1st_conn = curr_peak;
+        }
+    }
+
+    // Register peak heap use.
+    let max_heap_use = PEAK_ALLOC.peak_usage();
+    println!("peak heap use: {:.2}KiB", max_heap_use as f64 / 1024.0);
+
+    // Allocation growth should be under 5%.
+    let alloc_growth = max_heap_use as f64 / peak_heap_post_1st_conn as f64;
+    println!("alloc growth: {}", alloc_growth);
+    assert!(alloc_growth < 1.05);
+}

--- a/network/tests/cleanup.rs
+++ b/network/tests/cleanup.rs
@@ -21,8 +21,8 @@ use snarkos_testing::{
 
 use peak_alloc::PeakAlloc;
 
-#[ignore]
 #[tokio::test]
+#[ignore]
 async fn check_node_cleanup() {
     #[global_allocator]
     static PEAK_ALLOC: PeakAlloc = PeakAlloc;

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -44,6 +44,10 @@ version = "0.0.5"
 [dependencies.snarkvm-utilities]
 version = "0.0.5"
 
+[dependencies.snarkos]
+path = "../" 
+version = "1.2.0"
+
 [dependencies.snarkos-consensus]
 path = "../consensus"
 version = "1.2.0"

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -26,6 +26,7 @@ pub mod sync;
 use crate::consensus::{FIXTURE, FIXTURE_VK, TEST_CONSENSUS};
 
 use snarkos_network::{connection_reader::ConnReader, connection_writer::ConnWriter, errors::*, *};
+use snarkos::miner::MinerInstance;
 
 use parking_lot::Mutex;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
@@ -175,7 +176,8 @@ pub async fn test_node(setup: TestSetup) -> Node {
     node.start().await.unwrap();
 
     if is_miner {
-        // TODO(ljedrz/nkls): spawn a miner
+        let miner_address = FIXTURE.test_accounts[0].address.clone();
+        MinerInstance::new(miner_address, node.environment.clone(), node.clone()).spawn();
     }
 
     node

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -351,7 +351,7 @@ pub async fn handshaken_peer(node_listener: SocketAddr) -> FakeNode {
     FakeNode::new(peer_stream, peer_addr, noise)
 }
 
-pub async fn handshaken_node_and_peer(node_setup: TestSetup) -> (Server, FakeNode) {
+pub async fn handshaken_node_and_peer(node_setup: TestSetup) -> (Node, FakeNode) {
     // start a test node and listen for incoming connections
     let node = test_node(node_setup).await;
     let node_listener = node.local_address().unwrap();

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -25,8 +25,8 @@ pub mod sync;
 
 use crate::consensus::{FIXTURE, FIXTURE_VK, TEST_CONSENSUS};
 
-use snarkos_network::{connection_reader::ConnReader, connection_writer::ConnWriter, errors::*, *};
 use snarkos::miner::MinerInstance;
+use snarkos_network::{connection_reader::ConnReader, connection_writer::ConnWriter, errors::*, *};
 
 use parking_lot::Mutex;
 use std::{net::SocketAddr, sync::Arc, time::Duration};

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -309,11 +309,7 @@ pub async fn spawn_2_fake_nodes() -> (FakeNode, FakeNode) {
     (node0, node1)
 }
 
-pub async fn handshaken_node_and_peer(node_setup: TestSetup) -> (Node, FakeNode) {
-    // start a test node and listen for incoming connections
-    let node = test_node(node_setup).await;
-    let node_listener = node.local_address().unwrap();
-
+pub async fn handshaken_peer(node_listener: SocketAddr) -> FakeNode {
     // set up a fake node (peer), which is basically just a socket
     let mut peer_stream = TcpStream::connect(&node_listener).await.unwrap();
 
@@ -352,7 +348,14 @@ pub async fn handshaken_node_and_peer(node_setup: TestSetup) -> (Node, FakeNode)
 
     let noise = noise.into_transport_mode().unwrap();
 
-    let fake_node = FakeNode::new(peer_stream, peer_addr, noise);
+    FakeNode::new(peer_stream, peer_addr, noise)
+}
+
+pub async fn handshaken_node_and_peer(node_setup: TestSetup) -> (Server, FakeNode) {
+    // start a test node and listen for incoming connections
+    let node = test_node(node_setup).await;
+    let node_listener = node.local_address().unwrap();
+    let fake_node = handshaken_peer(node_listener).await;
 
     (node, fake_node)
 }

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -141,6 +141,26 @@ async fn block_responder_side() {
     assert_eq!(block, block_struct_1);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn block_propagation() {
+    let setup = TestSetup {
+        consensus_setup: Some(ConsensusSetup {
+            is_miner: true,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let (_node, mut peer) = handshaken_node_and_peer(setup).await;
+
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Block(..)));
+
+    // TODO: shutdown the miner task, currently there is no good way to do this. This test will
+    // currently hang after the assertion.
+}
+
 #[tokio::test]
 #[ignore]
 async fn block_two_node() {


### PR DESCRIPTION
This PR introduces miner setup and spawning for network tests and resource management testing. This will pave the way for network testing backed by a miner and implementing graceful shutdown. 

~~Note: this branch is based on #617, hence the large number of commits. The last 7 commits are part of this PR.~~ 

~~This builds on #635, last 7 commits are new.~~ (rebased)

new tests: 
- simple block propagation, ignored as a block needs to be mined
- memory leak testing, ignored as it is long running
