### PR TITLE
Make PeerBook locks more granular

### DIFF
--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -109,7 +109,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             0
         };
 
-        self.peer_book.read().sending_ping(remote_address);
+        self.peer_book.sending_ping(remote_address);
 
         self.outbound
             .send_request(Message::new(

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -54,7 +54,7 @@ pub struct PeerQuality {
 }
 
 /// A data structure containing information about a peer.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerInfo {
     /// The IP address of this peer.
     address: SocketAddr,
@@ -75,7 +75,7 @@ pub struct PeerInfo {
     pub quality: Arc<PeerQuality>,
     /// The handles for tasks associated exclusively with this peer.
     #[serde(skip)]
-    pub tasks: Mutex<Vec<task::JoinHandle<()>>>,
+    pub tasks: Arc<Mutex<Vec<task::JoinHandle<()>>>>,
 }
 
 impl PeerInfo {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -384,7 +384,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     ///
     #[inline]
     pub(crate) fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
-        debug!("Disconnecting from {}", remote_address);
+        debug!("Disconnecting from {} (if not disconnected yet)", remote_address);
 
         if let Some(ref consensus) = self.consensus() {
             if self.peer_book.is_syncing_blocks(remote_address) {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{message::*, ConnReader, ConnWriter, NetworkError, Node, Version};
+use crate::{message::*, ConnReader, ConnWriter, NetworkError, Node, SerializedPeerBook, Version};
 use snarkvm_objects::Storage;
 
 use std::{
@@ -34,7 +34,7 @@ use tokio::{
 impl<S: Storage> Node<S> {
     /// Obtain a list of addresses of currently connected peers.
     pub(crate) fn connected_addrs(&self) -> Vec<SocketAddr> {
-        self.peer_book.read().connected_peers().keys().copied().collect()
+        self.peer_book.connected_peers().keys().copied().collect()
     }
 }
 
@@ -44,7 +44,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     ///
     pub(crate) async fn update_peers(&self) -> Result<(), NetworkError> {
         // Fetch the number of connected peers.
-        let number_of_connected_peers = self.peer_book.read().number_of_connected_peers() as usize;
+        let number_of_connected_peers = self.peer_book.number_of_connected_peers() as usize;
         trace!(
             "Connected to {} peer{}",
             number_of_connected_peers,
@@ -54,10 +54,9 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // Drop peers whose RTT is too high or have too many failures.
         for (addr, peer_quality) in self
             .peer_book
-            .read()
             .connected_peers()
             .iter()
-            .map(|(addr, info)| (*addr, Arc::clone(&info.quality)))
+            .map(|(addr, info)| (*addr, &info.quality))
         {
             if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1000 || peer_quality.failures.load(Ordering::Relaxed) > 10
             {
@@ -94,7 +93,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
             let mut connected = self
                 .peer_book
-                .read()
                 .connected_peers()
                 .iter()
                 .map(|(addr, info)| (*addr, info.last_connected()))
@@ -111,17 +109,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // disconnect from peers after a while, even if they haven't sent a GetPeers
         let now = chrono::Utc::now();
 
-        #[allow(clippy::needless_collect)] // clippy reports a false positive here
         if self.config.is_bootnode() {
             let peers = self
                 .peer_book
-                .read()
                 .connected_peers()
-                .iter()
-                .map(|(addr, info)| (*addr, info.last_connected().unwrap()))
-                .collect::<Vec<_>>();
+                .into_iter()
+                .map(|(addr, info)| (addr, info.last_connected().unwrap()));
 
-            for (peer_addr, last_connected) in peers.into_iter() {
+            for (peer_addr, last_connected) in peers {
                 if (now - last_connected).num_seconds() > 10 {
                     let _ = self.disconnect_from_peer(peer_addr);
                 }
@@ -153,14 +148,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         {
             return Err(NetworkError::SelfConnectAttempt);
         }
-        if self.peer_book.read().is_connecting(remote_address) {
+        if self.peer_book.is_connecting(remote_address) {
             return Err(NetworkError::PeerAlreadyConnecting);
         }
-        if self.peer_book.read().is_connected(remote_address) {
+        if self.peer_book.is_connected(remote_address) {
             return Err(NetworkError::PeerAlreadyConnected);
         }
 
-        self.peer_book.write().set_connecting(remote_address)?;
+        self.peer_book.set_connecting(remote_address)?;
 
         // spawn a task that will be subject to a deadline
         let node = self.clone();
@@ -212,7 +207,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // save the outbound channel
             node.outbound.channels.write().insert(remote_address, Arc::new(writer));
 
-            node.peer_book.write().set_connected(remote_address, None)?;
+            node.peer_book.set_connected(remote_address, None)?;
 
             // spawn the inbound loop
             let node_clone = node.clone();
@@ -220,7 +215,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 node_clone.listen_for_messages(&mut reader).await;
             });
 
-            if let Ok(ref peer) = node.peer_book.read().get_peer(remote_address) {
+            if let Ok(ref peer) = node.peer_book.get_peer(remote_address) {
                 peer.register_task(conn_listening_task);
             } else {
                 // if the related peer is not found, it means it's already been dropped
@@ -295,7 +290,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // Iterate through a selection of random peers and attempt to connect.
         let random_peers = self
             .peer_book
-            .read()
             .disconnected_peers()
             .iter()
             .map(|(k, _)| k)
@@ -325,7 +319,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         };
 
         for remote_address in self.connected_addrs() {
-            self.peer_book.read().sending_ping(remote_address);
+            self.peer_book.sending_ping(remote_address);
 
             self.outbound
                 .send_request(Message::new(
@@ -370,7 +364,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     #[inline]
     fn save_peer_book_to_storage(&self) -> Result<(), NetworkError> {
         // Serialize the peer book.
-        let serialized_peer_book = bincode::serialize(&*self.peer_book.read())?;
+        let serialized_peer_book = bincode::serialize(&SerializedPeerBook::from(&self.peer_book))?;
 
         // TODO: the peer book should be stored outside of consensus
         if let Some(ref consensus) = self.consensus() {
@@ -390,14 +384,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         debug!("Disconnecting from {}", remote_address);
 
         if let Some(ref consensus) = self.consensus() {
-            if self.peer_book.read().is_syncing_blocks(remote_address) {
+            if self.peer_book.is_syncing_blocks(remote_address) {
                 consensus.finished_syncing_blocks();
             }
         }
 
         self.outbound.channels.write().remove(&remote_address);
 
-        self.peer_book.write().set_disconnected(remote_address)
+        self.peer_book.set_disconnected(remote_address)
         // TODO (howardwu): Attempt to blindly send disconnect message to peer.
     }
 
@@ -406,7 +400,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // Broadcast the sanitized list of connected peers back to requesting peer.
         let peers = if !self.config.is_bootnode() {
             self.peer_book
-                .read()
                 .connected_peers()
                 .iter()
                 .map(|(k, _)| k)
@@ -415,7 +408,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 .choose_multiple(&mut rand::thread_rng(), crate::SHARED_PEER_COUNT)
         } else {
             self.peer_book
-                .read()
                 .disconnected_peers()
                 .iter()
                 .map(|(k, _)| k)
@@ -443,7 +435,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // by informing the peer book of that we found peers.
         let local_address = self.local_address().unwrap(); // the address must be known by now
 
-        let number_of_connected_peers = self.peer_book.read().number_of_connected_peers();
+        let number_of_connected_peers = self.peer_book.number_of_connected_peers();
         let number_to_connect = self
             .config
             .maximum_number_of_connected_peers()
@@ -458,15 +450,13 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // Inform the peer book that we found a peer.
             // The peer book will determine if we have seen the peer before,
             // and include the peer if it is new.
-            self.peer_book.write().add_peer(peer_address);
+            self.peer_book.add_peer(peer_address);
         }
     }
 
     fn can_connect(&self) -> bool {
-        let peer_book = self.peer_book.read();
-        let num_connected = peer_book.number_of_connected_peers() as usize;
-        let num_connecting = peer_book.number_of_connecting_peers() as usize;
-        drop(peer_book);
+        let num_connected = self.peer_book.number_of_connected_peers() as usize;
+        let num_connecting = self.peer_book.number_of_connecting_peers() as usize;
 
         let max_peers = self.config.maximum_number_of_connected_peers() as usize;
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -391,7 +391,9 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
         self.outbound.channels.write().remove(&remote_address);
 
-        self.peer_book.set_disconnected(remote_address)
+        let result = self.peer_book.set_disconnected(remote_address);
+        debug!("Set {} as disconnected", remote_address);
+        result
         // TODO (howardwu): Attempt to blindly send disconnect message to peer.
     }
 

--- a/network/tests/cleanup.rs
+++ b/network/tests/cleanup.rs
@@ -42,11 +42,11 @@ async fn check_node_cleanup() {
     for i in 0u16..4096 {
         // Connect a peer.
         let peer = handshaken_peer(node.local_address().unwrap()).await;
-        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 1);
+        wait_until!(5, node.peer_book.number_of_connected_peers() == 1);
 
         // Drop the peer stream.
         drop(peer);
-        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 0);
+        wait_until!(5, node.peer_book.number_of_connected_peers() == 0);
 
         // Register heap bump after the connection was dropped.
         let curr_peak = PEAK_ALLOC.peak_usage();

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -60,10 +60,10 @@ async fn fuzzing_zeroes_pre_handshake() {
     let node_addr = node.local_address().unwrap();
 
     let mut stream = TcpStream::connect(node_addr).await.unwrap();
-    wait_until!(1, node.peer_book.read().number_of_connecting_peers() == 1);
+    wait_until!(1, node.peer_book.number_of_connecting_peers() == 1);
 
     let _ = stream.write_all(&[0u8; 64]).await;
-    wait_until!(1, node.peer_book.read().number_of_connecting_peers() == 0);
+    wait_until!(1, node.peer_book.number_of_connecting_peers() == 0);
 }
 
 #[tokio::test]
@@ -74,10 +74,10 @@ async fn fuzzing_zeroes_post_handshake() {
         ..Default::default()
     };
     let (node, fake_node) = handshaken_node_and_peer(node_setup).await;
-    wait_until!(1, node.peer_book.read().number_of_connected_peers() == 1);
+    wait_until!(1, node.peer_book.number_of_connected_peers() == 1);
 
     fake_node.write_bytes(&[0u8; 64]).await;
-    wait_until!(1, node.peer_book.read().number_of_connected_peers() == 0);
+    wait_until!(1, node.peer_book.number_of_connected_peers() == 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -206,7 +206,7 @@ async fn fuzzing_corrupted_version_pre_handshake() {
         let _ = stream.write_all(&corrupted_version).await;
     }
 
-    assert_eq!(node.peer_book.read().number_of_connected_peers(), 0);
+    assert_eq!(node.peer_book.number_of_connected_peers(), 0);
 }
 
 #[tokio::test]
@@ -271,7 +271,7 @@ async fn fuzzing_corrupted_empty_payloads_pre_handshake() {
         }
     }
 
-    assert_eq!(node.peer_book.read().number_of_connected_peers(), 0);
+    assert_eq!(node.peer_book.number_of_connected_peers(), 0);
 }
 
 #[tokio::test]
@@ -359,7 +359,7 @@ async fn fuzzing_corrupted_payloads_with_bodies_pre_handshake() {
         }
     }
 
-    assert_eq!(node.peer_book.read().number_of_connected_peers(), 0);
+    assert_eq!(node.peer_book.number_of_connected_peers(), 0);
 }
 
 // Using a multi-threaded rt for this test notably improves performance.
@@ -453,7 +453,7 @@ async fn fuzzing_corrupted_payloads_with_hashes_pre_handshake() {
         }
     }
 
-    assert_eq!(node.peer_book.read().number_of_connected_peers(), 0);
+    assert_eq!(node.peer_book.number_of_connected_peers(), 0);
 }
 
 #[tokio::test]

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -59,7 +59,7 @@ async fn handshake_responder_side() {
     let mut buffer: Box<[u8]> = vec![0u8; snarkos_network::NOISE_BUF_LEN].into();
     let mut buf = [0u8; snarkos_network::NOISE_BUF_LEN]; // a temporary intermediate buffer to decrypt from
 
-    wait_until!(1, node.peer_book.read().is_connecting(peer_address));
+    wait_until!(1, node.peer_book.is_connecting(peer_address));
 
     // -> e
     let len = noise.write_message(&[], &mut buffer).unwrap();
@@ -81,10 +81,9 @@ async fn handshake_responder_side() {
 
     // the node should now have register the peer as 'connected'
     sleep(Duration::from_millis(200)).await;
-    let peer_book = node.peer_book.read();
-    assert!(peer_book.is_connected(peer_address));
-    assert_eq!(peer_book.number_of_connecting_peers(), 0);
-    assert_eq!(peer_book.number_of_connected_peers(), 1);
+    assert!(node.peer_book.is_connected(peer_address));
+    assert_eq!(node.peer_book.number_of_connecting_peers(), 0);
+    assert_eq!(node.peer_book.number_of_connected_peers(), 1);
 }
 
 #[tokio::test]
@@ -106,7 +105,7 @@ async fn handshake_initiator_side() {
     // accept the node's connection on peer side
     let (mut peer_stream, _node_address) = peer_listener.accept().await.unwrap();
 
-    wait_until!(1, node.peer_book.read().is_connecting(peer_address));
+    wait_until!(1, node.peer_book.is_connecting(peer_address));
 
     let builder = snow::Builder::with_resolver(
         snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
@@ -141,10 +140,9 @@ async fn handshake_initiator_side() {
 
     // the node should now have registered the peer as 'connected'
     sleep(Duration::from_millis(200)).await;
-    let peer_book = node.peer_book.read();
-    assert!(peer_book.is_connected(peer_address));
-    assert_eq!(peer_book.number_of_connecting_peers(), 0);
-    assert_eq!(peer_book.number_of_connected_peers(), 1);
+    assert!(node.peer_book.is_connected(peer_address));
+    assert_eq!(node.peer_book.number_of_connecting_peers(), 0);
+    assert_eq!(node.peer_book.number_of_connected_peers(), 1);
 }
 
 async fn assert_node_rejected_message(node: &Node<LedgerStorage>, peer_stream: &mut TcpStream) {
@@ -157,9 +155,8 @@ async fn assert_node_rejected_message(node: &Node<LedgerStorage>, peer_stream: &
     assert!(buffer.is_empty());
 
     // check the node's state hasn't been altered by the message
-    let peer_book = node.peer_book.read();
-    wait_until!(1, !peer_book.is_connecting(peer_stream.local_addr().unwrap()));
-    assert_eq!(peer_book.number_of_connected_peers(), 0);
+    wait_until!(1, !node.peer_book.is_connecting(peer_stream.local_addr().unwrap()));
+    assert_eq!(node.peer_book.number_of_connected_peers(), 0);
 }
 
 #[tokio::test]
@@ -263,13 +260,13 @@ async fn handshake_timeout_initiator_side() {
     // the node should start connecting to all the configured bootnodes
     wait_until!(
         3,
-        node.peer_book.read().number_of_connecting_peers() == NUM_BOOTSTRAPPERS as u16
+        node.peer_book.number_of_connecting_peers() == NUM_BOOTSTRAPPERS as u16
     );
 
     // but since they won't reply, it should drop them after the handshake deadline
     wait_until!(
         snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64 + 1,
-        node.peer_book.read().number_of_connecting_peers() == 0
+        node.peer_book.number_of_connecting_peers() == 0
     );
 }
 
@@ -287,11 +284,11 @@ async fn handshake_timeout_responder_side() {
     let _fake_peer = TcpStream::connect(node_addr).await.unwrap();
 
     // the node should initally accept the connection
-    wait_until!(3, node.peer_book.read().number_of_connecting_peers() == 1 as u16);
+    wait_until!(3, node.peer_book.number_of_connecting_peers() == 1 as u16);
 
     // but since it won't conclude the handshake, it should be dropped after the handshake deadline
     wait_until!(
         snarkos_network::HANDSHAKE_TIME_LIMIT_SECS as u64 + 1,
-        node.peer_book.read().number_of_connecting_peers() == 0
+        node.peer_book.number_of_connecting_peers() == 0
     );
 }

--- a/network/tests/peers.rs
+++ b/network/tests/peers.rs
@@ -43,7 +43,7 @@ async fn peer_initiator_side() {
     peer.write_message(&Payload::Peers(vec![addr])).await;
 
     // check the address has been added to the disconnected list in the peer book
-    wait_until!(5, node.peer_book.read().is_disconnected(addr));
+    wait_until!(5, node.peer_book.is_disconnected(addr));
 }
 
 #[tokio::test]
@@ -87,10 +87,10 @@ async fn triangle() {
     let node_charlie = test_node(setup(vec![addr_bob.to_string()])).await;
 
     let triangle_is_formed = || {
-        node_charlie.peer_book.read().is_connected(addr_alice)
-            && node_alice.peer_book.read().number_of_connected_peers() == 2
-            && node_bob.peer_book.read().number_of_connected_peers() == 2
-            && node_charlie.peer_book.read().number_of_connected_peers() == 2
+        node_charlie.peer_book.is_connected(addr_alice)
+            && node_alice.peer_book.number_of_connected_peers() == 2
+            && node_bob.peer_book.number_of_connected_peers() == 2
+            && node_charlie.peer_book.number_of_connected_peers() == 2
     };
 
     // Make sure C connects to A => peer propagation works.

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -65,18 +65,12 @@ async fn spawn_nodes_in_a_line() {
     start_nodes(&nodes).await;
 
     // First and Last nodes should have 1 connected peer.
-    wait_until!(
-        5,
-        nodes.first().unwrap().peer_book.read().number_of_connected_peers() == 1
-    );
-    wait_until!(
-        5,
-        nodes.last().unwrap().peer_book.read().number_of_connected_peers() == 1
-    );
+    wait_until!(5, nodes.first().unwrap().peer_book.number_of_connected_peers() == 1);
+    wait_until!(5, nodes.last().unwrap().peer_book.number_of_connected_peers() == 1);
 
     // All other nodes should have two.
     for node in nodes.iter().take(nodes.len() - 1).skip(1) {
-        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 2);
+        wait_until!(5, node.peer_book.number_of_connected_peers() == 2);
     }
 }
 
@@ -92,7 +86,7 @@ async fn spawn_nodes_in_a_ring() {
     start_nodes(&nodes).await;
 
     for node in &nodes {
-        wait_until!(5, node.peer_book.read().number_of_connected_peers() == 2);
+        wait_until!(5, node.peer_book.number_of_connected_peers() == 2);
     }
 }
 
@@ -108,7 +102,7 @@ async fn spawn_nodes_in_a_star() {
     start_nodes(&nodes).await;
 
     let hub = nodes.first().unwrap();
-    wait_until!(10, hub.peer_book.read().number_of_connected_peers() as usize == N - 1);
+    wait_until!(10, hub.peer_book.number_of_connected_peers() as usize == N - 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -261,7 +255,7 @@ fn total_connection_count(nodes: &[Node<LedgerStorage>]) -> usize {
     let mut count = 0;
 
     for node in nodes {
-        count += node.peer_book.read().number_of_connected_peers()
+        count += node.peer_book.number_of_connected_peers()
     }
 
     (count / 2).into()
@@ -292,9 +286,7 @@ fn calculate_density(n: f64, ac: f64) -> f64 {
 }
 
 fn degree_centrality_delta(nodes: &[Node<LedgerStorage>]) -> u16 {
-    let dc = nodes
-        .iter()
-        .map(|node| node.peer_book.read().number_of_connected_peers());
+    let dc = nodes.iter().map(|node| node.peer_book.number_of_connected_peers());
     let min = dc.clone().min().unwrap();
     let max = dc.max().unwrap();
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -292,7 +292,7 @@ impl<S: Storage + Send + Sync + 'static> RpcFunctions for RpcImpl<S> {
     /// Fetch the number of connected peers this node has.
     fn get_connection_count(&self) -> Result<usize, RpcError> {
         // Create a temporary tokio runtime to make an asynchronous function call
-        let number = self.node.peer_book.read().number_of_connected_peers();
+        let number = self.node.peer_book.number_of_connected_peers();
 
         Ok(number as usize)
     }
@@ -300,7 +300,7 @@ impl<S: Storage + Send + Sync + 'static> RpcFunctions for RpcImpl<S> {
     /// Returns this nodes connected peers.
     fn get_peer_info(&self) -> Result<PeerInfo, RpcError> {
         // Create a temporary tokio runtime to make an asynchronous function call
-        let peers = self.node.peer_book.read().connected_peers().keys().copied().collect();
+        let peers = self.node.peer_book.connected_peers().keys().copied().collect();
 
         Ok(PeerInfo { peers })
     }


### PR DESCRIPTION
In some unlucky combinations of network events (when a disconnect was happening just as a read from the disconnecting peer was erroneous, causing another asynchronous disconnect attempt _and_ possibly with another peer trying to connect at the same time), a deadlock could happen, rendering the node unable to process any further messages.

The solution was to change the lock over the `PeerBook` into more granular, separate locks over its contents. In order to aid future debugging, some logs were extended too.

While very tricky to trigger in test conditions, a reproduction test case allowed to confirm that this solution fixes the issue. It was also put into overdrive and paired with a constant barrage of RPC in order to ensure that the node remains stable.

note: an impossible case from `PeerBook::set_disconnected` was additionally removed.