### PR TITLE
Increase inbound channel size, drop unresponsive and faulty peers

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -158,7 +158,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // Reset the failure indicator.
             failure = false;
 
-            // Read the next message from the channel. This is a blocking operation.
+            // Read the next message from the channel.
             let message = match reader.read_message().await {
                 Ok(message) => message,
                 Err(error) => {

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -43,7 +43,7 @@ pub struct Inbound {
 impl Inbound {
     pub fn new(channels: Arc<RwLock<Channels>>) -> Self {
         // Initialize the sender and receiver.
-        let (sender, receiver) = tokio::sync::mpsc::channel(1024);
+        let (sender, receiver) = tokio::sync::mpsc::channel(64 * 1024);
 
         Self {
             sender,

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -24,7 +24,7 @@ use tokio::task;
 use std::{
     net::SocketAddr,
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering},
         Arc,
     },
     time::Instant,
@@ -48,7 +48,7 @@ pub struct PeerQuality {
     /// The time it took to send a `Ping` to the peer and for it to respond with a `Pong`.
     pub rtt_ms: AtomicU64,
     /// The number of failures associated with the peer; grounds for dismissal.
-    pub failures: AtomicU8,
+    pub failures: AtomicU32,
     /// The number of remaining blocs to sync with.
     pub remaining_sync_blocks: AtomicU16,
 }

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -124,7 +124,7 @@ impl Default for Config {
                     .iter()
                     .map(|node| (*node).to_string())
                     .collect::<Vec<String>>(),
-                mempool_interval: 5,
+                mempool_interval: 15,
                 peer_sync_interval: 10,
                 block_sync_interval: 60,
                 min_peers: 7,


### PR DESCRIPTION
In addition to greatly increasing the capacity of the inbound channel and dropping peers with an RTT > 1s or more than 10 non-fatal failures, this PR also increases the memory pool sync interval from 5s to 15s.