### PR TITLE
Use ring as the noise resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,17 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2496,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,13 +3333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
 dependencies = [
  "blake2 0.9.1",
- "byteorder",
  "chacha20poly1305",
  "rand 0.7.3",
  "rand_core 0.5.1",
+ "ring",
  "rustc_version 0.2.3",
  "sha2",
- "sodiumoxide",
  "subtle 2.4.0",
  "x25519-dalek",
 ]
@@ -3352,15 +3355,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sodiumoxide"
-version = "0.2.6"
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
-dependencies = [
- "libc",
- "libsodium-sys",
- "serde",
-]
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stream-cipher"
@@ -3980,6 +3978,12 @@ dependencies = [
  "generic-array 0.14.4",
  "subtle 2.4.0",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,27 +69,16 @@ rustc_version = "0.2"
 capnpc = { version = "0.14", optional = true }
 
 [profile.release]
-opt-level = 3
 lto = "thin"
 incremental = true
 
 [profile.bench]
-opt-level = 3
-debug = false
-rpath = false
 lto = "thin"
 incremental = true
-debug-assertions = false
-
-[profile.dev]
-opt-level = 0
 
 [profile.test]
 opt-level = 3 # necessary for DPC testing
 lto = "thin"
-incremental = true
-debug-assertions = true
-debug = true
 
 [features]
 default = []

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -34,7 +34,7 @@ log = { version = "0.4.11" }
 parking_lot = { version = "0.11.1" }
 rand = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
-snow = { version = "0.7", default-features = false, features = ["libsodium-resolver", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"] }
+snow = { version = "0.7", default-features = false, features = ["ring-resolver", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"] }
 thiserror = { version = "1.0" }
 tokio = { version = "1" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -225,7 +225,7 @@ impl Inbound {
             crate::HANDSHAKE_PATTERN
                 .parse()
                 .expect("Invalid noise handshake pattern!"),
-            Box::new(snow::resolvers::SodiumResolver),
+            Box::new(snow::resolvers::RingResolver),
         );
         let static_key = builder.generate_keypair()?.private;
         let noise_builder = builder.local_private_key(&static_key).psk(3, crate::HANDSHAKE_PSK);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -116,7 +116,7 @@ impl Node {
             crate::HANDSHAKE_PATTERN
                 .parse()
                 .expect("Invalid noise handshake pattern!"),
-            Box::new(snow::resolvers::SodiumResolver),
+            Box::new(snow::resolvers::RingResolver),
         );
         let static_key = builder.generate_keypair()?.private;
         let noise_builder = builder.local_private_key(&static_key).psk(3, crate::HANDSHAKE_PSK);

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -48,7 +48,7 @@ async fn handshake_responder_side() {
 
     let builder = snow::Builder::with_resolver(
         snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
-        Box::new(snow::resolvers::SodiumResolver),
+        Box::new(snow::resolvers::RingResolver),
     );
     let static_key = builder.generate_keypair().unwrap().private;
     let noise_builder = builder
@@ -109,7 +109,7 @@ async fn handshake_initiator_side() {
 
     let builder = snow::Builder::with_resolver(
         snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
-        Box::new(snow::resolvers::SodiumResolver),
+        Box::new(snow::resolvers::RingResolver),
     );
     let static_key = builder.generate_keypair().unwrap().private;
     let noise_builder = builder

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = { version = "1.5.2" }
 parking_lot = { version = "0.11.1" }
 rand = { version = "0.8" }
 rand_xorshift = { version = "0.3" }
-snow = { version = "0.7", default-features = false, features = ["libsodium-resolver", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"] }
+snow = { version = "0.7", default-features = false, features = ["ring-resolver", "chacha20poly1305", "blake2", "sha2", "x25519-dalek", "rand"] }
 tokio = { version = "1", features = ["macros", "time"] }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { version = "0.2" }

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -240,7 +240,7 @@ pub async fn spawn_2_fake_nodes() -> (FakeNode, FakeNode) {
     // node0's noise - initiator
     let builder = snow::Builder::with_resolver(
         snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
-        Box::new(snow::resolvers::SodiumResolver),
+        Box::new(snow::resolvers::RingResolver),
     );
     let static_key = builder.generate_keypair().unwrap().private;
     let noise_builder = builder
@@ -251,7 +251,7 @@ pub async fn spawn_2_fake_nodes() -> (FakeNode, FakeNode) {
     // node1's noise - responder
     let builder = snow::Builder::with_resolver(
         snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
-        Box::new(snow::resolvers::SodiumResolver),
+        Box::new(snow::resolvers::RingResolver),
     );
     let static_key = builder.generate_keypair().unwrap().private;
     let noise_builder = builder
@@ -322,7 +322,7 @@ pub async fn handshaken_node_and_peer(node_setup: TestSetup) -> (Node, FakeNode)
 
     let builder = snow::Builder::with_resolver(
         snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
-        Box::new(snow::resolvers::SodiumResolver),
+        Box::new(snow::resolvers::RingResolver),
     );
     let static_key = builder.generate_keypair().unwrap().private;
     let noise_builder = builder


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/635, the last commit is new.

The previous `libsodium` pick was dictated by dependency incompatibilities, but now it's possible to use the more Rust-native [ring](https://crates.io/crates/ring) crate; it should make compilation times faster, and hopefully reduce the occurrence of CI build issues.