### PR TITLE
Introduce network topology metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,6 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
@@ -775,16 +766,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "eigenvalues"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5006bcbe67713f0b38e63e821e8022cbe16e15426e95dcde397234a703014f91"
-dependencies = [
- "approx 0.3.2",
- "nalgebra",
 ]
 
 [[package]]
@@ -1547,12 +1528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
-
-[[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,9 +1606,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+checksum = "5a8a15b776d9dfaecd44b03c5828c2199cddff5247215858aac14624f8d6b741"
 dependencies = [
  "rawpointer",
 ]
@@ -1829,18 +1804,15 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.24.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9002895a0de45e3cde58b36d0cf2f83249e7dba4a43ee64dafbf01bfd464ff"
+checksum = "476d1d59fe02fe54c86356e91650cd892f392782a1cb9fc524ec84f7aa9e1d06"
 dependencies = [
- "approx 0.4.0",
- "generic-array 0.14.4",
+ "approx",
  "matrixmultiply",
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.7.3",
- "rand_distr",
  "simba",
  "typenum",
 ]
@@ -1936,7 +1908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2358,16 +2329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
-dependencies = [
- "num-traits",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -2810,11 +2771,11 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simba"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bfe642b1728a6e89137ad428ef5d4738eca4efaba9590f9e110b8944028621"
+checksum = "5132a955559188f3d13c9ba831e77c802ddc8782783f050ed0c52f5988b95f4c"
 dependencies = [
- "approx 0.4.0",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-shim"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +775,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "eigenvalues"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5006bcbe67713f0b38e63e821e8022cbe16e15426e95dcde397234a703014f91"
+dependencies = [
+ "approx 0.3.2",
+ "nalgebra",
 ]
 
 [[package]]
@@ -1519,6 +1547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1628,15 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+dependencies = [
+ "rawpointer",
+]
 
 [[package]]
 name = "maybe-uninit"
@@ -1785,6 +1828,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9002895a0de45e3cde58b36d0cf2f83249e7dba4a43ee64dafbf01bfd464ff"
+dependencies = [
+ "approx 0.4.0",
+ "generic-array 0.14.4",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.7.3",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,6 +1900,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,12 +1919,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1957,6 +2039,12 @@ dependencies = [
  "smallvec",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "peak_alloc"
@@ -2273,6 +2361,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
+dependencies = [
+ "num-traits",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2405,12 @@ checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2705,6 +2809,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
+name = "simba"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bfe642b1728a6e89137ad428ef5d4738eca4efaba9590f9e110b8944028621"
+dependencies = [
+ "approx 0.4.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,10 +2941,12 @@ dependencies = [
  "chrono",
  "circular-queue",
  "derivative",
+ "eigenvalues",
  "fxhash",
  "hex",
  "log",
  "metrics",
+ "nalgebra",
  "once_cell",
  "parking_lot",
  "peak_alloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
@@ -766,6 +775,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "eigenvalues"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5006bcbe67713f0b38e63e821e8022cbe16e15426e95dcde397234a703014f91"
+dependencies = [
+ "approx 0.3.2",
+ "nalgebra 0.24.1",
 ]
 
 [[package]]
@@ -1528,6 +1547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1628,15 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+dependencies = [
+ "rawpointer",
+]
 
 [[package]]
 name = "matrixmultiply"
@@ -1804,16 +1838,34 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9002895a0de45e3cde58b36d0cf2f83249e7dba4a43ee64dafbf01bfd464ff"
+dependencies = [
+ "approx 0.4.0",
+ "generic-array 0.14.4",
+ "matrixmultiply 0.2.4",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.7.3",
+ "rand_distr",
+ "simba 0.3.1",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476d1d59fe02fe54c86356e91650cd892f392782a1cb9fc524ec84f7aa9e1d06"
 dependencies = [
- "approx",
- "matrixmultiply",
+ "approx 0.4.0",
+ "matrixmultiply 0.3.1",
  "num-complex",
  "num-rational",
  "num-traits",
- "simba",
+ "simba 0.4.0",
  "typenum",
 ]
 
@@ -1908,6 +1960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2329,6 +2382,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
+dependencies = [
+ "num-traits",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -2771,11 +2834,23 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simba"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bfe642b1728a6e89137ad428ef5d4738eca4efaba9590f9e110b8944028621"
+dependencies = [
+ "approx 0.4.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "simba"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5132a955559188f3d13c9ba831e77c802ddc8782783f050ed0c52f5988b95f4c"
 dependencies = [
- "approx",
+ "approx 0.4.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -2907,7 +2982,7 @@ dependencies = [
  "hex",
  "log",
  "metrics",
- "nalgebra",
+ "nalgebra 0.26.2",
  "once_cell",
  "parking_lot",
  "peak_alloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,15 +63,6 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
@@ -775,16 +766,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "eigenvalues"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5006bcbe67713f0b38e63e821e8022cbe16e15426e95dcde397234a703014f91"
-dependencies = [
- "approx 0.3.2",
- "nalgebra 0.24.1",
 ]
 
 [[package]]
@@ -1547,12 +1528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
-
-[[package]]
 name = "librocksdb-sys"
 version = "6.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,15 +1603,6 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
-dependencies = [
- "rawpointer",
-]
 
 [[package]]
 name = "matrixmultiply"
@@ -1838,34 +1804,16 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9002895a0de45e3cde58b36d0cf2f83249e7dba4a43ee64dafbf01bfd464ff"
-dependencies = [
- "approx 0.4.0",
- "generic-array 0.14.4",
- "matrixmultiply 0.2.4",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.7.3",
- "rand_distr",
- "simba 0.3.1",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476d1d59fe02fe54c86356e91650cd892f392782a1cb9fc524ec84f7aa9e1d06"
 dependencies = [
- "approx 0.4.0",
- "matrixmultiply 0.3.1",
+ "approx",
+ "matrixmultiply",
  "num-complex",
  "num-rational",
  "num-traits",
- "simba 0.4.0",
+ "simba",
  "typenum",
 ]
 
@@ -1960,7 +1908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2382,16 +2329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9532ada3929fb8b2e9dbe28d1e06c9b2cc65813f074fcb6bd5fbefeff9d56"
-dependencies = [
- "num-traits",
- "rand 0.7.3",
 ]
 
 [[package]]
@@ -2834,23 +2771,11 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simba"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bfe642b1728a6e89137ad428ef5d4738eca4efaba9590f9e110b8944028621"
-dependencies = [
- "approx 0.4.0",
- "num-complex",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "simba"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5132a955559188f3d13c9ba831e77c802ddc8782783f050ed0c52f5988b95f4c"
 dependencies = [
- "approx 0.4.0",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",
@@ -2977,12 +2902,11 @@ dependencies = [
  "chrono",
  "circular-queue",
  "derivative",
- "eigenvalues",
  "fxhash",
  "hex",
  "log",
  "metrics",
- "nalgebra 0.26.2",
+ "nalgebra",
  "once_cell",
  "parking_lot",
  "peak_alloc",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -77,9 +77,6 @@ version = "0.4.11"
 [dependencies.metrics]
 version = "0.15"
 
-[dependencies.nalgebra]
-version = "0.24"
-
 [dependencies.once_cell]
 version = "1.5.2"
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -62,6 +62,9 @@ version = "0.2"
 [dependencies.derivative]
 version = "2"
 
+[dependencies.eigenvalues]
+version = "0.4"
+
 [dependencies.fxhash]
 version = "0.2"
 
@@ -73,6 +76,9 @@ version = "0.4.11"
 
 [dependencies.metrics]
 version = "0.15"
+
+[dependencies.nalgebra]
+version = "0.24"
 
 [dependencies.once_cell]
 version = "1.5.2"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -62,9 +62,6 @@ version = "0.2"
 [dependencies.derivative]
 version = "2"
 
-[dependencies.eigenvalues]
-version = "0.4"
-
 [dependencies.fxhash]
 version = "0.2"
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -104,6 +104,7 @@ version = "1.0"
 
 [dependencies.tokio]
 version = "1"
+features = [ "io-util", "parking_lot", "macros", "net", "rt-multi-thread", "sync", "time" ]
 
 [dependencies.tracing]
 default-features = false

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -123,11 +123,8 @@ version = "0.2"
 [dev-dependencies.snarkos-testing]
 path = "../testing"
 
-[dev-dependencies.eigenvalues]
-version = "0.4"
-
 [dev-dependencies.nalgebra]
-version = "0.24"
+version = "0.26"
 
 [dev-dependencies.peak_alloc]
 version = "0.1.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -123,6 +123,12 @@ version = "0.2"
 [dev-dependencies.snarkos-testing]
 path = "../testing"
 
+[dev-dependencies.eigenvalues]
+version = "0.4"
+
+[dev-dependencies.nalgebra]
+version = "0.24"
+
 [dev-dependencies.peak_alloc]
 version = "0.1.0"
 

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -254,8 +254,10 @@ async fn binary_star_contact() {
 
     wait_until!(10, network_density(&nodes) >= 0.05);
 
+    // Computing the metrics for this ignored case, interesting to inspect, especially Fiedler
+    // partitioning as we have a graph with two clusters both centered around the bootnodes.
     let metrics = NetworkMetrics::new(&nodes);
-    dbg!(metrics);
+    assert_eq!(metrics.node_count, 51);
 }
 
 /// Network topology measurements.
@@ -421,7 +423,9 @@ fn adjacency_matrix(index: &BTreeMap<SocketAddr, usize>, nodes: &[Node<LedgerSto
 }
 
 /// Returns the difference between the highest and lowest degree centrality in the network.
-// TODO: could use degree matrix.
+// This could use the degree matrix, though as this is used extensively in tests and checked
+// repeatedly until it reaches a certain value, we want to keep its calculation decoupled from the
+// `NetworkMetrics`.
 fn degree_centrality_delta(nodes: &[Node<LedgerStorage>]) -> u16 {
     let dc = nodes.iter().map(|node| node.peer_book.number_of_connected_peers());
     let min = dc.clone().min().unwrap();
@@ -485,7 +489,7 @@ fn fiedler(index: &BTreeMap<SocketAddr, usize>, laplacian_matrix: DMatrix<f64>) 
     (*algebraic_connectivity, fiedler_values_indexed)
 }
 
-/// Computes the eiegenvalues and corresponding eigenvalues from the supplied symmetric matrix.
+/// Computes the eigenvalues and corresponding eigenvalues from the supplied symmetric matrix.
 fn sorted_eigenvalue_vector_pairs(matrix: DMatrix<f64>, ascending: bool) -> Vec<(f64, DVector<f64>)> {
     // Compute eigenvalues and eigenvectors.
     let eigen = SymmetricEigen::new(matrix);

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -306,9 +306,9 @@ impl NetworkMetrics {
         let adjacency_matrix = adjacency_matrix(&index, &nodes);
         let laplacian_matrix = degree_matrix.clone().sub(adjacency_matrix.clone());
 
-        let degree_centrality = degree_centrality(&index, degree_matrix.clone());
+        let degree_centrality = degree_centrality(&index, degree_matrix);
         let degree_centrality_delta = degree_centrality_delta(&nodes);
-        let eigenvector_centrality = eigenvector_centrality(&index, adjacency_matrix.clone());
+        let eigenvector_centrality = eigenvector_centrality(&index, adjacency_matrix);
         let (algebraic_connectivity, fiedler_vector_indexed) = fiedler(&index, laplacian_matrix);
 
         // Create the `NodeCentrality` instances for each node.

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -276,6 +276,9 @@ struct NetworkMetrics {
     /// This is the value of the Fiedler eigenvalue, the second-smallest eigenvalue of the network's
     /// Laplacian matrix.
     algebraic_connectivity: f64,
+    /// The difference between the node with the largest connection count and the node with the
+    /// lowest.
+    degree_centrality_delta: u16,
     /// Node centrality measurements mapped to each node's address.
     ///
     /// Includes degree centrality, eigenvector centrality (the relative importance of a node in
@@ -304,6 +307,7 @@ impl NetworkMetrics {
         let laplacian_matrix = degree_matrix.clone().sub(adjacency_matrix.clone());
 
         let degree_centrality = degree_centrality(&index, degree_matrix.clone());
+        let degree_centrality_delta = degree_centrality_delta(&nodes);
         let eigenvector_centrality = eigenvector_centrality(&index, adjacency_matrix.clone());
         let (algebraic_connectivity, fiedler_vector_indexed) = fiedler(&index, laplacian_matrix);
 
@@ -328,6 +332,7 @@ impl NetworkMetrics {
             connection_count,
             density,
             algebraic_connectivity,
+            degree_centrality_delta,
             centrality,
         }
     }
@@ -469,7 +474,7 @@ fn eigenvector_centrality(
         .collect()
 }
 
-/// Returns the fiedler values for each node in the network.
+/// Returns the Fiedler values for each node in the network.
 fn fiedler(index: &BTreeMap<SocketAddr, usize>, laplacian_matrix: DMatrix<f64>) -> (f64, BTreeMap<SocketAddr, f64>) {
     // Compute the eigenvectors and corresponding eigenvalues and sort in ascending order.
     let ascending = true;


### PR DESCRIPTION
This PR introduces a `NetworkMetrics` struct to consolidate topology measurements useful for testing, debugging and potentially monitoring (if visualised with a graph for instance). 

Measurements include: 
- node and connection counts
- network density
- algabraic connectivity (Fiedler eigenvalue)
- various centrality measurements for each node (degree centrality, eigenvalue centrality and Fiedler eigenvector value)

This set could be extended in future.

The whole spectrum is currently calculated (where eigenvalues/vectors are involved), this could be optimised in future with the Lanczos algorithm targeting only the portion of interest. The computation of the metrics is fairly fast for a small node set (tested with up to 50), though it hasn't yet been benchmarked for larger topologies. 