### PR TITLE
Use a blocking task for RPC purposes

### DIFF
--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -68,7 +68,7 @@ pub fn start_rpc_server<S: Storage + Send + Sync + 'static>(
         .start_http(&rpc_server)
         .expect("couldn't start the RPC server!");
 
-    tokio::task::spawn(async move {
+    tokio::task::spawn_blocking(|| {
         server.wait();
     })
 }


### PR DESCRIPTION
This bit must have been undetected before due to `.wait()` being visually so close to `await` :microscope:. [jsonrpc_http_server::Server::wait](https://docs.rs/jsonrpc-http-server/17.0.0/jsonrpc_http_server/struct.Server.html#method.wait) is blocking, so it should be used in the context of a thread dedicated to blocking tasks.