### PR TITLE
Add a protected RPC to disconnect from a peer

### DIFF
--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -460,7 +460,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// as disconnected from this node server.
     ///
     #[inline]
-    pub(crate) fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
+    pub fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
         // Set the peer as disconnected in the peer book.
         let result = self.peer_book.set_disconnected(remote_address);
 

--- a/rpc/documentation/private_endpoints/disconnect.md
+++ b/rpc/documentation/private_endpoints/disconnect.md
@@ -1,0 +1,20 @@
+Disconnects the node from the given address.
+
+### Protected Endpoint
+
+Yes
+
+### Arguments
+
+|      Parameter      |  Type  | Required |                  Description                   |
+|:-------------------:|:------:|:--------:|:---------------------------------------------- |
+| `address`           | string |    Yes   | The address to disconnect in an IP:port format |
+
+### Response
+
+null
+
+### Example
+```ignore
+curl --user username:password --data-binary '{"jsonrpc": "2.0", "id":"1", "method": "disconnect", "params": ["127.0.0.1:4141"] }' -H 'content-type: application/json' http://127.0.0.1:3030/
+```


### PR DESCRIPTION
Such a method can prove useful, especially in the testnet and some integration tests.

Cc #730.