### PR TITLE
Utilize the block sync expiry mechanism to avoid duplicate block requests

### DIFF
--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -390,16 +390,8 @@ impl PeerBook {
             pq.remaining_sync_blocks.fetch_sub(1, Ordering::SeqCst) == 1
         } else {
             warn!("Peer for got_sync_block purposes not found! (probably disconnected)");
-            true
-        }
-    }
-
-    /// Checks whether the current peer is involved in a block syncing process.
-    pub fn is_syncing_blocks(&self, addr: SocketAddr) -> bool {
-        if let Some(ref pq) = self.peer_quality(addr) {
-            pq.remaining_sync_blocks.load(Ordering::SeqCst) != 0
-        } else {
-            trace!("Peer for is_syncing_blocks purposes not found! (probably disconnected)");
+            // We might still be processing queued sync blocks; the sync expiry mechanism
+            // will handle going into the `Idle` state if the batch is incomplete.
             false
         }
     }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -461,12 +461,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     ///
     #[inline]
     pub(crate) fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
-        if let Some(ref sync) = self.sync() {
-            if self.peer_book.is_syncing_blocks(remote_address) {
-                sync.finished_syncing_blocks();
-            }
-        }
-
         // Set the peer as disconnected in the peer book.
         let result = self.peer_book.set_disconnected(remote_address);
 


### PR DESCRIPTION
This PR takes advantage of the block sync expiry mechanism: in order to avoid potentially requesting duplicate sync blocks, it doesn't automatically set the node's state to `Idle` once a sync provider is disconnected, as we might still be processing queued sync blocks from them. The fact that sync attempts expire also means that a situation where a node has no peers and is stuck at `Syncing` is no longer possible, so that check is removed. This change was taken out of #722.

Cc #730.