### PR TITLE
Add an option to display modules in logs

### DIFF
--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -49,7 +49,7 @@ fn initialize_logger(config: &Config) {
             match verbosity {
                 1 => std::env::set_var("RUST_LOG", "info"),
                 2 => std::env::set_var("RUST_LOG", "debug"),
-                3 => std::env::set_var("RUST_LOG", "trace"),
+                3 | 4 => std::env::set_var("RUST_LOG", "trace"),
                 _ => std::env::set_var("RUST_LOG", "info"),
             };
 
@@ -59,7 +59,7 @@ fn initialize_logger(config: &Config) {
             // initialize tracing
             tracing_subscriber::fmt()
                 .with_env_filter(filter)
-                .with_target(false)
+                .with_target(config.node.verbose == 4)
                 .init();
         }
     }

--- a/snarkos/parameters/option.rs
+++ b/snarkos/parameters/option.rs
@@ -103,6 +103,6 @@ pub const RPC_PASSWORD: OptionType = (
 pub const VERBOSE: OptionType = (
     "[verbose] --verbose=[verbose] 'Specify the verbosity (default = 1) of the node'",
     &[],
-    &["0", "1", "2", "3"],
+    &["0", "1", "2", "3", "4"],
     &[],
 );


### PR DESCRIPTION
This PR adds a new verbosity level, `4`, which includes module names in the logs.

Cc #730.