### PR TITLE
Temporarily disable incremental compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,3 +169,6 @@ lto = "thin"
 incremental = true
 debug-assertions = true
 debug = true
+
+[build]
+incremental = false # https://github.com/rust-lang/rust/issues/84970


### PR DESCRIPTION
See https://blog.rust-lang.org/2021/05/10/Rust-1.52.1 for the reasons behind this temporary change.