### PR TITLE
More info in the getnodeinfo RPC

### DIFF
--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -17,6 +17,7 @@
 use crate::*;
 use snarkvm_objects::Storage;
 
+use chrono::{DateTime, Utc};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use rand::{seq::SliceRandom, thread_rng, Rng};
@@ -62,6 +63,8 @@ pub struct InnerNode<S: Storage> {
     pub stats: Stats,
     /// The sync handler of this node.
     pub sync: OnceCell<Arc<Sync<S>>>,
+    /// The node's start-up timestamp.
+    pub launched: DateTime<Utc>,
     /// The tasks spawned by the node.
     tasks: Mutex<Vec<task::JoinHandle<()>>>,
     /// The threads spawned by the node.
@@ -140,6 +143,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
             outbound: Default::default(),
             peer_book: Default::default(),
             sync: Default::default(),
+            launched: Utc::now(),
             tasks: Default::default(),
             threads: Default::default(),
             shutting_down: Default::default(),

--- a/rpc/documentation/public_endpoints/getnodeinfo.md
+++ b/rpc/documentation/public_endpoints/getnodeinfo.md
@@ -2,14 +2,16 @@ Returns information about the node.
 
 ### Arguments
 
-None 
+None
 
 ### Response
 
-|   Parameter  | Type |                  Description                  |
-|:------------:|:----:|:---------------------------------------------:|
-|  `is_miner`  | bool | Flag indicating if the node is a miner        |
-| `is_snycing` | bool | Flag indicating if the node currently syncing |
+|   Parameter  |     Type      |                  Description                  |
+|:------------:|:-------------:|:---------------------------------------------:|
+| `is_miner`   | bool          | Flag indicating if the node is a miner        |
+| `is_syncing` | bool          | Flag indicating if the node currently syncing |
+| `launched`   | DateTime<Utc> | The timestamp of when the node was launched   |
+| `version`    | String        | The version of the client binary              |
 
 ### Example
 ```ignore

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -314,6 +314,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             is_miner: self.sync_handler()?.is_miner(),
             is_syncing: self.sync_handler()?.is_syncing_blocks(),
             launched: self.node.launched,
+            version: env!("CARGO_PKG_VERSION").into(),
         })
     }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -313,6 +313,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
         Ok(NodeInfo {
             is_miner: self.sync_handler()?.is_miner(),
             is_syncing: self.sync_handler()?.is_syncing_blocks(),
+            launched: self.node.launched,
         })
     }
 

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -16,6 +16,7 @@
 
 //! Structures for RPC endpoint requests and responses.
 
+use chrono::{DateTime, Utc};
 use jsonrpc_http_server::jsonrpc_core::Metadata;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -127,6 +128,9 @@ pub struct NodeInfo {
 
     /// Flag indicating if the node is currently syncing
     pub is_syncing: bool,
+
+    /// The timestamp of when the node was launched.
+    pub launched: DateTime<Utc>,
 }
 
 /// Returned value for the `getnodestats` rpc call

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -131,6 +131,9 @@ pub struct NodeInfo {
 
     /// The timestamp of when the node was launched.
     pub launched: DateTime<Utc>,
+
+    /// The version of the client binary.
+    pub version: String,
 }
 
 /// Returned value for the `getnodestats` rpc call


### PR DESCRIPTION
This PR extends the contents of the results of `getnodeinfo` with `launched` (node launch timestamp) and `version` (client's package version).