### PR TITLE
Some clippy lints

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::upper_case_acronyms)]
 #![deny(unused_import_braces, unused_qualifications, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_qualifications, variant_size_differences, stable_features, unreachable_pub)]
 #![deny(non_shorthand_field_patterns, unused_attributes, unused_extern_crates)]

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -56,7 +56,7 @@ impl<S: Storage> Deref for Node<S> {
     }
 }
 
-#[doc(hide)]
+#[doc(hidden)]
 pub struct InnerNode<S: Storage> {
     /// The node's random numeric identifier.
     pub name: u64,

--- a/parameters/examples/create_genesis_block.rs
+++ b/parameters/examples/create_genesis_block.rs
@@ -33,7 +33,7 @@ use chrono::Utc;
 use std::{
     fs::File,
     io::{Result as IoResult, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 pub fn generate<C: BaseDPCComponents>() -> Result<Vec<u8>, TransactionError> {
@@ -56,7 +56,7 @@ pub fn generate<C: BaseDPCComponents>() -> Result<Vec<u8>, TransactionError> {
     Ok(genesis_header.serialize().to_vec())
 }
 
-pub fn store(path: &PathBuf, bytes: &[u8]) -> IoResult<()> {
+pub fn store(path: &Path, bytes: &[u8]) -> IoResult<()> {
     let mut file = File::create(path)?;
     file.write_all(&bytes)?;
     drop(file);

--- a/parameters/examples/generate_transaction.rs
+++ b/parameters/examples/generate_transaction.rs
@@ -52,9 +52,7 @@ fn empty_ledger<T: Transaction, P: LoadableMerkleParameters, S: Storage>(
     path: &Path,
 ) -> Result<Ledger<T, P, S>, LedgerError> {
     fs::create_dir_all(&path).map_err(|err| LedgerError::Message(err.to_string()))?;
-    let storage = S::open(Some(path), None)
-        .map(|storage| storage)
-        .map_err(|err| LedgerError::Message(err.to_string()))?;
+    let storage = S::open(Some(path), None).map_err(|err| LedgerError::Message(err.to_string()))?;
 
     let leaves: &[[u8; 32]] = &[];
     let cm_merkle_tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter())?;
@@ -134,7 +132,7 @@ pub fn generate<S: Storage>(recipient: &str, value: u64, network_id: u8, file_na
             .hash(&[64u8 + (i as u8); 1])?;
         let old_record = DPC::generate_record(
             &consensus.public_parameters.system_parameters,
-            old_sn_nonce.clone(),
+            old_sn_nonce,
             dummy_account.address.clone(),
             true, // The input record is dummy
             0,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 // Compilation
+#![allow(clippy::upper_case_acronyms)]
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Documentation

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -46,7 +46,7 @@ mod rpc_tests {
 
         let node_consensus = snarkos_network::Consensus::new(
             node.clone(),
-            consensus.clone(),
+            consensus,
             consensus_setup.is_miner,
             Duration::from_secs(consensus_setup.block_sync_interval),
             Duration::from_secs(consensus_setup.tx_sync_interval),

--- a/snarkos/lib.rs
+++ b/snarkos/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::upper_case_acronyms)]
+
 #[macro_use]
 extern crate thiserror;
 

--- a/toolkit/src/lib.rs
+++ b/toolkit/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 #![allow(clippy::module_inception)]
+#![allow(clippy::upper_case_acronyms)]
 
 #[macro_use]
 extern crate thiserror;


### PR DESCRIPTION
This PR handles some `clippy` lints that sometimes show up in GitHub diff views, most notably `upper_case_acronyms`, which is now allowed in the crates where it is triggered.