### PR TITLE
Make a lot more methods non-async, tweak peer timestamps and sync logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "circular-queue"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34327ead1c743a10db339de35fb58957564b99d248a67985c55638b22c59b5"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,7 +2567,9 @@ dependencies = [
  "capnp",
  "capnpc",
  "chrono",
+ "circular-queue",
  "derivative",
+ "fxhash",
  "hex",
  "log",
  "once_cell",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -60,8 +60,14 @@ version = "0.14"
 version = "0.4"
 features = [ "serde" ]
 
+[dependencies.circular-queue]
+version = "0.2"
+
 [dependencies.derivative]
 version = "2"
+
+[dependencies.fxhash]
+version = "0.2"
 
 [dependencies.hex]
 version = "0.4.2"

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -42,7 +42,7 @@ pub struct Inbound {
 impl Default for Inbound {
     fn default() -> Self {
         // Initialize the sender and receiver.
-        let (sender, receiver) = tokio::sync::mpsc::channel(64 * 1024);
+        let (sender, receiver) = tokio::sync::mpsc::channel(crate::INBOUND_CHANNEL_DEPTH);
 
         Self {
             sender,
@@ -116,7 +116,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                 let remote_address = writer.addr;
 
                                 // Create a channel dedicated to sending messages to the connection.
-                                let (sender, receiver) = channel(1024);
+                                let (sender, receiver) = channel(crate::OUTBOUND_CHANNEL_DEPTH);
 
                                 // Listen for inbound messages.
                                 let node_clone = node.clone();

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -80,6 +80,11 @@ pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
 /// The maximum number of peers shared at once in response to a `GetPeers` message.
 pub const SHARED_PEER_COUNT: usize = 25;
 
+/// The depth of the common inbound channel.
+pub const INBOUND_CHANNEL_DEPTH: usize = 64 * 1024;
+/// The depth of the per-connection outbound channels.
+pub const OUTBOUND_CHANNEL_DEPTH: usize = 4096;
+
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 
 pub(crate) type Receiver = tokio::sync::mpsc::Receiver<Message>;

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -195,11 +195,6 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
             loop {
                 sleep(std::time::Duration::from_secs(5)).await;
 
-                // Make sure that the node doesn't remain in a sync state without peers.
-                if node_clone.state() == State::Syncing && node_clone.peer_book.number_of_connected_peers() == 0 {
-                    node_clone.set_state(State::Idle);
-                }
-
                 // Report node's current state.
                 trace!("Node state: {:?}", node_clone.state());
             }

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -171,8 +171,10 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         let node_clone = self.clone();
         let mut receiver = self.inbound.take_receiver();
         let incoming_task = task::spawn(async move {
+            let mut cache = Cache::default();
+
             loop {
-                if let Err(e) = node_clone.process_incoming_messages(&mut receiver).await {
+                if let Err(e) = node_clone.process_incoming_messages(&mut receiver, &mut cache).await {
                     error!("Node error: {}", e);
                 }
             }

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -49,7 +49,7 @@ impl Outbound {
     /// and attempts to send the given request to them.
     ///
     #[inline]
-    pub async fn send_request(&self, request: Message) {
+    pub fn send_request(&self, request: Message) {
         let target_addr = request.receiver();
         // Fetch the outbound channel.
         match self.outbound_channel(target_addr) {
@@ -89,7 +89,7 @@ impl Outbound {
 }
 
 impl<S: Storage + Send + Sync + 'static> Node<S> {
-    pub async fn send_ping(&self, remote_address: SocketAddr) {
+    pub fn send_ping(&self, remote_address: SocketAddr) {
         // Consider peering tests that don't use the sync layer.
         let current_block_height = if let Some(ref sync) = self.sync() {
             sync.current_block_height()
@@ -99,12 +99,10 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
         self.peer_book.sending_ping(remote_address);
 
-        self.outbound
-            .send_request(Message::new(
-                Direction::Outbound(remote_address),
-                Payload::Ping(current_block_height),
-            ))
-            .await;
+        self.outbound.send_request(Message::new(
+            Direction::Outbound(remote_address),
+            Payload::Ping(current_block_height),
+        ));
     }
 
     /// This method handles new outbound messages to a single connected node.

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -390,16 +390,8 @@ impl PeerBook {
             pq.remaining_sync_blocks.fetch_sub(1, Ordering::SeqCst) == 1
         } else {
             warn!("Peer for got_sync_block purposes not found! (probably disconnected)");
-            true
-        }
-    }
-
-    /// Checks whether the current peer is involved in a block syncing process.
-    pub fn is_syncing_blocks(&self, addr: SocketAddr) -> bool {
-        if let Some(ref pq) = self.peer_quality(addr) {
-            pq.remaining_sync_blocks.load(Ordering::SeqCst) != 0
-        } else {
-            trace!("Peer for is_syncing_blocks purposes not found! (probably disconnected)");
+            // We might still be processing queued sync blocks; the sync expiry mechanism
+            // will handle going into the `Idle` state if the batch is incomplete.
             false
         }
     }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -482,12 +482,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     ///
     #[inline]
     pub(crate) fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
-        if let Some(ref sync) = self.sync() {
-            if self.peer_book.is_syncing_blocks(remote_address) {
-                sync.finished_syncing_blocks();
-            }
-        }
-
         // Set the peer as disconnected in the peer book.
         let result = self.peer_book.set_disconnected(remote_address);
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -215,7 +215,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             let mut reader = ConnReader::new(remote_address, reader, buffer, noise);
 
             // Create a channel dedicated to sending messages to the connection.
-            let (sender, receiver) = channel(1024);
+            let (sender, receiver) = channel(crate::OUTBOUND_CHANNEL_DEPTH);
 
             // spawn the inbound loop
             let node_clone = node.clone();

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -24,7 +24,7 @@ impl<S: Storage> Sync<S> {
     ///
     /// Sends a `GetSync` request to the given sync node.
     ///
-    pub async fn update_blocks(&self, sync_node: Option<SocketAddr>) {
+    pub fn update_blocks(&self, sync_node: Option<SocketAddr>) {
         if let Some(sync_node) = sync_node {
             let block_locator_hashes = match self.storage().get_block_locator_hashes() {
                 Ok(block_locator_hashes) => block_locator_hashes,
@@ -37,13 +37,10 @@ impl<S: Storage> Sync<S> {
             info!("Updating blocks from {}", sync_node);
 
             // Send a GetSync to the selected sync node.
-            self.node()
-                .outbound
-                .send_request(Message::new(
-                    Direction::Outbound(sync_node),
-                    Payload::GetSync(block_locator_hashes),
-                ))
-                .await;
+            self.node().outbound.send_request(Message::new(
+                Direction::Outbound(sync_node),
+                Payload::GetSync(block_locator_hashes),
+            ));
         } else {
             // If no sync node is available, wait until peers have been established.
             debug!("No sync node is registered, blocks could not be synced");
@@ -51,25 +48,22 @@ impl<S: Storage> Sync<S> {
     }
 
     /// Broadcast block to connected peers
-    pub async fn propagate_block(&self, block_bytes: Vec<u8>, block_miner: SocketAddr) {
+    pub fn propagate_block(&self, block_bytes: Vec<u8>, block_miner: SocketAddr) {
         debug!("Propagating a block to peers");
 
         for remote_address in self.node().connected_peers() {
             if remote_address != block_miner {
                 // Send a `Block` message to the connected peer.
-                self.node()
-                    .outbound
-                    .send_request(Message::new(
-                        Direction::Outbound(remote_address),
-                        Payload::Block(block_bytes.clone()),
-                    ))
-                    .await;
+                self.node().outbound.send_request(Message::new(
+                    Direction::Outbound(remote_address),
+                    Payload::Block(block_bytes.clone()),
+                ));
             }
         }
     }
 
     /// A peer has sent us a new block to process.
-    pub(crate) async fn received_block(
+    pub(crate) fn received_block(
         &self,
         remote_address: SocketAddr,
         block: Vec<u8>,
@@ -112,14 +106,14 @@ impl<S: Storage> Sync<S> {
 
         // This is a new block, send it to our peers.
         if is_block_new && is_valid_block {
-            self.propagate_block(block, remote_address).await;
+            self.propagate_block(block, remote_address);
         }
 
         Ok(())
     }
 
     /// A peer has requested a block.
-    pub(crate) async fn received_get_blocks(
+    pub(crate) fn received_get_blocks(
         &self,
         remote_address: SocketAddr,
         header_hashes: Vec<BlockHeaderHash>,
@@ -128,20 +122,17 @@ impl<S: Storage> Sync<S> {
             let block = self.storage().get_block(&hash)?;
 
             // Send a `SyncBlock` message to the connected peer.
-            self.node()
-                .outbound
-                .send_request(Message::new(
-                    Direction::Outbound(remote_address),
-                    Payload::SyncBlock(block.serialize()?),
-                ))
-                .await;
+            self.node().outbound.send_request(Message::new(
+                Direction::Outbound(remote_address),
+                Payload::SyncBlock(block.serialize()?),
+            ));
         }
 
         Ok(())
     }
 
     /// A peer has requested our chain state to sync with.
-    pub(crate) async fn received_get_sync(
+    pub(crate) fn received_get_sync(
         &self,
         remote_address: SocketAddr,
         block_locator_hashes: Vec<BlockHeaderHash>,
@@ -181,26 +172,22 @@ impl<S: Storage> Sync<S> {
         // send a `Sync` message to the connected peer.
         self.node()
             .outbound
-            .send_request(Message::new(Direction::Outbound(remote_address), Payload::Sync(sync)))
-            .await;
+            .send_request(Message::new(Direction::Outbound(remote_address), Payload::Sync(sync)));
 
         Ok(())
     }
 
     /// A peer has sent us their chain state.
-    pub(crate) async fn received_sync(&self, remote_address: SocketAddr, block_hashes: Vec<BlockHeaderHash>) {
+    pub(crate) fn received_sync(&self, remote_address: SocketAddr, block_hashes: Vec<BlockHeaderHash>) {
         // If empty sync is no-op as chain states match
         if !block_hashes.is_empty() {
             for batch in block_hashes.chunks(crate::MAX_BLOCK_SYNC_COUNT as usize) {
                 // GetBlocks for each block hash: fire and forget, relying on block locator hashes to
                 // detect missing blocks and divergence in chain for now.
-                self.node()
-                    .outbound
-                    .send_request(Message::new(
-                        Direction::Outbound(remote_address),
-                        Payload::GetBlocks(batch.to_vec()),
-                    ))
-                    .await;
+                self.node().outbound.send_request(Message::new(
+                    Direction::Outbound(remote_address),
+                    Payload::GetBlocks(batch.to_vec()),
+                ));
             }
         }
     }

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -29,14 +29,13 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
     ///
     /// Triggers the memory pool sync with a selected peer.
     ///
-    pub async fn update_memory_pool(&self, sync_node: Option<SocketAddr>) {
+    pub fn update_memory_pool(&self, sync_node: Option<SocketAddr>) {
         if let Some(sync_node) = sync_node {
             info!("Updating memory pool from {}", sync_node);
 
             self.node()
                 .outbound
-                .send_request(Message::new(Direction::Outbound(sync_node), Payload::GetMemoryPool))
-                .await;
+                .send_request(Message::new(Direction::Outbound(sync_node), Payload::GetMemoryPool));
         } else {
             debug!("No sync node is registered, memory pool could not be synced");
         }
@@ -45,11 +44,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
     ///
     /// Broadcast memory pool transaction to connected peers.
     ///
-    pub(crate) async fn propagate_memory_pool_transaction(
-        &self,
-        transaction_bytes: Vec<u8>,
-        transaction_sender: SocketAddr,
-    ) -> Result<(), NetworkError> {
+    pub(crate) fn propagate_memory_pool_transaction(&self, transaction_bytes: Vec<u8>, transaction_sender: SocketAddr) {
         debug!("Propagating a memory pool transaction to connected peers");
 
         let local_address = self.node().local_address().unwrap();
@@ -57,24 +52,19 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
         for remote_address in self.node().connected_peers() {
             if remote_address != transaction_sender && remote_address != local_address {
                 // Send a `Transaction` message to the connected peer.
-                self.node()
-                    .outbound
-                    .send_request(Message::new(
-                        Direction::Outbound(remote_address),
-                        Payload::Transaction(transaction_bytes.clone()),
-                    ))
-                    .await;
+                self.node().outbound.send_request(Message::new(
+                    Direction::Outbound(remote_address),
+                    Payload::Transaction(transaction_bytes.clone()),
+                ));
             }
         }
-
-        Ok(())
     }
 
     ///
     /// Verifies a received memory pool transaction, adds it to the memory pool,
     /// and propagates it to peers.
     ///
-    pub(crate) async fn received_memory_pool_transaction(
+    pub(crate) fn received_memory_pool_transaction(
         &self,
         source: SocketAddr,
         transaction: Vec<u8>,
@@ -104,7 +94,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
             if let Ok(inserted) = insertion {
                 if inserted.is_some() {
                     info!("Transaction added to memory pool.");
-                    self.propagate_memory_pool_transaction(transaction, source).await?;
+                    self.propagate_memory_pool_transaction(transaction, source);
                 }
             }
         }
@@ -113,7 +103,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
     }
 
     /// A peer has requested our memory pool transactions.
-    pub(crate) async fn received_get_memory_pool(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
+    pub(crate) fn received_get_memory_pool(&self, remote_address: SocketAddr) {
         // TODO (howardwu): This should have been written with Rayon - it is easily parallelizable.
         let transactions = {
             let mut txs = vec![];
@@ -130,16 +120,11 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
 
         if !transactions.is_empty() {
             // Send a `MemoryPool` message to the connected peer.
-            self.node()
-                .outbound
-                .send_request(Message::new(
-                    Direction::Outbound(remote_address),
-                    Payload::MemoryPool(transactions),
-                ))
-                .await;
+            self.node().outbound.send_request(Message::new(
+                Direction::Outbound(remote_address),
+                Payload::MemoryPool(transactions),
+            ));
         }
-
-        Ok(())
     }
 
     /// A peer has sent us their memory pool transactions.

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -19,7 +19,6 @@ use snarkos_consensus::Miner;
 use snarkvm_dpc::{base_dpc::instantiated::*, AccountAddress};
 use snarkvm_objects::Storage;
 
-use tokio::runtime;
 use tracing::*;
 
 use std::{sync::Arc, thread, time::Duration};
@@ -39,7 +38,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
     /// Spawns a new miner on a new thread using MinerInstance parameters.
     /// Once a block is found, A block message is sent to all peers.
     /// Calling this function multiple times will spawn additional listeners on separate threads.
-    pub fn spawn(self, tokio_handle: runtime::Handle) -> thread::JoinHandle<()> {
+    pub fn spawn(self) -> thread::JoinHandle<()> {
         let local_address = self.node.local_address().unwrap();
         info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
         let miner = Miner::new(
@@ -109,12 +108,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                     continue;
                 };
 
-                let node = self.node.clone();
-                tokio_handle.spawn(async move {
-                    node.expect_sync()
-                        .propagate_block(serialized_block, local_address)
-                        .await;
-                });
+                self.node.expect_sync().propagate_block(serialized_block, local_address);
             }
         });
 

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -35,7 +35,7 @@ async fn test_nodes(n: usize, setup: TestSetup) -> Vec<Node<LedgerStorage>> {
 
     for _ in 0..n {
         let environment = test_config(setup.clone());
-        let node = Node::new(environment).await.unwrap();
+        let node = Node::new(environment).unwrap();
 
         node.listen().await.unwrap();
         nodes.push(node);
@@ -49,7 +49,7 @@ async fn start_nodes(nodes: &[Node<LedgerStorage>]) {
         // Nodes are started with a slight delay to avoid having peering intervals in phase (this
         // is the hypothetical worst case scenario).
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        node.start_services().await;
+        node.start_services();
     }
 }
 
@@ -197,8 +197,8 @@ async fn binary_star_contact() {
     };
     let environment_a = test_config(bootnode_setup.clone());
     let environment_b = test_config(bootnode_setup.clone());
-    let bootnode_a = Node::new(environment_a).await.unwrap();
-    let bootnode_b = Node::new(environment_b).await.unwrap();
+    let bootnode_a = Node::new(environment_a).unwrap();
+    let bootnode_b = Node::new(environment_b).unwrap();
 
     bootnode_a.listen().await.unwrap();
     bootnode_b.listen().await.unwrap();

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -70,7 +70,7 @@ mod protected_rpc_tests {
         }
     }
 
-    async fn initialize_test_rpc(
+    fn initialize_test_rpc(
         ledger: Arc<MerkleTreeLedger<LedgerStorage>>,
     ) -> (MetaIoHandler<Meta>, Arc<Consensus<LedgerStorage>>) {
         let credentials = RpcCredentials {
@@ -79,7 +79,7 @@ mod protected_rpc_tests {
         };
 
         let environment = test_config(TestSetup::default());
-        let mut node = Node::new(environment).await.unwrap();
+        let mut node = Node::new(environment).unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::sync::create_test_consensus_from_ledger(ledger.clone()));
 
@@ -101,11 +101,11 @@ mod protected_rpc_tests {
         (io, consensus)
     }
 
-    #[tokio::test]
-    async fn test_rpc_authentication() {
+    #[test]
+    fn test_rpc_authentication() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let meta = invalid_authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let method = "getrecordcommitments".to_string();
         let request = format!("{{ \"jsonrpc\":\"2.0\", \"id\": 1, \"method\": \"{}\" }}", method);
@@ -117,13 +117,13 @@ mod protected_rpc_tests {
         assert_eq!(extracted["error"]["message"], expected_result);
     }
 
-    #[tokio::test]
-    async fn test_rpc_fetch_record_commitment_count() {
+    #[test]
+    fn test_rpc_fetch_record_commitment_count() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         storage.store_record(&DATA.records_1[0]).unwrap();
 
         let meta = authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let method = "getrecordcommitmentcount".to_string();
         let request = format!("{{ \"jsonrpc\":\"2.0\", \"id\": 1, \"method\": \"{}\" }}", method);
@@ -134,13 +134,13 @@ mod protected_rpc_tests {
         assert_eq!(extracted["result"], 1);
     }
 
-    #[tokio::test]
-    async fn test_rpc_fetch_record_commitments() {
+    #[test]
+    fn test_rpc_fetch_record_commitments() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         storage.store_record(&DATA.records_1[0]).unwrap();
 
         let meta = authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let method = "getrecordcommitments".to_string();
         let request = format!("{{ \"jsonrpc\":\"2.0\", \"id\": 1, \"method\": \"{}\" }}", method);
@@ -155,13 +155,13 @@ mod protected_rpc_tests {
         assert_eq!(extracted["result"], expected_result);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_raw_record() {
+    #[test]
+    fn test_rpc_get_raw_record() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         storage.store_record(&DATA.records_1[0]).unwrap();
 
         let meta = authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let method = "getrawrecord".to_string();
         let params = hex::encode(to_bytes![DATA.records_1[0].commitment()].unwrap());
@@ -178,11 +178,11 @@ mod protected_rpc_tests {
         assert_eq!(extracted["result"], expected_result);
     }
 
-    #[tokio::test]
-    async fn test_rpc_decode_record() {
+    #[test]
+    fn test_rpc_decode_record() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let meta = authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let record = &DATA.records_1[0];
 
@@ -218,11 +218,11 @@ mod protected_rpc_tests {
         assert_eq!(commitment_randomness, record_info["commitment_randomness"]);
     }
 
-    #[tokio::test]
-    async fn test_rpc_decrypt_record() {
+    #[test]
+    fn test_rpc_decrypt_record() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let meta = authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let system_parameters = &FIXTURE_VK.parameters.system_parameters;
         let [miner_acc, _, _] = FIXTURE_VK.test_accounts.clone();
@@ -263,12 +263,12 @@ mod protected_rpc_tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_rpc_create_raw_transaction() {
+    #[test]
+    fn test_rpc_create_raw_transaction() {
         let storage = Arc::new(FIXTURE.ledger());
         let meta = authentication();
 
-        let (rpc, consensus) = initialize_test_rpc(storage).await;
+        let (rpc, consensus) = initialize_test_rpc(storage);
 
         consensus.receive_block(&DATA.block_1).unwrap();
 
@@ -315,12 +315,12 @@ mod protected_rpc_tests {
         let _transaction: Tx = FromBytes::read(&transaction_bytes[..]).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_rpc_create_transaction_kernel() {
+    #[test]
+    fn test_rpc_create_transaction_kernel() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let meta = authentication();
 
-        let (rpc, consensus) = initialize_test_rpc(storage).await;
+        let (rpc, consensus) = initialize_test_rpc(storage);
 
         consensus.receive_block(&DATA.block_1).unwrap();
 
@@ -362,12 +362,12 @@ mod protected_rpc_tests {
             FromBytes::read(&transaction_kernel_bytes[..]).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_rpc_create_transaction() {
+    #[test]
+    fn test_rpc_create_transaction() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let meta = authentication();
 
-        let (rpc, consensus) = initialize_test_rpc(storage).await;
+        let (rpc, consensus) = initialize_test_rpc(storage);
 
         consensus.receive_block(&DATA.block_1).unwrap();
 
@@ -400,11 +400,11 @@ mod protected_rpc_tests {
         let _transaction: Tx = FromBytes::read(&transaction_bytes[..]).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_create_account() {
+    #[test]
+    fn test_create_account() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let meta = authentication();
-        let (rpc, _consensus) = initialize_test_rpc(storage).await;
+        let (rpc, _consensus) = initialize_test_rpc(storage);
 
         let method = "createaccount".to_string();
 

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -36,9 +36,9 @@ mod rpc_tests {
     use serde_json::Value;
     use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-    async fn initialize_test_rpc(ledger: Arc<MerkleTreeLedger<LedgerStorage>>) -> Rpc {
+    fn initialize_test_rpc(ledger: Arc<MerkleTreeLedger<LedgerStorage>>) -> Rpc {
         let environment = test_config(TestSetup::default());
-        let mut node = Node::new(environment).await.unwrap();
+        let mut node = Node::new(environment).unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::sync::create_test_consensus_from_ledger(ledger.clone()));
 
@@ -119,10 +119,10 @@ mod rpc_tests {
         extracted["result"].clone()
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_block() {
+    #[test]
+    fn test_rpc_get_block() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let response = rpc.request("getblock", &[hex::encode(GENESIS_BLOCK_HEADER_HASH.to_vec())]);
 
@@ -152,10 +152,10 @@ mod rpc_tests {
         assert_eq!(genesis_block.header.nonce, block_response["nonce"]);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_block_count() {
+    #[test]
+    fn test_rpc_get_block_count() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let method = "getblockcount".to_string();
 
@@ -164,10 +164,10 @@ mod rpc_tests {
         assert_eq!(result.as_u64().unwrap(), 1u64);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_best_block_hash() {
+    #[test]
+    fn test_rpc_get_best_block_hash() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let method = "getbestblockhash".to_string();
 
@@ -179,10 +179,10 @@ mod rpc_tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_block_hash() {
+    #[test]
+    fn test_rpc_get_block_hash() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         assert_eq!(rpc.request("getblockhash", &[0u32]), format![
             r#""{}""#,
@@ -190,10 +190,10 @@ mod rpc_tests {
         ]);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_raw_transaction() {
+    #[test]
+    fn test_rpc_get_raw_transaction() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let genesis_block = genesis();
 
@@ -206,10 +206,10 @@ mod rpc_tests {
         ]);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_transaction_info() {
+    #[test]
+    fn test_rpc_get_transaction_info() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let genesis_block = genesis();
         let transaction = &genesis_block.transactions.0[0];
@@ -223,10 +223,10 @@ mod rpc_tests {
         verify_transaction_info(to_bytes![transaction].unwrap(), transaction_info);
     }
 
-    #[tokio::test]
-    async fn test_rpc_decode_raw_transaction() {
+    #[test]
+    fn test_rpc_decode_raw_transaction() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let response = rpc.request("decoderawtransaction", &[hex::encode(TRANSACTION_1.to_vec())]);
 
@@ -235,10 +235,10 @@ mod rpc_tests {
         verify_transaction_info(TRANSACTION_1.to_vec(), transaction_info);
     }
 
-    #[tokio::test]
-    async fn test_rpc_send_raw_transaction() {
+    #[test]
+    fn test_rpc_send_raw_transaction() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let transaction = Tx::read(&TRANSACTION_1[..]).unwrap();
 
@@ -248,10 +248,10 @@ mod rpc_tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_rpc_validate_transaction() {
+    #[test]
+    fn test_rpc_validate_transaction() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         assert_eq!(
             rpc.request("validaterawtransaction", &[hex::encode(TRANSACTION_1.to_vec())]),
@@ -259,10 +259,10 @@ mod rpc_tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_connection_count() {
+    #[test]
+    fn test_rpc_get_connection_count() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let method = "getconnectioncount".to_string();
 
@@ -271,10 +271,10 @@ mod rpc_tests {
         assert_eq!(result.as_u64().unwrap(), 0u64);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_peer_info() {
+    #[test]
+    fn test_rpc_get_peer_info() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let method = "getpeerinfo".to_string();
 
@@ -287,10 +287,10 @@ mod rpc_tests {
         assert_eq!(peer_info.peers, expected_peers);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_node_info() {
+    #[test]
+    fn test_rpc_get_node_info() {
         let storage = Arc::new(FIXTURE_VK.ledger());
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let method = "getnodeinfo".to_string();
 
@@ -302,13 +302,13 @@ mod rpc_tests {
         assert_eq!(peer_info.is_syncing, false);
     }
 
-    #[tokio::test]
-    async fn test_rpc_get_block_template() {
+    #[test]
+    fn test_rpc_get_block_template() {
         let storage = Arc::new(FIXTURE_VK.ledger());
         let curr_height = storage.get_current_block_height();
         let latest_block_hash = hex::encode(storage.get_latest_block().unwrap().header.get_hash().0);
 
-        let rpc = initialize_test_rpc(storage).await;
+        let rpc = initialize_test_rpc(storage);
 
         let method = "getblocktemplate".to_string();
 

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -177,7 +177,7 @@ pub fn test_config(setup: TestSetup) -> Config {
 pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
     let is_miner = setup.consensus_setup.as_ref().map(|c| c.is_miner) == Some(true);
     let config = test_config(setup.clone());
-    let mut node = Node::new(config).await.unwrap();
+    let mut node = Node::new(config).unwrap();
 
     if let Some(consensus_setup) = setup.consensus_setup {
         let consensus = test_consensus(consensus_setup, node.clone());
@@ -185,12 +185,11 @@ pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
     }
 
     node.listen().await.unwrap();
-    node.start_services().await;
+    node.start_services();
 
     if is_miner {
-        let tokio_handle = setup.tokio_handle.unwrap();
         let miner_address = FIXTURE.test_accounts[0].address.clone();
-        MinerInstance::new(miner_address, node.clone()).spawn(tokio_handle);
+        MinerInstance::new(miner_address, node.clone()).spawn();
     }
 
     node


### PR DESCRIPTION
After https://github.com/AleoHQ/snarkOS/pull/719, many methods can become non-async, as they are no longer using any asynchronous calls; in addition, changing the `Inbound` channel's sending logic to `Sender::try_send` instead of `::send` allows it to become non-async too. The slight downside is that overflowing messages will not get delivered (but there's the sync and propagation logic to fix that), but the benefit is that the node is not susceptible to being "flooded" with messages waiting to be processed; that channel has a fairly large capacity too.

In addition, in order to avoid situations where a node would ask for a block sync while still processing queued sync blocks (which can now happen when a peer disconnects just after having sent a batch), this PR leverages the block sync expiry mechanism more, so that a disconnect from a peer that has just provided sync blocks no longer automatically changes the node's state to `Idle`.

Finally, there's a small performance tweak that omits a peer's timestamp update if their message is a sync block, avoiding updating it many times when processing a batch of sync blocks.