### PR TITLE
Enable RPC with in-memory storage

### DIFF
--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -65,13 +65,9 @@ pub fn render_welcome(config: &Config) -> String {
         i => format!("testnet{}", i),
     };
     if is_miner {
-        output += &format!("Starting a mining node on {}.\n\n", network).bold().to_string();
+        output += &format!("Starting a mining node on {}.\n", network).bold().to_string();
     } else {
-        output += &format!("Starting a client node on {}.\n\n", network).bold().to_string();
-    }
-
-    if config.rpc.json_rpc {
-        output += &format!("Listening for RPC requests on port {}\n", config.rpc.port);
+        output += &format!("Starting a client node on {}.\n", network).bold().to_string();
     }
 
     output

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -197,6 +197,8 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
             config.rpc.password,
         )
         .await;
+
+        info!("Listening for RPC requests on port {}", config.rpc.port);
     }
 
     // Start the network services

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -40,7 +40,6 @@ use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use parking_lot::Mutex;
 use tokio::runtime::Builder;
-use tracing_futures::Instrument;
 use tracing_subscriber::EnvFilter;
 
 fn initialize_logger(config: &Config) {
@@ -55,7 +54,7 @@ fn initialize_logger(config: &Config) {
             };
 
             // disable undesirable logs
-            let filter = EnvFilter::from_default_env().add_directive("tokio_reactor=off".parse().unwrap());
+            let filter = EnvFilter::from_default_env().add_directive("mio=off".parse().unwrap());
 
             // initialize tracing
             tracing_subscriber::fmt()
@@ -214,13 +213,12 @@ fn main() -> Result<(), NodeError> {
 
     let config: Config = ConfigCli::parse(&arguments)?;
     config.check().map_err(|e| NodeError::Message(e.to_string()))?;
-    let node_span = debug_span!("node");
 
     Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(4 * 1024 * 1024)
         .build()?
-        .block_on(start_server(config).instrument(node_span))?;
+        .block_on(start_server(config))?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR allows RPC calls to be made when the node is running with an in-memory storage. In addition the RPC log is now displayed only once its instance is running and the `mio` (previously `tokio-reactor`) logs are hidden.