### PR TITLE
Specialized bootstrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,18 +173,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
@@ -199,15 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
  "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -577,7 +556,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
  "subtle 1.0.0",
 ]
 
@@ -684,7 +663,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 dependencies = [
- "generic-array 0.9.0",
+ "generic-array 0.9.1",
 ]
 
 [[package]]
@@ -693,7 +672,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -768,12 +747,6 @@ dependencies = [
  "fsio",
  "indexmap",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "flate2"
@@ -933,7 +906,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -951,18 +924,18 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+checksum = "6d00328cedcac5e81c683e5620ca6a30756fc23027ebf9bff405c0e8da1fbb7e"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
@@ -1051,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1066,7 +1039,6 @@ dependencies = [
  "tokio 1.2.0",
  "tokio-util 0.6.3",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1083,9 +1055,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "headers"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62689dc57c7456e69712607ffcbd0aa1dfcccf9af73727e9b25bc1825375cac3"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64",
  "bitflags",
@@ -1093,7 +1065,7 @@ dependencies = [
  "headers-core",
  "http",
  "mime",
- "sha-1 0.8.2",
+ "sha-1",
  "time",
 ]
 
@@ -1117,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1207,7 +1179,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.0",
+ "h2 0.3.1",
  "http",
  "http-body 0.4.0",
  "httparse",
@@ -1490,9 +1462,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "libloading"
@@ -1775,9 +1747,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "oorandom"
@@ -1910,15 +1882,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "0cf491442e4b033ed1c722cb9f0df5fcfcf4de682466c46469c36bc47dc5548a"
 
 [[package]]
 name = "pin-utils"
@@ -2290,7 +2262,7 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2512,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2557,23 +2529,11 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha-1"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpuid-bool 0.1.2",
  "digest 0.9.0",
@@ -2586,7 +2546,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpuid-bool 0.1.2",
  "digest 0.9.0",
@@ -3299,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
@@ -3336,7 +3296,7 @@ dependencies = [
  "memchr",
  "mio 0.6.23",
  "num_cpus",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "slab",
 ]
 
@@ -3353,7 +3313,7 @@ dependencies = [
  "mio 0.7.9",
  "num_cpus",
  "parking_lot",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "tokio-macros",
 ]
 
@@ -3385,7 +3345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "tokio 1.2.0",
 ]
 
@@ -3412,7 +3372,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "tokio 0.2.25",
 ]
 
@@ -3426,7 +3386,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "tokio 1.2.0",
 ]
 
@@ -3453,7 +3413,7 @@ checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.5",
  "tracing-core",
 ]
 
@@ -3539,7 +3499,7 @@ dependencies = [
  "input_buffer",
  "log",
  "rand 0.8.3",
- "sha-1 0.9.4",
+ "sha-1",
  "url 2.2.1",
  "utf-8",
 ]
@@ -3931,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8977234acab718eb2820494b2f96cbb16004c19dddf88b7445b27381450997"
+checksum = "8264fcea9b7a036a4a5103d7153e988dbc2ebbafb34f68a3c2d404b6b82d74b6"
 dependencies = [
  "byteorder",
  "bzip2",

--- a/benchmarks/syncing/syncing.rs
+++ b/benchmarks/syncing/syncing.rs
@@ -32,17 +32,17 @@ fn providing_sync_blocks(c: &mut Criterion) {
     let blocks = TestBlocks::load(NUM_BLOCKS);
     for block in &blocks.0 {
         provider
-            .consensus()
+            .expect_consensus()
             .consensus_parameters()
             .receive_block(
-                provider.consensus().dpc_parameters(),
-                &provider.consensus().storage(),
-                &mut provider.consensus().memory_pool().lock(),
+                provider.expect_consensus().dpc_parameters(),
+                &provider.expect_consensus().storage(),
+                &mut provider.expect_consensus().memory_pool().lock(),
                 &block,
             )
             .unwrap();
     }
-    assert_eq!(provider.consensus().current_block_height() as usize, NUM_BLOCKS);
+    assert_eq!(provider.expect_consensus().current_block_height() as usize, NUM_BLOCKS);
 
     c.bench_function("providing_sync_blocks", move |b| {
         b.to_async(&rt).iter(|| async {

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -36,7 +36,7 @@ pub type Channels = HashMap<SocketAddr, Arc<ConnWriter>>;
 #[derive(Debug, Clone)]
 pub struct Inbound {
     /// The producer for sending inbound messages to the server.
-    sender: Sender,
+    pub(crate) sender: Sender,
     /// The consumer for receiving inbound messages to the server.
     receiver: Arc<Mutex<Option<Receiver>>>,
     /// The map of remote addresses to their active read channels.

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -118,7 +118,7 @@ impl Node {
     }
 
     #[inline]
-    #[doc(hide)]
+    #[doc(hidden)]
     pub fn has_consensus(&self) -> bool {
         self.consensus.is_some()
     }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -250,7 +250,7 @@ impl Node {
                 }
             }
             Payload::GetPeers => {
-                self.send_get_peers(source.unwrap()).await;
+                self.send_peers(source.unwrap()).await;
             }
             Payload::Peers(peers) => {
                 self.process_inbound_peers(peers);

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -61,6 +61,8 @@ pub const NOISE_BUF_LEN: usize = 65535;
 pub const NOISE_TAG_LEN: usize = 16;
 /// The maximum number of block hashes that can be requested or provided in a single batch.
 pub const MAX_BLOCK_SYNC_COUNT: u32 = 250;
+/// The maximum number of peers shared at once in response to a `GetPeers` message.
+pub const SHARED_PEER_COUNT: usize = 25;
 
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 

--- a/network/src/message/message.rs
+++ b/network/src/message/message.rs
@@ -90,17 +90,17 @@ pub enum Payload {
     Transaction(Vec<u8>),
 
     // a placeholder indicating the introduction of a new payload type; used for forward compatibility
-    #[doc(hide)]
+    #[doc(hidden)]
     Unknown,
 
     /* internal messages */
-    #[doc(hide)]
+    #[doc(hidden)]
     ConnectedTo(SocketAddr, Option<SocketAddr>),
-    #[doc(hide)]
+    #[doc(hidden)]
     ConnectingTo(SocketAddr),
     // TODO: used internally, but can also be used to allow a clean disconnect for connected peers on shutdown
     // add a doc if this is introduced
-    #[doc(hide)]
+    #[doc(hidden)]
     Disconnect(SocketAddr),
 }
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -81,6 +81,16 @@ impl Node {
             }
         }
 
+        // disconnect from peers after a while, even if they haven't sent a GetPeers
+        let now = chrono::Utc::now();
+        if self.environment.is_bootnode() {
+            for (peer_addr, peer_info) in self.connected_peers() {
+                if (now - peer_info.last_connected().unwrap()).num_seconds() > 10 {
+                    let _ = self.disconnect_from_peer(peer_addr);
+                }
+            }
+        }
+
         if number_of_connected_peers != 0 {
             if !self.environment.is_bootnode() {
                 // Send a `Ping` to every connected peer.

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -315,6 +315,15 @@ impl Node {
         self.outbound
             .send_request(Message::new(Direction::Outbound(remote_address), Payload::Peers(peers)))
             .await;
+
+        // the bootstrapper's job is finished once it's sent its peer a list of peers
+        if self.environment.is_bootnode() {
+            let _ = self
+                .inbound
+                .sender
+                .send(Message::new(Direction::Internal, Payload::Disconnect(remote_address)))
+                .await;
+        }
     }
 
     /// A miner has sent their list of peer addresses.

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -300,7 +300,7 @@ impl Node {
         // TODO (howardwu): Attempt to blindly send disconnect message to peer.
     }
 
-    pub(crate) async fn send_get_peers(&self, remote_address: SocketAddr) {
+    pub(crate) async fn send_peers(&self, remote_address: SocketAddr) {
         // TODO (howardwu): Simplify this and parallelize this with Rayon.
         // Broadcast the sanitized list of connected peers back to requesting peer.
         let mut peers = Vec::new();

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -211,9 +211,14 @@ impl Node {
     async fn connect_to_disconnected_peers(&self, count: usize) {
         trace!("Connecting to disconnected peers");
 
-        // Iterate through each connected peer and attempts a connection request.
-        let disconnected_peers = self.peer_book.read().disconnected_peers().clone();
-        for remote_address in disconnected_peers.keys().take(count).copied() {
+        // Iterate through a selection of random peers and attempt to connect.
+        let random_peers = self
+            .disconnected_peers()
+            .into_iter()
+            .map(|(k, _)| k)
+            .choose_multiple(&mut rand::thread_rng(), count);
+
+        for remote_address in random_peers {
             if let Err(e) = self.initiate_connection(remote_address).await {
                 trace!("Couldn't connect to the disconnected peer {}: {}", remote_address, e);
                 let _ = self.disconnect_from_peer(remote_address);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -82,8 +82,10 @@ impl Node {
         }
 
         if number_of_connected_peers != 0 {
-            // Send a `Ping` to every connected peer.
-            self.broadcast_pings().await;
+            if !self.environment.is_bootnode() {
+                // Send a `Ping` to every connected peer.
+                self.broadcast_pings().await;
+            }
 
             // Store the peer book to storage.
             self.save_peer_book_to_storage()?;

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -303,8 +303,13 @@ impl Node {
     pub(crate) async fn send_peers(&self, remote_address: SocketAddr) {
         // TODO (howardwu): Simplify this and parallelize this with Rayon.
         // Broadcast the sanitized list of connected peers back to requesting peer.
-        let mut peers = Vec::new();
-        for peer_address in self.peer_book.read().connected_peers().keys().copied() {
+        let own_peers = if !self.environment.is_bootnode() {
+            self.connected_peers()
+        } else {
+            self.disconnected_peers()
+        };
+
+        for peer_address in own_peers.keys().copied() {
             // Skip the iteration if the requesting peer that we're sending the response to
             // appears in the list of peers.
             if peer_address == remote_address {

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -53,6 +53,9 @@ pub enum RpcError {
     #[error("{}", _0)]
     Message(String),
 
+    #[error("The node doesn't have the consensus layer running")]
+    NoConsensus,
+
     #[error("{}", _0)]
     StorageError(StorageError),
 

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -21,8 +21,6 @@ use crate::{
     update::UpdateCLI,
 };
 
-use snarkos_network::errors::NetworkError;
-
 use clap::ArgMatches;
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
@@ -323,15 +321,19 @@ impl Config {
         }
     }
 
-    pub fn check(&self) -> Result<(), NetworkError> {
+    pub fn check(&self) -> Result<(), CliError> {
         // Check that the minimum and maximum number of peers is valid.
         if self.p2p.min_peers == 0 || self.p2p.max_peers == 0 {
-            return Err(NetworkError::PeerCountInvalid);
+            return Err(CliError::PeerCountInvalid);
         }
 
         // Check that the sync interval is a reasonable number of seconds.
         if !(2..=300).contains(&self.p2p.peer_sync_interval) || !(2..=300).contains(&self.p2p.block_sync_interval) {
-            return Err(NetworkError::SyncIntervalInvalid);
+            return Err(CliError::SyncIntervalInvalid);
+        }
+
+        if self.node.is_bootnode && self.miner.is_miner {
+            return Err(CliError::MinerBootstrapper);
         }
 
         // TODO (howardwu): Check the memory pool interval.

--- a/snarkos/errors/cli.rs
+++ b/snarkos/errors/cli.rs
@@ -27,4 +27,13 @@ pub enum CliError {
 
     #[error("TomlDeError: {0}")]
     TomlDeError(#[from] toml::de::Error),
+
+    #[error("The node can't be a bootstrapper and a miner at the same time")]
+    MinerBootstrapper,
+
+    #[error("The minimum or maximum value for peer count is invalid")]
+    PeerCountInvalid,
+
+    #[error("One of the sync intervals is invalid")]
+    SyncIntervalInvalid,
 }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -89,47 +89,6 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let mut path = config.node.dir;
     path.push(&config.node.db);
 
-    let consensus = if !config.node.is_bootnode {
-        let storage = Arc::new(MerkleTreeLedger::open_at_path(path.clone())?);
-        let memory_pool = Arc::new(Mutex::new(MemoryPool::from_storage(&storage)?));
-
-    info!("Loading Aleo parameters...");
-    let dpc_parameters = Arc::new(PublicParameters::<Components>::load(!config.miner.is_miner)?);
-    info!("Loading complete.");
-
-    // Fetch the set of valid inner circuit IDs.
-    let inner_snark_vk: <<Components as BaseDPCComponents>::InnerSNARK as SNARK>::VerificationParameters =
-        dpc_parameters.inner_snark_parameters.1.clone().into();
-    let inner_snark_id = dpc_parameters
-        .system_parameters
-        .inner_snark_verification_key_crh
-        .hash(&to_bytes![inner_snark_vk]?)?;
-
-    let authorized_inner_snark_ids = vec![to_bytes![inner_snark_id]?];
-
-    // Set the initial consensus parameters.
-    let consensus_params = Arc::new(ConsensusParameters {
-        max_block_size: 1_000_000_000usize,
-        max_nonce: u32::max_value(),
-        target_block_time: 10i64,
-        network_id: Network::from_network_id(config.aleo.network_id),
-        verifier: PoswMarlin::verify_only().expect("could not instantiate PoSW verifier"),
-        authorized_inner_snark_ids,
-    });
-
-        Some(Consensus::new(
-            storage,
-            memory_pool,
-            consensus_params,
-            dpc_parameters,
-            config.miner.is_miner,
-            Duration::from_secs(config.p2p.block_sync_interval.into()),
-            Duration::from_secs(config.p2p.mempool_interval.into()),
-        ))
-    } else {
-        None
-    };
-
     let mut environment = Environment::new(
         Some(socket_address),
         config.p2p.min_peers,
@@ -145,8 +104,49 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // before any other object (miner, RPC) needs to use it.
     let mut node = Node::new(environment.clone()).await?;
 
-    // Set the consensus on the node.
-    node.set_consensus(consensus);
+    // Enable the consensus layer if the node is not a bootstrapper.
+    if !config.node.is_bootnode {
+        let storage = Arc::new(MerkleTreeLedger::open_at_path(path.clone())?);
+        let memory_pool = Arc::new(Mutex::new(MemoryPool::from_storage(&storage)?));
+
+        info!("Loading Aleo parameters...");
+        let dpc_parameters = Arc::new(PublicParameters::<Components>::load(!config.miner.is_miner)?);
+        info!("Loading complete.");
+
+        // Fetch the set of valid inner circuit IDs.
+        let inner_snark_vk: <<Components as BaseDPCComponents>::InnerSNARK as SNARK>::VerificationParameters =
+            dpc_parameters.inner_snark_parameters.1.clone().into();
+        let inner_snark_id = dpc_parameters
+            .system_parameters
+            .inner_snark_verification_key_crh
+            .hash(&to_bytes![inner_snark_vk]?)?;
+
+        let authorized_inner_snark_ids = vec![to_bytes![inner_snark_id]?];
+
+        // Set the initial consensus parameters.
+        let consensus_params = Arc::new(ConsensusParameters {
+            max_block_size: 1_000_000_000usize,
+            max_nonce: u32::max_value(),
+            target_block_time: 10i64,
+            network_id: Network::from_network_id(config.aleo.network_id),
+            verifier: PoswMarlin::verify_only().expect("could not instantiate PoSW verifier"),
+            authorized_inner_snark_ids,
+        });
+
+        let consensus = Consensus::new(
+            node.clone(),
+            storage,
+            memory_pool,
+            consensus_params,
+            dpc_parameters,
+            config.miner.is_miner,
+            Duration::from_secs(config.p2p.block_sync_interval.into()),
+            Duration::from_secs(config.p2p.mempool_interval.into()),
+        );
+
+        node.set_consensus(consensus);
+    };
+
     // Establish the address of the node.
     node.establish_address().await?;
     environment.set_local_address(node.local_address().unwrap());

--- a/snarkos/miner.rs
+++ b/snarkos/miner.rs
@@ -51,7 +51,7 @@ impl MinerInstance {
             info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
             let miner = Miner::new(
                 self.miner_address.clone(),
-                Arc::clone(self.node.consensus().consensus_parameters()),
+                Arc::clone(self.node.expect_consensus().consensus_parameters()),
             );
             info!("Miner instantiated; starting to mine blocks");
 
@@ -60,7 +60,7 @@ impl MinerInstance {
 
             loop {
                 info!("Starting to mine the next block");
-                let consensus = self.node.consensus();
+                let consensus = self.node.expect_consensus();
 
                 let (block, _coinbase_records) = match miner
                     .mine_block(consensus.dpc_parameters(), consensus.storage(), consensus.memory_pool())
@@ -96,7 +96,7 @@ impl MinerInstance {
                 };
 
                 self.node
-                    .consensus()
+                    .expect_consensus()
                     .propagate_block(serialized_block, local_address, &peers)
                     .await;
             }

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -87,8 +87,18 @@ async fn block_initiator_side() {
     peer.write_message(&block_2).await;
 
     // check the blocks have been added to the node's chain
-    wait_until!(1, node.consensus().storage().block_hash_exists(&block_1_header_hash));
-    wait_until!(1, node.consensus().storage().block_hash_exists(&block_2_header_hash));
+    wait_until!(
+        1,
+        node.expect_consensus()
+            .storage()
+            .block_hash_exists(&block_1_header_hash)
+    );
+    wait_until!(
+        1,
+        node.expect_consensus()
+            .storage()
+            .block_hash_exists(&block_2_header_hash)
+    );
 }
 
 #[tokio::test]
@@ -98,12 +108,12 @@ async fn block_responder_side() {
 
     // insert block into node
     let block_struct_1 = snarkvm_objects::Block::deserialize(&BLOCK_1).unwrap();
-    node.consensus()
+    node.expect_consensus()
         .consensus_parameters()
         .receive_block(
-            node.consensus().dpc_parameters(),
-            &node.consensus().storage(),
-            &mut node.consensus().memory_pool().lock(),
+            node.expect_consensus().dpc_parameters(),
+            &node.expect_consensus().storage(),
+            &mut node.expect_consensus().memory_pool().lock(),
             &block_struct_1,
         )
         .unwrap();
@@ -178,12 +188,12 @@ async fn block_two_node() {
 
     for block in blocks {
         node_alice
-            .consensus()
+            .expect_consensus()
             .consensus_parameters()
             .receive_block(
-                node_alice.consensus().dpc_parameters(),
-                &node_alice.consensus().storage(),
-                &mut node_alice.consensus().memory_pool().lock(),
+                node_alice.expect_consensus().dpc_parameters(),
+                &node_alice.expect_consensus().storage(),
+                &mut node_alice.expect_consensus().memory_pool().lock(),
                 &block,
             )
             .unwrap();
@@ -201,7 +211,10 @@ async fn block_two_node() {
     let node_bob = test_node(setup).await;
 
     // check blocks present in alice's chain were synced to bob's
-    wait_until!(30, node_bob.consensus().current_block_height() as usize == NUM_BLOCKS);
+    wait_until!(
+        30,
+        node_bob.expect_consensus().current_block_height() as usize == NUM_BLOCKS
+    );
 }
 
 #[tokio::test]
@@ -236,8 +249,8 @@ async fn transaction_initiator_side() {
     };
 
     // Verify the transactions have been stored in the node's memory pool
-    wait_until!(1, node.consensus().memory_pool().lock().contains(&entry_1));
-    wait_until!(1, node.consensus().memory_pool().lock().contains(&entry_2));
+    wait_until!(1, node.expect_consensus().memory_pool().lock().contains(&entry_1));
+    wait_until!(1, node.expect_consensus().memory_pool().lock().contains(&entry_2));
 }
 
 #[tokio::test]
@@ -246,8 +259,8 @@ async fn transaction_responder_side() {
     let (node, mut peer) = handshaken_node_and_peer(TestSetup::default()).await;
 
     // insert transaction into node
-    let mut memory_pool = node.consensus().memory_pool().lock();
-    let storage = node.consensus().storage();
+    let mut memory_pool = node.expect_consensus().memory_pool().lock();
+    let storage = node.expect_consensus().storage();
 
     let entry_1 = Entry {
         size_in_bytes: TRANSACTION_1.len(),
@@ -292,8 +305,8 @@ async fn transaction_two_node() {
     let alice_address = node_alice.local_address().unwrap();
 
     // insert transaction into node_alice
-    let mut memory_pool = node_alice.consensus().memory_pool().lock();
-    let storage = node_alice.consensus().storage();
+    let mut memory_pool = node_alice.expect_consensus().memory_pool().lock();
+    let storage = node_alice.expect_consensus().storage();
 
     let transaction = Tx::read(&TRANSACTION_1[..]).unwrap();
     let size = TRANSACTION_1.len();
@@ -319,5 +332,5 @@ async fn transaction_two_node() {
     let node_bob = test_node(setup).await;
 
     // check transaction is present in bob's memory pool
-    wait_until!(5, node_bob.consensus().memory_pool().lock().contains(&entry));
+    wait_until!(5, node_bob.expect_consensus().memory_pool().lock().contains(&entry));
 }


### PR DESCRIPTION
As it currently stands, bootstrapper nodes can participate in almost all the activities of regular nodes; this PR introduces changes that make them more specialized, so they can fulfill their primary purpose (peering) as well as possible:

- disregard all messages that aren't `GetPeers` or `Internal`
- don't broadcast anything
- don't start the consensus layer
- disconnect from peers as soon as they are provided with `Peers`
- disconnect from peers after 10s regardless of whether they had asked for peers or not
- obtain the list of peers to provide to nodes at random from the list of disconnected peers
- disallow mining in bootstrapper mode

Those changes make the bootstrappers much faster, more reliable, and easy/practical to run at many different locations due to their reduced resource use. In addition, since they now share all their known peers (as opposed to just the connected ones) at random, they reduce the probability of "islands" forming in the network and causing potential forking to occur.

This doesn't mean that any technical/"in-house" miner nodes can't be listed as bootstrappers for all the peers to try to connect to (which might be desirable in testnets) - they should just not be launched in bootstrapper node themselves, and there should be at least 1 node dedicated only to providing new peers with addresses of other peers (running in bootstrapper mode).

In addition, this PR makes the choice of peers to connect to from the list of disconnected peers (in case of an insufficient number of peers) random, in order to avoid trying to connect to unavailable peers.