### PR TITLE
Fuzz test slightly corrupted messages

### DIFF
--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -56,7 +56,7 @@ async fn fuzzing_zeroes_pre_handshake() {
     let mut stream = TcpStream::connect(node_addr).await.unwrap();
     wait_until!(1, node.peer_book.read().number_of_connecting_peers() == 1);
 
-    let _ = stream.write_all(&vec![0u8; 64]).await;
+    let _ = stream.write_all(&[0u8; 64]).await;
     wait_until!(1, node.peer_book.read().number_of_connecting_peers() == 0);
 }
 
@@ -70,7 +70,7 @@ async fn fuzzing_zeroes_post_handshake() {
     let (node, fake_node) = handshaken_node_and_peer(node_setup).await;
     wait_until!(1, node.peer_book.read().number_of_connected_peers() == 1);
 
-    fake_node.write_bytes(&vec![0u8; 64]).await;
+    fake_node.write_bytes(&[0u8; 64]).await;
     wait_until!(1, node.peer_book.read().number_of_connected_peers() == 0);
 }
 

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -25,7 +25,7 @@ use tokio::{io::AsyncWriteExt, net::TcpStream};
 
 use std::net::SocketAddr;
 
-pub const ITERATIONS: usize = 10000;
+pub const ITERATIONS: usize = 5000;
 pub const CORRUPTION_PROBABILITY: f64 = 0.1;
 
 fn corrupt_bytes(serialized: &[u8]) -> Vec<u8> {

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -25,7 +25,7 @@ use tokio::{io::AsyncWriteExt, net::TcpStream};
 
 use std::net::SocketAddr;
 
-pub const ITERATIONS: usize = 1000;
+pub const ITERATIONS: usize = 10000;
 
 #[tokio::test]
 async fn fuzzing_zeroes_pre_handshake() {
@@ -271,6 +271,7 @@ async fn fuzzing_corrupted_empty_payloads_post_handshake() {
 #[tokio::test(flavor = "multi_thread")]
 async fn fuzzing_corrupted_payloads_with_blobs_pre_handshake() {
     // tracing_subscriber::fmt::init();
+
     let node_setup = TestSetup {
         consensus_setup: None,
         ..Default::default()
@@ -347,6 +348,7 @@ async fn fuzzing_corrupted_payloads_with_blobs_post_handshake() {
 #[tokio::test(flavor = "multi_thread")]
 async fn fuzzing_corrupted_payloads_with_hashes_pre_handshake() {
     // tracing_subscriber::fmt::init();
+
     let node_setup = TestSetup {
         consensus_setup: None,
         ..Default::default()
@@ -421,6 +423,7 @@ async fn fuzzing_corrupted_payloads_with_hashes_post_handshake() {
 #[tokio::test(flavor = "multi_thread")]
 async fn fuzzing_currupted_peers_pre_handshake() {
     // tracing_subscriber::fmt::init();
+
     let node_setup = TestSetup {
         consensus_setup: None,
         ..Default::default()

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -75,8 +75,8 @@ async fn spawn_nodes_in_a_line() {
     );
 
     // All other nodes should have two.
-    for i in 1..(nodes.len() - 1) {
-        wait_until!(5, nodes[i].peer_book.read().number_of_connected_peers() == 2);
+    for node in nodes.iter().take(nodes.len() - 1).skip(1) {
+        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 2);
     }
 }
 

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -99,7 +99,7 @@ async fn star(nodes: &mut Vec<Node<LedgerStorage>>) {
 
     // Start the rest of the nodes with the core node as the bootnode.
     let bootnodes = vec![hub_address];
-    for i in 1..nodes.len() {
-        nodes[i].environment.bootnodes = bootnodes.clone();
+    for node in nodes.iter_mut().skip(1) {
+        node.environment.bootnodes = bootnodes.clone();
     }
 }


### PR DESCRIPTION
This collection of fuzz tests aims to test messages with a small percentage of their bytes randomly replaced and is an extension of currently implemented fuzz tests. 

Testing slightly corrupted but otherwise valid messages is more likely to expose issues with deserialisation than completely random payloads. These tests target both pre and post-handshake nodes.