### PR TITLE
Lockless connection writes, fix a peering error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           name: Build and run tests
           no_output_timeout: 60m
           command: >
-            RUST_MIN_STACK=8388608 cargo test --all -- --skip startup_handshake_stored_peers --skip test_rpc_create_raw_transaction --skip fuzzing_zeroes_pre_handshake --skip fuzzing_zeroes_post_handshake --skip reject_non_version_messages_before_handshake --skip handshake_timeout_responder_side --skip handshake_timeout_initiator_side
+            RUST_MIN_STACK=8388608 cargo test --all -- --skip test_rpc_create_raw_transaction
       - persist_to_workspace:
           root: ~/
           paths: project/
@@ -85,7 +85,7 @@ jobs:
       - run:
           name: Build and test
           no_output_timeout: 60m
-          command: RUST_MIN_STACK=8388608 cargo test --all -- --skip startup_handshake_stored_peers --skip test_rpc_create_raw_transaction --skip fuzzing_zeroes_pre_handshake --skip fuzzing_zeroes_post_handshake --skip reject_non_version_messages_before_handshake --skip handshake_timeout_responder_side --skip handshake_timeout_initiator_side
+          command: RUST_MIN_STACK=8388608 cargo test --all -- --skip test_rpc_create_raw_transaction
       - clear_environment:
           cache_key: snarkos-nightly-cache
 workflows:

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -167,7 +167,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// This method handles new inbound messages from a single connected node.
     pub async fn listen_for_inbound_messages(&self, reader: &mut ConnReader) {
         let mut failure_count = 0u8;
-        let mut fatal_count = 0u8;
 
         loop {
             // Read the next message from the channel.
@@ -178,13 +177,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     error!("Unable to read message from {}: {}", reader.addr, error);
                     failure_count += 1;
 
-                    // Increment the fatal count if the error is a fatal error.
-                    if error.is_fatal() {
-                        fatal_count += 1;
-                    }
-
                     // Determine if we should disconnect.
-                    let disconnect_from_peer = fatal_count >= 2 || failure_count >= 10;
+                    let disconnect_from_peer = error.is_fatal() || failure_count >= 10;
 
                     // Determine if we should send a disconnect message.
                     match disconnect_from_peer {

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -112,7 +112,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
                                 let node_clone = node.clone();
                                 let peer_listening_task = tokio::spawn(async move {
-                                    node_clone.listen_for_messages(&mut reader).await;
+                                    node_clone.listen_for_inbound_messages(&mut reader).await;
                                 });
 
                                 trace!("Connected to {}", remote_address);
@@ -147,8 +147,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         Ok(())
     }
 
-    /// This method handles new inbound messages from connected nodes.
-    pub async fn listen_for_messages(&self, reader: &mut ConnReader) {
+    /// This method handles new inbound messages from a single connected node.
+    pub async fn listen_for_inbound_messages(&self, reader: &mut ConnReader) {
         let mut failure_count = 0u8;
         let mut fatal_count = 0u8;
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -53,16 +53,30 @@ pub use peers::*;
 pub mod sync;
 pub use sync::*;
 
-pub const BLOCK_SYNC_EXPIRATION_SECS: u8 = 60;
-pub const HANDSHAKE_PATTERN: &str = "Noise_XXpsk3_25519_ChaChaPoly_SHA256";
-pub const HANDSHAKE_PSK: &[u8] = b"b765e427e836e0029a1e2a22ba60c52a"; // the PSK must be 32B
-pub const HANDSHAKE_BOOTNODE_TIMEOUT_SECS: u8 = 30;
-pub const HANDSHAKE_PEER_TIMEOUT_SECS: u8 = 5;
-pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
-pub const NOISE_BUF_LEN: usize = 65535;
-pub const NOISE_TAG_LEN: usize = 16;
 /// The maximum number of block hashes that can be requested or provided in a single batch.
 pub const MAX_BLOCK_SYNC_COUNT: u32 = 64;
+/// The maximum amount of time allowed to process a single batch of sync blocks. It should be aligned
+/// with `MAX_BLOCK_SYNC_COUNT`.
+pub const BLOCK_SYNC_EXPIRATION_SECS: u8 = 30;
+
+/// The noise handshake pattern.
+pub const HANDSHAKE_PATTERN: &str = "Noise_XXpsk3_25519_ChaChaPoly_SHA256";
+/// The pre-shared key for the noise handshake.
+pub const HANDSHAKE_PSK: &[u8] = b"b765e427e836e0029a1e2a22ba60c52a"; // the PSK must be 32B
+/// The spec-compliant size of the noise buffer.
+pub const NOISE_BUF_LEN: usize = 65535;
+/// The spec-compliant size of the noise tag field.
+pub const NOISE_TAG_LEN: usize = 16;
+
+/// The maximum amount of time in which a handshake with a bootnode can conclude before dropping the
+/// connection; it should be no greater than the `peer_sync_interval`.
+pub const HANDSHAKE_BOOTNODE_TIMEOUT_SECS: u8 = 10;
+/// The maximum amount of time in which a handshake with a regular node can conclude before dropping the
+/// connection; it should be no greater than the `peer_sync_interval`.
+pub const HANDSHAKE_PEER_TIMEOUT_SECS: u8 = 5;
+
+/// The maximum size of a message that can be transmitted in the network.
+pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
 /// The maximum number of peers shared at once in response to a `GetPeers` message.
 pub const SHARED_PEER_COUNT: usize = 25;
 

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -18,10 +18,9 @@ use crate::*;
 use snarkvm_objects::Storage;
 
 use once_cell::sync::OnceCell;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use std::{
-    collections::HashMap,
     net::SocketAddr,
     ops::Deref,
     sync::{
@@ -129,19 +128,13 @@ impl<S: Storage> Node<S> {
 impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
     /// Creates a new instance of `Node`.
     pub async fn new(config: Config) -> Result<Self, NetworkError> {
-        // Create the inbound and outbound handlers.
-        let (inbound, outbound) = {
-            let channels: Arc<RwLock<HashMap<SocketAddr, Arc<ConnWriter>>>> = Default::default();
-            (Inbound::new(channels.clone()), Outbound::new(channels))
-        };
-
         Ok(Self(Arc::new(InnerNode {
             name: thread_rng().gen(),
             state: Default::default(),
             local_address: Default::default(),
             config,
-            inbound,
-            outbound,
+            inbound: Default::default(),
+            outbound: Default::default(),
             peer_book: Default::default(),
             sync: Default::default(),
             tasks: Default::default(),

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -52,23 +52,6 @@ impl Outbound {
     ///
     #[inline]
     pub async fn send_request(&self, request: Message) {
-        self.send(&request).await
-    }
-
-    ///
-    /// Establishes an outbound channel to the given remote address, if it does not exist.
-    ///
-    #[inline]
-    async fn outbound_channel(&self, remote_address: SocketAddr) -> Result<Arc<ConnWriter>, NetworkError> {
-        Ok(self
-            .channels
-            .read()
-            .get(&remote_address)
-            .ok_or(NetworkError::OutboundChannelMissing)?
-            .clone())
-    }
-
-    async fn send(&self, request: &Message) {
         let target_addr = request.receiver();
         // Fetch the outbound channel.
         let channel = match self.outbound_channel(target_addr).await {
@@ -89,6 +72,19 @@ impl Outbound {
                 self.send_failure_count.fetch_add(1, Ordering::SeqCst);
             }
         }
+    }
+
+    ///
+    /// Establishes an outbound channel to the given remote address, if it does not exist.
+    ///
+    #[inline]
+    async fn outbound_channel(&self, remote_address: SocketAddr) -> Result<Arc<ConnWriter>, NetworkError> {
+        Ok(self
+            .channels
+            .read()
+            .get(&remote_address)
+            .ok_or(NetworkError::OutboundChannelMissing)?
+            .clone())
     }
 }
 

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -33,10 +33,10 @@ use parking_lot::RwLock;
 type Channels = HashMap<SocketAddr, Arc<ConnWriter>>;
 
 /// A core data structure for handling outbound network traffic.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Outbound {
     /// The map of remote addresses to their active write channels.
-    pub(crate) channels: Arc<RwLock<Channels>>,
+    pub(crate) channels: RwLock<Channels>,
     /// The monotonic counter for the number of send requests that succeeded.
     send_success_count: AtomicU64,
     /// The monotonic counter for the number of send requests that failed.
@@ -44,14 +44,6 @@ pub struct Outbound {
 }
 
 impl Outbound {
-    pub fn new(channels: Arc<RwLock<Channels>>) -> Self {
-        Self {
-            channels,
-            send_success_count: Default::default(),
-            send_failure_count: Default::default(),
-        }
-    }
-
     ///
     /// Sends the given request to the address associated with it.
     ///

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -450,7 +450,7 @@ mod tests {
         assert_eq!(false, peer_book.is_connected(remote_address));
         assert_eq!(false, peer_book.is_disconnected(remote_address));
 
-        peer_book.set_connected(remote_address, None).unwrap();
+        peer_book.set_connected(remote_address, None);
         assert_eq!(false, peer_book.is_connecting(remote_address));
         assert_eq!(true, peer_book.is_connected(remote_address));
         assert_eq!(false, peer_book.is_disconnected(remote_address));
@@ -484,7 +484,7 @@ mod tests {
         assert_eq!(false, peer_book.is_connected(remote_address));
         assert_eq!(false, peer_book.is_disconnected(remote_address));
 
-        peer_book.set_connected(remote_address, None).unwrap();
+        peer_book.set_connected(remote_address, None);
         assert_eq!(false, peer_book.is_connecting(remote_address));
         assert_eq!(true, peer_book.is_connected(remote_address));
         assert_eq!(false, peer_book.is_disconnected(remote_address));
@@ -501,13 +501,13 @@ mod tests {
         let remote_address = SocketAddr::from((IpAddr::V4(Ipv4Addr::LOCALHOST), 4031));
 
         peer_book.set_connecting(remote_address).unwrap();
-        peer_book.set_connected(remote_address, None).unwrap();
+        peer_book.set_connected(remote_address, None);
         peer_book.set_disconnected(remote_address).unwrap();
         assert_eq!(false, peer_book.is_connecting(remote_address));
         assert_eq!(false, peer_book.is_connected(remote_address));
         assert_eq!(true, peer_book.is_disconnected(remote_address));
 
-        assert!(peer_book.set_connected(remote_address, None).is_ok());
+        peer_book.set_connected(remote_address, None);
 
         assert_eq!(false, peer_book.is_connecting(remote_address));
         assert_eq!(true, peer_book.is_connected(remote_address));

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -189,7 +189,7 @@ impl PeerBook {
     ///
     /// Adds the given address to the connected peers in the `PeerBook`.
     ///
-    pub fn set_connected(&self, address: SocketAddr, listener: Option<SocketAddr>) -> Result<(), NetworkError> {
+    pub fn set_connected(&self, address: SocketAddr, listener: Option<SocketAddr>) {
         // If listener.is_some(), then it's different than the address; otherwise it's just the address param.
         let listener = if let Some(addr) = listener { addr } else { address };
 
@@ -205,14 +205,12 @@ impl PeerBook {
         self.connecting_peers.write().remove(&address);
 
         // Update the peer info to connected.
-        peer_info.set_connected()?;
+        peer_info.set_connected();
 
         // Add the address into the connected peers.
         let success = self.connected_peers.write().insert(listener, peer_info).is_none();
         // On success, increment the connected peer count.
         connected_peers_inc!(success);
-
-        Ok(())
     }
 
     ///

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -174,17 +174,15 @@ impl PeerInfo {
     ///
     /// Updates the peer to connected.
     ///
-    pub(crate) fn set_connected(&mut self) -> Result<(), NetworkError> {
+    pub(crate) fn set_connected(&mut self) {
         if self.status() != PeerStatus::Connected {
             // Set the state of this peer to connected.
             self.status = PeerStatus::Connected;
 
             self.last_connected = Some(Utc::now());
             self.connected_count += 1;
-
-            Ok(())
         } else {
-            Err(NetworkError::PeerAlreadyConnected)
+            trace!("Peer {} was set as connected more than once", self.address);
         }
     }
 

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -241,7 +241,7 @@ mod tests {
         let address: SocketAddr = "127.0.0.1:4130".parse().unwrap();
         let mut peer_info = PeerInfo::new(address);
 
-        peer_info.set_connected().unwrap();
+        peer_info.set_connected();
         assert_eq!(address, peer_info.address());
         assert_eq!(PeerStatus::Connected, peer_info.status());
         assert_eq!(1, peer_info.connected_count());
@@ -272,14 +272,14 @@ mod tests {
         let address: SocketAddr = "127.0.0.1:4130".parse().unwrap();
         let mut peer_info = PeerInfo::new(address);
 
-        peer_info.set_connected().unwrap();
+        peer_info.set_connected();
         peer_info.set_disconnected().unwrap();
         assert_eq!(address, peer_info.address());
         assert_eq!(PeerStatus::Disconnected, peer_info.status());
         assert_eq!(1, peer_info.connected_count());
         assert_eq!(1, peer_info.disconnected_count());
 
-        assert!(peer_info.set_connected().is_ok());
+        peer_info.set_connected();
 
         assert_eq!(address, peer_info.address());
         assert_eq!(PeerStatus::Connected, peer_info.status());

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -484,7 +484,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// as disconnected from this node server.
     ///
     #[inline]
-    pub(crate) async fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
+    pub(crate) fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
         if let Some(ref sync) = self.sync() {
             if self.peer_book.is_syncing_blocks(remote_address) {
                 sync.finished_syncing_blocks();

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -93,10 +93,10 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         }
 
         // Attempt to connect to the default bootnodes of the network.
-        self.connect_to_bootnodes().await;
+        self.connect_to_bootnodes();
 
         // Attempt to connect to each disconnected peer saved in the peer book.
-        self.connect_to_disconnected_peers().await;
+        self.connect_to_disconnected_peers();
 
         // Broadcast a `GetPeers` message to request for more peers.
         self.broadcast_getpeers_requests().await;
@@ -283,7 +283,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// This function filters out any bootnode peers the node server is
     /// either connnecting to or already connected to.
     ///
-    async fn connect_to_bootnodes(&self) {
+    fn connect_to_bootnodes(&self) {
         // Local address must be known by now.
         let own_address = self.local_address().unwrap();
 
@@ -318,7 +318,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     ///
     /// Broadcasts a connection request to all disconnected peers.
     ///
-    async fn connect_to_disconnected_peers(&self) {
+    fn connect_to_disconnected_peers(&self) {
         // Local address must be known by now.
         let own_address = self.local_address().unwrap();
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -72,7 +72,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             .filter(|(addr, _)| !bootnodes.contains(addr)) // Skip this check if the peer is a bootnode.
             .map(|(addr, info)| (*addr, &info.quality))
         {
-            if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1000 || peer_quality.failures.load(Ordering::Relaxed) > 10
+            if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1500 || peer_quality.failures.load(Ordering::Relaxed) > 10
             {
                 warn!("Peer {} has a low quality score; disconnecting.", addr);
                 let _ = self.disconnect_from_peer(addr);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -219,7 +219,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // spawn the inbound loop
             let node_clone = node.clone();
             let conn_listening_task = tokio::spawn(async move {
-                node_clone.listen_for_messages(&mut reader).await;
+                node_clone.listen_for_inbound_messages(&mut reader).await;
             });
 
             if let Ok(ref peer) = node.peer_book.get_peer(remote_address) {

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -73,7 +73,7 @@ async fn fuzzing_zeroes_post_handshake() {
         is_bootnode: true,
         ..Default::default()
     };
-    let (node, fake_node) = handshaken_node_and_peer(node_setup).await;
+    let (node, mut fake_node) = handshaken_node_and_peer(node_setup).await;
     wait_until!(1, node.peer_book.number_of_connected_peers() == 1);
 
     fake_node.write_bytes(&[0u8; 64]).await;
@@ -106,7 +106,7 @@ async fn fuzzing_valid_header_pre_handshake() {
 async fn fuzzing_valid_header_post_handshake() {
     // tracing_subscriber::fmt::init();
 
-    let (node1, mut node2) = spawn_2_fake_nodes().await;
+    let (mut node1, mut node2) = spawn_2_fake_nodes().await;
     let write_finished = Arc::new(AtomicBool::new(false));
     let should_exit = Arc::clone(&write_finished);
 
@@ -157,7 +157,7 @@ async fn fuzzing_pre_handshake() {
 async fn fuzzing_post_handshake() {
     // tracing_subscriber::fmt::init();
 
-    let (node1, mut node2) = spawn_2_fake_nodes().await;
+    let (mut node1, mut node2) = spawn_2_fake_nodes().await;
     let write_finished = Arc::new(AtomicBool::new(false));
     let should_exit = Arc::clone(&write_finished);
 
@@ -213,7 +213,7 @@ async fn fuzzing_corrupted_version_pre_handshake() {
 async fn fuzzing_corrupted_version_post_handshake() {
     // tracing_subscriber::fmt::init();
 
-    let (node1, mut node2) = spawn_2_fake_nodes().await;
+    let (mut node1, mut node2) = spawn_2_fake_nodes().await;
     let write_finished = Arc::new(AtomicBool::new(false));
     let should_exit = Arc::clone(&write_finished);
 
@@ -278,7 +278,7 @@ async fn fuzzing_corrupted_empty_payloads_pre_handshake() {
 async fn fuzzing_corrupted_empty_payloads_post_handshake() {
     // tracing_subscriber::fmt::init();
 
-    let (node1, mut node2) = spawn_2_fake_nodes().await;
+    let (mut node1, mut node2) = spawn_2_fake_nodes().await;
     let write_finished = Arc::new(AtomicBool::new(false));
     let should_exit = Arc::clone(&write_finished);
 
@@ -367,7 +367,7 @@ async fn fuzzing_corrupted_payloads_with_bodies_pre_handshake() {
 async fn fuzzing_corrupted_payloads_with_bodies_post_handshake() {
     // tracing_subscriber::fmt::init();
 
-    let (node1, mut node2) = spawn_2_fake_nodes().await;
+    let (mut node1, mut node2) = spawn_2_fake_nodes().await;
     let write_finished = Arc::new(AtomicBool::new(false));
     let should_exit = Arc::clone(&write_finished);
 
@@ -460,7 +460,7 @@ async fn fuzzing_corrupted_payloads_with_hashes_pre_handshake() {
 async fn fuzzing_corrupted_payloads_with_hashes_post_handshake() {
     // tracing_subscriber::fmt::init();
 
-    let (node1, mut node2) = spawn_2_fake_nodes().await;
+    let (mut node1, mut node2) = spawn_2_fake_nodes().await;
     let write_finished = Arc::new(AtomicBool::new(false));
     let should_exit = Arc::clone(&write_finished);
 

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -265,7 +265,7 @@ async fn handshake_timeout_initiator_side() {
 
     // but since they won't reply, it should drop them after the handshake deadline
     wait_until!(
-        snarkos_network::HANDSHAKE_PEER_TIMEOUT_SECS as u64 + 1,
+        snarkos_network::HANDSHAKE_BOOTNODE_TIMEOUT_SECS as u64 + 1,
         node.peer_book.number_of_connecting_peers() == 0
     );
 }

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -124,7 +124,7 @@ impl Default for Config {
                     .map(|node| (*node).to_string())
                     .collect::<Vec<String>>(),
                 mempool_sync_interval: 12,
-                peer_sync_interval: 8,
+                peer_sync_interval: 15,
                 block_sync_interval: 4,
                 min_peers: 7,
                 max_peers: 25,

--- a/testing/src/network/encryption.rs
+++ b/testing/src/network/encryption.rs
@@ -22,7 +22,7 @@ use rand::{distributions::Standard, thread_rng, Rng};
 
 #[tokio::test]
 async fn encrypt_and_decrypt_a_big_payload() {
-    let (node0, mut node1) = spawn_2_fake_nodes().await;
+    let (mut node0, mut node1) = spawn_2_fake_nodes().await;
 
     // account for the overhead of serialization and noise tags
     let block_size = snarkos_network::MAX_MESSAGE_SIZE / 2;
@@ -47,7 +47,7 @@ async fn encrypt_and_decrypt_a_big_payload() {
 
 #[tokio::test]
 async fn encrypt_and_decrypt_small_payloads() {
-    let (node0, mut node1) = spawn_2_fake_nodes().await;
+    let (mut node0, mut node1) = spawn_2_fake_nodes().await;
 
     let mut rng = thread_rng();
 

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -229,13 +229,13 @@ impl FakeNode {
         Ok(message.payload)
     }
 
-    pub async fn write_message(&self, payload: &Payload) {
+    pub async fn write_message(&mut self, payload: &Payload) {
         self.writer.write_message(payload).await.unwrap();
         debug!("wrote a message containing a {} to the stream", payload);
     }
 
-    pub async fn write_bytes(&self, bytes: &[u8]) {
-        self.writer.writer.lock().await.write_all(bytes).await.unwrap();
+    pub async fn write_bytes(&mut self, bytes: &[u8]) {
+        self.writer.writer.write_all(bytes).await.unwrap();
         debug!("wrote {}B to the stream", bytes.len());
     }
 }


### PR DESCRIPTION
This PR changes the connection write architecture so that writes are queued in per-connection `channel`s and processed in per-connection tasks. This allows us to remove the locks inside the `ConnWriter` object.

In addition, a logic bug in `update_peers` that caused connections to be dropped is fixed and some constants are tweaked.

Re-enabling the temporarily-disabled fuzz tests required the following changes:
- making fatal errors cause disconnects again (those errors indicate that the connection is unrecoverable)
- removing `async` from `Peers::disconnect_from_peer`

Fixes https://github.com/AleoHQ/snarkOS/issues/717.