### PR TITLE
Name the miner thread

### DIFF
--- a/network/src/consensus/miner.rs
+++ b/network/src/consensus/miner.rs
@@ -51,7 +51,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
         let mut mining_failure_count = 0;
         let mining_failure_threshold = 10;
 
-        thread::spawn(move || {
+        let mining_thread = thread::Builder::new().name("snarkOS_miner".into()).spawn(move || {
             loop {
                 if self.node.is_shutting_down() {
                     debug!("The node is shutting down, stopping mining");
@@ -116,6 +116,8 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                         .await;
                 });
             }
-        })
+        });
+
+        mining_thread.expect("failed to spawn the miner thread")
     }
 }


### PR DESCRIPTION
Sets the name of the dedicated miner thread to `snarkOS_miner`. The extra call to `.expect(...)` is no different than when calling `thread::spawn`, which also does so internally.