### PR TITLE
Handshake timeouts, async connection attempts

### DIFF
--- a/network/src/errors/network.rs
+++ b/network/src/errors/network.rs
@@ -26,6 +26,7 @@ pub enum NetworkError {
     BlockError(BlockError),
     CapnProto(capnp::Error),
     ConsensusError(ConsensusError),
+    HandshakeTimeout,
     Io(std::io::Error),
     InvalidHandshake,
     MessageTooBig(usize),

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -55,6 +55,7 @@ pub use peers::*;
 
 pub const HANDSHAKE_PATTERN: &str = "Noise_XXpsk3_25519_ChaChaPoly_SHA256";
 pub const HANDSHAKE_PSK: &[u8] = b"b765e427e836e0029a1e2a22ba60c52a"; // the PSK must be 32B
+pub const HANDSHAKE_TIME_LIMIT_SECS: u8 = 5;
 pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
 pub const NOISE_BUF_LEN: usize = 65535;
 pub const NOISE_TAG_LEN: usize = 16;

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -268,7 +268,7 @@ async fn handshake_timeout_initiator_side() {
 
     // but since they won't reply, it should drop them after the handshake deadline
     wait_until!(
-        snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64,
+        snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64 + 1,
         node.peer_book.read().number_of_connecting_peers() == 0
     );
 }
@@ -291,7 +291,7 @@ async fn handshake_timeout_responder_side() {
 
     // but since it won't conclude the handshake, it should be dropped after the handshake deadline
     wait_until!(
-        snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64,
+        snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64 + 1,
         node.peer_book.read().number_of_connecting_peers() == 0
     );
 }

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -235,3 +235,40 @@ async fn reject_non_version_messages_before_handshake() {
     write_message_to_stream(Payload::Transaction(transaction), &mut peer_stream).await;
     assert_node_rejected_message(&node, &mut peer_stream).await;
 }
+
+#[tokio::test]
+async fn handshake_timeout_initiator_side() {
+    const NUM_BOOTSTRAPPERS: usize = 5;
+
+    // set up bootnodes that won't perform a valid handshake
+    let mut failing_bootnodes = Vec::with_capacity(NUM_BOOTSTRAPPERS);
+    for _ in 0..NUM_BOOTSTRAPPERS {
+        failing_bootnodes.push(TcpListener::bind("127.0.0.1:0").await.unwrap());
+    }
+
+    // start the node
+    let setup = TestSetup {
+        consensus_setup: None,
+        bootnodes: failing_bootnodes
+            .iter()
+            .map(|l| {
+                let addr = l.local_addr().unwrap();
+                format!("{}:{}", addr.ip(), addr.port())
+            })
+            .collect(),
+        ..Default::default()
+    };
+    let node = test_node(setup).await;
+
+    // the node should start connecting to all the configured bootnodes
+    wait_until!(
+        3,
+        node.peer_book.read().number_of_connecting_peers() == NUM_BOOTSTRAPPERS as u16
+    );
+
+    // but since they won't reply, it should drop them after the handshake deadline
+    wait_until!(
+        snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64,
+        node.peer_book.read().number_of_connecting_peers() == 0
+    );
+}

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -26,9 +26,9 @@ use snarkos_testing::{
     wait_until,
 };
 
-const N: usize = 50;
+const N: usize = 25;
 const MIN_PEERS: u16 = 5;
-const MAX_PEERS: u16 = 10;
+const MAX_PEERS: u16 = 30;
 
 async fn test_nodes(n: usize, setup: TestSetup) -> Vec<Node<LedgerStorage>> {
     let mut nodes = Vec::with_capacity(n);


### PR DESCRIPTION
This PR imposes a 5s deadline on all handshakes, breaking the connection in case it's not complete within that limit. In addition, it makes multiple connection attempts (connecting to bootstrappers and disconnected peers) happen asynchronously, so that they can be completed faster.

2 tests for this new behavior are added to the network handshake tests.