### PR TITLE
Feature-gate capnpc use in build.rs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
             export PATH="$PATH:$CIRCLE_WORKING_DIRECTORY/.bin"
             export RUSTC_WRAPPER="sccache"
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
-            sudo apt-get update && sudo apt-get install -y clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev capnproto
+            sudo apt-get update && sudo apt-get install -y clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
       - restore_cache:
           keys:
             - << parameters.cache_key >>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,25 +53,11 @@ jobs:
           override: true
           components: clippy
 
-      - name: Check examples
+      - name: Run clippy accross the workspace against all targets
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --examples --all
-
-      - name: Check examples with all features on stable
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --examples --all-features --all
-        if: matrix.rust == 'stable'
-
-      - name: Check benchmarks on nightly
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --examples --all --benches
-        if: matrix.rust == 'nightly'
+          args: --workspace --all-targets
 
   test-wasm:
     name: WASM Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,6 @@ jobs:
           override: true
           components: clippy
 
-      - name: Install capnproto
-        run: sudo apt-get install capnproto
-
       - name: Check examples
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rusty-hook = { version = "0.11.2" }
 
 [build-dependencies]
 rustc_version = "0.2"
-capnpc = "0.14"
+capnpc = { version = "0.14", optional = true }
 
 [profile.release]
 opt-level = 3
@@ -91,3 +91,7 @@ lto = "thin"
 incremental = true
 debug-assertions = true
 debug = true
+
+[features]
+default = []
+compile_capnp_schema = ["capnpc"] # use when the Cap'n Proto schema is updated so that it's recompiled

--- a/build.rs
+++ b/build.rs
@@ -18,14 +18,17 @@
 use rustc_version::{version_meta, Channel};
 
 fn main() {
-    capnpc::CompilerCommand::new()
-        .file(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/network/src/message/payload.capnp"
-        ))
-        .output_path(".")
-        .run()
-        .expect("cap'n'proto network schema compilation failed");
+    #[cfg(feature = "compile_capnp_schema")]
+    {
+        capnpc::CompilerCommand::new()
+            .file(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/network/src/message/payload.capnp"
+            ))
+            .output_path(".")
+            .run()
+            .expect("cap'n'proto network schema compilation failed");
+    }
 
     // Set cfg flags depending on release channel
     match version_meta().unwrap().channel {


### PR DESCRIPTION
This PR takes advantage of the fact that the auto-generated file based on the Cap'n Proto schema (`snarkos_network/src/message/payload_capnp.rs`) is being committed, and puts the `capnpc` dependency and its use in `build.rs` behind a new `compile_capnp_schema` feature that's disabled by default.

This removes the need to download and use `capnproto` unless one wants to alter the schema (after which just the changes to the schema and the updated auto-generated file need to be committed).