### PR TITLE
Fix blockheight for consensus-less nodes 

### DIFF
--- a/network/src/environment.rs
+++ b/network/src/environment.rs
@@ -209,7 +209,10 @@ impl Environment {
     /// Returns the current block height of the ledger from storage.
     #[inline]
     pub fn current_block_height(&self) -> u32 {
-        self.consensus().storage.read().get_current_block_height()
+        match &self.consensus {
+            Some(consensus) => consensus.storage.read().get_current_block_height(),
+            None => 0,
+        }
     }
 
     /// Returns the interval between each peer sync.


### PR DESCRIPTION
Return a blockheight of `0` when the node doesn't have a consensus. This is useful for testing purposes and doesn't impact consensus-less bootnodes as they don't send `Ping` messages in the first place. 