### PR TITLE
Enforce network protocol version

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -91,6 +91,11 @@ pub const INBOUND_CHANNEL_DEPTH: usize = 16 * 1024;
 /// The depth of the per-connection outbound channels.
 pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 
+/// The version of the network protocol; it can be incremented in order to force users to update.
+/// FIXME: probably doesn't need to be a u64, could also be more informative than just a number
+// TODO (raychu86): Establish a formal node version.
+pub const PROTOCOL_VERSION: u64 = 2;
+
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 
 pub(crate) type Receiver = tokio::sync::mpsc::Receiver<Message>;

--- a/network/src/message/serialization.rs
+++ b/network/src/message/serialization.rs
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn serialize_deserialize_version() {
-        let version = Version::new(1, 4141, 0);
+        let version = Version::new(crate::PROTOCOL_VERSION, 4141, 0);
 
         assert_eq!(
             Version::deserialize(&Version::serialize(&version).unwrap()).unwrap(),

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -194,9 +194,13 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             if peer_version.node_id == node.id {
                 return Err(NetworkError::SelfConnectAttempt);
             }
+            if peer_version.version != crate::PROTOCOL_VERSION {
+                return Err(NetworkError::InvalidHandshake);
+            }
 
             // -> s, se, psk
-            let own_version = Version::serialize(&Version::new(1u64, own_address.port(), node.id)).unwrap();
+            let own_version =
+                Version::serialize(&Version::new(crate::PROTOCOL_VERSION, own_address.port(), node.id)).unwrap();
             let len = noise.write_message(&own_version, &mut buffer)?;
             writer.write_all(&[len as u8]).await?;
             writer.write_all(&buffer[..len]).await?;

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -196,7 +196,12 @@ async fn fuzzing_corrupted_version_pre_handshake() {
 
     for i in 0..ITERATIONS {
         let mut stream = TcpStream::connect(node_addr).await.unwrap();
-        let version = Version::serialize(&Version::new(1u64, stream.local_addr().unwrap().port(), i as u64)).unwrap();
+        let version = Version::serialize(&Version::new(
+            snarkos_network::PROTOCOL_VERSION,
+            stream.local_addr().unwrap().port(),
+            i as u64,
+        ))
+        .unwrap();
 
         let corrupted_version = corrupt_bytes(&version);
 
@@ -227,7 +232,7 @@ async fn fuzzing_corrupted_version_post_handshake() {
         }
     });
 
-    let version = Version::serialize(&Version::new(1, 4141, 0)).unwrap();
+    let version = Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, 4141, 0)).unwrap();
     for _ in 0..ITERATIONS {
         // Replace a random percentage of random bytes at random indices in the serialised message.
         let corrupted_version = corrupt_bytes(&version);

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -74,7 +74,8 @@ async fn handshake_responder_side() {
     let _node_version = Version::deserialize(&buffer[..len]).unwrap();
 
     // -> s, se, psk
-    let peer_version = Version::serialize(&Version::new(1u64, peer_address.port(), 0)).unwrap(); // TODO (raychu86): Establish a formal node version.
+    let peer_version =
+        Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, peer_address.port(), 0)).unwrap();
     let len = noise.write_message(&peer_version, &mut buffer).unwrap();
     peer_stream.write_all(&[len as u8]).await.unwrap();
     peer_stream.write_all(&buffer[..len]).await.unwrap();
@@ -126,7 +127,8 @@ async fn handshake_initiator_side() {
     noise.read_message(&buf[..len], &mut buffer).unwrap();
 
     // -> e, ee, s, es
-    let peer_version = Version::serialize(&Version::new(1u64, peer_address.port(), 0)).unwrap(); // TODO (raychu86): Establish a formal node version.
+    let peer_version =
+        Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, peer_address.port(), 0)).unwrap();
     let len = noise.write_message(&peer_version, &mut buffer).unwrap();
     peer_stream.write_all(&[len as u8]).await.unwrap();
     peer_stream.write_all(&buffer[..len]).await.unwrap();

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -294,7 +294,7 @@ pub async fn spawn_2_fake_nodes() -> (FakeNode, FakeNode) {
     node1_noise.read_message(&buf[..len], &mut buffer).unwrap();
 
     // -> e, ee, s, es (node1)
-    let version = Version::serialize(&Version::new(1u64, node1_addr.port(), 1)).unwrap();
+    let version = Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, node1_addr.port(), 1)).unwrap();
     let len = node1_noise.write_message(&version, &mut buffer).unwrap();
     node1_stream.write_all(&[len as u8]).await.unwrap();
     node1_stream.write_all(&buffer[..len]).await.unwrap();
@@ -307,7 +307,8 @@ pub async fn spawn_2_fake_nodes() -> (FakeNode, FakeNode) {
     let _version = Version::deserialize(&buffer[..len]).unwrap();
 
     // -> s, se, psk (node0)
-    let peer_version = Version::serialize(&Version::new(1u64, node0_addr.port(), 0)).unwrap();
+    let peer_version =
+        Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, node0_addr.port(), 0)).unwrap();
     let len = node0_noise.write_message(&peer_version, &mut buffer).unwrap();
     node0_stream.write_all(&[len as u8]).await.unwrap();
     node0_stream.write_all(&buffer[..len]).await.unwrap();
@@ -360,7 +361,8 @@ pub async fn handshaken_peer(node_listener: SocketAddr) -> FakeNode {
     let _node_version = Version::deserialize(&buffer[..len]).unwrap();
 
     // -> s, se, psk
-    let peer_version = Version::serialize(&Version::new(1u64, peer_addr.port(), 0)).unwrap(); // TODO (raychu86): Establish a formal node version.
+    let peer_version =
+        Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, peer_addr.port(), 0)).unwrap();
     let len = noise.write_message(&peer_version, &mut buffer).unwrap();
     peer_stream.write_all(&[len as u8]).await.unwrap();
     peer_stream.write_all(&buffer[..len]).await.unwrap();


### PR DESCRIPTION
While formal node versioning is still a `TODO`, we can use that value to force users to update when some fundamental changes are introduced in the future, at least during the testnet phase.

This PR sets it to `2`, forcing an update once deployed (as the previous value was `1`).

Cc #730.