### PR TITLE
Detailed node stats

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -203,8 +203,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 // Handle Ping/Pong messages immediately in order not to skew latency calculation.
                 match &message.payload {
                     Payload::Ping(..) => {
-                        self.outbound
-                            .send_request(Message::new(Direction::Outbound(reader.addr), Payload::Pong))
+                        self.send_request(Message::new(Direction::Outbound(reader.addr), Payload::Pong))
                             .await;
                     }
                     Payload::Pong => {

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -154,6 +154,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     }
                     Err(e) => error!("Failed to accept a connection: {}", e),
                 }
+                node.stats.inbound_connection_requests.fetch_add(1, Ordering::Relaxed);
             }
         });
 

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -222,7 +222,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     pub async fn process_incoming_messages(&self, receiver: &mut Receiver) -> Result<(), NetworkError> {
         let Message { direction, payload } = receiver.recv().await.ok_or(NetworkError::ReceiverFailedToParse)?;
 
-        self.stats.inbound.queued_messages.fetch_sub(1, Ordering::SeqCst);
+        self.stats.queues.inbound.fetch_sub(1, Ordering::SeqCst);
 
         let source = if let Direction::Inbound(addr) = direction {
             self.peer_book.update_last_seen(addr);
@@ -417,7 +417,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         if let Err(err) = self.inbound.sender.send(response).await {
             error!("Failed to route a response for a message: {}", err);
         } else {
-            self.stats.inbound.queued_messages.fetch_add(1, Ordering::SeqCst);
+            self.stats.queues.inbound.fetch_add(1, Ordering::SeqCst);
         }
     }
 }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -50,6 +50,9 @@ pub use outbound::*;
 pub mod peers;
 pub use peers::*;
 
+pub mod stats;
+pub use stats::*;
+
 pub mod sync;
 pub use sync::*;
 

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -58,6 +58,8 @@ pub struct InnerNode<S: Storage> {
     pub outbound: Outbound,
     /// The list of connected and disconnected peers of this node.
     pub peer_book: PeerBook,
+    /// A collection of node's statistics.
+    pub stats: Stats,
     /// The sync handler of this node.
     pub sync: OnceCell<Arc<Sync<S>>>,
     /// The tasks spawned by the node.
@@ -131,6 +133,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         Ok(Self(Arc::new(InnerNode {
             name: thread_rng().gen(),
             state: Default::default(),
+            stats: Default::default(),
             local_address: Default::default(),
             config,
             inbound: Default::default(),

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -176,10 +176,10 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         let incoming_task = task::spawn(async move {
             loop {
                 if let Err(e) = node_clone.process_incoming_messages(&mut receiver).await {
-                    node_clone.stats.recv_failure_count.fetch_add(1, Ordering::Relaxed);
+                    node_clone.stats.inbound.all_failures.fetch_add(1, Ordering::Relaxed);
                     error!("Node error: {}", e);
                 } else {
-                    node_clone.stats.recv_success_count.fetch_add(1, Ordering::Relaxed);
+                    node_clone.stats.inbound.all_successes.fetch_add(1, Ordering::Relaxed);
                 }
             }
         });

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -176,7 +176,10 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         let incoming_task = task::spawn(async move {
             loop {
                 if let Err(e) = node_clone.process_incoming_messages(&mut receiver).await {
+                    node_clone.stats.recv_failure_count.fetch_add(1, Ordering::Relaxed);
                     error!("Node error: {}", e);
+                } else {
+                    node_clone.stats.recv_success_count.fetch_add(1, Ordering::Relaxed);
                 }
             }
         });

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -67,19 +67,19 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         "Couldn't send a {} to {}: the send channel is full",
                         request, target_addr
                     );
-                    self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
+                    self.stats.outbound.all_failures.fetch_add(1, Ordering::Relaxed);
                 }
                 Err(TrySendError::Closed(request)) => {
                     error!(
                         "Couldn't send a {} to {}: the send channel is closed",
                         request, target_addr
                     );
-                    self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
+                    self.stats.outbound.all_failures.fetch_add(1, Ordering::Relaxed);
                 }
             },
             Err(_) => {
                 warn!("Failed to send a {}: peer is disconnected", request);
-                self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
+                self.stats.outbound.all_failures.fetch_add(1, Ordering::Relaxed);
             }
         }
     }
@@ -108,11 +108,11 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             if let Some(message) = receiver.recv().await {
                 match writer.write_message(&message.payload).await {
                     Ok(_) => {
-                        self.stats.send_success_count.fetch_add(1, Ordering::Relaxed);
+                        self.stats.outbound.all_successes.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(error) => {
                         warn!("Failed to send a {}: {}", message, error);
-                        self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
+                        self.stats.outbound.all_failures.fetch_add(1, Ordering::Relaxed);
                     }
                 }
             }

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -67,16 +67,19 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         "Couldn't send a {} to {}: the send channel is full",
                         request, target_addr
                     );
+                    self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
                 }
                 Err(TrySendError::Closed(request)) => {
                     error!(
                         "Couldn't send a {} to {}: the send channel is closed",
                         request, target_addr
                     );
+                    self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
                 }
             },
             Err(_) => {
                 warn!("Failed to send a {}: peer is disconnected", request);
+                self.stats.send_failure_count.fetch_add(1, Ordering::Relaxed);
             }
         }
     }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -417,8 +417,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         trace!("Sending `GetPeers` requests to connected peers");
 
         for remote_address in self.connected_peers() {
-            self.outbound
-                .send_request(Message::new(Direction::Outbound(remote_address), Payload::GetPeers))
+            self.send_request(Message::new(Direction::Outbound(remote_address), Payload::GetPeers))
                 .await;
 
             // // Fetch the connection channel.
@@ -449,12 +448,11 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         for remote_address in self.connected_peers() {
             self.peer_book.sending_ping(remote_address);
 
-            self.outbound
-                .send_request(Message::new(
-                    Direction::Outbound(remote_address),
-                    Payload::Ping(current_block_height),
-                ))
-                .await;
+            self.send_request(Message::new(
+                Direction::Outbound(remote_address),
+                Payload::Ping(current_block_height),
+            ))
+            .await;
         }
     }
 
@@ -515,8 +513,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             .copied()
             .choose_multiple(&mut rand::thread_rng(), crate::SHARED_PEER_COUNT);
 
-        self.outbound
-            .send_request(Message::new(Direction::Outbound(remote_address), Payload::Peers(peers)))
+        self.send_request(Message::new(Direction::Outbound(remote_address), Payload::Peers(peers)))
             .await;
     }
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -159,6 +159,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             return Err(NetworkError::PeerAlreadyConnected);
         }
 
+        self.stats.outbound_connection_requests.fetch_add(1, Ordering::Relaxed);
+
         self.peer_book.set_connecting(remote_address)?;
 
         debug!("Connecting to {}...", remote_address);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -159,7 +159,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             return Err(NetworkError::PeerAlreadyConnected);
         }
 
-        self.stats.outbound_connection_requests.fetch_add(1, Ordering::Relaxed);
+        self.stats.connections.all_initiated.fetch_add(1, Ordering::Relaxed);
 
         self.peer_book.set_connecting(remote_address)?;
 

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -16,6 +16,8 @@
 
 use std::sync::atomic::{AtomicU32, AtomicU64};
 
+// TODO: make members private and make gathering of stats feature-gated and possibly
+// interchangeable with prometheus metrics.
 #[derive(Default)]
 pub struct Stats {
     /// The monotonic counter for the number of send requests that succeeded.
@@ -34,4 +36,31 @@ pub struct Stats {
     pub outbound_connection_requests: AtomicU64,
     /// The number of mined blocks.
     pub blocks_mined: AtomicU32,
+
+    /// The number of all received `Block` messages.
+    pub recv_blocks: AtomicU64,
+    /// The number of all received `GetBlocks` messages.
+    pub recv_getblocks: AtomicU64,
+    /// The number of all received `GetMemoryPool` messages.
+    pub recv_getmemorypool: AtomicU64,
+    /// The number of all received `GetPeers` messages.
+    pub recv_getpeers: AtomicU64,
+    /// The number of all received `GetSync` messages.
+    pub recv_getsync: AtomicU64,
+    /// The number of all received `MemoryPool` messages.
+    pub recv_memorypool: AtomicU64,
+    /// The number of all received `Peers` messages.
+    pub recv_peers: AtomicU64,
+    /// The number of all received `Ping` messages.
+    pub recv_pings: AtomicU64,
+    /// The number of all received `Pong` messages.
+    pub recv_pongs: AtomicU64,
+    /// The number of all received `Sync` messages.
+    pub recv_syncs: AtomicU64,
+    /// The number of all received `SyncBlock` messages.
+    pub recv_syncblocks: AtomicU64,
+    /// The number of all received `Transaction` messages.
+    pub recv_transactions: AtomicU64,
+    /// The number of all received `Unknown` messages.
+    pub recv_unknown: AtomicU64,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -20,47 +20,67 @@ use std::sync::atomic::{AtomicU32, AtomicU64};
 // interchangeable with prometheus metrics.
 #[derive(Default)]
 pub struct Stats {
-    /// The monotonic counter for the number of send requests that succeeded.
-    pub send_success_count: AtomicU64,
-    /// The monotonic counter for the number of send requests that failed.
-    pub send_failure_count: AtomicU64,
-    /// The number of successfully processed inbound messages.
-    pub recv_success_count: AtomicU64,
-    /// The number of inbound messages that couldn't be processed.
-    pub recv_failure_count: AtomicU64,
-    /// The current number of items in the inbound channel.
-    pub inbound_channel_items: AtomicU64,
-    /// The number of all connection requests the node has received.
-    pub inbound_connection_requests: AtomicU64,
-    /// The number of outbound connection requests.
-    pub outbound_connection_requests: AtomicU64,
+    /// Stats related to messages received by the node.
+    pub inbound: InboundStats,
+    /// Stats related to messages sent by the node.
+    pub outbound: OutboundStats,
+    /// Stats related to the node's connections.
+    pub connections: ConnectionStats,
+
     /// The number of mined blocks.
     pub blocks_mined: AtomicU32,
+}
+
+#[derive(Default)]
+pub struct InboundStats {
+    /// The number of successfully processed inbound messages.
+    pub all_successes: AtomicU64,
+    /// The number of inbound messages that couldn't be processed.
+    pub all_failures: AtomicU64,
+
+    /// The current number of messages queued in the inbound channel.
+    pub queued_messages: AtomicU64,
 
     /// The number of all received `Block` messages.
-    pub recv_blocks: AtomicU64,
+    pub blocks: AtomicU64,
     /// The number of all received `GetBlocks` messages.
-    pub recv_getblocks: AtomicU64,
+    pub getblocks: AtomicU64,
     /// The number of all received `GetMemoryPool` messages.
-    pub recv_getmemorypool: AtomicU64,
+    pub getmemorypool: AtomicU64,
     /// The number of all received `GetPeers` messages.
-    pub recv_getpeers: AtomicU64,
+    pub getpeers: AtomicU64,
     /// The number of all received `GetSync` messages.
-    pub recv_getsync: AtomicU64,
+    pub getsync: AtomicU64,
     /// The number of all received `MemoryPool` messages.
-    pub recv_memorypool: AtomicU64,
+    pub memorypool: AtomicU64,
     /// The number of all received `Peers` messages.
-    pub recv_peers: AtomicU64,
+    pub peers: AtomicU64,
     /// The number of all received `Ping` messages.
-    pub recv_pings: AtomicU64,
+    pub pings: AtomicU64,
     /// The number of all received `Pong` messages.
-    pub recv_pongs: AtomicU64,
+    pub pongs: AtomicU64,
     /// The number of all received `Sync` messages.
-    pub recv_syncs: AtomicU64,
+    pub syncs: AtomicU64,
     /// The number of all received `SyncBlock` messages.
-    pub recv_syncblocks: AtomicU64,
+    pub syncblocks: AtomicU64,
     /// The number of all received `Transaction` messages.
-    pub recv_transactions: AtomicU64,
+    pub transactions: AtomicU64,
     /// The number of all received `Unknown` messages.
-    pub recv_unknown: AtomicU64,
+    pub unknown: AtomicU64,
+}
+
+#[derive(Default)]
+pub struct OutboundStats {
+    /// The number of messages successfully sent by the node.
+    pub all_successes: AtomicU64,
+    /// The number of messages that failed to be sent to peers.
+    pub all_failures: AtomicU64,
+}
+
+#[derive(Default)]
+pub struct ConnectionStats {
+    /// The number of all connections the node has accepted.
+    pub all_accepted: AtomicU64,
+    /// The number of all connections the node has initiated.
+    pub all_initiated: AtomicU64,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -30,9 +30,8 @@ pub struct Stats {
     pub handshakes: HandshakeStats,
     /// Stats related to the node's queues.
     pub queues: QueueStats,
-
-    /// The number of mined blocks.
-    pub blocks_mined: AtomicU32,
+    /// Miscellaneous stats related to the node.
+    pub misc: MiscStats,
 }
 
 #[derive(Default)]
@@ -108,4 +107,14 @@ pub struct QueueStats {
     pub inbound: AtomicU32,
     /// The number of messages queued in the individual outbound channels.
     pub outbound: AtomicU32,
+}
+
+#[derive(Default)]
+pub struct MiscStats {
+    /// The number of mined blocks.
+    pub blocks_mined: AtomicU32,
+    /// The number of duplicate blocks received.
+    pub duplicate_blocks: AtomicU64,
+    /// The number of duplicate sync blocks received.
+    pub duplicate_sync_blocks: AtomicU64,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -26,6 +26,8 @@ pub struct Stats {
     pub outbound: OutboundStats,
     /// Stats related to the node's connections.
     pub connections: ConnectionStats,
+    /// Stats related to the node's handshakes.
+    pub handshakes: HandshakeStats,
 
     /// The number of mined blocks.
     pub blocks_mined: AtomicU32,
@@ -83,4 +85,20 @@ pub struct ConnectionStats {
     pub all_accepted: AtomicU64,
     /// The number of all connections the node has initiated.
     pub all_initiated: AtomicU64,
+}
+
+#[derive(Default)]
+pub struct HandshakeStats {
+    /// The number of failed handshakes as the initiator.
+    pub failures_init: AtomicU64,
+    /// The number of failed handshakes as the responder.
+    pub failures_resp: AtomicU64,
+    /// The number of successful handshakes as the initiator.
+    pub successes_init: AtomicU64,
+    /// The number of successful handshakes as the responder.
+    pub successes_resp: AtomicU64,
+    /// The number of handshake timeouts as the initiator.
+    pub timeouts_init: AtomicU64,
+    /// The number of handshake timeouts as the responder.
+    pub timeouts_resp: AtomicU64,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::atomic::AtomicU64;
+
+#[derive(Default)]
+pub struct Stats {
+    /// The monotonic counter for the number of send requests that succeeded.
+    pub send_success_count: AtomicU64,
+    /// The monotonic counter for the number of send requests that failed.
+    pub send_failure_count: AtomicU64,
+}

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -24,4 +24,6 @@ pub struct Stats {
     pub send_failure_count: AtomicU64,
     /// The current number of items in the inbound channel.
     pub inbound_channel_items: AtomicU64,
+    /// The number of all connection requests the node has received.
+    pub inbound_connection_requests: AtomicU64,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -22,4 +22,6 @@ pub struct Stats {
     pub send_success_count: AtomicU64,
     /// The monotonic counter for the number of send requests that failed.
     pub send_failure_count: AtomicU64,
+    /// The current number of items in the inbound channel.
+    pub inbound_channel_items: AtomicU64,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -22,6 +22,10 @@ pub struct Stats {
     pub send_success_count: AtomicU64,
     /// The monotonic counter for the number of send requests that failed.
     pub send_failure_count: AtomicU64,
+    /// The number of successfully processed inbound messages.
+    pub recv_success_count: AtomicU64,
+    /// The number of inbound messages that couldn't be processed.
+    pub recv_failure_count: AtomicU64,
     /// The current number of items in the inbound channel.
     pub inbound_channel_items: AtomicU64,
     /// The number of all connection requests the node has received.

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 
 #[derive(Default)]
 pub struct Stats {
@@ -28,4 +28,6 @@ pub struct Stats {
     pub inbound_connection_requests: AtomicU64,
     /// The number of outbound connection requests.
     pub outbound_connection_requests: AtomicU64,
+    /// The number of mined blocks.
+    pub blocks_mined: AtomicU32,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -28,6 +28,8 @@ pub struct Stats {
     pub connections: ConnectionStats,
     /// Stats related to the node's handshakes.
     pub handshakes: HandshakeStats,
+    /// Stats related to the node's queues.
+    pub queues: QueueStats,
 
     /// The number of mined blocks.
     pub blocks_mined: AtomicU32,
@@ -39,9 +41,6 @@ pub struct InboundStats {
     pub all_successes: AtomicU64,
     /// The number of inbound messages that couldn't be processed.
     pub all_failures: AtomicU64,
-
-    /// The current number of messages queued in the inbound channel.
-    pub queued_messages: AtomicU64,
 
     /// The number of all received `Block` messages.
     pub blocks: AtomicU64,
@@ -101,4 +100,12 @@ pub struct HandshakeStats {
     pub timeouts_init: AtomicU64,
     /// The number of handshake timeouts as the responder.
     pub timeouts_resp: AtomicU64,
+}
+
+#[derive(Default)]
+pub struct QueueStats {
+    /// The number of messages queued in the common inbound channel.
+    pub inbound: AtomicU32,
+    /// The number of messages queued in the individual outbound channels.
+    pub outbound: AtomicU32,
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -26,4 +26,6 @@ pub struct Stats {
     pub inbound_channel_items: AtomicU64,
     /// The number of all connection requests the node has received.
     pub inbound_connection_requests: AtomicU64,
+    /// The number of outbound connection requests.
+    pub outbound_connection_requests: AtomicU64,
 }

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -20,7 +20,7 @@ use snarkvm_objects::{Block, BlockHeaderHash, Storage};
 
 use std::net::SocketAddr;
 
-impl<S: Storage> Sync<S> {
+impl<S: Storage + Send + std::marker::Sync + 'static> Sync<S> {
     ///
     /// Sends a `GetSync` request to the given sync node.
     ///
@@ -38,7 +38,6 @@ impl<S: Storage> Sync<S> {
 
             // Send a GetSync to the selected sync node.
             self.node()
-                .outbound
                 .send_request(Message::new(
                     Direction::Outbound(sync_node),
                     Payload::GetSync(block_locator_hashes),
@@ -58,7 +57,6 @@ impl<S: Storage> Sync<S> {
             if remote_address != block_miner {
                 // Send a `Block` message to the connected peer.
                 self.node()
-                    .outbound
                     .send_request(Message::new(
                         Direction::Outbound(remote_address),
                         Payload::Block(block_bytes.clone()),
@@ -129,7 +127,6 @@ impl<S: Storage> Sync<S> {
 
             // Send a `SyncBlock` message to the connected peer.
             self.node()
-                .outbound
                 .send_request(Message::new(
                     Direction::Outbound(remote_address),
                     Payload::SyncBlock(block.serialize()?),
@@ -180,7 +177,6 @@ impl<S: Storage> Sync<S> {
 
         // send a `Sync` message to the connected peer.
         self.node()
-            .outbound
             .send_request(Message::new(Direction::Outbound(remote_address), Payload::Sync(sync)))
             .await;
 
@@ -195,7 +191,6 @@ impl<S: Storage> Sync<S> {
                 // GetBlocks for each block hash: fire and forget, relying on block locator hashes to
                 // detect missing blocks and divergence in chain for now.
                 self.node()
-                    .outbound
                     .send_request(Message::new(
                         Direction::Outbound(remote_address),
                         Payload::GetBlocks(batch.to_vec()),

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -34,7 +34,6 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
             info!("Updating memory pool from {}", sync_node);
 
             self.node()
-                .outbound
                 .send_request(Message::new(Direction::Outbound(sync_node), Payload::GetMemoryPool))
                 .await;
         } else {
@@ -58,7 +57,6 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
             if remote_address != transaction_sender && remote_address != local_address {
                 // Send a `Transaction` message to the connected peer.
                 self.node()
-                    .outbound
                     .send_request(Message::new(
                         Direction::Outbound(remote_address),
                         Payload::Transaction(transaction_bytes.clone()),
@@ -131,7 +129,6 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Sync<S> {
         if !transactions.is_empty() {
             // Send a `MemoryPool` message to the connected peer.
             self.node()
-                .outbound
                 .send_request(Message::new(
                     Direction::Outbound(remote_address),
                     Payload::MemoryPool(transactions),

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -104,7 +104,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                     self.node.set_state(State::Idle);
                 }
 
-                self.node.stats.blocks_mined.fetch_add(1, Ordering::Relaxed);
+                self.node.stats.misc.blocks_mined.fetch_add(1, Ordering::Relaxed);
 
                 info!("Mined a new block: {:?}", hex::encode(block.header.get_hash().0));
 

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -22,7 +22,11 @@ use snarkvm_objects::Storage;
 use tokio::runtime;
 use tracing::*;
 
-use std::{sync::Arc, thread, time::Duration};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    thread,
+    time::Duration,
+};
 
 /// Parameters for spawning a miner that runs proof of work to find a block.
 pub struct MinerInstance<S: Storage> {
@@ -99,6 +103,8 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                 if self.node.state() == State::Mining {
                     self.node.set_state(State::Idle);
                 }
+
+                self.node.stats.blocks_mined.fetch_add(1, Ordering::Relaxed);
 
                 info!("Mined a new block: {:?}", hex::encode(block.header.get_hash().0));
 

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -6,12 +6,13 @@ None
 
 ### Response
 
-|            Parameter          | Type |                        Description                      |
-|:-----------------------------:|:----:|:-------------------------------------------------------:|
-| `send_success_count`          | u64  | The number of successfully sent messages                |
-| `send_failure_count`          | u64  | The number of failures to send messages                 |
-| `inbound_channel_items`       | u64  | The number of inbound items queued to be processed      |
-| `inbound_connection_requests` | u64  | The number of connection requests the node has received |
+|            Parameter           | Type |                        Description                      |
+|:------------------------------:|:----:|:-------------------------------------------------------:|
+| `send_success_count`           | u64  | The number of successfully sent messages                |
+| `send_failure_count`           | u64  | The number of failures to send messages                 |
+| `inbound_channel_items`        | u64  | The number of inbound items queued to be processed      |
+| `inbound_connection_requests`  | u64  | The number of connection requests the node has received |
+| `outbound_connection_requests` | u64  | The number of connection requests the node has made     |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -15,6 +15,7 @@ None
 | `outbound_connection_requests` | u64  | The number of connection requests the node has made     |
 | `number_of_connected_peers`    | u16  | The number of currently connected peers                 |
 | `number_of_connecting_peers`   | u16  | The number of currently connecting peers                |
+| `blocks_mined`                 | u32  | The number of blocks the node has mined                 |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -6,38 +6,39 @@ None
 
 ### Response
 
-|             Parameter            | Type |                         Description                       |
-|:--------------------------------:|:----:|:---------------------------------------------------------:|
-| `block_height`                   | u32  | The current block height of the node                      |
-| `blocks_mined`                   | u32  | The number of blocks the node has mined                   |
-| `connections.all_accepted`       | u64  | The number of connection requests the node has received   |
-| `connections.all_initiated`      | u64  | The number of connection requests the node has made       |
-| `connections.connected_peers`    | u16  | The number of currently connected peers                   |
-| `connections.connecting_peers`   | u16  | The number of currently connecting peers                  |
-| `connections.disconnected_peers` | u16  | The number of known disconnected peers                    |
-| `handshakes.failures_init`       | u64  | The number of failed handshakes as the initiator          |
-| `handshakes.failures_resp`       | u64  | The number of failed handshakes as the responder          |
-| `handshakes.successes_init`      | u64  | The number of successful handshakes as the initiator      |
-| `handshakes.successes_resp`      | u64  | The number of successful handshakes as the responder      |
-| `handshakes.timeouts_init`       | u64  | The number of handshake timeouts as the initiator         |
-| `handshakes.timeouts_resp`       | u64  | The number of handshake timeouts as the responder         |
-| `inbound.all_successes`          | u64  | The number of successfully processed inbound messages     |
-| `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed |
-| `inbound.queued_messages`        | u64  | The number of inbound messages queued to be processed     |
-| `inbound.blocks`                 | u64  | The number of all received Block messages                 |
-| `inbound.getmemorypool`          | u64  | The number of all received GetMemoryPool messages         |
-| `inbound.getpeers`               | u64  | The number of all received GetPeers messages              |
-| `inbound.getsync`                | u64  | The number of all received GetSync messages               |
-| `inbound.memorypool`             | u64  | The number of all received MemoryPool messages            |
-| `inbound.peers`                  | u64  | The number of all received Peers messages                 |
-| `inbound.pings`                  | u64  | The number of all received Ping messages                  |
-| `inbound.pongs`                  | u64  | The number of all received Pong messages                  |
-| `inbound.syncs`                  | u64  | The number of all received Sync messages                  |
-| `inbound.syncblocks`             | u64  | The number of all received SyncBlock messages             |
-| `inbound.transactions`           | u64  | The number of all received Transaction messages           |
-| `inbound.unknown`                | u64  | The number of all received Unknown messages               |
-| `outbound.all_successes`         | u64  | The number of successfully sent messages                  |
-| `outbound.all_failures`          | u64  | The number of failures to send messages                   |
+|             Parameter            | Type |                             Description                           |
+|:--------------------------------:|:----:|:-----------------------------------------------------------------:|
+| `block_height`                   | u32  | The current block height of the node                              |
+| `blocks_mined`                   | u32  | The number of blocks the node has mined                           |
+| `connections.all_accepted`       | u64  | The number of connection requests the node has received           |
+| `connections.all_initiated`      | u64  | The number of connection requests the node has made               |
+| `connections.connected_peers`    | u16  | The number of currently connected peers                           |
+| `connections.connecting_peers`   | u16  | The number of currently connecting peers                          |
+| `connections.disconnected_peers` | u16  | The number of known disconnected peers                            |
+| `handshakes.failures_init`       | u64  | The number of failed handshakes as the initiator                  |
+| `handshakes.failures_resp`       | u64  | The number of failed handshakes as the responder                  |
+| `handshakes.successes_init`      | u64  | The number of successful handshakes as the initiator              |
+| `handshakes.successes_resp`      | u64  | The number of successful handshakes as the responder              |
+| `handshakes.timeouts_init`       | u64  | The number of handshake timeouts as the initiator                 |
+| `handshakes.timeouts_resp`       | u64  | The number of handshake timeouts as the responder                 |
+| `inbound.all_successes`          | u64  | The number of successfully processed inbound messages             |
+| `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed         |
+| `inbound.blocks`                 | u64  | The number of all received Block messages                         |
+| `inbound.getmemorypool`          | u64  | The number of all received GetMemoryPool messages                 |
+| `inbound.getpeers`               | u64  | The number of all received GetPeers messages                      |
+| `inbound.getsync`                | u64  | The number of all received GetSync messages                       |
+| `inbound.memorypool`             | u64  | The number of all received MemoryPool messages                    |
+| `inbound.peers`                  | u64  | The number of all received Peers messages                         |
+| `inbound.pings`                  | u64  | The number of all received Ping messages                          |
+| `inbound.pongs`                  | u64  | The number of all received Pong messages                          |
+| `inbound.syncs`                  | u64  | The number of all received Sync messages                          |
+| `inbound.syncblocks`             | u64  | The number of all received SyncBlock messages                     |
+| `inbound.transactions`           | u64  | The number of all received Transaction messages                   |
+| `inbound.unknown`                | u64  | The number of all received Unknown messages                       |
+| `outbound.all_successes`         | u64  | The number of successfully sent messages                          |
+| `outbound.all_failures`          | u64  | The number of failures to send messages                           |
+| `queues.inbound`                 | u32  | The number of messages queued in the common inbound channel       |
+| `queues.outbound`                | u32  | The number of messages queued in the individual outbound channels |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -8,29 +8,29 @@ None
 
 |            Parameter           | Type |                         Description                       |
 |:------------------------------:|:----:|:---------------------------------------------------------:|
-| `send_success_count`           | u64  | The number of successfully sent messages                  |
-| `send_failure_count`           | u64  | The number of failures to send messages                   |
-| `recv_success_count`           | u64  | The number of successfully processed inbound messages     |
-| `recv_failure_count`           | u64  | The number of inbound messages that couldn't be processed |
-| `inbound_channel_items`        | u64  | The number of inbound items queued to be processed        |
-| `inbound_connection_requests`  | u64  | The number of connection requests the node has received   |
-| `outbound_connection_requests` | u64  | The number of connection requests the node has made       |
-| `number_of_connected_peers`    | u16  | The number of currently connected peers                   |
-| `number_of_connecting_peers`   | u16  | The number of currently connecting peers                  |
-| `blocks_mined`                 | u32  | The number of blocks the node has mined                   |
 | `block_height`                 | u32  | The current block height of the node                      |
-| `recv_blocks`                  | u64  | The number of all received Block messages                 |
-| `recv_getmemorypool`           | u64  | The number of all received GetMemoryPool messages         |
-| `recv_getpeers`                | u64  | The number of all received GetPeers messages              |
-| `recv_getsync`                 | u64  | The number of all received GetSync messages               |
-| `recv_memorypool`              | u64  | The number of all received MemoryPool messages            |
-| `recv_peers`                   | u64  | The number of all received Peers messages                 |
-| `recv_pings`                   | u64  | The number of all received Ping messages                  |
-| `recv_pongs`                   | u64  | The number of all received Pong messages                  |
-| `recv_syncs`                   | u64  | The number of all received Sync messages                  |
-| `recv_syncblocks`              | u64  | The number of all received SyncBlock messages             |
-| `recv_transactions`            | u64  | The number of all received Transaction messages           |
-| `recv_unknown`                 | u64  | The number of all received Unknown messages               |
+| `blocks_mined`                 | u32  | The number of blocks the node has mined                   |
+| `connections.all_accepted`     | u64  | The number of connection requests the node has received   |
+| `connections.all_initiated`    | u64  | The number of connection requests the node has made       |
+| `connections.connected_peers`  | u16  | The number of currently connected peers                   |
+| `connections.connecting_peers` | u16  | The number of currently connecting peers                  |
+| `inbound.all_successes`        | u64  | The number of successfully processed inbound messages     |
+| `inbound.all_failures`         | u64  | The number of inbound messages that couldn't be processed |
+| `inbound.queued_messages`      | u64  | The number of inbound items queued to be processed        |
+| `inbound.blocks`               | u64  | The number of all received Block messages                 |
+| `inbound.getmemorypool`        | u64  | The number of all received GetMemoryPool messages         |
+| `inbound.getpeers`             | u64  | The number of all received GetPeers messages              |
+| `inbound.getsync`              | u64  | The number of all received GetSync messages               |
+| `inbound.memorypool`           | u64  | The number of all received MemoryPool messages            |
+| `inbound.peers`                | u64  | The number of all received Peers messages                 |
+| `inbound.pings`                | u64  | The number of all received Ping messages                  |
+| `inbound.pongs`                | u64  | The number of all received Pong messages                  |
+| `inbound.syncs`                | u64  | The number of all received Sync messages                  |
+| `inbound.syncblocks`           | u64  | The number of all received SyncBlock messages             |
+| `inbound.transactions`         | u64  | The number of all received Transaction messages           |
+| `inbound.unknown`              | u64  | The number of all received Unknown messages               |
+| `outbound.all_successes`       | u64  | The number of successfully sent messages                  |
+| `outbound.all_failures`        | u64  | The number of failures to send messages                   |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -13,6 +13,8 @@ None
 | `inbound_channel_items`        | u64  | The number of inbound items queued to be processed      |
 | `inbound_connection_requests`  | u64  | The number of connection requests the node has received |
 | `outbound_connection_requests` | u64  | The number of connection requests the node has made     |
+| `number_of_connected_peers`    | u16  | The number of currently connected peers                 |
+| `number_of_connecting_peers`   | u16  | The number of currently connecting peers                |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -1,0 +1,18 @@
+Returns statistics related to the node.
+
+### Arguments
+
+None
+
+### Response
+
+|         Parameter       | Type |                     Description                    |
+|:-----------------------:|:----:|:--------------------------------------------------:|
+| `send_success_count`    | u64  | The number of successfully sent messages           |
+| `send_failure_count`    | u64  | The number of failures to send messages            |
+| `inbound_channel_items` | u64  | The number of inbound items queued to be processed |
+
+### Example
+```ignore
+curl --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getnodestats", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:3030/
+```

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -6,31 +6,32 @@ None
 
 ### Response
 
-|            Parameter           | Type |                         Description                       |
-|:------------------------------:|:----:|:---------------------------------------------------------:|
-| `block_height`                 | u32  | The current block height of the node                      |
-| `blocks_mined`                 | u32  | The number of blocks the node has mined                   |
-| `connections.all_accepted`     | u64  | The number of connection requests the node has received   |
-| `connections.all_initiated`    | u64  | The number of connection requests the node has made       |
-| `connections.connected_peers`  | u16  | The number of currently connected peers                   |
-| `connections.connecting_peers` | u16  | The number of currently connecting peers                  |
-| `inbound.all_successes`        | u64  | The number of successfully processed inbound messages     |
-| `inbound.all_failures`         | u64  | The number of inbound messages that couldn't be processed |
-| `inbound.queued_messages`      | u64  | The number of inbound items queued to be processed        |
-| `inbound.blocks`               | u64  | The number of all received Block messages                 |
-| `inbound.getmemorypool`        | u64  | The number of all received GetMemoryPool messages         |
-| `inbound.getpeers`             | u64  | The number of all received GetPeers messages              |
-| `inbound.getsync`              | u64  | The number of all received GetSync messages               |
-| `inbound.memorypool`           | u64  | The number of all received MemoryPool messages            |
-| `inbound.peers`                | u64  | The number of all received Peers messages                 |
-| `inbound.pings`                | u64  | The number of all received Ping messages                  |
-| `inbound.pongs`                | u64  | The number of all received Pong messages                  |
-| `inbound.syncs`                | u64  | The number of all received Sync messages                  |
-| `inbound.syncblocks`           | u64  | The number of all received SyncBlock messages             |
-| `inbound.transactions`         | u64  | The number of all received Transaction messages           |
-| `inbound.unknown`              | u64  | The number of all received Unknown messages               |
-| `outbound.all_successes`       | u64  | The number of successfully sent messages                  |
-| `outbound.all_failures`        | u64  | The number of failures to send messages                   |
+|             Parameter            | Type |                         Description                       |
+|:--------------------------------:|:----:|:---------------------------------------------------------:|
+| `block_height`                   | u32  | The current block height of the node                      |
+| `blocks_mined`                   | u32  | The number of blocks the node has mined                   |
+| `connections.all_accepted`       | u64  | The number of connection requests the node has received   |
+| `connections.all_initiated`      | u64  | The number of connection requests the node has made       |
+| `connections.connected_peers`    | u16  | The number of currently connected peers                   |
+| `connections.connecting_peers`   | u16  | The number of currently connecting peers                  |
+| `connections.disconnected_peers` | u16  | The number of known disconnected peers                    |
+| `inbound.all_successes`          | u64  | The number of successfully processed inbound messages     |
+| `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed |
+| `inbound.queued_messages`        | u64  | The number of inbound messages queued to be processed     |
+| `inbound.blocks`                 | u64  | The number of all received Block messages                 |
+| `inbound.getmemorypool`          | u64  | The number of all received GetMemoryPool messages         |
+| `inbound.getpeers`               | u64  | The number of all received GetPeers messages              |
+| `inbound.getsync`                | u64  | The number of all received GetSync messages               |
+| `inbound.memorypool`             | u64  | The number of all received MemoryPool messages            |
+| `inbound.peers`                  | u64  | The number of all received Peers messages                 |
+| `inbound.pings`                  | u64  | The number of all received Ping messages                  |
+| `inbound.pongs`                  | u64  | The number of all received Pong messages                  |
+| `inbound.syncs`                  | u64  | The number of all received Sync messages                  |
+| `inbound.syncblocks`             | u64  | The number of all received SyncBlock messages             |
+| `inbound.transactions`           | u64  | The number of all received Transaction messages           |
+| `inbound.unknown`                | u64  | The number of all received Unknown messages               |
+| `outbound.all_successes`         | u64  | The number of successfully sent messages                  |
+| `outbound.all_failures`          | u64  | The number of failures to send messages                   |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -19,6 +19,18 @@ None
 | `number_of_connecting_peers`   | u16  | The number of currently connecting peers                  |
 | `blocks_mined`                 | u32  | The number of blocks the node has mined                   |
 | `block_height`                 | u32  | The current block height of the node                      |
+| `recv_blocks`                  | u64  | The number of all received Block messages                 |
+| `recv_getmemorypool`           | u64  | The number of all received GetMemoryPool messages         |
+| `recv_getpeers`                | u64  | The number of all received GetPeers messages              |
+| `recv_getsync`                 | u64  | The number of all received GetSync messages               |
+| `recv_memorypool`              | u64  | The number of all received MemoryPool messages            |
+| `recv_peers`                   | u64  | The number of all received Peers messages                 |
+| `recv_pings`                   | u64  | The number of all received Ping messages                  |
+| `recv_pongs`                   | u64  | The number of all received Pong messages                  |
+| `recv_syncs`                   | u64  | The number of all received Sync messages                  |
+| `recv_syncblocks`              | u64  | The number of all received SyncBlock messages             |
+| `recv_transactions`            | u64  | The number of all received Transaction messages           |
+| `recv_unknown`                 | u64  | The number of all received Unknown messages               |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -16,6 +16,7 @@ None
 | `number_of_connected_peers`    | u16  | The number of currently connected peers                 |
 | `number_of_connecting_peers`   | u16  | The number of currently connecting peers                |
 | `blocks_mined`                 | u32  | The number of blocks the node has mined                 |
+| `block_height`                 | u32  | The current block height of the node                    |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -6,11 +6,12 @@ None
 
 ### Response
 
-|         Parameter       | Type |                     Description                    |
-|:-----------------------:|:----:|:--------------------------------------------------:|
-| `send_success_count`    | u64  | The number of successfully sent messages           |
-| `send_failure_count`    | u64  | The number of failures to send messages            |
-| `inbound_channel_items` | u64  | The number of inbound items queued to be processed |
+|            Parameter          | Type |                        Description                      |
+|:-----------------------------:|:----:|:-------------------------------------------------------:|
+| `send_success_count`          | u64  | The number of successfully sent messages                |
+| `send_failure_count`          | u64  | The number of failures to send messages                 |
+| `inbound_channel_items`       | u64  | The number of inbound items queued to be processed      |
+| `inbound_connection_requests` | u64  | The number of connection requests the node has received |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -24,6 +24,7 @@ None
 | `inbound.all_successes`          | u64  | The number of successfully processed inbound messages             |
 | `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed         |
 | `inbound.blocks`                 | u64  | The number of all received Block messages                         |
+| `inbound.getblocks`              | u64  | The number of all received GetBlocks messages                     |
 | `inbound.getmemorypool`          | u64  | The number of all received GetMemoryPool messages                 |
 | `inbound.getpeers`               | u64  | The number of all received GetPeers messages                      |
 | `inbound.getsync`                | u64  | The number of all received GetSync messages                       |

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -8,8 +8,6 @@ None
 
 |             Parameter            | Type |                             Description                           |
 |:--------------------------------:|:----:|:-----------------------------------------------------------------:|
-| `block_height`                   | u32  | The current block height of the node                              |
-| `blocks_mined`                   | u32  | The number of blocks the node has mined                           |
 | `connections.all_accepted`       | u64  | The number of connection requests the node has received           |
 | `connections.all_initiated`      | u64  | The number of connection requests the node has made               |
 | `connections.connected_peers`    | u16  | The number of currently connected peers                           |
@@ -36,6 +34,10 @@ None
 | `inbound.syncblocks`             | u64  | The number of all received SyncBlock messages                     |
 | `inbound.transactions`           | u64  | The number of all received Transaction messages                   |
 | `inbound.unknown`                | u64  | The number of all received Unknown messages                       |
+| `misc.block_height`              | u32  | The current block height of the node                              |
+| `misc.blocks_mined`              | u32  | The number of blocks the node has mined                           |
+| `misc.duplicate_blocks`          | u64  | The number of duplicate blocks received                           |
+| `misc.duplicate_sync_blocks`     | u64  | The number of duplicate sync blocks received                      |
 | `outbound.all_successes`         | u64  | The number of successfully sent messages                          |
 | `outbound.all_failures`          | u64  | The number of failures to send messages                           |
 | `queues.inbound`                 | u32  | The number of messages queued in the common inbound channel       |

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -15,6 +15,12 @@ None
 | `connections.connected_peers`    | u16  | The number of currently connected peers                   |
 | `connections.connecting_peers`   | u16  | The number of currently connecting peers                  |
 | `connections.disconnected_peers` | u16  | The number of known disconnected peers                    |
+| `handshakes.failures_init`       | u64  | The number of failed handshakes as the initiator          |
+| `handshakes.failures_resp`       | u64  | The number of failed handshakes as the responder          |
+| `handshakes.successes_init`      | u64  | The number of successful handshakes as the initiator      |
+| `handshakes.successes_resp`      | u64  | The number of successful handshakes as the responder      |
+| `handshakes.timeouts_init`       | u64  | The number of handshake timeouts as the initiator         |
+| `handshakes.timeouts_resp`       | u64  | The number of handshake timeouts as the responder         |
 | `inbound.all_successes`          | u64  | The number of successfully processed inbound messages     |
 | `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed |
 | `inbound.queued_messages`        | u64  | The number of inbound messages queued to be processed     |

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -6,17 +6,19 @@ None
 
 ### Response
 
-|            Parameter           | Type |                        Description                      |
-|:------------------------------:|:----:|:-------------------------------------------------------:|
-| `send_success_count`           | u64  | The number of successfully sent messages                |
-| `send_failure_count`           | u64  | The number of failures to send messages                 |
-| `inbound_channel_items`        | u64  | The number of inbound items queued to be processed      |
-| `inbound_connection_requests`  | u64  | The number of connection requests the node has received |
-| `outbound_connection_requests` | u64  | The number of connection requests the node has made     |
-| `number_of_connected_peers`    | u16  | The number of currently connected peers                 |
-| `number_of_connecting_peers`   | u16  | The number of currently connecting peers                |
-| `blocks_mined`                 | u32  | The number of blocks the node has mined                 |
-| `block_height`                 | u32  | The current block height of the node                    |
+|            Parameter           | Type |                         Description                       |
+|:------------------------------:|:----:|:---------------------------------------------------------:|
+| `send_success_count`           | u64  | The number of successfully sent messages                  |
+| `send_failure_count`           | u64  | The number of failures to send messages                   |
+| `recv_success_count`           | u64  | The number of successfully processed inbound messages     |
+| `recv_failure_count`           | u64  | The number of inbound messages that couldn't be processed |
+| `inbound_channel_items`        | u64  | The number of inbound items queued to be processed        |
+| `inbound_connection_requests`  | u64  | The number of connection requests the node has received   |
+| `outbound_connection_requests` | u64  | The number of connection requests the node has made       |
+| `number_of_connected_peers`    | u16  | The number of currently connected peers                   |
+| `number_of_connecting_peers`   | u16  | The number of currently connecting peers                  |
+| `blocks_mined`                 | u32  | The number of blocks the node has mined                   |
+| `block_height`                 | u32  | The current block height of the node                      |
 
 ### Example
 ```ignore

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -319,31 +319,39 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     /// Returns statistics related to the node.
     fn get_node_stats(&self) -> Result<NodeStats, RpcError> {
         Ok(NodeStats {
-            send_success_count: self.node.stats.send_success_count.load(Ordering::Relaxed),
-            send_failure_count: self.node.stats.send_failure_count.load(Ordering::Relaxed),
-            recv_success_count: self.node.stats.recv_success_count.load(Ordering::Relaxed),
-            recv_failure_count: self.node.stats.recv_failure_count.load(Ordering::Relaxed),
-            inbound_channel_items: self.node.stats.inbound_channel_items.load(Ordering::SeqCst),
-            inbound_connection_requests: self.node.stats.inbound_connection_requests.load(Ordering::Relaxed),
-            outbound_connection_requests: self.node.stats.outbound_connection_requests.load(Ordering::Relaxed),
-            number_of_connected_peers: self.node.peer_book.number_of_connected_peers(),
-            number_of_connecting_peers: self.node.peer_book.number_of_connecting_peers(),
+            inbound: NodeInboundStats {
+                all_successes: self.node.stats.inbound.all_successes.load(Ordering::Relaxed),
+                all_failures: self.node.stats.inbound.all_failures.load(Ordering::Relaxed),
+
+                queued_messages: self.node.stats.inbound.queued_messages.load(Ordering::SeqCst),
+
+                blocks: self.node.stats.inbound.blocks.load(Ordering::Relaxed),
+                getblocks: self.node.stats.inbound.getblocks.load(Ordering::Relaxed),
+                getmemorypool: self.node.stats.inbound.getmemorypool.load(Ordering::Relaxed),
+                getpeers: self.node.stats.inbound.getpeers.load(Ordering::Relaxed),
+                getsync: self.node.stats.inbound.getsync.load(Ordering::Relaxed),
+                memorypool: self.node.stats.inbound.memorypool.load(Ordering::Relaxed),
+                peers: self.node.stats.inbound.peers.load(Ordering::Relaxed),
+                pings: self.node.stats.inbound.pings.load(Ordering::Relaxed),
+                pongs: self.node.stats.inbound.pongs.load(Ordering::Relaxed),
+                syncs: self.node.stats.inbound.syncs.load(Ordering::Relaxed),
+                syncblocks: self.node.stats.inbound.syncblocks.load(Ordering::Relaxed),
+                transactions: self.node.stats.inbound.transactions.load(Ordering::Relaxed),
+                unknown: self.node.stats.inbound.unknown.load(Ordering::Relaxed),
+            },
+            outbound: NodeOutboundStats {
+                all_successes: self.node.stats.outbound.all_successes.load(Ordering::Relaxed),
+                all_failures: self.node.stats.outbound.all_failures.load(Ordering::Relaxed),
+            },
+            connections: NodeConnectionStats {
+                all_accepted: self.node.stats.connections.all_accepted.load(Ordering::Relaxed),
+                all_initiated: self.node.stats.connections.all_initiated.load(Ordering::Relaxed),
+                connected_peers: self.node.peer_book.number_of_connected_peers(),
+                connecting_peers: self.node.peer_book.number_of_connecting_peers(),
+            },
+
             blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),
             block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),
-
-            recv_blocks: self.node.stats.recv_blocks.load(Ordering::Relaxed),
-            recv_getblocks: self.node.stats.recv_getblocks.load(Ordering::Relaxed),
-            recv_getmemorypool: self.node.stats.recv_getmemorypool.load(Ordering::Relaxed),
-            recv_getpeers: self.node.stats.recv_getpeers.load(Ordering::Relaxed),
-            recv_getsync: self.node.stats.recv_getsync.load(Ordering::Relaxed),
-            recv_memorypool: self.node.stats.recv_memorypool.load(Ordering::Relaxed),
-            recv_peers: self.node.stats.recv_peers.load(Ordering::Relaxed),
-            recv_pings: self.node.stats.recv_pings.load(Ordering::Relaxed),
-            recv_pongs: self.node.stats.recv_pongs.load(Ordering::Relaxed),
-            recv_syncs: self.node.stats.recv_syncs.load(Ordering::Relaxed),
-            recv_syncblocks: self.node.stats.recv_syncblocks.load(Ordering::Relaxed),
-            recv_transactions: self.node.stats.recv_transactions.load(Ordering::Relaxed),
-            recv_unknown: self.node.stats.recv_unknown.load(Ordering::Relaxed),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -350,6 +350,14 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                 connecting_peers: self.node.peer_book.number_of_connecting_peers(),
                 disconnected_peers: self.node.peer_book.number_of_disconnected_peers(),
             },
+            handshakes: NodeHandshakeStats {
+                successes_init: self.node.stats.handshakes.successes_init.load(Ordering::Relaxed),
+                successes_resp: self.node.stats.handshakes.successes_resp.load(Ordering::Relaxed),
+                failures_init: self.node.stats.handshakes.failures_init.load(Ordering::Relaxed),
+                failures_resp: self.node.stats.handshakes.failures_resp.load(Ordering::Relaxed),
+                timeouts_init: self.node.stats.handshakes.timeouts_init.load(Ordering::Relaxed),
+                timeouts_resp: self.node.stats.handshakes.timeouts_resp.load(Ordering::Relaxed),
+            },
 
             blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),
             block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -330,6 +330,20 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             number_of_connecting_peers: self.node.peer_book.number_of_connecting_peers(),
             blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),
             block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),
+
+            recv_blocks: self.node.stats.recv_blocks.load(Ordering::Relaxed),
+            recv_getblocks: self.node.stats.recv_getblocks.load(Ordering::Relaxed),
+            recv_getmemorypool: self.node.stats.recv_getmemorypool.load(Ordering::Relaxed),
+            recv_getpeers: self.node.stats.recv_getpeers.load(Ordering::Relaxed),
+            recv_getsync: self.node.stats.recv_getsync.load(Ordering::Relaxed),
+            recv_memorypool: self.node.stats.recv_memorypool.load(Ordering::Relaxed),
+            recv_peers: self.node.stats.recv_peers.load(Ordering::Relaxed),
+            recv_pings: self.node.stats.recv_pings.load(Ordering::Relaxed),
+            recv_pongs: self.node.stats.recv_pongs.load(Ordering::Relaxed),
+            recv_syncs: self.node.stats.recv_syncs.load(Ordering::Relaxed),
+            recv_syncblocks: self.node.stats.recv_syncblocks.load(Ordering::Relaxed),
+            recv_transactions: self.node.stats.recv_transactions.load(Ordering::Relaxed),
+            recv_unknown: self.node.stats.recv_unknown.load(Ordering::Relaxed),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -348,6 +348,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                 all_initiated: self.node.stats.connections.all_initiated.load(Ordering::Relaxed),
                 connected_peers: self.node.peer_book.number_of_connected_peers(),
                 connecting_peers: self.node.peer_book.number_of_connecting_peers(),
+                disconnected_peers: self.node.peer_book.number_of_disconnected_peers(),
             },
 
             blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -327,6 +327,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             number_of_connected_peers: self.node.peer_book.number_of_connected_peers(),
             number_of_connecting_peers: self.node.peer_book.number_of_connecting_peers(),
             blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),
+            block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -323,8 +323,6 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                 all_successes: self.node.stats.inbound.all_successes.load(Ordering::Relaxed),
                 all_failures: self.node.stats.inbound.all_failures.load(Ordering::Relaxed),
 
-                queued_messages: self.node.stats.inbound.queued_messages.load(Ordering::SeqCst),
-
                 blocks: self.node.stats.inbound.blocks.load(Ordering::Relaxed),
                 getblocks: self.node.stats.inbound.getblocks.load(Ordering::Relaxed),
                 getmemorypool: self.node.stats.inbound.getmemorypool.load(Ordering::Relaxed),
@@ -357,6 +355,10 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                 failures_resp: self.node.stats.handshakes.failures_resp.load(Ordering::Relaxed),
                 timeouts_init: self.node.stats.handshakes.timeouts_init.load(Ordering::Relaxed),
                 timeouts_resp: self.node.stats.handshakes.timeouts_resp.load(Ordering::Relaxed),
+            },
+            queues: NodeQueueStats {
+                inbound: self.node.stats.queues.inbound.load(Ordering::SeqCst),
+                outbound: self.node.stats.queues.outbound.load(Ordering::SeqCst),
             },
 
             blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -324,6 +324,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             inbound_channel_items: self.node.stats.inbound_channel_items.load(Ordering::SeqCst),
             inbound_connection_requests: self.node.stats.inbound_connection_requests.load(Ordering::Relaxed),
             outbound_connection_requests: self.node.stats.outbound_connection_requests.load(Ordering::Relaxed),
+            number_of_connected_peers: self.node.peer_book.number_of_connected_peers(),
+            number_of_connecting_peers: self.node.peer_book.number_of_connecting_peers(),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -323,6 +323,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             send_failure_count: self.node.stats.send_failure_count.load(Ordering::Relaxed),
             inbound_channel_items: self.node.stats.inbound_channel_items.load(Ordering::SeqCst),
             inbound_connection_requests: self.node.stats.inbound_connection_requests.load(Ordering::Relaxed),
+            outbound_connection_requests: self.node.stats.outbound_connection_requests.load(Ordering::Relaxed),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -322,6 +322,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             send_success_count: self.node.stats.send_success_count.load(Ordering::Relaxed),
             send_failure_count: self.node.stats.send_failure_count.load(Ordering::Relaxed),
             inbound_channel_items: self.node.stats.inbound_channel_items.load(Ordering::SeqCst),
+            inbound_connection_requests: self.node.stats.inbound_connection_requests.load(Ordering::Relaxed),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -326,6 +326,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             outbound_connection_requests: self.node.stats.outbound_connection_requests.load(Ordering::Relaxed),
             number_of_connected_peers: self.node.peer_book.number_of_connected_peers(),
             number_of_connecting_peers: self.node.peer_book.number_of_connecting_peers(),
+            blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -360,9 +360,12 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                 inbound: self.node.stats.queues.inbound.load(Ordering::SeqCst),
                 outbound: self.node.stats.queues.outbound.load(Ordering::SeqCst),
             },
-
-            blocks_mined: self.node.stats.blocks_mined.load(Ordering::Relaxed),
-            block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),
+            misc: NodeMiscStats {
+                block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),
+                blocks_mined: self.node.stats.misc.blocks_mined.load(Ordering::Relaxed),
+                duplicate_blocks: self.node.stats.misc.duplicate_blocks.load(Ordering::Relaxed),
+                duplicate_sync_blocks: self.node.stats.misc.duplicate_sync_blocks.load(Ordering::Relaxed),
+            },
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -321,6 +321,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
         Ok(NodeStats {
             send_success_count: self.node.stats.send_success_count.load(Ordering::Relaxed),
             send_failure_count: self.node.stats.send_failure_count.load(Ordering::Relaxed),
+            recv_success_count: self.node.stats.recv_success_count.load(Ordering::Relaxed),
+            recv_failure_count: self.node.stats.recv_failure_count.load(Ordering::Relaxed),
             inbound_channel_items: self.node.stats.inbound_channel_items.load(Ordering::SeqCst),
             inbound_connection_requests: self.node.stats.inbound_connection_requests.load(Ordering::Relaxed),
             outbound_connection_requests: self.node.stats.outbound_connection_requests.load(Ordering::Relaxed),

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -74,6 +74,10 @@ pub trait RpcFunctions {
     #[rpc(name = "getnodeinfo")]
     fn get_node_info(&self) -> Result<NodeInfo, RpcError>;
 
+    #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getnodestats.md"))]
+    #[rpc(name = "getnodestats")]
+    fn get_node_stats(&self) -> Result<NodeStats, RpcError>;
+
     #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getblocktemplate.md"))]
     #[rpc(name = "getblocktemplate")]
     fn get_block_template(&self) -> Result<BlockTemplate, RpcError>;

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -143,6 +143,9 @@ pub struct NodeStats {
 
     /// The number of connection requests the node has received
     pub inbound_connection_requests: u64,
+
+    /// The number of connection requests the node has made
+    pub outbound_connection_requests: u64,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -140,6 +140,8 @@ pub struct NodeStats {
     pub connections: NodeConnectionStats,
     /// Stats related to the node's handshakes.
     pub handshakes: NodeHandshakeStats,
+    /// Stats related to the node's queues.
+    pub queues: NodeQueueStats,
 
     /// The number of blocks the node has mined.
     pub blocks_mined: u32,
@@ -153,9 +155,6 @@ pub struct NodeInboundStats {
     pub all_successes: u64,
     /// The number of inbound messages that couldn't be processed.
     pub all_failures: u64,
-
-    /// The current number of messages queued in the inbound channel.
-    pub queued_messages: u64,
 
     /// The number of all received `Block` messages.
     pub blocks: u64,
@@ -221,6 +220,14 @@ pub struct NodeHandshakeStats {
     pub timeouts_init: u64,
     /// The number of handshake timeouts as the responder.
     pub timeouts_resp: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeQueueStats {
+    /// The number of messages queued in the common inbound channel.
+    pub inbound: u32,
+    /// The number of messages queued in the individual outbound channels.
+    pub outbound: u32,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -164,6 +164,45 @@ pub struct NodeStats {
 
     /// The current block height of the node.
     pub block_height: u32,
+
+    /// The number of all received `Block` messages.
+    pub recv_blocks: u64,
+
+    /// The number of all received `GetBlocks` messages.
+    pub recv_getblocks: u64,
+
+    /// The number of all received `GetMemoryPool` messages.
+    pub recv_getmemorypool: u64,
+
+    /// The number of all received `GetPeers` messages.
+    pub recv_getpeers: u64,
+
+    /// The number of all received `GetSync` messages.
+    pub recv_getsync: u64,
+
+    /// The number of all received `MemoryPool` messages.
+    pub recv_memorypool: u64,
+
+    /// The number of all received `Peers` messages.
+    pub recv_peers: u64,
+
+    /// The number of all received `Ping` messages.
+    pub recv_pings: u64,
+
+    /// The number of all received `Pong` messages.
+    pub recv_pongs: u64,
+
+    /// The number of all received `Sync` messages.
+    pub recv_syncs: u64,
+
+    /// The number of all received `SyncBlock` messages.
+    pub recv_syncblocks: u64,
+
+    /// The number of all received `Transaction` messages.
+    pub recv_transactions: u64,
+
+    /// The number of all received `Unknown` messages.
+    pub recv_unknown: u64,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -138,6 +138,12 @@ pub struct NodeStats {
     /// The number of failures to send messages
     pub send_failure_count: u64,
 
+    /// The number of successfully processed inbound messages.
+    pub recv_success_count: u64,
+
+    /// The number of inbound messages that couldn't be processed.
+    pub recv_failure_count: u64,
+
     /// The number of inbound items queued to be processed
     pub inbound_channel_items: u64,
 

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -201,6 +201,8 @@ pub struct NodeConnectionStats {
     pub connected_peers: u16,
     /// Number of currently connecting peers.
     pub connecting_peers: u16,
+    /// Number of known disconnected peers.
+    pub disconnected_peers: u16,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -129,6 +129,19 @@ pub struct NodeInfo {
     pub is_syncing: bool,
 }
 
+/// Returned value for the `getnodestats` rpc call
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeStats {
+    /// The number of successfully sent messages
+    pub send_success_count: u64,
+
+    /// The number of failures to send messages
+    pub send_failure_count: u64,
+
+    /// The number of inbound items queued to be processed
+    pub inbound_channel_items: u64,
+}
+
 /// Returned value for the `getpeerinfo` rpc call
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerInfo {

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -146,6 +146,12 @@ pub struct NodeStats {
 
     /// The number of connection requests the node has made
     pub outbound_connection_requests: u64,
+
+    /// Number of currently connected peers.
+    pub number_of_connected_peers: u16,
+
+    /// Number of currently connecting peers.
+    pub number_of_connecting_peers: u16,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -155,6 +155,9 @@ pub struct NodeStats {
 
     /// The number of blocks the node has mined.
     pub blocks_mined: u32,
+
+    /// The current block height of the node.
+    pub block_height: u32,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -152,6 +152,9 @@ pub struct NodeStats {
 
     /// Number of currently connecting peers.
     pub number_of_connecting_peers: u16,
+
+    /// The number of blocks the node has mined.
+    pub blocks_mined: u32,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -140,6 +140,9 @@ pub struct NodeStats {
 
     /// The number of inbound items queued to be processed
     pub inbound_channel_items: u64,
+
+    /// The number of connection requests the node has received
+    pub inbound_connection_requests: u64,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -142,11 +142,8 @@ pub struct NodeStats {
     pub handshakes: NodeHandshakeStats,
     /// Stats related to the node's queues.
     pub queues: NodeQueueStats,
-
-    /// The number of blocks the node has mined.
-    pub blocks_mined: u32,
-    /// The current block height of the node.
-    pub block_height: u32,
+    /// Miscellaneous stats related to the node.
+    pub misc: NodeMiscStats,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -228,6 +225,18 @@ pub struct NodeQueueStats {
     pub inbound: u32,
     /// The number of messages queued in the individual outbound channels.
     pub outbound: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeMiscStats {
+    /// The current block height of the node.
+    pub block_height: u32,
+    /// The number of blocks the node has mined.
+    pub blocks_mined: u32,
+    /// The number of duplicate blocks received.
+    pub duplicate_blocks: u64,
+    /// The number of duplicate sync blocks received.
+    pub duplicate_sync_blocks: u64,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -138,6 +138,8 @@ pub struct NodeStats {
     pub outbound: NodeOutboundStats,
     /// Stats related to the node's connections.
     pub connections: NodeConnectionStats,
+    /// Stats related to the node's handshakes.
+    pub handshakes: NodeHandshakeStats,
 
     /// The number of blocks the node has mined.
     pub blocks_mined: u32,
@@ -203,6 +205,22 @@ pub struct NodeConnectionStats {
     pub connecting_peers: u16,
     /// Number of known disconnected peers.
     pub disconnected_peers: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeHandshakeStats {
+    /// The number of failed handshakes as the initiator.
+    pub failures_init: u64,
+    /// The number of failed handshakes as the responder.
+    pub failures_resp: u64,
+    /// The number of successful handshakes as the initiator.
+    pub successes_init: u64,
+    /// The number of successful handshakes as the responder.
+    pub successes_resp: u64,
+    /// The number of handshake timeouts as the initiator.
+    pub timeouts_init: u64,
+    /// The number of handshake timeouts as the responder.
+    pub timeouts_resp: u64,
 }
 
 /// Returned value for the `getpeerinfo` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -132,77 +132,75 @@ pub struct NodeInfo {
 /// Returned value for the `getnodestats` rpc call
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeStats {
-    /// The number of successfully sent messages
-    pub send_success_count: u64,
-
-    /// The number of failures to send messages
-    pub send_failure_count: u64,
-
-    /// The number of successfully processed inbound messages.
-    pub recv_success_count: u64,
-
-    /// The number of inbound messages that couldn't be processed.
-    pub recv_failure_count: u64,
-
-    /// The number of inbound items queued to be processed
-    pub inbound_channel_items: u64,
-
-    /// The number of connection requests the node has received
-    pub inbound_connection_requests: u64,
-
-    /// The number of connection requests the node has made
-    pub outbound_connection_requests: u64,
-
-    /// Number of currently connected peers.
-    pub number_of_connected_peers: u16,
-
-    /// Number of currently connecting peers.
-    pub number_of_connecting_peers: u16,
+    /// Stats related to messages received by the node.
+    pub inbound: NodeInboundStats,
+    /// Stats related to messages sent by the node.
+    pub outbound: NodeOutboundStats,
+    /// Stats related to the node's connections.
+    pub connections: NodeConnectionStats,
 
     /// The number of blocks the node has mined.
     pub blocks_mined: u32,
-
     /// The current block height of the node.
     pub block_height: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeInboundStats {
+    /// The number of successfully processed inbound messages.
+    pub all_successes: u64,
+    /// The number of inbound messages that couldn't be processed.
+    pub all_failures: u64,
+
+    /// The current number of messages queued in the inbound channel.
+    pub queued_messages: u64,
 
     /// The number of all received `Block` messages.
-    pub recv_blocks: u64,
-
+    pub blocks: u64,
     /// The number of all received `GetBlocks` messages.
-    pub recv_getblocks: u64,
-
+    pub getblocks: u64,
     /// The number of all received `GetMemoryPool` messages.
-    pub recv_getmemorypool: u64,
-
+    pub getmemorypool: u64,
     /// The number of all received `GetPeers` messages.
-    pub recv_getpeers: u64,
-
+    pub getpeers: u64,
     /// The number of all received `GetSync` messages.
-    pub recv_getsync: u64,
-
+    pub getsync: u64,
     /// The number of all received `MemoryPool` messages.
-    pub recv_memorypool: u64,
-
+    pub memorypool: u64,
     /// The number of all received `Peers` messages.
-    pub recv_peers: u64,
-
+    pub peers: u64,
     /// The number of all received `Ping` messages.
-    pub recv_pings: u64,
-
+    pub pings: u64,
     /// The number of all received `Pong` messages.
-    pub recv_pongs: u64,
-
+    pub pongs: u64,
     /// The number of all received `Sync` messages.
-    pub recv_syncs: u64,
-
+    pub syncs: u64,
     /// The number of all received `SyncBlock` messages.
-    pub recv_syncblocks: u64,
-
+    pub syncblocks: u64,
     /// The number of all received `Transaction` messages.
-    pub recv_transactions: u64,
-
+    pub transactions: u64,
     /// The number of all received `Unknown` messages.
-    pub recv_unknown: u64,
+    pub unknown: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeOutboundStats {
+    /// The number of messages successfully sent by the node.
+    pub all_successes: u64,
+    /// The number of messages that failed to be sent to peers.
+    pub all_failures: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeConnectionStats {
+    /// The number of all connections the node has accepted.
+    pub all_accepted: u64,
+    /// The number of all connections the node has initiated.
+    pub all_initiated: u64,
+    /// Number of currently connected peers.
+    pub connected_peers: u16,
+    /// Number of currently connecting peers.
+    pub connecting_peers: u16,
 }
 
 /// Returned value for the `getpeerinfo` rpc call


### PR DESCRIPTION
This PR introduces detailed statistics accounting for the `Node`, available as a new `getnodestats` RPC endpoint. They are primarily designed to aid debugging and performance analysis, but have good informational value as well.

The `result` object returned by the new RPC is structured as follows (a fresh node that hasn't done anything yet):
```
$ curl -s --data-binary '{"jsonrpc": "2.0", "id":"1", "method": "getnodestats" }' -H 'content-type: application/json' http://127.0.0.1:3030/ | jq .result

{
  "block_height": 0,
  "blocks_mined": 0,
  "connections": {
    "all_accepted": 0,
    "all_initiated": 0,
    "connected_peers": 0,
    "connecting_peers": 0,
    "disconnected_peers": 0
  },
  "handshakes": {
    "failures_init": 0,
    "failures_resp": 0,
    "successes_init": 0,
    "successes_resp": 0,
    "timeouts_init": 0,
    "timeouts_resp": 0
  },
  "inbound": {
    "all_failures": 0,
    "all_successes": 0,
    "blocks": 0,
    "getblocks": 0,
    "getmemorypool": 0,
    "getpeers": 0,
    "getsync": 0,
    "memorypool": 0,
    "peers": 0,
    "pings": 0,
    "pongs": 0,
    "syncblocks": 0,
    "syncs": 0,
    "transactions": 0,
    "unknown": 0
  },
  "outbound": {
    "all_failures": 0,
    "all_successes": 0
  },
  "queues": {
    "inbound": 0,
    "outbound": 0
  }
}
```
These stats will provide us with a background for any future issues that the nodes might be having, including:
- malicious message spam
- malicious connection spam
- hitting inbound/outbound channel capacity
- inability to sync or mine blocks over a period of time

The new RPC can be run in a timed loop (every 5s or 10s should suffice) with the following command:
```
curl -s --data-binary '{"jsonrpc": "2.0", "id":"1", "method": "getnodestats" }' -H 'content-type: application/json' http://127.0.0.1:3030/ | jq .result -cM >> some_file.log
```
Which can later be transformed into a time series and analyzed for any possible issues.

In addition, the last commits removes a workaround for cleanups of `connecting` peers, the fix for which was found in the meantime.