### PR TITLE
Include build.rs in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,9 @@ keywords = [
   "zero-knowledge"
 ]
 categories = [ "cryptography::cryptocurrencies", "operating-systems" ]
-include = [ "Cargo.toml", "snarkos", "README.md", "LICENSE.md" ]
+include = [ "Cargo.toml", "snarkos", "README.md", "LICENSE.md", "build.rs" ]
 license = "GPL-3.0"
 edition = "2018"
-build = "build.rs"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ git clone https://github.com/AleoHQ/snarkOS --depth 1
 
 Next, compile and install snarkOS:
 ```bash
-cd snarkOS && cargo install --path .
+cargo install --path . --locked
 ```
 
 #### Step 3. Start snarkOS


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

(Write your motivation here)
Getting
```bash
Compiling snarkos v1.2.0
     Running `rustc --crate-name build_script_build --edition=2018 /Users/austinabell/.cargo/registry/src/github.com-1ecc6299db9ec823/snarkos-1.2.0/build.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debug-assertions=off --cfg 'feature="default"' -C metadata=02234fe76e2ae320 -C extra-filename=-02234fe76e2ae320 --out-dir /var/folders/0m/xjqfz9ss161gwc_ln15mlnhh0000gn/T/cargo-install7OqKGB/release/build/snarkos-02234fe76e2ae320 -L dependency=/var/folders/0m/xjqfz9ss161gwc_ln15mlnhh0000gn/T/cargo-install7OqKGB/release/deps --extern rustc_version=/var/folders/0m/xjqfz9ss161gwc_ln15mlnhh0000gn/T/cargo-install7OqKGB/release/deps/librustc_version-2fffcad4c0a168c8.rlib --cap-lints allow`
error: couldn't read /Users/austinabell/.cargo/registry/src/github.com-1ecc6299db9ec823/snarkos-1.2.0/build.rs: No such file or directory (os error 2)
```
when building through crates.io.

The build.rs file was not included in the publish, and I'm not sure why this doesn't cause issues for others.

Edit: Also fixes the install from source instruction, as it was broken

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

(Link your related PRs here)
