### PR TITLE
Update the code and CI to Rust stable 1.50

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
 jobs:
   rust_stable:
     docker:
-      - image: cimg/rust:1.49.0
+      - image: cimg/rust:1.50.0
     resource_class: xlarge
     steps:
       - checkout

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let address: SocketAddr = format!("127.0.0.1:4130").parse().unwrap();
+        let address: SocketAddr = "127.0.0.1:4130".parse().unwrap();
         let peer_info = PeerInfo::new(address);
 
         assert_eq!(address, peer_info.address());
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_set_disconnected_from_connected() {
-        let address: SocketAddr = format!("127.0.0.1:4130").parse().unwrap();
+        let address: SocketAddr = "127.0.0.1:4130".parse().unwrap();
         let mut peer_info = PeerInfo::new(address);
 
         peer_info.set_connected().unwrap();
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_set_disconnected_from_never_connected() {
-        let address: SocketAddr = format!("127.0.0.1:4130").parse().unwrap();
+        let address: SocketAddr = "127.0.0.1:4130".parse().unwrap();
         let mut peer_info = PeerInfo::new(address);
 
         assert!(peer_info.set_disconnected().is_err());
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_set_connected_from_disconnected() {
-        let address: SocketAddr = format!("127.0.0.1:4130").parse().unwrap();
+        let address: SocketAddr = "127.0.0.1:4130".parse().unwrap();
         let mut peer_info = PeerInfo::new(address);
 
         peer_info.set_connected().unwrap();


### PR DESCRIPTION
Since Rust has only just been updated to 1.50, the CI might not have the fresh image yet; if that happens, the PR's CI runs can be restarted a bit later on.