### PR TITLE
A few tweaks

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -47,7 +47,7 @@ pub struct Inbound {
 impl Default for Inbound {
     fn default() -> Self {
         // Initialize the sender and receiver.
-        let (sender, receiver) = tokio::sync::mpsc::channel(16 * 1024);
+        let (sender, receiver) = tokio::sync::mpsc::channel(crate::INBOUND_CHANNEL_DEPTH);
 
         Self {
             sender,
@@ -110,7 +110,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                             match handshake_result {
                                 Ok(Ok((mut writer, mut reader, remote_listener))) => {
                                     // Create a channel dedicated to sending messages to the connection.
-                                    let (sender, receiver) = channel(1024);
+                                    let (sender, receiver) = channel(crate::OUTBOUND_CHANNEL_DEPTH);
 
                                     // Listen for inbound messages.
                                     let node_clone = node.clone();

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -265,11 +265,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     // Update the peer and possibly finish the sync process.
                     if self.peer_book.got_sync_block(source) {
                         sync.finished_syncing_blocks();
-                    } else {
-                        // Since we confirmed that the block is a valid sync block
-                        // and we're expecting more blocks from the peer, we can set
-                        // the node's status to Syncing.
-                        sync.node().set_state(State::Syncing);
                     }
                 }
             }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{errors::NetworkError, message::*, ConnReader, ConnWriter, Node, Receiver, Sender, State};
+use crate::{errors::NetworkError, message::*, ConnReader, ConnWriter, Node, Receiver, Sender};
 
 use std::{
     collections::HashMap,
@@ -322,22 +322,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 self.stats.inbound.pings.fetch_add(1, Ordering::Relaxed);
 
                 self.peer_book.received_ping(source, block_height);
-
-                // TODO (howardwu): Delete me after stabilizing new sync logic for blocks.
-                // if let Some(ref sync) = self.sync() {
-                //     if block_height > sync.current_block_height() + 1 {
-                //         // If the node is syncing, check if that sync attempt hasn't expired.
-                //         if !sync.is_syncing_blocks() || sync.has_block_sync_expired() {
-                //             // Cancel any possibly ongoing sync attempts.
-                //             self.set_state(State::Idle);
-                //             self.peer_book.cancel_any_unfinished_syncing();
-                //
-                //             // Begin a new sync attempt.
-                //             sync.register_block_sync_attempt(source);
-                //             sync.update_blocks(source).await;
-                //         }
-                //     }
-                // }
             }
             Payload::Pong => {
                 self.stats.inbound.pongs.fetch_add(1, Ordering::Relaxed);

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -301,7 +301,10 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
                 if let Some(ref sync_handler) = self.sync() {
                     if sync.is_empty() {
-                        trace!("{} doesn't have sync blocks to share", source);
+                        // An empty `Sync` is unexpected, as `GetSync` requests are only
+                        // sent to peers that declare a greater block height.
+                        self.peer_book.register_failure(source);
+                        warn!("{} doesn't have sync blocks to share", source);
                     } else if self.peer_book.expecting_sync_blocks(source, sync.len()) {
                         trace!("Received {} sync block hashes from {}", sync.len(), source);
                         sync_handler.received_sync(source, sync).await;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -86,6 +86,11 @@ pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
 /// The maximum number of peers shared at once in response to a `GetPeers` message.
 pub const SHARED_PEER_COUNT: usize = 25;
 
+/// The depth of the common inbound channel.
+pub const INBOUND_CHANNEL_DEPTH: usize = 16 * 1024;
+/// The depth of the per-connection outbound channels.
+pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
+
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 
 pub(crate) type Receiver = tokio::sync::mpsc::Receiver<Message>;

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -301,7 +301,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
 
                             // Begin a new sync attempt.
                             sync_clone.register_block_sync_attempt();
-                            sync_clone.update_blocks(Some(*sync_node)).await;
+                            sync_clone.update_blocks(*sync_node).await;
                         }
                     }
 

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -220,7 +220,7 @@ impl PeerBook {
     pub fn set_disconnected(&self, address: SocketAddr) -> Result<bool, NetworkError> {
         // Case 1 - The given address is a connecting peer, attempt to disconnect.
         if self.connecting_peers.write().remove(&address) {
-            return Ok(true);
+            return Ok(false);
         }
 
         // Case 2 - The given address is a connected peer, attempt to disconnect.

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -411,6 +411,13 @@ impl PeerBook {
             }
         }
     }
+
+    /// Registers a non-critical failure related to a peer.
+    pub fn register_failure(&self, addr: SocketAddr) {
+        if let Some(pq) = self.peer_quality(addr) {
+            pq.failures.fetch_add(1, Ordering::Relaxed);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -406,6 +406,8 @@ impl PeerBook {
                     missing_sync_blocks,
                     peer_info.address(),
                 );
+
+                peer_info.quality.failures.fetch_add(1, Ordering::Relaxed);
             }
         }
     }

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -331,7 +331,7 @@ impl PeerBook {
         if let Some(ref quality) = self.peer_quality(addr) {
             *quality.last_seen.write() = Some(chrono::Utc::now());
         } else {
-            warn!("Tried updating state of a peer that's not connected: {}", addr);
+            trace!("Tried updating state of a peer that's not connected: {}", addr);
         }
     }
 
@@ -379,7 +379,7 @@ impl PeerBook {
             pq.remaining_sync_blocks.store(count as u32, Ordering::SeqCst);
             true
         } else {
-            warn!("Peer for expecting_sync_blocks purposes not found! (probably disconnected)");
+            trace!("Peer for expecting_sync_blocks purposes not found! (probably disconnected)");
             false
         }
     }
@@ -389,7 +389,7 @@ impl PeerBook {
         if let Some(ref pq) = self.peer_quality(addr) {
             pq.remaining_sync_blocks.fetch_sub(1, Ordering::SeqCst) == 1
         } else {
-            warn!("Peer for got_sync_block purposes not found! (probably disconnected)");
+            trace!("Peer for got_sync_block purposes not found! (probably disconnected)");
             // We might still be processing queued sync blocks; the sync expiry mechanism
             // will handle going into the `Idle` state if the batch is incomplete.
             false

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -297,7 +297,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     Err(NetworkError::PeerAlreadyConnecting) | Err(NetworkError::PeerAlreadyConnected) => {
                         // no issue here, already connecting
                     }
-                    Err(e @ NetworkError::TooManyConnections) | Err(e @ NetworkError::SelfConnectAttempt) => {
+                    Err(e @ NetworkError::TooManyConnections) => {
                         warn!("Couldn't connect to bootnode {}: {}", bootnode_address, e);
                         // the connection hasn't been established, no need to disconnect
                     }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -69,7 +69,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             .map(|(addr, info)| (*addr, &info.quality))
         {
             if peer_quality.rtt_ms.load(Ordering::Relaxed) > 1500
-                || peer_quality.failures.load(Ordering::Relaxed) > 10
+                || peer_quality.failures.load(Ordering::Relaxed) >= 3
                 || peer_quality.is_inactive(now)
             {
                 warn!("Peer {} has a low quality score; disconnecting.", addr);

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -209,7 +209,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             let mut reader = ConnReader::new(remote_address, reader, buffer, noise);
 
             // Create a channel dedicated to sending messages to the connection.
-            let (sender, receiver) = channel(1024);
+            let (sender, receiver) = channel(crate::OUTBOUND_CHANNEL_DEPTH);
 
             // spawn the inbound loop
             let node_clone = node.clone();

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -24,29 +24,24 @@ impl<S: Storage + Send + std::marker::Sync + 'static> Sync<S> {
     ///
     /// Sends a `GetSync` request to the given sync node.
     ///
-    pub async fn update_blocks(&self, sync_node: Option<SocketAddr>) {
-        if let Some(sync_node) = sync_node {
-            let block_locator_hashes = match self.storage().get_block_locator_hashes() {
-                Ok(block_locator_hashes) => block_locator_hashes,
-                _ => {
-                    error!("Unable to get block locator hashes from storage");
-                    return;
-                }
-            };
+    pub async fn update_blocks(&self, sync_node: SocketAddr) {
+        let block_locator_hashes = match self.storage().get_block_locator_hashes() {
+            Ok(block_locator_hashes) => block_locator_hashes,
+            _ => {
+                error!("Unable to get block locator hashes from storage");
+                return;
+            }
+        };
 
-            info!("Updating blocks from {}", sync_node);
+        info!("Updating blocks from {}", sync_node);
 
-            // Send a GetSync to the selected sync node.
-            self.node()
-                .send_request(Message::new(
-                    Direction::Outbound(sync_node),
-                    Payload::GetSync(block_locator_hashes),
-                ))
-                .await;
-        } else {
-            // If no sync node is available, wait until peers have been established.
-            debug!("No sync node is registered, blocks could not be synced");
-        }
+        // Send a GetSync to the selected sync node.
+        self.node()
+            .send_request(Message::new(
+                Direction::Outbound(sync_node),
+                Payload::GetSync(block_locator_hashes),
+            ))
+            .await;
     }
 
     /// Broadcast block to connected peers

--- a/network/src/sync/sync.rs
+++ b/network/src/sync/sync.rs
@@ -128,6 +128,7 @@ impl<S: Storage> Sync<S> {
     /// Register that the node attempted to sync blocks.
     pub fn register_block_sync_attempt(&self) {
         *self.last_block_sync.write() = Some(Instant::now());
+        self.node.set_state(State::Syncing);
     }
 
     /// Returns the interval between each block sync.


### PR DESCRIPTION
This PR introduces a few low-impact tweaks, the most notable of which are:
- set the node's state to `Syncing` as soon as a sync provider is chosen; the previous behavior was that a node would only set its state to `Syncing` once it has started receiving actual `SyncBlocks`, but low block sync interval could cause a `GetSync` request to be sent twice
- be more strict about non-critical peer failures; reduce the penalty disconnect threshold from `> 10` to `>= 3`

Cc https://github.com/AleoHQ/snarkOS/issues/730.