### PR TITLE
Introduce a cache of recently processed Blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "circular-queue"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d34327ead1c743a10db339de35fb58957564b99d248a67985c55638b22c59b5"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,7 +2567,9 @@ dependencies = [
  "capnp",
  "capnpc",
  "chrono",
+ "circular-queue",
  "derivative",
+ "fxhash",
  "hex",
  "log",
  "once_cell",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -60,8 +60,14 @@ version = "0.14"
 version = "0.4"
 features = [ "serde" ]
 
+[dependencies.circular-queue]
+version = "0.2"
+
 [dependencies.derivative]
 version = "2"
+
+[dependencies.fxhash]
+version = "0.2"
 
 [dependencies.hex]
 version = "0.4.2"

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -174,8 +174,10 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         let node_clone = self.clone();
         let mut receiver = self.inbound.take_receiver();
         let incoming_task = task::spawn(async move {
+            let mut cache = Cache::default();
+
             loop {
-                if let Err(e) = node_clone.process_incoming_messages(&mut receiver).await {
+                if let Err(e) = node_clone.process_incoming_messages(&mut receiver, &mut cache).await {
                     node_clone.stats.inbound.all_failures.fetch_add(1, Ordering::Relaxed);
                     error!("Node error: {}", e);
                 } else {


### PR DESCRIPTION
The current block propagation mechanism makes nodes broadcast mined blocks and new (non-sync) received blocks to all peers except for the direct source; this method causes some duplication in meshes. In order to avoid some of the resulting overhead, introduce a small, fixed-size cache containing fast hashes of recent blocks.

In the future, this cache could easily be extended to other expensive-to-process messages (which could have their own hash collections within the `Cache` object).