### PR TITLE
Connect to peers faster, delay mining

### DIFF
--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -159,12 +159,12 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let peer_sync_interval = self.config.peer_sync_interval();
         let peering_task = task::spawn(async move {
             loop {
-                sleep(peer_sync_interval).await;
                 info!("Updating peers");
 
                 if let Err(e) = self_clone.update_peers().await {
                     error!("Peer update error: {}", e);
                 }
+                sleep(peer_sync_interval).await;
             }
         });
         self.register_task(peering_task);


### PR DESCRIPTION
This short PR adjusts the node's start-up process by starting its network services before mining, connecting to peers without an initial delay, and delaying mining by a few seconds.