### PR TITLE
Dedicate an OS thread to mining

### DIFF
--- a/benchmarks/syncing/syncing.rs
+++ b/benchmarks/syncing/syncing.rs
@@ -23,8 +23,13 @@ use snarkos_testing::network::{blocks::*, handshaken_node_and_peer, TestSetup};
 fn providing_sync_blocks(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
+    let test_setup = TestSetup {
+        tokio_handle: Some(rt.handle().clone()),
+        ..Default::default()
+    };
+
     // prepare the block provider node and a fake requester node
-    let (provider, requester) = rt.block_on(handshaken_node_and_peer(TestSetup::default()));
+    let (provider, requester) = rt.block_on(handshaken_node_and_peer(test_setup));
     let requester = tokio::sync::Mutex::new(requester);
 
     const NUM_BLOCKS: usize = 10;

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -121,10 +121,13 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                     node_clone.listen_for_messages(&mut reader).await;
                                 });
 
+                                trace!("Connected to {}", remote_address);
+
+                                // immediately send a ping to provide the peer with our block height
+                                node.send_ping(remote_address).await;
+
                                 if let Ok(ref peer) = node.peer_book.read().get_peer(remote_address) {
                                     peer.register_task(conn_listening_task);
-
-                                    trace!("Connected to {}", remote_address);
                                 } else {
                                     // if the related peer is not found, it means it's already been dropped
                                     conn_listening_task.abort();

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -123,6 +123,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
                                 if let Ok(ref peer) = node.peer_book.read().get_peer(remote_address) {
                                     peer.register_task(conn_listening_task);
+
+                                    trace!("Connected to {}", remote_address);
                                 } else {
                                     // if the related peer is not found, it means it's already been dropped
                                     conn_listening_task.abort();

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -159,12 +159,12 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let peer_sync_interval = self.config.peer_sync_interval();
         let peering_task = task::spawn(async move {
             loop {
-                sleep(peer_sync_interval).await;
                 info!("Updating peers");
 
                 if let Err(e) = self_clone.update_peers().await {
                     error!("Peer update error: {}", e);
                 }
+                sleep(peer_sync_interval).await;
             }
         });
         self.register_task(peering_task);

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ConnWriter, Message, NetworkError};
+use crate::{ConnWriter, Direction, Message, NetworkError, Node, Payload};
+
+use snarkvm_objects::Storage;
 
 use std::{
     collections::HashMap,
@@ -95,5 +97,25 @@ impl Outbound {
                 self.send_failure_count.fetch_add(1, Ordering::SeqCst);
             }
         }
+    }
+}
+
+impl<S: Storage + Send + Sync + 'static> Node<S> {
+    pub async fn send_ping(&self, remote_address: SocketAddr) {
+        // consider peering tests that don't use the consensus layer
+        let current_block_height = if let Some(ref consensus) = self.consensus() {
+            consensus.current_block_height()
+        } else {
+            0
+        };
+
+        self.peer_book.read().sending_ping(remote_address);
+
+        self.outbound
+            .send_request(Message::new(
+                Direction::Outbound(remote_address),
+                Payload::Ping(current_block_height),
+            ))
+            .await;
     }
 }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -204,6 +204,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             conn_listening_task.abort();
         }
 
+        trace!("Connected to {}", remote_address);
+
         Ok(())
     }
 

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -31,7 +31,7 @@ use std::{
     },
 };
 
-pub const ITERATIONS: usize = 5000;
+pub const ITERATIONS: usize = 1000;
 pub const CORRUPTION_PROBABILITY: f64 = 0.1;
 
 fn corrupt_bytes(serialized: &[u8]) -> Vec<u8> {

--- a/network/tests/peers.rs
+++ b/network/tests/peers.rs
@@ -30,6 +30,10 @@ async fn peer_initiator_side() {
     };
     let (node, mut peer) = handshaken_node_and_peer(setup).await;
 
+    // check if the peer has received an automatic Ping message from the node
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Ping(..)));
+
     // check if the peer has received the GetPeers message from the node
     let payload = peer.read_payload().await.unwrap();
     assert!(matches!(payload, Payload::GetPeers));
@@ -49,6 +53,10 @@ async fn peer_responder_side() {
         ..Default::default()
     };
     let (_node, mut peer) = handshaken_node_and_peer(setup).await;
+
+    // check if the peer has received an automatic Ping message from the node
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Ping(..)));
 
     // send GetPeers message
     peer.write_message(&Payload::GetPeers).await;

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -44,6 +44,10 @@ async fn block_initiator_side() {
     };
     let (node, mut peer) = handshaken_node_and_peer(setup).await;
 
+    // check if the peer has received an automatic Ping message from the node
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Ping(..)));
+
     // wait for the block_sync_interval to "expire"
     sleep(Duration::from_secs(1)).await;
 
@@ -105,6 +109,10 @@ async fn block_initiator_side() {
 async fn block_responder_side() {
     // handshake between a fake node and a full node
     let (node, mut peer) = handshaken_node_and_peer(TestSetup::default()).await;
+
+    // check if the peer has received an automatic Ping message from the node
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Ping(..)));
 
     // insert block into node
     let block_struct_1 = snarkvm_objects::Block::deserialize(&BLOCK_1).unwrap();
@@ -223,6 +231,10 @@ async fn transaction_initiator_side() {
     };
     let (node, mut peer) = handshaken_node_and_peer(setup).await;
 
+    // check if the peer has received an automatic Ping message from the node
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Ping(..)));
+
     // check GetMemoryPool message was received
     let payload = peer.read_payload().await.unwrap();
     assert!(matches!(payload, Payload::GetMemoryPool));
@@ -251,6 +263,10 @@ async fn transaction_initiator_side() {
 async fn transaction_responder_side() {
     // handshake between a fake node and a full node
     let (node, mut peer) = handshaken_node_and_peer(TestSetup::default()).await;
+
+    // check if the peer has received an automatic Ping message from the node
+    let payload = peer.read_payload().await.unwrap();
+    assert!(matches!(payload, Payload::Ping(..)));
 
     // insert transaction into node
     let mut memory_pool = node.expect_consensus().memory_pool().lock();

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -146,24 +146,29 @@ async fn block_responder_side() {
     assert_eq!(block, block_struct_1);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test]
 #[ignore]
-async fn block_propagation() {
+fn block_propagation() {
+    let rt = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+
     let setup = TestSetup {
         consensus_setup: Some(ConsensusSetup {
             is_miner: true,
             ..Default::default()
         }),
+        tokio_handle: Some(rt.handle().clone()),
         ..Default::default()
     };
 
-    let (_node, mut peer) = handshaken_node_and_peer(setup).await;
+    rt.block_on(async move {
+        let (_node, mut peer) = handshaken_node_and_peer(setup).await;
 
-    let payload = peer.read_payload().await.unwrap();
-    assert!(matches!(payload, Payload::Block(..)));
+        let payload = peer.read_payload().await.unwrap();
+        assert!(matches!(payload, Payload::Block(..)));
 
-    // TODO: shutdown the miner task, currently there is no good way to do this. This test will
-    // currently hang after the assertion.
+        // TODO: shutdown the miner task, currently there is no good way to do this. This test will
+        // currently hang after the assertion.
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
Spawning a miner currently only spawns an asynchronous task, but mining is a synchronous process, which means it can cause blocking to the async executor (even though it's multi-threaded). This PR uses an actual OS thread instead, which frees the async executor so it can carry out other functionalities, notably anything network-related.

Filing it as a draft for now, as it'll need to be rebased after the pending refactoring PRs are merged.