### PR TITLE
Introduce node state, assorted tweaks

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -95,7 +95,7 @@ impl<S: Storage> Consensus<S> {
                 self.parameters
                     .verify_header(&block.header, &parent_block.header, &merkle_root, &pedersen_merkle_root)
             {
-                println!("header failed to verify: {:?}", err);
+                error!("block header failed to verify: {:?}", err);
                 return Ok(false);
             }
         }
@@ -116,15 +116,15 @@ impl<S: Storage> Consensus<S> {
 
         // Check that there is only 1 coinbase transaction
         if coinbase_transaction_count > 1 {
-            println!("error - multiple coinbase transactions");
+            error!("multiple coinbase transactions");
             return Ok(false);
         }
 
         // Check that the block value balances are correct
         let expected_block_reward = crate::get_block_reward(self.ledger.len() as u32).0;
         if total_value_balance.0 + expected_block_reward != 0 {
-            println!("total_value_balance: {:?}", total_value_balance);
-            println!("expected_block_reward: {:?}", expected_block_reward);
+            trace!("total_value_balance: {:?}", total_value_balance);
+            trace!("expected_block_reward: {:?}", expected_block_reward);
 
             return Ok(false);
         }

--- a/consensus/src/difficulty.rs
+++ b/consensus/src/difficulty.rs
@@ -38,8 +38,8 @@ pub fn naive_retarget(
         x *= parent_diff;
         x = parent_diff - x;
 
-        println!("old difficulty        {:#x}", parent_difficulty);
-        println!("new difficulty        {:#x}", x as u64);
+        trace!("old difficulty        {:#x}", parent_difficulty);
+        trace!("new difficulty        {:#x}", x as u64);
 
         x as u64
     }
@@ -91,8 +91,8 @@ pub fn ethereum_retarget(block_timestamp: i64, parent_timestamp: i64, parent_dif
     x *= y;
     x += parent_diff;
 
-    println!("old difficulty        {:#x}", parent_difficulty);
-    println!("new difficulty        {:#x}", x as u64);
+    trace!("old difficulty        {:#x}", parent_difficulty);
+    trace!("new difficulty        {:#x}", x as u64);
 
     x as u64
 }

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 /// A core data structure containing the pre-configured parameters for the node.
-pub struct Environment {
+pub struct Config {
     /// The pre-configured desired address of this node.
     pub desired_address: Option<SocketAddr>,
     /// The minimum number of peers required to maintain connections with.
@@ -40,7 +40,7 @@ pub struct Environment {
     peer_sync_interval: Duration,
 }
 
-impl Environment {
+impl Config {
     /// Creates a new instance of `Environment`.
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/network/src/consensus/consensus.rs
+++ b/network/src/consensus/consensus.rs
@@ -24,6 +24,7 @@ use snarkvm_objects::Storage;
 
 use parking_lot::{Mutex, RwLock};
 use std::{
+    net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -120,8 +121,9 @@ impl<S: Storage> Consensus<S> {
             && self.last_block_sync.read().elapsed() > self.block_sync_interval
     }
 
-    /// Register that the node attempted to sync blocks.
-    pub fn register_block_sync_attempt(&self) {
+    /// Register that the node attempted to sync blocks with the given peer.
+    pub fn register_block_sync_attempt(&self, provider: SocketAddr) {
+        trace!("Attempting to sync with {}", provider);
         *self.last_block_sync.write() = Instant::now();
         self.node.set_state(State::Syncing);
     }

--- a/network/src/consensus/consensus.rs
+++ b/network/src/consensus/consensus.rs
@@ -125,7 +125,6 @@ impl<S: Storage> Consensus<S> {
     pub fn register_block_sync_attempt(&self, provider: SocketAddr) {
         trace!("Attempting to sync with {}", provider);
         *self.last_block_sync.write() = Instant::now();
-        self.node.set_state(State::Syncing);
     }
 
     /// Returns the interval between each transaction (memory pool) sync.

--- a/network/src/consensus/consensus.rs
+++ b/network/src/consensus/consensus.rs
@@ -114,9 +114,10 @@ impl<S: Storage> Consensus<S> {
         self.consensus.ledger.get_current_block_height()
     }
 
-    /// Checks whether enough time has elapsed for the node to attempt another block sync.
-    pub fn should_sync_blocks(&self) -> bool {
-        !self.is_syncing_blocks() && self.last_block_sync.read().elapsed() > self.block_sync_interval
+    /// Checks whether the conditions for the node to attempt another block sync are met.
+    pub fn should_sync_blocks(&self, peer_block_height: u32) -> bool {
+        peer_block_height > self.current_block_height() + 1
+            && self.last_block_sync.read().elapsed() > self.block_sync_interval
     }
 
     /// Register that the node attempted to sync blocks.

--- a/network/src/consensus/miner.rs
+++ b/network/src/consensus/miner.rs
@@ -42,8 +42,13 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
     /// Miner threads are asynchronous so the only way to stop them is to kill the runtime they were started in. This may be changed in the future.
     pub fn spawn(self) -> task::JoinHandle<()> {
         task::spawn(async move {
-            let local_address = self.node.environment.local_address().unwrap();
             info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
+
+            let local_address = self
+                .node
+                .local_address()
+                .expect("tried to spawn a miner before the network was initialized!");
+
             let miner = Miner::new(
                 self.miner_address.clone(),
                 Arc::clone(&self.node.expect_consensus().consensus),

--- a/network/src/consensus/miner.rs
+++ b/network/src/consensus/miner.rs
@@ -61,7 +61,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
             loop {
                 // don't mine if the node is currently syncing
                 if self.node.state() == State::Syncing {
-                    time::sleep(Duration::from_secs(1)).await;
+                    time::sleep(Duration::from_secs(5)).await;
                     continue;
                 } else {
                     self.node.set_state(State::Mining);

--- a/network/src/environment.rs
+++ b/network/src/environment.rs
@@ -16,20 +16,17 @@
 
 use crate::NetworkError;
 
-use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
-use rand::{thread_rng, Rng};
 use std::{
     net::SocketAddr,
     time::Duration,
     {self},
 };
 
-/// A core data structure containing the networking parameters for this node.
+/// A core data structure containing the pre-configured parameters for the node.
 pub struct Environment {
-    pub name: u64,
-    /// The local address of this node.
-    local_address: OnceCell<SocketAddr>,
+    /// The pre-configured desired address of this node.
+    pub desired_address: Option<SocketAddr>,
     /// The minimum number of peers required to maintain connections with.
     minimum_number_of_connected_peers: u16,
     /// The maximum number of peers permitted to maintain connections with.
@@ -47,6 +44,7 @@ impl Environment {
     /// Creates a new instance of `Environment`.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        desired_address: Option<SocketAddr>,
         minimum_number_of_connected_peers: u16,
         maximum_number_of_connected_peers: u16,
         bootnodes_addresses: Vec<String>,
@@ -61,33 +59,14 @@ impl Environment {
             }
         }
 
-        // Generate the node name.
-        let mut rng = thread_rng();
-        let name = rng.gen();
-
         Ok(Self {
-            local_address: Default::default(),
-            name,
+            desired_address,
             minimum_number_of_connected_peers,
             maximum_number_of_connected_peers,
             bootnodes: RwLock::new(bootnodes),
             is_bootnode,
             peer_sync_interval,
         })
-    }
-
-    /// Returns the local address of the node.
-    #[inline]
-    pub fn local_address(&self) -> Option<SocketAddr> {
-        self.local_address.get().copied()
-    }
-
-    /// Sets the local address of the node to the given value.
-    #[inline]
-    pub fn set_local_address(&self, addr: SocketAddr) {
-        self.local_address
-            .set(addr)
-            .expect("local address was set more than once!");
     }
 
     /// Returns the default bootnodes of the network.

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -68,10 +68,6 @@ impl Inbound {
 
             // Determine if we should disconnect.
             *disconnect_from_peer = error.is_fatal() || *failure_count >= 10;
-
-            if *disconnect_from_peer {
-                debug!("Should disconnect from peer");
-            }
         } else {
             debug!("A connection errored again in the same loop (error message: {})", error);
         }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -324,14 +324,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         }
         let len = reader.read_exact(&mut buf[..len]).await?;
         noise.read_message(&buf[..len], &mut buffer)?;
-        trace!("received e (XX handshake part 1/3)");
+        trace!("received e (XX handshake part 1/3) from {}", remote_address);
 
         // -> e, ee, s, es
         let own_version = Version::serialize(&Version::new(1u64, listener_address.port())).unwrap(); // TODO (raychu86): Establish a formal node version.
         let len = noise.write_message(&own_version, &mut buffer)?;
         writer.write_all(&[len as u8]).await?;
         writer.write_all(&buffer[..len]).await?;
-        trace!("sent e, ee, s, es (XX handshake part 2/3)");
+        trace!("sent e, ee, s, es (XX handshake part 2/3) to {}", remote_address);
 
         // <- s, se, psk
         reader.read_exact(&mut buf[..1]).await?;
@@ -342,7 +342,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let len = reader.read_exact(&mut buf[..len]).await?;
         let len = noise.read_message(&buf[..len], &mut buffer)?;
         let peer_version = Version::deserialize(&buffer[..len])?;
-        trace!("received s, se, psk (XX handshake part 3/3)");
+        trace!("received s, se, psk (XX handshake part 3/3) from {}", remote_address);
 
         // the remote listening address
         let remote_listener = SocketAddr::from((remote_address.ip(), peer_version.listening_port));

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -272,8 +272,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         consensus.register_block_sync_attempt();
                         trace!("Attempting to sync with {}", source.unwrap());
                         consensus.update_blocks(source.unwrap()).await;
-                    } else {
-                        consensus.finished_syncing_blocks();
                     }
                 }
             }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -269,8 +269,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         && !self.peer_book.read().is_syncing_blocks(source.unwrap())
                     {
                         self.peer_book.write().cancel_any_ongoing_syncing();
-                        consensus.register_block_sync_attempt();
-                        trace!("Attempting to sync with {}", source.unwrap());
+                        consensus.register_block_sync_attempt(source.unwrap());
                         consensus.update_blocks(source.unwrap()).await;
                     }
                 }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -94,8 +94,8 @@ impl Inbound {
 }
 
 impl<S: Storage + Send + Sync + 'static> Node<S> {
-    pub async fn listen(&self, desired_address: Option<SocketAddr>) -> Result<(), NetworkError> {
-        let (listener_address, listener) = if let Some(addr) = desired_address {
+    pub async fn listen(&self) -> Result<(), NetworkError> {
+        let (listener_address, listener) = if let Some(addr) = self.environment.desired_address {
             let listener = TcpListener::bind(&addr).await?;
             (listener.local_addr()?, listener)
         } else {
@@ -103,8 +103,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             let listener_address = listener.local_addr()?;
             (listener_address, listener)
         };
-        self.environment.set_local_address(listener_address);
-        info!("Node {:x} listening at {}", self.environment.name, listener_address);
+        self.set_local_address(listener_address);
+        info!("Node {:x} listening at {}", self.name, listener_address);
 
         let node = self.clone();
         let listener_handle = task::spawn(async move {

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -95,7 +95,7 @@ impl Inbound {
 
 impl<S: Storage + Send + Sync + 'static> Node<S> {
     pub async fn listen(&self) -> Result<(), NetworkError> {
-        let (listener_address, listener) = if let Some(addr) = self.environment.desired_address {
+        let (listener_address, listener) = if let Some(addr) = self.config.desired_address {
             let listener = TcpListener::bind(&addr).await?;
             (listener.local_addr()?, listener)
         } else {
@@ -193,7 +193,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     pub async fn process_incoming_messages(&self, receiver: &mut Receiver) -> Result<(), NetworkError> {
         let Message { direction, payload } = receiver.recv().await.ok_or(NetworkError::ReceiverFailedToParse)?;
 
-        if self.environment.is_bootnode() && payload != Payload::GetPeers {
+        if self.config.is_bootnode() && payload != Payload::GetPeers {
             // the bootstrapper nodes should ignore inbound messages other than GetPeers
             return Ok(());
         }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -276,11 +276,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             }
             Payload::Ping(block_height) => {
                 if let Some(ref consensus) = self.consensus() {
-                    if !consensus.is_syncing_blocks()
-                        && consensus.should_sync_blocks(block_height)
-                        && !self.peer_book.read().is_syncing_blocks(source.unwrap())
-                    {
-                        self.peer_book.write().cancel_any_ongoing_syncing();
+                    if !consensus.is_syncing_blocks() && consensus.should_sync_blocks(block_height) {
+                        self.peer_book.write().cancel_any_unfinished_syncing();
                         consensus.register_block_sync_attempt(source.unwrap());
                         consensus.update_blocks(source.unwrap()).await;
                     }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -44,19 +44,14 @@ pub use inbound::*;
 pub mod message;
 pub use message::*;
 
+pub mod node;
+pub use node::*;
+
 pub mod outbound;
 pub use outbound::*;
 
 pub mod peers;
 pub use peers::*;
-
-use crate::ConnWriter;
-use snarkvm_objects::Storage;
-
-use once_cell::sync::OnceCell;
-use parking_lot::{Mutex, RwLock};
-use std::{collections::HashMap, net::SocketAddr, ops::Deref, sync::Arc};
-use tokio::{task, time::sleep};
 
 pub const HANDSHAKE_PATTERN: &str = "Noise_XXpsk3_25519_ChaChaPoly_SHA256";
 pub const HANDSHAKE_PSK: &[u8] = b"b765e427e836e0029a1e2a22ba60c52a"; // the PSK must be 32B
@@ -71,165 +66,3 @@ pub const SHARED_PEER_COUNT: usize = 25;
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 
 pub(crate) type Receiver = tokio::sync::mpsc::Receiver<Message>;
-
-/// A core data structure for operating the networking stack of this node.
-// TODO: remove inner Arcs once the Node itself is passed around in an Arc or contains an inner object wrapped in an Arc (causing all the Node's contents that are not to be "cloned around" to be Arced too).
-#[derive(Derivative)]
-#[derivative(Clone(bound = ""))]
-pub struct Node<S: Storage>(Arc<InnerNode<S>>);
-
-impl<S: Storage> Deref for Node<S> {
-    type Target = Arc<InnerNode<S>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[doc(hide)]
-pub struct InnerNode<S: Storage> {
-    /// The parameters and settings of this node.
-    pub environment: Environment,
-    /// The inbound handler of this node.
-    inbound: Inbound,
-    /// The outbound handler of this node.
-    outbound: Outbound,
-    /// The list of connected and disconnected peers of this node.
-    pub peer_book: RwLock<PeerBook>,
-    /// The objects related to consensus.
-    pub consensus: OnceCell<Arc<Consensus<S>>>,
-    /// The tasks spawned by the node.
-    tasks: Mutex<Vec<task::JoinHandle<()>>>,
-}
-
-impl<S: Storage + Send + Sync + 'static> Node<S> {
-    /// Creates a new instance of `Node`.
-    pub async fn new(environment: Environment) -> Result<Self, NetworkError> {
-        let channels: Arc<RwLock<HashMap<SocketAddr, Arc<ConnWriter>>>> = Default::default();
-        // Create the inbound and outbound handlers.
-        let inbound = Inbound::new(channels.clone());
-        let outbound = Outbound::new(channels);
-
-        Ok(Self(Arc::new(InnerNode {
-            environment,
-            inbound,
-            outbound,
-            peer_book: Default::default(),
-            consensus: Default::default(),
-            tasks: Default::default(),
-        })))
-    }
-
-    pub fn set_consensus(&mut self, consensus: Consensus<S>) {
-        if self.consensus.set(Arc::new(consensus)).is_err() {
-            panic!("consensus was set more than once!");
-        }
-    }
-
-    /// Returns a reference to the consensus objects.
-    #[inline]
-    pub fn consensus(&self) -> Option<&Arc<Consensus<S>>> {
-        self.consensus.get()
-    }
-
-    /// Returns a reference to the consensus objects, expecting them to be available.
-    #[inline]
-    pub fn expect_consensus(&self) -> &Consensus<S> {
-        self.consensus().expect("no consensus!")
-    }
-
-    #[inline]
-    #[doc(hidden)]
-    pub fn has_consensus(&self) -> bool {
-        self.consensus().is_some()
-    }
-
-    pub async fn start_services(&self) {
-        let self_clone = self.clone();
-        let mut receiver = self.inbound.take_receiver();
-        let incoming_task = task::spawn(async move {
-            loop {
-                if let Err(e) = self_clone.process_incoming_messages(&mut receiver).await {
-                    error!("Node error: {}", e);
-                }
-            }
-        });
-        self.register_task(incoming_task);
-
-        let self_clone = self.clone();
-        let peer_sync_interval = self.environment.peer_sync_interval();
-        let peering_task = task::spawn(async move {
-            loop {
-                sleep(peer_sync_interval).await;
-                info!("Updating peers");
-
-                if let Err(e) = self_clone.update_peers().await {
-                    error!("Peer update error: {}", e);
-                }
-            }
-        });
-        self.register_task(peering_task);
-
-        if !self.environment.is_bootnode() {
-            if let Some(ref consensus) = self.consensus() {
-                let self_clone = self.clone();
-                let consensus = Arc::clone(consensus);
-                let transaction_sync_interval = consensus.transaction_sync_interval();
-                let tx_sync_task = task::spawn(async move {
-                    loop {
-                        sleep(transaction_sync_interval).await;
-
-                        if !consensus.is_syncing_blocks() {
-                            info!("Updating transactions");
-
-                            // select last seen node as block sync node
-                            let sync_node = self_clone.peer_book.read().last_seen();
-                            consensus.update_transactions(sync_node).await;
-                        }
-                    }
-                });
-                self.register_task(tx_sync_task);
-            }
-        }
-    }
-
-    pub fn shut_down(&self) {
-        debug!("Shutting down");
-
-        for addr in self.connected_addrs() {
-            let _ = self.disconnect_from_peer(addr);
-        }
-
-        for handle in self.tasks.lock().drain(..).rev() {
-            handle.abort();
-        }
-    }
-
-    pub fn register_task(&self, handle: task::JoinHandle<()>) {
-        self.tasks.lock().push(handle);
-    }
-
-    #[inline]
-    pub fn local_address(&self) -> Option<SocketAddr> {
-        self.environment.local_address()
-    }
-}
-
-impl<S: Storage> Drop for InnerNode<S> {
-    // this won't make a difference in regular scenarios, but will be practical for test
-    // purposes, so that there are no lingering tasks
-    fn drop(&mut self) {
-        // since we're going out of scope, we don't care about holding the read lock here
-        // also, the connections are going to be broken automatically, so we only need to
-        // take care of the associated tasks here
-        for peer_info in self.peer_book.read().connected_peers().values() {
-            for handle in peer_info.tasks.lock().drain(..).rev() {
-                handle.abort();
-            }
-        }
-
-        for handle in self.tasks.lock().drain(..).rev() {
-            handle.abort();
-        }
-    }
-}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -32,8 +32,8 @@ extern crate snarkos_metrics;
 pub mod consensus;
 pub use consensus::*;
 
-pub mod environment;
-pub use environment::*;
+pub mod config;
+pub use config::*;
 
 pub mod errors;
 pub use errors::*;

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use tokio::{task, time::sleep};
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum State {
     Idle = 0,

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -1,0 +1,184 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::*;
+use snarkvm_objects::Storage;
+
+use once_cell::sync::OnceCell;
+use parking_lot::{Mutex, RwLock};
+use std::{collections::HashMap, net::SocketAddr, ops::Deref, sync::Arc};
+use tokio::{task, time::sleep};
+
+/// A core data structure for operating the networking stack of this node.
+#[derive(Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct Node<S: Storage>(Arc<InnerNode<S>>);
+
+impl<S: Storage> Deref for Node<S> {
+    type Target = Arc<InnerNode<S>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[doc(hide)]
+pub struct InnerNode<S: Storage> {
+    /// The parameters and settings of this node.
+    pub environment: Environment,
+    /// The inbound handler of this node.
+    pub inbound: Inbound,
+    /// The outbound handler of this node.
+    pub outbound: Outbound,
+    /// The list of connected and disconnected peers of this node.
+    pub peer_book: RwLock<PeerBook>,
+    /// The objects related to consensus.
+    pub consensus: OnceCell<Arc<Consensus<S>>>,
+    /// The tasks spawned by the node.
+    tasks: Mutex<Vec<task::JoinHandle<()>>>,
+}
+
+impl<S: Storage + Send + Sync + 'static> Node<S> {
+    /// Creates a new instance of `Node`.
+    pub async fn new(environment: Environment) -> Result<Self, NetworkError> {
+        let channels: Arc<RwLock<HashMap<SocketAddr, Arc<ConnWriter>>>> = Default::default();
+        // Create the inbound and outbound handlers.
+        let inbound = Inbound::new(channels.clone());
+        let outbound = Outbound::new(channels);
+
+        Ok(Self(Arc::new(InnerNode {
+            environment,
+            inbound,
+            outbound,
+            peer_book: Default::default(),
+            consensus: Default::default(),
+            tasks: Default::default(),
+        })))
+    }
+
+    pub fn set_consensus(&mut self, consensus: Consensus<S>) {
+        if self.consensus.set(Arc::new(consensus)).is_err() {
+            panic!("consensus was set more than once!");
+        }
+    }
+
+    /// Returns a reference to the consensus objects.
+    #[inline]
+    pub fn consensus(&self) -> Option<&Arc<Consensus<S>>> {
+        self.consensus.get()
+    }
+
+    /// Returns a reference to the consensus objects, expecting them to be available.
+    #[inline]
+    pub fn expect_consensus(&self) -> &Consensus<S> {
+        self.consensus().expect("no consensus!")
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn has_consensus(&self) -> bool {
+        self.consensus().is_some()
+    }
+
+    pub async fn start_services(&self) {
+        let self_clone = self.clone();
+        let mut receiver = self.inbound.take_receiver();
+        let incoming_task = task::spawn(async move {
+            loop {
+                if let Err(e) = self_clone.process_incoming_messages(&mut receiver).await {
+                    error!("Node error: {}", e);
+                }
+            }
+        });
+        self.register_task(incoming_task);
+
+        let self_clone = self.clone();
+        let peer_sync_interval = self.environment.peer_sync_interval();
+        let peering_task = task::spawn(async move {
+            loop {
+                sleep(peer_sync_interval).await;
+                info!("Updating peers");
+
+                if let Err(e) = self_clone.update_peers().await {
+                    error!("Peer update error: {}", e);
+                }
+            }
+        });
+        self.register_task(peering_task);
+
+        if !self.environment.is_bootnode() {
+            if let Some(ref consensus) = self.consensus() {
+                let self_clone = self.clone();
+                let consensus = Arc::clone(consensus);
+                let transaction_sync_interval = consensus.transaction_sync_interval();
+                let tx_sync_task = task::spawn(async move {
+                    loop {
+                        sleep(transaction_sync_interval).await;
+
+                        if !consensus.is_syncing_blocks() {
+                            info!("Updating transactions");
+
+                            // select last seen node as block sync node
+                            let sync_node = self_clone.peer_book.read().last_seen();
+                            consensus.update_transactions(sync_node).await;
+                        }
+                    }
+                });
+                self.register_task(tx_sync_task);
+            }
+        }
+    }
+
+    pub fn shut_down(&self) {
+        debug!("Shutting down");
+
+        for addr in self.connected_addrs() {
+            let _ = self.disconnect_from_peer(addr);
+        }
+
+        for handle in self.tasks.lock().drain(..).rev() {
+            handle.abort();
+        }
+    }
+
+    pub fn register_task(&self, handle: task::JoinHandle<()>) {
+        self.tasks.lock().push(handle);
+    }
+
+    #[inline]
+    pub fn local_address(&self) -> Option<SocketAddr> {
+        self.environment.local_address()
+    }
+}
+
+impl<S: Storage> Drop for InnerNode<S> {
+    // this won't make a difference in regular scenarios, but will be practical for test
+    // purposes, so that there are no lingering tasks
+    fn drop(&mut self) {
+        // since we're going out of scope, we don't care about holding the read lock here
+        // also, the connections are going to be broken automatically, so we only need to
+        // take care of the associated tasks here
+        for peer_info in self.peer_book.read().connected_peers().values() {
+            for handle in peer_info.tasks.lock().drain(..).rev() {
+                handle.abort();
+            }
+        }
+
+        for handle in self.tasks.lock().drain(..).rev() {
+            handle.abort();
+        }
+    }
+}

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -343,7 +343,7 @@ impl PeerBook {
         if let Some(ref pq) = self.peer_quality(addr) {
             pq.remaining_sync_blocks.store(count as u16, Ordering::SeqCst);
         } else {
-            error!("Peer for expecting_sync_blocks purposes not found!");
+            warn!("Peer for expecting_sync_blocks purposes not found! (probably disconnected)");
         }
     }
 
@@ -352,7 +352,7 @@ impl PeerBook {
         if let Some(ref pq) = self.peer_quality(addr) {
             pq.remaining_sync_blocks.fetch_sub(1, Ordering::SeqCst) == 1
         } else {
-            error!("Peer for got_sync_block purposes not found!");
+            warn!("Peer for got_sync_block purposes not found! (probably disconnected)");
             true
         }
     }
@@ -362,7 +362,7 @@ impl PeerBook {
         if let Some(ref pq) = self.peer_quality(addr) {
             pq.remaining_sync_blocks.load(Ordering::SeqCst) != 0
         } else {
-            error!("Peer for got_sync_block purposes not found!");
+            warn!("Peer for is_syncing_blocks purposes not found! (probably disconnected)");
             false
         }
     }

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -306,7 +306,7 @@ impl PeerBook {
         if let Some(ref quality) = self.peer_quality(addr) {
             *quality.last_seen.write() = Some(chrono::Utc::now());
         } else {
-            warn!("Attempted to update state of a peer that's not connected: {}", addr);
+            trace!("Attempted to update state of a peer that's not connected: {}", addr);
         }
     }
 
@@ -365,7 +365,7 @@ impl PeerBook {
         if let Some(ref pq) = self.peer_quality(addr) {
             pq.remaining_sync_blocks.load(Ordering::SeqCst) != 0
         } else {
-            warn!("Peer for is_syncing_blocks purposes not found! (probably disconnected)");
+            trace!("Peer for is_syncing_blocks purposes not found! (probably disconnected)");
             false
         }
     }

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -371,7 +371,7 @@ impl PeerBook {
     }
 
     /// Cancels any expected sync block counts from all peers.
-    pub fn cancel_any_ongoing_syncing(&mut self) {
+    pub fn cancel_any_unfinished_syncing(&mut self) {
         for peer_info in self.connected_peers.values_mut() {
             let missing_sync_blocks = peer_info.quality.remaining_sync_blocks.swap(0, Ordering::SeqCst);
             if missing_sync_blocks != 0 {

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -327,6 +327,7 @@ impl PeerBook {
             if quality.expecting_pong.load(Ordering::SeqCst) {
                 let ping_sent = quality.last_ping_sent.lock().unwrap();
                 let rtt = ping_sent.elapsed().as_millis() as u64;
+                trace!("RTT for {} is {}ms", source, rtt);
                 quality.rtt_ms.store(rtt, Ordering::SeqCst);
                 quality.expecting_pong.store(false, Ordering::SeqCst);
             } else {

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -24,7 +24,7 @@ use tokio::task;
 use std::{
     net::SocketAddr,
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8},
+        atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8, Ordering},
         Arc,
     },
     time::Instant,
@@ -190,6 +190,8 @@ impl PeerInfo {
                 self.status = PeerStatus::Disconnected;
 
                 self.last_disconnected = Some(Utc::now());
+                self.quality.expecting_pong.store(false, Ordering::SeqCst);
+                self.quality.remaining_sync_blocks.store(0, Ordering::SeqCst);
                 self.disconnected_count += 1;
 
                 for handle in self.tasks.lock().drain(..).rev() {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -162,7 +162,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let len = noise.write_message(&[], &mut buffer)?;
         writer.write_all(&[len as u8]).await?;
         writer.write_all(&buffer[..len]).await?;
-        trace!("sent e (XX handshake part 1/3)");
+        trace!("sent e (XX handshake part 1/3) to {}", remote_address);
 
         // <- e, ee, s, es
         reader.read_exact(&mut buf[..1]).await?;
@@ -173,14 +173,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let len = reader.read_exact(&mut buf[..len]).await?;
         let len = noise.read_message(&buf[..len], &mut buffer)?;
         let _peer_version = Version::deserialize(&buffer[..len])?;
-        trace!("received e, ee, s, es (XX handshake part 2/3)");
+        trace!("received e, ee, s, es (XX handshake part 2/3) from {}", remote_address);
 
         // -> s, se, psk
         let own_version = Version::serialize(&Version::new(1u64, own_address.port())).unwrap();
         let len = noise.write_message(&own_version, &mut buffer)?;
         writer.write_all(&[len as u8]).await?;
         writer.write_all(&buffer[..len]).await?;
-        trace!("sent s, se, psk (XX handshake part 3/3)");
+        trace!("sent s, se, psk (XX handshake part 3/3) to {}", remote_address);
 
         let noise = Arc::new(Mutex::new(noise.into_transport_mode()?));
         let writer = ConnWriter::new(remote_address, writer, buffer.clone(), Arc::clone(&noise));

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -386,7 +386,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // TODO (howardwu): Simplify this and parallelize this with Rayon.
         // Process all of the peers sent in the message,
         // by informing the peer book of that we found peers.
-        let local_address = self.environment.local_address().unwrap(); // the address must be known by now
+        let local_address = self.local_address().unwrap(); // the address must be known by now
 
         let number_of_connected_peers = self.peer_book.read().number_of_connected_peers();
         let number_to_connect = self

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -57,7 +57,7 @@ async fn fuzzing_zeroes_pre_handshake() {
         ..Default::default()
     };
     let node = test_node(node_setup).await;
-    let node_addr = node.environment.local_address().unwrap();
+    let node_addr = node.local_address().unwrap();
 
     let mut stream = TcpStream::connect(node_addr).await.unwrap();
     wait_until!(1, node.peer_book.read().number_of_connecting_peers() == 1);
@@ -90,7 +90,7 @@ async fn fuzzing_valid_header_pre_handshake() {
         ..Default::default()
     };
     let node = test_node(node_setup).await;
-    let node_addr = node.environment.local_address().unwrap();
+    let node_addr = node.local_address().unwrap();
 
     for _ in 0..ITERATIONS {
         let random_len: usize = thread_rng().gen_range(1..(64 * 1024));
@@ -142,7 +142,7 @@ async fn fuzzing_pre_handshake() {
         ..Default::default()
     };
     let node = test_node(node_setup).await;
-    let node_addr = node.environment.local_address().unwrap();
+    let node_addr = node.local_address().unwrap();
 
     for _ in 0..ITERATIONS {
         let random_len: usize = thread_rng().gen_range(1..(64 * 1024));

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -37,7 +37,7 @@ async fn test_nodes(n: usize, setup: TestSetup) -> Vec<Node<LedgerStorage>> {
         let environment = test_environment(setup.clone());
         let node = Node::new(environment).await.unwrap();
 
-        node.listen(setup.socket_address).await.unwrap();
+        node.listen().await.unwrap();
         nodes.push(node);
     }
 
@@ -206,8 +206,8 @@ async fn binary_star_contact() {
     let bootnode_a = Node::new(environment_a).await.unwrap();
     let bootnode_b = Node::new(environment_b).await.unwrap();
 
-    bootnode_a.listen(bootnode_setup.socket_address).await.unwrap();
-    bootnode_b.listen(bootnode_setup.socket_address).await.unwrap();
+    bootnode_a.listen().await.unwrap();
+    bootnode_b.listen().await.unwrap();
 
     let ba = bootnode_a.local_address().unwrap().to_string();
     let bb = bootnode_b.local_address().unwrap().to_string();

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -18,7 +18,7 @@ use snarkos_network::Node;
 use snarkos_storage::LedgerStorage;
 use snarkos_testing::{
     network::{
-        test_environment,
+        test_config,
         test_node,
         topology::{connect_nodes, Topology},
         TestSetup,
@@ -34,7 +34,7 @@ async fn test_nodes(n: usize, setup: TestSetup) -> Vec<Node<LedgerStorage>> {
     let mut nodes = Vec::with_capacity(n);
 
     for _ in 0..n {
-        let environment = test_environment(setup.clone());
+        let environment = test_config(setup.clone());
         let node = Node::new(environment).await.unwrap();
 
         node.listen().await.unwrap();
@@ -201,8 +201,8 @@ async fn binary_star_contact() {
         is_bootnode: true,
         ..Default::default()
     };
-    let environment_a = test_environment(bootnode_setup.clone());
-    let environment_b = test_environment(bootnode_setup.clone());
+    let environment_a = test_config(bootnode_setup.clone());
+    let environment_b = test_config(bootnode_setup.clone());
     let bootnode_a = Node::new(environment_a).await.unwrap();
     let bootnode_b = Node::new(environment_b).await.unwrap();
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -307,12 +307,9 @@ impl<S: Storage + Send + Sync + 'static> RpcFunctions for RpcImpl<S> {
 
     /// Returns data about the node.
     fn get_node_info(&self) -> Result<NodeInfo, RpcError> {
-        // FIXME(ljedrz): actually check if syncing
-        let is_syncing = false;
-
         Ok(NodeInfo {
             is_miner: self.consensus_layer()?.is_miner(),
-            is_syncing,
+            is_syncing: self.consensus_layer()?.is_syncing_blocks(),
         })
     }
 

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -22,7 +22,7 @@ mod protected_rpc_tests {
     use snarkos_storage::LedgerStorage;
     use snarkos_testing::{
         consensus::*,
-        network::{test_environment, ConsensusSetup, TestSetup},
+        network::{test_config, ConsensusSetup, TestSetup},
     };
 
     use snarkvm_dpc::{
@@ -78,7 +78,7 @@ mod protected_rpc_tests {
             password: TEST_PASSWORD.to_string(),
         };
 
-        let environment = test_environment(TestSetup::default());
+        let environment = test_config(TestSetup::default());
         let mut node = Node::new(environment).await.unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::consensus::create_test_consensus_from_ledger(

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -22,7 +22,7 @@ mod rpc_tests {
     use snarkos_storage::LedgerStorage;
     use snarkos_testing::{
         consensus::*,
-        network::{test_environment, ConsensusSetup, TestSetup},
+        network::{test_config, ConsensusSetup, TestSetup},
     };
     use snarkvm_dpc::base_dpc::instantiated::Tx;
     use snarkvm_objects::Transaction;
@@ -37,7 +37,7 @@ mod rpc_tests {
     use std::{net::SocketAddr, sync::Arc, time::Duration};
 
     async fn initialize_test_rpc(ledger: Arc<MerkleTreeLedger<LedgerStorage>>) -> Rpc {
-        let environment = test_environment(TestSetup::default());
+        let environment = test_config(TestSetup::default());
         let mut node = Node::new(environment).await.unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::consensus::create_test_consensus_from_ledger(

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -86,12 +86,13 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     print_welcome(&config);
 
     let address = format! {"{}:{}", config.node.ip, config.node.port};
-    let socket_address = address.parse::<SocketAddr>()?;
+    let desired_address = address.parse::<SocketAddr>()?;
 
     let mut path = config.node.dir;
     path.push(&config.node.db);
 
     let environment = Environment::new(
+        Some(desired_address),
         config.p2p.min_peers,
         config.p2p.max_peers,
         config.p2p.bootnodes.clone(),
@@ -162,7 +163,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     };
 
     // Start listening for incoming connections.
-    node.listen(Some(socket_address)).await?;
+    node.listen().await?;
 
     // Start the miner task if mining configuration is enabled.
     if config.miner.is_miner {

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -24,7 +24,7 @@ use snarkos::{
     errors::NodeError,
 };
 use snarkos_consensus::{ConsensusParameters, MemoryPool, MerkleTreeLedger};
-use snarkos_network::{environment::Environment, Consensus, MinerInstance, Node};
+use snarkos_network::{config::Config as NodeConfig, Consensus, MinerInstance, Node};
 use snarkos_rpc::start_rpc_server;
 use snarkos_storage::LedgerStorage;
 use snarkvm_algorithms::{CRH, SNARK};
@@ -91,7 +91,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let mut path = config.node.dir;
     path.push(&config.node.db);
 
-    let environment = Environment::new(
+    let node_config = NodeConfig::new(
         Some(desired_address),
         config.p2p.min_peers,
         config.p2p.max_peers,
@@ -104,7 +104,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (miner, RPC) needs to use it.
-    let mut node = Node::new(environment).await?;
+    let mut node = Node::new(node_config).await?;
 
     let is_storage_in_memory = LedgerStorage::IN_MEMORY;
 

--- a/storage/src/key_value.rs
+++ b/storage/src/key_value.rs
@@ -67,7 +67,7 @@ impl FromBytes for TransactionLocation {
     }
 }
 
-pub fn bytes_to_u32(bytes: Vec<u8>) -> u32 {
+pub fn bytes_to_u32(bytes: &[u8]) -> u32 {
     let mut num_bytes = [0u8; 4];
     num_bytes.copy_from_slice(&bytes);
 

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -133,7 +133,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
 
                 for (commitment_key, index_value) in storage.get_col(COL_COMMITMENT)? {
                     let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
-                    let index = bytes_to_u32(index_value.to_vec()) as usize;
+                    let index = bytes_to_u32(&index_value) as usize;
 
                     cm_and_indices.push((commitment, index));
                 }
@@ -144,7 +144,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
                 let merkle_tree = MerkleTree::new(ledger_parameters.clone(), commitments)?;
 
                 Ok(Self {
-                    current_block_height: AtomicU32::new(bytes_to_u32(val)),
+                    current_block_height: AtomicU32::new(bytes_to_u32(&val)),
                     storage,
                     cm_merkle_tree: RwLock::new(merkle_tree),
                     ledger_parameters,
@@ -178,7 +178,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
                 .storage
                 .get(COL_META, &KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec())?
                 .ok_or_else(|| StorageError::Message("can't determine current block height".into()))?;
-            let new_current_block_height = bytes_to_u32(current_block_height_bytes);
+            let new_current_block_height = bytes_to_u32(&current_block_height_bytes);
             let current_block_height = self.get_current_block_height();
 
             // If the new block height is greater than the stored block height,

--- a/storage/src/objects/block.rs
+++ b/storage/src/objects/block.rs
@@ -67,7 +67,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     /// Get the block number given a block hash.
     pub fn get_block_number(&self, block_hash: &BlockHeaderHash) -> Result<u32, StorageError> {
         match self.storage.get(COL_BLOCK_LOCATOR, &block_hash.0)? {
-            Some(block_num_bytes) => Ok(bytes_to_u32(block_num_bytes)),
+            Some(block_num_bytes) => Ok(bytes_to_u32(&block_num_bytes)),
             None => Err(StorageError::MissingBlockNumber(block_hash.to_string())),
         }
     }

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -28,7 +28,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     /// Get the current commitment index
     pub fn current_cm_index(&self) -> Result<usize, StorageError> {
         match self.storage.get(COL_META, KEY_CURR_CM_INDEX.as_bytes())? {
-            Some(cm_index_bytes) => Ok(bytes_to_u32(cm_index_bytes) as usize),
+            Some(cm_index_bytes) => Ok(bytes_to_u32(&cm_index_bytes) as usize),
             None => Ok(0),
         }
     }
@@ -36,7 +36,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     /// Get the current serial number index
     pub fn current_sn_index(&self) -> Result<usize, StorageError> {
         match self.storage.get(COL_META, KEY_CURR_SN_INDEX.as_bytes())? {
-            Some(sn_index_bytes) => Ok(bytes_to_u32(sn_index_bytes) as usize),
+            Some(sn_index_bytes) => Ok(bytes_to_u32(&sn_index_bytes) as usize),
             None => Ok(0),
         }
     }
@@ -44,7 +44,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     /// Get the current memo index
     pub fn current_memo_index(&self) -> Result<usize, StorageError> {
         match self.storage.get(COL_META, KEY_CURR_MEMO_INDEX.as_bytes())? {
-            Some(memo_index_bytes) => Ok(bytes_to_u32(memo_index_bytes) as usize),
+            Some(memo_index_bytes) => Ok(bytes_to_u32(&memo_index_bytes) as usize),
             None => Ok(0),
         }
     }
@@ -111,7 +111,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         let mut old_cm_and_indices = vec![];
         for (commitment_key, index_value) in self.storage.get_col(COL_COMMITMENT)? {
             let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
-            let index = bytes_to_u32(index_value.to_vec()) as usize;
+            let index = bytes_to_u32(&index_value) as usize;
 
             old_cm_and_indices.push((commitment, index));
         }

--- a/storage/src/objects/ledger_scheme.rs
+++ b/storage/src/objects/ledger_scheme.rs
@@ -50,7 +50,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> LedgerScheme for L
         }?;
 
         if let Some(block_num) = storage.get(COL_META, KEY_BEST_BLOCK_NUMBER.as_bytes())? {
-            if bytes_to_u32(block_num) != 0 {
+            if bytes_to_u32(&block_num) != 0 {
                 return Err(LedgerError::ExistingDatabase.into());
             }
         }

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -158,6 +158,7 @@ pub fn test_consensus(setup: ConsensusSetup, node: Node<LedgerStorage>) -> Conse
 /// Returns an `Environment` struct with given arguments
 pub fn test_environment(setup: TestSetup) -> Environment {
     Environment::new(
+        setup.socket_address,
         setup.min_peers,
         setup.max_peers,
         setup.bootnodes,
@@ -178,7 +179,7 @@ pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
         node.set_consensus(consensus);
     }
 
-    node.listen(setup.socket_address).await.unwrap();
+    node.listen().await.unwrap();
     node.start_services().await;
 
     if is_miner {

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -155,9 +155,9 @@ pub fn test_consensus(setup: ConsensusSetup, node: Node<LedgerStorage>) -> Conse
     )
 }
 
-/// Returns an `Environment` struct with given arguments
-pub fn test_environment(setup: TestSetup) -> Environment {
-    Environment::new(
+/// Returns a `Config` struct based on the given `TestSetup`.
+pub fn test_config(setup: TestSetup) -> Config {
+    Config::new(
         setup.socket_address,
         setup.min_peers,
         setup.max_peers,
@@ -171,8 +171,8 @@ pub fn test_environment(setup: TestSetup) -> Environment {
 /// Starts a node with the specified bootnodes.
 pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
     let is_miner = setup.consensus_setup.as_ref().map(|c| c.is_miner) == Some(true);
-    let environment = test_environment(setup.clone());
-    let mut node = Node::new(environment).await.unwrap();
+    let config = test_config(setup.clone());
+    let mut node = Node::new(config).await.unwrap();
 
     if let Some(consensus_setup) = setup.consensus_setup {
         let consensus = test_consensus(consensus_setup, node.clone());

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -56,7 +56,7 @@ async fn line(nodes: &mut Vec<Node<LedgerStorage>>) {
     // Start each node with the previous as a bootnode.
     for node in nodes {
         if let Some(addr) = prev_node {
-            node.environment.bootnodes.write().push(addr);
+            node.config.bootnodes.write().push(addr);
         };
 
         // Assumes the node has an established address.
@@ -71,7 +71,7 @@ async fn ring(nodes: &mut Vec<Node<LedgerStorage>>) {
 
     // Connect the first to the last.
     let first_addr = nodes.first().unwrap().local_address().unwrap();
-    nodes.last().unwrap().environment.bootnodes.write().push(first_addr);
+    nodes.last().unwrap().config.bootnodes.write().push(first_addr);
 }
 
 /// Connects the network nodes in a mesh topology. The inital peers are selected at random based on the
@@ -84,11 +84,11 @@ async fn mesh(nodes: &mut Vec<Node<LedgerStorage>>) {
         let random_addrs = local_addresses
             .choose_multiple(
                 &mut rand::thread_rng(),
-                node.environment.minimum_number_of_connected_peers().into(),
+                node.config.minimum_number_of_connected_peers().into(),
             )
             .copied()
             .collect();
-        *node.environment.bootnodes.write() = random_addrs;
+        *node.config.bootnodes.write() = random_addrs;
     }
 }
 
@@ -100,6 +100,6 @@ async fn star(nodes: &mut Vec<Node<LedgerStorage>>) {
     // Start the rest of the nodes with the core node as the bootnode.
     let bootnodes = vec![hub_address];
     for node in nodes.iter_mut().skip(1) {
-        *node.environment.bootnodes.write() = bootnodes.clone();
+        *node.config.bootnodes.write() = bootnodes.clone();
     }
 }


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/683; the new changes can be seen [here](https://github.com/AleoHQ/snarkOS/pull/693/files/fa721c5b23da96fc3284a48353359c9673c8ff66..539df9ebe73833235063813615797f971ac326ea).

The introduction of `node::State` is designed to improve and simplify synchronization logic, make it apparent to the user what the node is currently doing and to improve the interaction between the node and the miner instance.

In addition, this PR implements fast/prioritized `Ping`/`Pong` exchange in order to improve latency calculation, especially in sync scenarios, and a few other assorted tweaks that are described in commit messages.
