### PR TITLE
Allow concurrent connection requests

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -95,7 +95,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                 .connections
                                 .all_rejected
                                 .fetch_add(1, Ordering::Relaxed);
-                            warn!("Maximum number of connections reached; rejecting {}", remote_address);
                             continue;
                         }
 
@@ -157,6 +156,9 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                 }
                             }
                         });
+
+                        // add a tiny delay to avoid connecting above the limit
+                        tokio::time::sleep(Duration::from_millis(1)).await;
                     }
                     Err(e) => error!("Failed to accept a connection: {}", e),
                 }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -80,76 +80,81 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         self.set_local_address(listener_address);
         info!("Initializing listener for node ({:x})", self.id);
 
-        let node = self.clone();
+        let node_clone = self.clone();
         let listener_handle = task::spawn(async move {
             info!("Listening for nodes at {}", listener_address);
-
-            let bootnodes = node.config.bootnodes();
 
             loop {
                 match listener.accept().await {
                     Ok((stream, remote_address)) => {
                         info!("Got a connection request from {}", remote_address);
 
-                        // Wait a maximum timeout limit for a connection request.
-                        let handshake_result = tokio::time::timeout(
-                            Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
-                            node.connection_request(listener_address, remote_address, stream),
-                        )
-                        .await;
+                        let node = node_clone.clone();
+                        task::spawn(async move {
+                            // Wait a maximum timeout limit for a connection request.
+                            let handshake_result = tokio::time::timeout(
+                                Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
+                                node.connection_request(listener_address, remote_address, stream),
+                            )
+                            .await;
 
-                        match handshake_result {
-                            Ok(Ok((mut writer, mut reader, remote_listener))) => {
-                                // Create a channel dedicated to sending messages to the connection.
-                                let (sender, receiver) = channel(1024);
+                            match handshake_result {
+                                Ok(Ok((mut writer, mut reader, remote_listener))) => {
+                                    // Create a channel dedicated to sending messages to the connection.
+                                    let (sender, receiver) = channel(1024);
 
-                                // Listen for inbound messages.
-                                let node_clone = node.clone();
-                                let peer_reading_task = tokio::spawn(async move {
-                                    node_clone.listen_for_inbound_messages(&mut reader).await;
-                                });
+                                    // Listen for inbound messages.
+                                    let node_clone = node.clone();
+                                    let peer_reading_task = tokio::spawn(async move {
+                                        node_clone.listen_for_inbound_messages(&mut reader).await;
+                                    });
 
-                                // Listen for outbound messages.
-                                let node_clone = node.clone();
-                                let peer_writing_task = tokio::spawn(async move {
-                                    node_clone.listen_for_outbound_messages(receiver, &mut writer).await;
-                                });
+                                    // Listen for outbound messages.
+                                    let node_clone = node.clone();
+                                    let peer_writing_task = tokio::spawn(async move {
+                                        node_clone.listen_for_outbound_messages(receiver, &mut writer).await;
+                                    });
 
-                                // Save the channel under the provided remote address.
-                                node.outbound.channels.write().insert(remote_listener, sender);
+                                    // Save the channel under the provided remote address.
+                                    node.outbound.channels.write().insert(remote_listener, sender);
 
-                                // Finally, mark the peer as connected.
-                                node.peer_book.set_connected(remote_address, Some(remote_listener));
+                                    // Finally, mark the peer as connected.
+                                    node.peer_book.set_connected(remote_address, Some(remote_listener));
 
-                                trace!("Connected to {} (listener: {})", remote_address, remote_listener);
+                                    trace!("Connected to {} (listener: {})", remote_address, remote_listener);
 
-                                // Immediately send a ping to provide the peer with our block height.
-                                node.send_ping(remote_listener).await;
+                                    // Immediately send a ping to provide the peer with our block height.
+                                    node.send_ping(remote_listener).await;
 
-                                if let Ok(ref peer) = node.peer_book.get_peer(remote_listener) {
-                                    peer.register_task(peer_reading_task);
-                                    peer.register_task(peer_writing_task);
-                                } else {
-                                    // If the related peer is not found, it means it's already been dropped.
-                                    peer_reading_task.abort();
-                                    peer_writing_task.abort();
+                                    if let Ok(ref peer) = node.peer_book.get_peer(remote_listener) {
+                                        peer.register_task(peer_reading_task);
+                                        peer.register_task(peer_writing_task);
+                                    } else {
+                                        // If the related peer is not found, it means it's already been dropped.
+                                        peer_reading_task.abort();
+                                        peer_writing_task.abort();
+                                    }
+                                }
+                                Ok(Err(e)) => {
+                                    error!("Failed to accept a connection request: {}", e);
+                                    let _ = node.disconnect_from_peer(remote_address);
+                                    node.stats.handshakes.failures_resp.fetch_add(1, Ordering::Relaxed);
+                                }
+                                Err(_) => {
+                                    error!("Failed to accept a connection request: the handshake timed out");
+                                    let _ = node.disconnect_from_peer(remote_address);
+                                    node.stats.handshakes.timeouts_resp.fetch_add(1, Ordering::Relaxed);
                                 }
                             }
-                            Ok(Err(e)) => {
-                                error!("Failed to accept a connection request: {}", e);
-                                let _ = node.disconnect_from_peer(remote_address);
-                                node.stats.handshakes.failures_resp.fetch_add(1, Ordering::Relaxed);
-                            }
-                            Err(_) => {
-                                error!("Failed to accept a connection request: the handshake timed out");
-                                let _ = node.disconnect_from_peer(remote_address);
-                                node.stats.handshakes.timeouts_resp.fetch_add(1, Ordering::Relaxed);
-                            }
-                        }
+                        });
                     }
                     Err(e) => error!("Failed to accept a connection: {}", e),
                 }
-                node.stats.connections.all_accepted.fetch_add(1, Ordering::Relaxed);
+                node_clone
+                    .stats
+                    .connections
+                    .all_accepted
+                    .fetch_add(1, Ordering::Relaxed);
             }
         });
 

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -92,12 +92,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         info!("Got a connection request from {}", remote_address);
 
                         // Wait a maximum timeout limit for a connection request.
-                        let timeout = match bootnodes.contains(&remote_address) {
-                            true => Duration::from_secs(crate::HANDSHAKE_BOOTNODE_TIMEOUT_SECS as u64),
-                            false => Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
-                        };
                         let handshake_result = tokio::time::timeout(
-                            timeout,
+                            Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
                             node.connection_request(listener_address, remote_address, stream),
                         )
                         .await;

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -90,6 +90,11 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         info!("Got a connection request from {}", remote_address);
 
                         if !node_clone.can_connect() {
+                            node_clone
+                                .stats
+                                .connections
+                                .all_rejected
+                                .fetch_add(1, Ordering::Relaxed);
                             warn!("Maximum number of connections reached; rejecting {}", remote_address);
                             continue;
                         }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -89,6 +89,11 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     Ok((stream, remote_address)) => {
                         info!("Got a connection request from {}", remote_address);
 
+                        if !node_clone.can_connect() {
+                            warn!("Maximum number of connections reached; rejecting {}", remote_address);
+                            continue;
+                        }
+
                         let node = node_clone.clone();
                         task::spawn(async move {
                             // Wait a maximum timeout limit for a connection request.

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -83,6 +83,8 @@ pub struct ConnectionStats {
     pub all_accepted: AtomicU64,
     /// The number of all connections the node has initiated.
     pub all_initiated: AtomicU64,
+    /// The number of rejected inbound connection requests.
+    pub all_rejected: AtomicU64,
 }
 
 #[derive(Default)]

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -499,10 +499,12 @@ async fn fuzzing_corrupted_payloads_with_hashes_post_handshake() {
 
 #[tokio::test]
 async fn connection_request_spam() {
-    const NUM_ATTEMPTS: usize = 100;
+    const NUM_ATTEMPTS: usize = 200;
 
+    let max_peers = NUM_ATTEMPTS as u16 / 2;
     let node_setup = TestSetup {
         consensus_setup: None,
+        max_peers,
         ..Default::default()
     };
 
@@ -520,7 +522,7 @@ async fn connection_request_spam() {
         });
     }
 
-    wait_until!(1, node.peer_book.number_of_connecting_peers() > 0);
+    wait_until!(3, node.peer_book.number_of_connecting_peers() == max_peers);
 
     wait_until!(
         snarkos_network::HANDSHAKE_PEER_TIMEOUT_SECS as u64 * 2,

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -10,6 +10,7 @@ None
 |:--------------------------------:|:----:|:-----------------------------------------------------------------:|
 | `connections.all_accepted`       | u64  | The number of connection requests the node has received           |
 | `connections.all_initiated`      | u64  | The number of connection requests the node has made               |
+| `connections.all_rejected`       | u64  | The number of connection requests the node has rejected           |
 | `connections.connected_peers`    | u16  | The number of currently connected peers                           |
 | `connections.connecting_peers`   | u16  | The number of currently connecting peers                          |
 | `connections.disconnected_peers` | u16  | The number of known disconnected peers                            |

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -344,6 +344,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             connections: NodeConnectionStats {
                 all_accepted: self.node.stats.connections.all_accepted.load(Ordering::Relaxed),
                 all_initiated: self.node.stats.connections.all_initiated.load(Ordering::Relaxed),
+                all_rejected: self.node.stats.connections.all_rejected.load(Ordering::Relaxed),
                 connected_peers: self.node.peer_book.number_of_connected_peers(),
                 connecting_peers: self.node.peer_book.number_of_connecting_peers(),
                 disconnected_peers: self.node.peer_book.number_of_disconnected_peers(),

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -195,6 +195,8 @@ pub struct NodeConnectionStats {
     pub all_accepted: u64,
     /// The number of all connections the node has initiated.
     pub all_initiated: u64,
+    /// The number of rejected inbound connection requests.
+    pub all_rejected: u64,
     /// Number of currently connected peers.
     pub connected_peers: u16,
     /// Number of currently connecting peers.


### PR DESCRIPTION
The inbound connection requests are currently processed in sequence; under normal conditions this is fine and avoids a situation where a node would accept too many connections at once, but it is susceptible to connection request spam attacks, even with the handshake timeout mechanism we have in place.

This PR makes inbound connection processing concurrent, by spawning tasks dedicated to handshake handling as soon as a connection is accepted. In order to avoid connecting to too many peers and having to rely only on the peer cleanup mechanism, the `max_peer` limit is enforced, and the node registers all rejected requests in its `Stats`.

There's also a dedicated test case that verifies this new behavior.

Cc https://github.com/AleoHQ/snarkOS/issues/730 (since limiting inbound connections will have a positive impact on the `Too many open files` issues and reduces the possibility of OOMs).