### PR TITLE
Update snarkVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472ed062cdd1f54076312dd34e5fb56bd585c80c12209045f4b5bbbd368e9000"
+checksum = "bdf8ca73d429824090b96f751846e37e539f24c527f1f1ce0254984ade6d17b2"
 dependencies = [
  "blake2",
  "derivative",
@@ -2804,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfdfa3aa137f64a7f49df03393e5d0269f133ca8c8c79e569cb3bb13181aeb2"
+checksum = "64610b135b8b1152439d5dfa4f745515933366082f08651961344aa0bb5abfca"
 dependencies = [
  "derivative",
  "rand 0.8.3",
@@ -2820,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2ba967601ff2534adbc6a71a691be4285e61c83d23d54a59824f8fa80f6038"
+checksum = "46c9829b6e2023b4c7c4d6c55e88fe755dd997171a6c9c063b75c28161d04326"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2833,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4cb55898089843ba44b9f96448dcb2badcc1ce12daa8d7365d4e41513e37bc"
+checksum = "491ae936e24e17c358d112ff8638b260500b5a982ecefc804861e28b5279f552"
 dependencies = [
  "anyhow",
  "base58",
@@ -2859,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9ea954196e76fe8968fb99eced7ccf08f901ab22747c4c489bda6674a7cb39"
+checksum = "8c49c69d02df11be58e07f626c9d6f5804c6dd4ccf42e425f2be8d79fe6e5bb7"
 dependencies = [
  "bincode",
  "derivative",
@@ -2874,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdda42a0a6484d9f008801a8a4d494a69a4db3f7b317057a8cc3c6e4b3ef6884"
+checksum = "bd6f9ac2a166d926e1755a06fdae21ce40ce6164c75c89120401b8d78f3b7ba4"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-marlin"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc28d14212f3e8ee334968bc684da71d64dc55fd66d6edd915995ad4f6b06d0"
+checksum = "d89930e437512ffa3d6e3c1ec21c12f16d8b03fc41a056e89b8e3878124a6db7"
 dependencies = [
  "blake2",
  "derivative",
@@ -2912,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-objects"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20d13db49cedc147df06c4a6f2dd727ea25640bdf50b876f40005331767a68f"
+checksum = "9bd9779ec6ab9211f34a6ba25566feb575a396f4c41cc0e002ec2d48d7560a2a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2933,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35fa1819d803e45b4e99fe822e6981f177716f5384eef27245b5f6ed59a8305"
+checksum = "98378f612206fc7dd44a26f4e345bd1f3ba51bd325acad1e5cc3785d14750ec5"
 dependencies = [
  "curl",
  "hex",
@@ -2946,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-polycommit"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2459d0f741f49ab211770c166c83c0469ed443093242c08194cc162218ec3ef4"
+checksum = "d206a736e44ccdd8e298ade136ba2670be1ef820388842f04eda185fde73f214"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2962,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-posw"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee5a1e765fbed72c34483da2473943936899ba2ca27e68eba4ebcb33d355ae6"
+checksum = "499a934e8e3359c278881d5e4cf66064158dc06edccb94748abfdd3d0dbb69aa"
 dependencies = [
  "blake2",
  "rand 0.8.3",
@@ -2984,15 +2984,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7834d57af37a31f2f280f08b61d07a04a9a4b7720819b06ca325da32a5a925f5"
+checksum = "b2460ac01c25f79f5ea306e4de82a1d4105e811f868206b4fd31c0c9b62a3d7b"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0838118f276e7bb673cbf3741f4966c56861aaff399a46d343fc98c12851d9eb"
+checksum = "a3a0d54b15802976aff7522765dd29d5733f338612449629cc57c5a4a4d51f05"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -3005,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5598f7f71c8aaf4fc267b5b420b2440a4d86c9243cecd57ff0af5c366217e5cc"
+checksum = "c763843fa67a3aa4ce68173c8cd96b4f04aaa135a5792bc051c36eec0fe1cd73"
 dependencies = [
  "bincode",
  "rand 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,20 +39,20 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-posw]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-consensus]
 path = "./consensus"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -28,7 +28,7 @@ path = "network/network.rs"
 harness = false
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,22 +18,22 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-posw]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -36,7 +36,7 @@ features = [ "macros", "rt-multi-thread" ]
 version = "0.3"
 
 [dev-dependencies.snarkvm-derives]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.serial_test]
 version = "0.5.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -18,16 +18,16 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -18,14 +18,14 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-parameters]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.curl]
@@ -33,19 +33,19 @@ version = "0.4.35"
 optional = true
 
 [dev-dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.snarkvm-marlin]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.snarkvm-posw]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.snarkos-consensus]
 path = "../consensus"

--- a/parameters/examples/generate_transaction.rs
+++ b/parameters/examples/generate_transaction.rs
@@ -56,8 +56,8 @@ fn empty_ledger<T: Transaction, P: LoadableMerkleParameters, S: Storage>(
         .map(|storage| storage)
         .map_err(|err| LedgerError::Message(err.to_string()))?;
 
-    let leaves: Vec<[u8; 32]> = vec![];
-    let cm_merkle_tree = MerkleTree::<P>::new(parameters.clone(), &leaves)?;
+    let leaves: &[[u8; 32]] = &[];
+    let cm_merkle_tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter())?;
 
     Ok(Ledger {
         current_block_height: Default::default(),

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,17 +18,17 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -23,19 +23,19 @@ rocksdb_storage = ["rocksdb"]
 mem_storage = []
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-parameters]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-parameters]
 path = "../parameters"
@@ -71,7 +71,7 @@ version = "1.0"
 path = "../consensus"
 
 [dev-dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -122,9 +122,9 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
                 }
 
                 cm_and_indices.sort_by(|&(_, i), &(_, j)| i.cmp(&j));
-                let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm).collect::<Vec<_>>();
+                let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm);
 
-                let merkle_tree = MerkleTree::new(ledger_parameters.clone(), &commitments)?;
+                let merkle_tree = MerkleTree::new(ledger_parameters.clone(), commitments)?;
 
                 Ok(Self {
                     current_block_height: AtomicU32::new(bytes_to_u32(val)),
@@ -175,7 +175,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
                 // the secondary instance requires it.
                 if update_merkle_tree {
                     // Update the Merkle tree of the secondary instance.
-                    *self.cm_merkle_tree.write() = self.build_merkle_tree(vec![])?;
+                    self.rebuild_merkle_tree(vec![])?;
                 }
             }
         }

--- a/storage/src/mem.rs
+++ b/storage/src/mem.rs
@@ -27,9 +27,7 @@ pub struct MemDb {
 }
 
 impl Storage for MemDb {
-    fn in_memory(&self) -> bool {
-        true
-    }
+    const IN_MEMORY: bool = true;
 
     fn open(_path: Option<&Path>, _secondary_path: Option<&Path>) -> Result<Self, StorageError> {
         // the paths are just ignored
@@ -84,9 +82,5 @@ impl Storage for MemDb {
     fn try_catch_up_with_primary(&self) -> Result<(), StorageError> {
         // used only in Ledger::catch_up_secondary, doesn't cause an early return
         Err(StorageError::Message("MemDb has no secondary instance".into()))
-    }
-
-    fn destroy(&self) -> Result<(), StorageError> {
-        Ok(()) // nothing to do here: the Drop impl takes care of the associated in-memory objects
     }
 }

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -105,10 +105,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     }
 
     /// Build a new commitment merkle tree from the stored commitments
-    pub fn rebuild_merkle_tree(
-        &self,
-        additional_cms: Vec<(T::Commitment, usize)>,
-    ) -> Result<(), StorageError> {
+    pub fn rebuild_merkle_tree(&self, additional_cms: Vec<(T::Commitment, usize)>) -> Result<(), StorageError> {
         let mut new_cm_and_indices = additional_cms;
 
         let mut old_cm_and_indices = vec![];

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -252,9 +252,8 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
 
         let height = self.get_current_block_height();
 
-        let is_genesis = block.header.previous_block_hash == BlockHeaderHash([0u8; 32])
-            && height == 0
-            && self.is_empty();
+        let is_genesis =
+            block.header.previous_block_hash == BlockHeaderHash([0u8; 32]) && height == 0 && self.is_empty();
 
         let mut new_best_block_number = 0;
         if !is_genesis {

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -250,11 +250,12 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
 
         // Update the best block number
 
+        let height = self.get_current_block_height();
+
         let is_genesis = block.header.previous_block_hash == BlockHeaderHash([0u8; 32])
-            && self.get_current_block_height() == 0
+            && height == 0
             && self.is_empty();
 
-        let height = self.get_current_block_height();
         let mut new_best_block_number = 0;
         if !is_genesis {
             new_best_block_number = height + 1;

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -280,8 +280,8 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         });
 
         // Rebuild the new commitment merkle tree
-        let new_merkle_tree = self.build_merkle_tree(transaction_cms)?;
-        let new_digest = new_merkle_tree.root();
+        self.rebuild_merkle_tree(transaction_cms)?;
+        let new_digest = self.cm_merkle_tree.read().root();
 
         database_transaction.push(Op::Insert {
             col: COL_DIGEST,
@@ -293,8 +293,6 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
             key: KEY_CURR_DIGEST.as_bytes().to_vec(),
             value: to_bytes![new_digest]?.to_vec(),
         });
-
-        *self.cm_merkle_tree.write() = new_merkle_tree;
 
         self.storage.batch(database_transaction)?;
 

--- a/storage/src/objects/ledger_scheme.rs
+++ b/storage/src/objects/ledger_scheme.rs
@@ -55,8 +55,8 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> LedgerScheme for L
             }
         }
 
-        let leaves: Vec<[u8; 32]> = vec![];
-        let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), &leaves)?;
+        let leaves: &[[u8; 32]] = &[];
+        let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), leaves.iter())?;
 
         let ledger_storage = Self {
             current_block_height: Default::default(),

--- a/storage/src/rocks.rs
+++ b/storage/src/rocks.rs
@@ -30,9 +30,7 @@ pub struct RocksDb {
 }
 
 impl Storage for RocksDb {
-    fn in_memory(&self) -> bool {
-        false
-    }
+    const IN_MEMORY: bool = false;
 
     fn open(path: Option<&Path>, secondary_path: Option<&Path>) -> Result<Self, StorageError> {
         assert!(path.is_some(), "RocksDB must have an associated filesystem path!");
@@ -101,10 +99,6 @@ impl Storage for RocksDb {
         self.db()
             .try_catch_up_with_primary()
             .map_err(|e| StorageError::Message(format!("Can't catch up with primary storage: {}", e)))
-    }
-
-    fn destroy(&self) -> Result<(), StorageError> {
-        Ok(()) // the Drop impl of DB has to be triggered; delegated to Drop
     }
 }
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -22,25 +22,25 @@ default = ["network"]
 network = ["snarkos-network", "snow", "tokio", "tracing", "tracing-futures", "tracing-subscriber"]
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-parameters]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-posw]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/toolkit/Cargo.toml
+++ b/toolkit/Cargo.toml
@@ -26,20 +26,20 @@ path = "benches/account.rs"
 harness = false
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 features = ["wasm"]
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-objects]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.anyhow]
 version = "1.0.40"


### PR DESCRIPTION
This PR updates snarkVM to `0.2.2` and adjusts the relevant APIs.