### PR TITLE
Resource-oriented refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,7 @@ dependencies = [
  "derivative",
  "hex",
  "log",
+ "once_cell",
  "parking_lot",
  "peak_alloc",
  "rand 0.8.3",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -69,6 +69,9 @@ version = "0.4.2"
 [dependencies.log]
 version = "0.4.11"
 
+[dependencies.once_cell]
+version = "1.5.2"
+
 [dependencies.parking_lot]
 version = "0.11.1"
 

--- a/network/src/consensus/miner.rs
+++ b/network/src/consensus/miner.rs
@@ -40,7 +40,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
     /// Once a block is found, A block message is sent to all peers.
     /// Calling this function multiple times will spawn additional listeners on separate threads.
     /// Miner threads are asynchronous so the only way to stop them is to kill the runtime they were started in. This may be changed in the future.
-    pub fn spawn(self) {
+    pub fn spawn(self) -> task::JoinHandle<()> {
         task::spawn(async move {
             let local_address = self.node.environment.local_address().unwrap();
             info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
@@ -91,6 +91,6 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                     .propagate_block(serialized_block, local_address, &peers)
                     .await;
             }
-        });
+        })
     }
 }

--- a/network/src/consensus/miner.rs
+++ b/network/src/consensus/miner.rs
@@ -78,7 +78,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                 };
 
                 info!("Mined a new block: {:?}", hex::encode(block.header.get_hash().0));
-                let peers = self.node.peer_book.read().connected_peers().clone();
+
                 let serialized_block = if let Ok(block) = block.serialize() {
                     block
                 } else {
@@ -88,7 +88,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
 
                 self.node
                     .expect_consensus()
-                    .propagate_block(serialized_block, local_address, &peers)
+                    .propagate_block(serialized_block, local_address)
                     .await;
             }
         })

--- a/network/src/environment.rs
+++ b/network/src/environment.rs
@@ -17,6 +17,7 @@
 use crate::NetworkError;
 
 use once_cell::sync::OnceCell;
+use parking_lot::RwLock;
 use rand::{thread_rng, Rng};
 use std::{
     net::SocketAddr,
@@ -25,7 +26,6 @@ use std::{
 };
 
 /// A core data structure containing the networking parameters for this node.
-#[derive(Clone)]
 pub struct Environment {
     pub name: u64,
     /// The local address of this node.
@@ -35,7 +35,7 @@ pub struct Environment {
     /// The maximum number of peers permitted to maintain connections with.
     maximum_number_of_connected_peers: u16,
     /// The default bootnodes of the network.
-    pub bootnodes: Vec<SocketAddr>,
+    pub bootnodes: RwLock<Vec<SocketAddr>>,
     /// If `true`, initializes this node as a bootnode and forgoes connecting
     /// to the default bootnodes or saved peers in the peer book.
     is_bootnode: bool,
@@ -70,7 +70,7 @@ impl Environment {
             name,
             minimum_number_of_connected_peers,
             maximum_number_of_connected_peers,
-            bootnodes,
+            bootnodes: RwLock::new(bootnodes),
             is_bootnode,
             peer_sync_interval,
         })
@@ -90,10 +90,10 @@ impl Environment {
             .expect("local address was set more than once!");
     }
 
-    /// Returns a reference to the default bootnodes of the network.
+    /// Returns the default bootnodes of the network.
     #[inline]
-    pub fn bootnodes(&self) -> &Vec<SocketAddr> {
-        &self.bootnodes
+    pub fn bootnodes(&self) -> Vec<SocketAddr> {
+        self.bootnodes.read().clone()
     }
 
     /// Returns `true` if this node is a bootnode. Otherwise, returns `false`.

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -16,11 +16,7 @@
 
 use crate::{errors::NetworkError, message::*, ConnReader, ConnWriter, Environment, Receiver, Sender};
 
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::{atomic::AtomicU64, Arc},
-};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use parking_lot::{Mutex, RwLock};
 use tokio::{
@@ -41,12 +37,6 @@ pub struct Inbound {
     receiver: Arc<Mutex<Option<Receiver>>>,
     /// The map of remote addresses to their active read channels.
     channels: Arc<RwLock<Channels>>,
-    /// A counter for the number of received responses the handler processes.
-    receive_response_count: Arc<AtomicU64>,
-    /// A counter for the number of received responses that succeeded.
-    receive_success_count: Arc<AtomicU64>,
-    /// A counter for the number of received responses that failed.
-    receive_failure_count: Arc<AtomicU64>,
     /// The tasks dedicated to handling inbound messages.
     pub(crate) tasks: Arc<Mutex<HashMap<SocketAddr, JoinHandle<()>>>>,
 }
@@ -60,9 +50,6 @@ impl Inbound {
             sender,
             receiver: Arc::new(Mutex::new(Some(receiver))),
             channels,
-            receive_response_count: Default::default(),
-            receive_success_count: Default::default(),
-            receive_failure_count: Default::default(),
             tasks: Default::default(),
         }
     }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -127,6 +127,9 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
                                 if let Ok(ref peer) = node.peer_book.read().get_peer(remote_address) {
                                     peer.register_task(conn_listening_task);
+                                } else {
+                                    // if the related peer is not found, it means it's already been dropped
+                                    conn_listening_task.abort();
                                 }
                             }
                             Err(e) => {

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -30,12 +30,12 @@ use tokio::{
 pub type Channels = HashMap<SocketAddr, Arc<ConnWriter>>;
 
 /// A stateless component for handling inbound network traffic.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Inbound {
     /// The producer for sending inbound messages to the server.
     pub(crate) sender: Sender,
     /// The consumer for receiving inbound messages to the server.
-    receiver: Arc<Mutex<Option<Receiver>>>,
+    receiver: Mutex<Option<Receiver>>,
     /// The map of remote addresses to their active write channels.
     pub(crate) channels: Arc<RwLock<Channels>>,
 }
@@ -47,7 +47,7 @@ impl Inbound {
 
         Self {
             sender,
-            receiver: Arc::new(Mutex::new(Some(receiver))),
+            receiver: Mutex::new(Some(receiver)),
             channels,
         }
     }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -190,7 +190,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     pub async fn process_incoming_messages(&self, receiver: &mut Receiver) -> Result<(), NetworkError> {
         let Message { direction, payload } = receiver.recv().await.ok_or(NetworkError::ReceiverFailedToParse)?;
 
-        if self.environment.is_bootnode() && !(payload == Payload::GetPeers || direction == Direction::Internal) {
+        if self.environment.is_bootnode() && payload != Payload::GetPeers {
             // the bootstrapper nodes should ignore inbound messages other than GetPeers
             return Ok(());
         }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -208,23 +208,17 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         match payload {
             Payload::Transaction(transaction) => {
                 if let Some(ref consensus) = self.consensus() {
-                    let connected_peers = self.peer_book.read().connected_peers().clone();
-                    consensus
-                        .received_transaction(source.unwrap(), transaction, connected_peers)
-                        .await?;
+                    consensus.received_transaction(source.unwrap(), transaction).await?;
                 }
             }
             Payload::Block(block) => {
                 if let Some(ref consensus) = self.consensus() {
-                    let connected_peers = self.peer_book.read().connected_peers().clone();
-                    consensus
-                        .received_block(source.unwrap(), block, Some(connected_peers))
-                        .await?;
+                    consensus.received_block(source.unwrap(), block, true).await?;
                 }
             }
             Payload::SyncBlock(block) => {
                 if let Some(ref consensus) = self.consensus() {
-                    consensus.received_block(source.unwrap(), block, None).await?;
+                    consensus.received_block(source.unwrap(), block, false).await?;
                     if self.peer_book.read().got_sync_block(source.unwrap()) {
                         consensus.finished_syncing_blocks();
                     }

--- a/network/src/message/message.rs
+++ b/network/src/message/message.rs
@@ -92,16 +92,6 @@ pub enum Payload {
     // a placeholder indicating the introduction of a new payload type; used for forward compatibility
     #[doc(hidden)]
     Unknown,
-
-    /* internal messages */
-    #[doc(hidden)]
-    ConnectedTo(SocketAddr, Option<SocketAddr>),
-    #[doc(hidden)]
-    ConnectingTo(SocketAddr),
-    // TODO: used internally, but can also be used to allow a clean disconnect for connected peers on shutdown
-    // add a doc if this is introduced
-    #[doc(hidden)]
-    Disconnect(SocketAddr),
 }
 
 impl fmt::Display for Payload {
@@ -119,9 +109,6 @@ impl fmt::Display for Payload {
             Self::Sync(..) => "sync",
             Self::SyncBlock(..) => "syncblock",
             Self::Transaction(..) => "transaction",
-            Self::ConnectedTo(..) => "connectedto",
-            Self::ConnectingTo(..) => "connectingto",
-            Self::Disconnect(..) => "disconnect",
             Self::Unknown => "unknown",
         };
 

--- a/network/src/message/message.rs
+++ b/network/src/message/message.rs
@@ -23,7 +23,6 @@ use std::{fmt, net::SocketAddr};
 pub enum Direction {
     Inbound(SocketAddr),
     Outbound(SocketAddr),
-    Internal,
 }
 
 impl fmt::Display for Direction {
@@ -31,7 +30,6 @@ impl fmt::Display for Direction {
         match self {
             Self::Inbound(addr) => write!(f, "from {}", addr),
             Self::Outbound(addr) => write!(f, "to {}", addr),
-            Self::Internal => write!(f, "<internal>"),
         }
     }
 }

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -31,14 +31,14 @@ use parking_lot::RwLock;
 type Channels = HashMap<SocketAddr, Arc<ConnWriter>>;
 
 /// A core data structure for handling outbound network traffic.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Outbound {
     /// The map of remote addresses to their active write channels.
     pub(crate) channels: Arc<RwLock<Channels>>,
     /// The monotonic counter for the number of send requests that succeeded.
-    send_success_count: Arc<AtomicU64>,
+    send_success_count: AtomicU64,
     /// The monotonic counter for the number of send requests that failed.
-    send_failure_count: Arc<AtomicU64>,
+    send_failure_count: AtomicU64,
 }
 
 impl Outbound {

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -236,7 +236,7 @@ impl PeerBook {
     ///
     /// Returns a reference to the peer info of the given address, if it exists.
     ///
-    pub fn get_peer(&mut self, address: SocketAddr) -> Result<&PeerInfo, NetworkError> {
+    pub fn get_peer(&self, address: SocketAddr) -> Result<&PeerInfo, NetworkError> {
         // Check if the address is a connected peer.
         if self.is_connected(address) {
             // Fetch the peer info of the connected peer.

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -54,7 +54,7 @@ pub struct PeerQuality {
 }
 
 /// A data structure containing information about a peer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PeerInfo {
     /// The IP address of this peer.
     address: SocketAddr,
@@ -75,7 +75,7 @@ pub struct PeerInfo {
     pub quality: Arc<PeerQuality>,
     /// The handles for tasks associated exclusively with this peer.
     #[serde(skip)]
-    tasks: Arc<Mutex<Vec<task::JoinHandle<()>>>>,
+    tasks: Mutex<Vec<task::JoinHandle<()>>>,
 }
 
 impl PeerInfo {

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -75,7 +75,7 @@ pub struct PeerInfo {
     pub quality: Arc<PeerQuality>,
     /// The handles for tasks associated exclusively with this peer.
     #[serde(skip)]
-    tasks: Mutex<Vec<task::JoinHandle<()>>>,
+    pub tasks: Mutex<Vec<task::JoinHandle<()>>>,
 }
 
 impl PeerInfo {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -26,6 +26,13 @@ use tokio::{
     net::TcpStream,
 };
 
+impl<S: Storage> Node<S> {
+    /// Obtain a list of addresses of currently connected peers.
+    pub(crate) fn connected_addrs(&self) -> Vec<SocketAddr> {
+        self.peer_book.read().connected_peers().keys().copied().collect()
+    }
+}
+
 impl<S: Storage + Send + Sync + 'static> Node<S> {
     ///
     /// Broadcasts updates with connected peers and maintains a permitted number of connected peers.
@@ -65,17 +72,17 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 number_to_disconnect
             );
 
-            let connected_peers = self.peer_book.read().connected_peers().clone();
-
-            let mut connected = connected_peers
+            let mut connected = self
+                .peer_book
+                .read()
+                .connected_peers()
                 .iter()
-                .map(|(_, peer_info)| peer_info)
+                .map(|(addr, info)| (*addr, info.last_connected()))
                 .collect::<Vec<_>>();
-            connected.sort_unstable_by_key(|info| info.last_connected());
+            connected.sort_unstable_by_key(|(_, info)| *info);
 
             for _ in 0..number_to_disconnect {
-                if let Some(peer_info) = connected.pop() {
-                    let addr = peer_info.address();
+                if let Some((addr, _)) = connected.pop() {
                     let _ = self.disconnect_from_peer(addr);
                 }
             }
@@ -83,9 +90,19 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
         // disconnect from peers after a while, even if they haven't sent a GetPeers
         let now = chrono::Utc::now();
+
+        #[allow(clippy::needless_collect)] // clippy reports a false positive here
         if self.environment.is_bootnode() {
-            for (peer_addr, peer_info) in self.peer_book.read().connected_peers().clone() {
-                if (now - peer_info.last_connected().unwrap()).num_seconds() > 10 {
+            let peers = self
+                .peer_book
+                .read()
+                .connected_peers()
+                .iter()
+                .map(|(addr, info)| (*addr, info.last_connected().unwrap()))
+                .collect::<Vec<_>>();
+
+            for (peer_addr, last_connected) in peers.into_iter() {
+                if (now - last_connected).num_seconds() > 10 {
                     let _ = self.disconnect_from_peer(peer_addr);
                 }
             }
@@ -202,14 +219,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         trace!("Connecting to default bootnodes");
 
         // Fetch the current connected peers of this node.
-        let connected_peers = self.peer_book.read().connected_peers().clone();
+        let connected_peers = self.connected_addrs();
 
         // Iterate through each bootnode address and attempt a connection request.
         for bootnode_address in self
             .environment
             .bootnodes()
             .iter()
-            .filter(|addr| !connected_peers.contains_key(addr))
+            .filter(|addr| !connected_peers.contains(addr))
             .copied()
         {
             if let Err(e) = self.initiate_connection(bootnode_address).await {
@@ -251,8 +268,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         } else {
             0
         };
-        let connected_peers = self.peer_book.read().connected_peers().clone();
-        for (remote_address, _) in connected_peers {
+
+        for remote_address in self.connected_addrs() {
             self.peer_book.read().sending_ping(remote_address);
 
             self.outbound
@@ -268,8 +285,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     async fn broadcast_getpeers_requests(&self) {
         trace!("Sending GetPeers requests to connected peers");
 
-        let connected_peers = self.peer_book.read().connected_peers().clone();
-        for (remote_address, _) in connected_peers {
+        for remote_address in self.connected_addrs() {
             self.outbound
                 .send_request(Message::new(Direction::Outbound(remote_address), Payload::GetPeers))
                 .await;

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -179,8 +179,12 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let conn_listening_task = tokio::spawn(async move {
             node.listen_for_messages(&mut reader).await;
         });
+
         if let Ok(ref peer) = self.peer_book.read().get_peer(remote_address) {
             peer.register_task(conn_listening_task);
+        } else {
+            // if the related peer is not found, it means it's already been dropped
+            conn_listening_task.abort();
         }
 
         Ok(())

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -35,9 +35,9 @@ async fn test_nodes(n: usize, setup: TestSetup) -> Vec<Node<LedgerStorage>> {
 
     for _ in 0..n {
         let environment = test_environment(setup.clone());
-        let mut node = Node::new(environment).await.unwrap();
+        let node = Node::new(environment).await.unwrap();
 
-        node.establish_address().await.unwrap();
+        node.listen(setup.socket_address).await.unwrap();
         nodes.push(node);
     }
 
@@ -202,12 +202,12 @@ async fn binary_star_contact() {
         ..Default::default()
     };
     let environment_a = test_environment(bootnode_setup.clone());
-    let environment_b = test_environment(bootnode_setup);
-    let mut bootnode_a = Node::new(environment_a).await.unwrap();
-    let mut bootnode_b = Node::new(environment_b).await.unwrap();
+    let environment_b = test_environment(bootnode_setup.clone());
+    let bootnode_a = Node::new(environment_a).await.unwrap();
+    let bootnode_b = Node::new(environment_b).await.unwrap();
 
-    bootnode_a.establish_address().await.unwrap();
-    bootnode_b.establish_address().await.unwrap();
+    bootnode_a.listen(bootnode_setup.socket_address).await.unwrap();
+    bootnode_b.listen(bootnode_setup.socket_address).await.unwrap();
 
     let ba = bootnode_a.local_address().unwrap().to_string();
     let bb = bootnode_b.local_address().unwrap().to_string();

--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -26,6 +26,7 @@ use snarkos_network::Node;
 use snarkvm_objects::Storage;
 
 use jsonrpc_http_server::{cors::AccessControlAllowHeaders, hyper, ServerBuilder};
+use tokio::task;
 
 use std::{net::SocketAddr, sync::Arc};
 
@@ -33,13 +34,13 @@ use std::{net::SocketAddr, sync::Arc};
 /// Rpc failures will error on the thread level but not affect the main network server.
 /// This may be changed in the future to give the node more control of the rpc server.
 #[allow(clippy::too_many_arguments)]
-pub async fn start_rpc_server<S: Storage + Send + Sync + 'static>(
+pub fn start_rpc_server<S: Storage + Send + Sync + 'static>(
     rpc_port: u16,
     secondary_storage: Arc<MerkleTreeLedger<S>>,
     node_server: Node<S>,
     username: Option<String>,
     password: Option<String>,
-) {
+) -> task::JoinHandle<()> {
     let rpc_server: SocketAddr = format!("0.0.0.0:{}", rpc_port).parse().unwrap();
 
     let credentials = match (username, password) {
@@ -69,5 +70,5 @@ pub async fn start_rpc_server<S: Storage + Send + Sync + 'static>(
 
     tokio::task::spawn(async move {
         server.wait();
-    });
+    })
 }

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -79,7 +79,7 @@ mod protected_rpc_tests {
         };
 
         let environment = test_environment(TestSetup::default());
-        let mut node = Node::new(environment.clone()).await.unwrap();
+        let mut node = Node::new(environment).await.unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::consensus::create_test_consensus_from_ledger(
             ledger.clone(),

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -38,7 +38,7 @@ mod rpc_tests {
 
     async fn initialize_test_rpc(ledger: Arc<MerkleTreeLedger<LedgerStorage>>) -> Rpc {
         let environment = test_environment(TestSetup::default());
-        let mut node = Node::new(environment.clone()).await.unwrap();
+        let mut node = Node::new(environment).await.unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::consensus::create_test_consensus_from_ledger(
             ledger.clone(),

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -158,7 +158,6 @@ pub fn test_consensus(setup: ConsensusSetup, node: Node<LedgerStorage>) -> Conse
 /// Returns an `Environment` struct with given arguments
 pub fn test_environment(setup: TestSetup) -> Environment {
     Environment::new(
-        setup.socket_address,
         setup.min_peers,
         setup.max_peers,
         setup.bootnodes,
@@ -179,7 +178,8 @@ pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
         node.set_consensus(consensus);
     }
 
-    node.start().await.unwrap();
+    node.listen(setup.socket_address).await.unwrap();
+    node.start_services().await;
 
     if is_miner {
         let miner_address = FIXTURE.test_accounts[0].address.clone();

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -56,7 +56,7 @@ async fn line(nodes: &mut Vec<Node<LedgerStorage>>) {
     // Start each node with the previous as a bootnode.
     for node in nodes {
         if let Some(addr) = prev_node {
-            node.environment.bootnodes.push(addr);
+            node.environment.bootnodes.write().push(addr);
         };
 
         // Assumes the node has an established address.
@@ -71,7 +71,7 @@ async fn ring(nodes: &mut Vec<Node<LedgerStorage>>) {
 
     // Connect the first to the last.
     let first_addr = nodes.first().unwrap().local_address().unwrap();
-    nodes.last_mut().unwrap().environment.bootnodes.push(first_addr);
+    nodes.last().unwrap().environment.bootnodes.write().push(first_addr);
 }
 
 /// Connects the network nodes in a mesh topology. The inital peers are selected at random based on the
@@ -88,7 +88,7 @@ async fn mesh(nodes: &mut Vec<Node<LedgerStorage>>) {
             )
             .copied()
             .collect();
-        node.environment.bootnodes = random_addrs;
+        *node.environment.bootnodes.write() = random_addrs;
     }
 }
 
@@ -100,6 +100,6 @@ async fn star(nodes: &mut Vec<Node<LedgerStorage>>) {
     // Start the rest of the nodes with the core node as the bootnode.
     let bootnodes = vec![hub_address];
     for node in nodes.iter_mut().skip(1) {
-        node.environment.bootnodes = bootnodes.clone();
+        *node.environment.bootnodes.write() = bootnodes.clone();
     }
 }


### PR DESCRIPTION
We've already had some task accounting, but some of it was still not in place due to the objects involved not being sufficiently accessible. This PR refactors some of them so that the following goals can be achieved:
- complete `task` accounting
- truly asynchronous connection handling (especially valuable for disconnects)
- a `Node::shut_down` method and task cleanup performed on `Drop`
- more cohesive object handling with less room for them becoming disjoint (most notably `Environment`)

Notable changes:
- `Environment, Inbound, Outbound, PeerInfo` are no longer `Clone`
- `Node` now only contains an `Arc<InnerNode>` (transparent in terms of ergonomics)
- `Direction::Internal` no longer exists, and neither do related internal messages
- `Consensus`-related methods no longer require the list of peers to be passed to them (it's available from within them)