### PR TITLE
Discard non-sync Blocks while Syncing

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{errors::NetworkError, message::*, Cache, ConnReader, ConnWriter, Node, Receiver, Sender};
+use crate::{errors::NetworkError, message::*, Cache, ConnReader, ConnWriter, Node, Receiver, Sender, State};
 
 use std::{
     collections::HashMap,
@@ -246,7 +246,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         };
 
         // Check if the message hasn't already been processed recently if it's a `Block`.
-        if matches!(payload, Payload::Block(..)) && cache.contains(&payload) {
+        // The node should also reject them while syncing, as it is bound to receive them later.
+        if matches!(payload, Payload::Block(..)) && (self.state() == State::Syncing || cache.contains(&payload)) {
             return Ok(());
         }
 

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -84,10 +84,10 @@ async fn block_initiator_side() {
     assert!(block_hashes.contains(&block_1_header_hash) && block_hashes.contains(&block_2_header_hash));
 
     // respond with the full blocks
-    let block_1 = Payload::Block(BLOCK_1.to_vec());
+    let block_1 = Payload::SyncBlock(BLOCK_1.to_vec());
     peer.write_message(&block_1).await;
 
-    let block_2 = Payload::Block(BLOCK_2.to_vec());
+    let block_2 = Payload::SyncBlock(BLOCK_2.to_vec());
     peer.write_message(&block_2).await;
 
     // check the blocks have been added to the node's chain


### PR DESCRIPTION
If the node is already receiving sync blocks, it should discard any non-sync blocks in the meantime, as they are going to be orphans and they'll be sent in the correct order as part of a sync batch in the future.

Cc #730.