### PR TITLE
Peer handling improvements

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -77,6 +77,9 @@ pub const HANDSHAKE_BOOTNODE_TIMEOUT_SECS: u8 = 10;
 /// The maximum amount of time in which a handshake with a regular node can conclude before dropping the
 /// connection; it should be no greater than the `peer_sync_interval`.
 pub const HANDSHAKE_PEER_TIMEOUT_SECS: u8 = 5;
+/// The amount of time after which a peer will be considered inactive an disconnected from if they have
+/// not sent any messages in the meantime.
+pub const MAX_PEER_INACTIVITY_SECS: u8 = 30;
 
 /// The maximum size of a message that can be transmitted in the network.
 pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB

--- a/network/src/message/payload.capnp
+++ b/network/src/message/payload.capnp
@@ -75,4 +75,5 @@ struct Payload {
 struct Version {
     version @0 :UInt64;
     listeningPort @1 :UInt16;
+    nodeId @2 :UInt64;
 }

--- a/network/src/message/payload_capnp.rs
+++ b/network/src/message/payload_capnp.rs
@@ -2457,6 +2457,10 @@ pub mod version {
     pub fn get_listening_port(self) -> u16 {
       self.reader.get_data_field::<u16>(4)
     }
+    #[inline]
+    pub fn get_node_id(self) -> u64 {
+      self.reader.get_data_field::<u64>(2)
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -2523,6 +2527,14 @@ pub mod version {
     pub fn set_listening_port(&mut self, value: u16)  {
       self.builder.set_data_field::<u16>(4, value);
     }
+    #[inline]
+    pub fn get_node_id(self) -> u64 {
+      self.builder.get_data_field::<u64>(2)
+    }
+    #[inline]
+    pub fn set_node_id(&mut self, value: u64)  {
+      self.builder.set_data_field::<u64>(2, value);
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -2535,7 +2547,7 @@ pub mod version {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 2, pointers: 0 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 3, pointers: 0 };
     pub const TYPE_ID: u64 = 0xf6b9_300e_617a_79e5;
   }
 }

--- a/network/src/message/serialization.rs
+++ b/network/src/message/serialization.rs
@@ -52,6 +52,7 @@ impl Version {
         Ok(Version {
             version: version.get_version(),
             listening_port: version.get_listening_port(),
+            node_id: version.get_node_id(),
         })
     }
 
@@ -60,6 +61,7 @@ impl Version {
         let mut builder = message.init_root::<version::Builder>();
         builder.set_version(self.version);
         builder.set_listening_port(self.listening_port);
+        builder.set_node_id(self.node_id);
 
         let mut writer = Vec::new();
         capnp::serialize_packed::write_message(&mut writer, &message)?;
@@ -363,7 +365,7 @@ mod tests {
 
     #[test]
     fn serialize_deserialize_version() {
-        let version = Version::new(1, 4141);
+        let version = Version::new(1, 4141, 0);
 
         assert_eq!(
             Version::deserialize(&Version::serialize(&version).unwrap()).unwrap(),

--- a/network/src/message/version.rs
+++ b/network/src/message/version.rs
@@ -21,13 +21,16 @@ pub struct Version {
     pub version: u64,
     /// The listening port of the sender.
     pub listening_port: u16,
+    /// The node id of the sender.
+    pub node_id: u64,
 }
 
 impl Version {
-    pub fn new(version: u64, listening_port: u16) -> Self {
+    pub fn new(version: u64, listening_port: u16, node_id: u64) -> Self {
         Self {
             version,
             listening_port,
+            node_id,
         }
     }
 }

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -45,7 +45,7 @@ pub struct StateCode(AtomicU8);
 /// The internal state of a node.
 pub struct InnerNode<S: Storage> {
     /// The node's random numeric identifier.
-    pub name: u64,
+    pub id: u64,
     /// The current state of the node.
     state: StateCode,
     /// The local address of this node.
@@ -131,7 +131,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
     /// Creates a new instance of `Node`.
     pub async fn new(config: Config) -> Result<Self, NetworkError> {
         Ok(Self(Arc::new(InnerNode {
-            name: thread_rng().gen(),
+            id: thread_rng().gen(),
             state: Default::default(),
             stats: Default::default(),
             local_address: Default::default(),

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -57,9 +57,7 @@ pub struct PeerQuality {
 }
 
 impl PeerQuality {
-    pub fn is_inactive(&self) -> bool {
-        let now = Utc::now();
-
+    pub fn is_inactive(&self, now: DateTime<Utc>) -> bool {
         let last_seen = *self.last_seen.read();
         if let Some(last_seen) = last_seen {
             now - last_seen > chrono::Duration::seconds(crate::MAX_PEER_INACTIVITY_SECS.into())

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -56,6 +56,22 @@ pub struct PeerQuality {
     pub remaining_sync_blocks: AtomicU32,
 }
 
+impl PeerQuality {
+    pub fn is_inactive(&self) -> bool {
+        let now = Utc::now();
+
+        let last_seen = *self.last_seen.read();
+        if let Some(last_seen) = last_seen {
+            now - last_seen > chrono::Duration::seconds(crate::MAX_PEER_INACTIVITY_SECS.into())
+        } else {
+            // Impossible to trigger, as completing a connection
+            // marks the peer with a timestamp. That being said,
+            // it's safest to leave this as `true` for future-proofing.
+            true
+        }
+    }
+}
+
 /// A data structure containing information about a peer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerInfo {
@@ -179,7 +195,9 @@ impl PeerInfo {
             // Set the state of this peer to connected.
             self.status = PeerStatus::Connected;
 
-            self.last_connected = Some(Utc::now());
+            let now = Utc::now();
+            self.last_connected = Some(now);
+            *self.quality.last_seen.write() = Some(now);
             self.connected_count += 1;
         } else {
             trace!("Peer {} was set as connected more than once", self.address);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -60,6 +60,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let bootnodes = self.config.bootnodes();
 
         // Drop peers whose RTT is too high or have too many failures.
+        let now = chrono::Utc::now();
         for (addr, peer_quality) in self
             .peer_book
             .connected_peers()
@@ -69,7 +70,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         {
             if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1500
                 || peer_quality.failures.load(Ordering::Relaxed) > 10
-                || peer_quality.is_inactive()
+                || peer_quality.is_inactive(now)
             {
                 warn!("Peer {} has a low quality score; disconnecting.", addr);
                 let _ = self.disconnect_from_peer(addr);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -67,7 +67,9 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             .filter(|(addr, _)| !bootnodes.contains(addr)) // Skip this check if the peer is a bootnode.
             .map(|(addr, info)| (*addr, &info.quality))
         {
-            if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1500 || peer_quality.failures.load(Ordering::Relaxed) > 10
+            if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1500
+                || peer_quality.failures.load(Ordering::Relaxed) > 10
+                || peer_quality.is_inactive()
             {
                 warn!("Peer {} has a low quality score; disconnecting.", addr);
                 let _ = self.disconnect_from_peer(addr);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -187,11 +187,15 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             }
             let len = reader.read_exact(&mut buf[..len]).await?;
             let len = noise.read_message(&buf[..len], &mut buffer)?;
-            let _peer_version = Version::deserialize(&buffer[..len])?;
+            let peer_version = Version::deserialize(&buffer[..len])?;
             trace!("received e, ee, s, es (XX handshake part 2/3) from {}", remote_address);
 
+            if peer_version.node_id == node.id {
+                return Err(NetworkError::SelfConnectAttempt);
+            }
+
             // -> s, se, psk
-            let own_version = Version::serialize(&Version::new(1u64, own_address.port())).unwrap();
+            let own_version = Version::serialize(&Version::new(1u64, own_address.port(), node.id)).unwrap();
             let len = noise.write_message(&own_version, &mut buffer)?;
             writer.write_all(&[len as u8]).await?;
             writer.write_all(&buffer[..len]).await?;

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -499,22 +499,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         // by informing the peer book of that we found peers.
         let local_address = self.local_address().unwrap(); // the address must be known by now
 
-        let number_of_connected_peers = self.peer_book.number_of_connected_peers();
-        let number_to_connect = if self.config.is_bootnode() {
-            // If this node is a bootnode, catalogue all of the peers for bootstrapping purposes.
-            number_of_connected_peers
-        } else {
-            self.config
-                .maximum_number_of_connected_peers()
-                .saturating_sub(number_of_connected_peers)
-        };
-
-        for peer_address in peers
-            .iter()
-            .take(number_to_connect as usize)
-            .filter(|&peer_addr| *peer_addr != local_address)
-            .copied()
-        {
+        for peer_address in peers.into_iter().filter(|&peer_addr| peer_addr != local_address) {
             // Inform the peer book that we found a peer.
             // The peer book will determine if we have seen the peer before,
             // and include the peer if it is new.

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -194,9 +194,9 @@ async fn fuzzing_corrupted_version_pre_handshake() {
     let node = test_node(node_setup).await;
     let node_addr = node.local_address().unwrap();
 
-    for _ in 0..ITERATIONS {
+    for i in 0..ITERATIONS {
         let mut stream = TcpStream::connect(node_addr).await.unwrap();
-        let version = Version::serialize(&Version::new(1u64, stream.local_addr().unwrap().port())).unwrap();
+        let version = Version::serialize(&Version::new(1u64, stream.local_addr().unwrap().port(), i as u64)).unwrap();
 
         let corrupted_version = corrupt_bytes(&version);
 
@@ -227,7 +227,7 @@ async fn fuzzing_corrupted_version_post_handshake() {
         }
     });
 
-    let version = Version::serialize(&Version::new(1, 4141)).unwrap();
+    let version = Version::serialize(&Version::new(1, 4141, 0)).unwrap();
     for _ in 0..ITERATIONS {
         // Replace a random percentage of random bytes at random indices in the serialised message.
         let corrupted_version = corrupt_bytes(&version);

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -74,7 +74,7 @@ async fn handshake_responder_side() {
     let _node_version = Version::deserialize(&buffer[..len]).unwrap();
 
     // -> s, se, psk
-    let peer_version = Version::serialize(&Version::new(1u64, peer_address.port())).unwrap(); // TODO (raychu86): Establish a formal node version.
+    let peer_version = Version::serialize(&Version::new(1u64, peer_address.port(), 0)).unwrap(); // TODO (raychu86): Establish a formal node version.
     let len = noise.write_message(&peer_version, &mut buffer).unwrap();
     peer_stream.write_all(&[len as u8]).await.unwrap();
     peer_stream.write_all(&buffer[..len]).await.unwrap();
@@ -126,7 +126,7 @@ async fn handshake_initiator_side() {
     noise.read_message(&buf[..len], &mut buffer).unwrap();
 
     // -> e, ee, s, es
-    let peer_version = Version::serialize(&Version::new(1u64, peer_address.port())).unwrap(); // TODO (raychu86): Establish a formal node version.
+    let peer_version = Version::serialize(&Version::new(1u64, peer_address.port(), 0)).unwrap(); // TODO (raychu86): Establish a formal node version.
     let len = noise.write_message(&peer_version, &mut buffer).unwrap();
     peer_stream.write_all(&[len as u8]).await.unwrap();
     peer_stream.write_all(&buffer[..len]).await.unwrap();


### PR DESCRIPTION
This PR improves the peer-handling logic by introducing the following changes:
- disconnect from completely inactive peers according to a `MAX_PEER_INACTIVITY_SECS` const
- enforce `max-peers` for bootnodes (they should just be started with high `min-peers` and `max-peers` values)
- don't limit the number of entries saved from peer lists
- use the node's `id` (formerly `name`) to avoid self-connections

In addition, there are 2 more `ignore`d tests that check connection cleanups. It doesn't seem that any sockets "leak", but it's possible that in real-life scenarios some disconnects are not visible to the node, which should be solved with the new check for inactivity.

note: the last of these changes changes the cap'n proto serialization logic, but it's backward-compatible.

should fix https://github.com/AleoHQ/snarkOS/issues/726