### PR TITLE
Advanced Prometheus-compatible metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
+name = "ahash"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -49,6 +60,15 @@ name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
+name = "atomic-shim"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20fdac7156779a1a30d970e838195558b4810dd06aa69e7c7461bdc518edf9b"
+dependencies = [
+ "crossbeam",
+]
 
 [[package]]
 name = "atty"
@@ -141,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -208,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "capnp"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9ccceaeeb86670017acc4ee196ebecf4c2e322e7e5c13d4aca0b205ef7d14f"
+checksum = "57a0c69996d49009cc837defe299dabc9bd722cfb7029837b71fe33a76bc8dd6"
 
 [[package]]
 name = "capnpc"
@@ -412,18 +432,12 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+checksum = "4f508f5ff4df34cfd12172af9f98f5c307db8b36ceb0c63264eccb43be5ed635"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crc32fast"
@@ -445,7 +459,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "futures 0.3.14",
+ "futures 0.3.15",
  "itertools 0.10.0",
  "lazy_static",
  "num-traits",
@@ -473,13 +487,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "crossbeam-channel 0.4.4",
+ "crossbeam-deque 0.7.3",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-queue",
+ "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.4",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -489,28 +538,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.9.4",
+ "crossbeam-utils 0.8.4",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
+ "autocfg",
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
- "memoffset",
+ "maybe-uninit",
+ "memoffset 0.5.6",
  "scopeguard",
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.3"
+name = "crossbeam-epoch"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.4",
+ "lazy_static",
+ "memoffset 0.6.3",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -550,10 +636,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.36"
+name = "ctor"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bac9f84ca0977c4d9b8db998689de55b9e976656a6bc87fada2ca710d504c7"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adba2012502267c1fdde381e0e3acc44bf8be96b2f7d455089dcc2c8ad2f67bd"
 dependencies = [
  "curl-sys",
  "libc",
@@ -566,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.42+curl-7.76.0"
+version = "0.4.43+curl-7.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4636d8d6109c842707018a104051436bffb8991ea20b2d1293db70b6e0ee4c7c"
+checksum = "a802c7a9828b7d139efaed1bc92471ab6681ed86d19a105605f5eadcb0837d11"
 dependencies = [
  "cc",
  "libc",
@@ -590,6 +686,16 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
 ]
 
 [[package]]
@@ -757,9 +863,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -772,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -782,15 +888,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -800,16 +906,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -818,22 +925,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures 0.1.31",
  "futures-channel",
  "futures-core",
@@ -951,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -979,6 +1087,15 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "headers"
@@ -1043,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -1054,15 +1171,21 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "httpdate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "hyper"
@@ -1078,7 +1201,7 @@ dependencies = [
  "http",
  "http-body 0.3.1",
  "httparse",
- "httpdate",
+ "httpdate 0.3.2",
  "itoa",
  "pin-project",
  "socket2 0.3.19",
@@ -1090,19 +1213,19 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.2",
+ "h2 0.3.3",
  "http",
- "http-body 0.4.1",
+ "http-body 0.4.2",
  "httparse",
- "httpdate",
+ "httpdate 1.0.0",
  "itoa",
  "pin-project",
  "socket2 0.4.0",
@@ -1119,7 +1242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.0.1",
- "hyper 0.14.5",
+ "hyper 0.14.7",
  "native-tls",
  "tokio 1.5.0",
  "tokio-native-tls",
@@ -1154,7 +1277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1228,18 +1351,18 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1251,7 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b6c6ad01c7354d60de493148c30ac8a82b759e22ae678c8705e9b8e0c566a4"
 dependencies = [
  "derive_more",
- "futures 0.3.14",
+ "futures 0.3.15",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -1266,7 +1389,7 @@ version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
 dependencies = [
- "futures 0.3.14",
+ "futures 0.3.15",
  "log",
  "serde",
  "serde_derive",
@@ -1279,7 +1402,7 @@ version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ac9d56dc729912796637c30f475bbf834594607b27740dfea6e5fa7ba40d1f1"
 dependencies = [
- "futures 0.3.14",
+ "futures 0.3.15",
  "jsonrpc-client-transports",
 ]
 
@@ -1301,7 +1424,7 @@ version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff2303c4f0562afcbd2dae75e3e21815095f8994749a80fbcd365877e44ed64"
 dependencies = [
- "futures 0.3.14",
+ "futures 0.3.15",
  "hyper 0.13.10",
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -1317,7 +1440,7 @@ version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c48dbebce7a9c88ab272a4db7d6478aa4c6d9596e6c086366e89efc4e9ed89e"
 dependencies = [
- "futures 0.3.14",
+ "futures 0.3.15",
  "jsonrpc-core",
  "lazy_static",
  "log",
@@ -1333,7 +1456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4207cce738bf713a82525065b750a008f28351324f438f56b33d698ada95bb4"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.14",
+ "futures 0.3.15",
  "globset",
  "jsonrpc-core",
  "lazy_static",
@@ -1381,9 +1504,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libloading"
@@ -1420,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
  "libc",
@@ -1432,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -1446,6 +1569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1464,10 +1596,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "memchr"
-version = "2.3.4"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -1476,6 +1623,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c53c23fff9a59f261498953cf41dc9ffc2522fd79723bdf283c1e88dc1633624"
+dependencies = [
+ "metrics-macros",
+ "proc-macro-hack",
+ "t1ha",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954533c2d91c118cf2405264a4ac3a5592e84efac12b1f18561400ffef0597eb"
+dependencies = [
+ "hyper 0.14.7",
+ "metrics",
+ "metrics-util",
+ "parking_lot",
+ "quanta",
+ "thiserror",
+ "tokio 1.5.0",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22572ba9964744e261d34553568683b76db277bcd309ebf7215e28e0982505d"
+dependencies = [
+ "lazy_static",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6586f4c52af81a3f7832cf0bc86141d2fca7207bedd09fdd3f7da60c8dcd0c4a"
+dependencies = [
+ "aho-corasick",
+ "atomic-shim",
+ "crossbeam-epoch 0.9.4",
+ "crossbeam-utils 0.8.4",
+ "dashmap",
+ "hashbrown 0.11.2",
+ "indexmap",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "parking_lot",
+ "quanta",
+ "sketches-ddsketch",
+ "t1ha",
 ]
 
 [[package]]
@@ -1684,9 +1893,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1698,21 +1907,30 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8919aecb97e5ee9aceef27e24f39c46b11831130f4a6b7b091ec5de0de12"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1948,9 +2166,24 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.22.1"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7f4a129bb3754c25a4e04032a90173c68f85168f77118ac4cb4936e7f06f92"
+checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
+
+[[package]]
+name = "quanta"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76a3afdefd0ce2c0363bf3146271e947782240ea617885dd64e56c4de9fb3c9"
+dependencies = [
+ "atomic-shim",
+ "ctor",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "quick-error"
@@ -2067,13 +2300,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg",
- "crossbeam-deque",
+ "crossbeam-deque 0.8.0",
  "either",
  "rayon-core",
 ]
@@ -2084,18 +2326,18 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-channel 0.5.1",
+ "crossbeam-deque 0.8.0",
+ "crossbeam-utils 0.8.4",
  "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -2112,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2133,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -2158,8 +2400,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body 0.4.1",
- "hyper 0.14.5",
+ "http-body 0.4.2",
+ "hyper 0.14.7",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2174,7 +2416,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio 1.5.0",
  "tokio-native-tls",
- "url 2.2.1",
+ "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2301,7 +2543,7 @@ checksum = "6fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c"
 dependencies = [
  "either",
  "flate2",
- "hyper 0.14.5",
+ "hyper 0.14.7",
  "indicatif",
  "log",
  "quick-xml",
@@ -2423,26 +2665,26 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.4"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
+checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -2463,10 +2705,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
-name = "slab"
-version = "0.4.2"
+name = "sketches-ddsketch"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "76a77a8fd93886010f05e7ea0720e569d6d16c65329dbe3ec033bbbccccb017b"
+
+[[package]]
+name = "slab"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -2484,6 +2732,8 @@ dependencies = [
  "colored",
  "dirs",
  "hex",
+ "metrics",
+ "metrics-exporter-prometheus",
  "parking_lot",
  "rand 0.8.3",
  "rustc_version 0.3.3",
@@ -2578,6 +2828,7 @@ dependencies = [
  "fxhash",
  "hex",
  "log",
+ "metrics",
  "once_cell",
  "parking_lot",
  "peak_alloc",
@@ -2585,7 +2836,6 @@ dependencies = [
  "rustc_version 0.3.3",
  "serde",
  "snarkos-consensus",
- "snarkos-metrics",
  "snarkos-storage",
  "snarkos-testing",
  "snarkvm-algorithms",
@@ -3031,9 +3281,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3050,6 +3300,18 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "t1ha"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa44aa51ae1a544e2c35a38831ba54ae40591f21384816f531b84f3e984b9ccc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "lazy_static",
+ "num-traits",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3274,9 +3536,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -3286,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -3367,7 +3629,7 @@ dependencies = [
  "log",
  "rand 0.8.3",
  "sha-1",
- "url 2.2.1",
+ "url 2.2.2",
  "utf-8",
 ]
 
@@ -3427,9 +3689,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
@@ -3454,9 +3716,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna 0.2.3",
@@ -3516,10 +3778,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
  "bytes 1.0.1",
- "futures 0.3.14",
+ "futures 0.3.15",
  "headers",
  "http",
- "hyper 0.14.5",
+ "hyper 0.14.7",
  "log",
  "mime",
  "mime_guess",
@@ -3552,9 +3814,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3564,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3579,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3591,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3601,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3614,15 +3876,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e972e914de63aa53bd84865e54f5c761bd274d48e5be3a6329a662c0386aa67a"
+checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -3634,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6153a8f9bf24588e9f25c87223414fff124049f68d3a442a0f0eab4768a8b6"
+checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3644,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3727,18 +3989,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,13 @@ version = "3.0.2"
 [dependencies.hex]
 version = "0.4.1"
 
+[dependencies.metrics]
+version = "0.15"
+
+[dependencies.metrics-exporter-prometheus]
+version = "0.4"
+optional = true
+
 [dependencies.parking_lot]
 version = "0.11.1"
 
@@ -144,6 +151,7 @@ rustc_version = "0.3"
 
 [features]
 default = [ ]
+prometheus = [ "metrics-exporter-prometheus" ]
 compile_capnp_schema = [ "capnpc" ]
 noconfig = [ ]
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -71,6 +71,9 @@ version = "0.4.2"
 [dependencies.log]
 version = "0.4.11"
 
+[dependencies.metrics]
+version = "0.15"
+
 [dependencies.once_cell]
 version = "1.5.2"
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -33,10 +33,6 @@ version = "0.2.2"
 path = "../consensus"
 version = "1.3.3"
 
-[dependencies.snarkos-metrics]
-path = "../metrics"
-version = "1.3.3"
-
 [dependencies.snarkos-storage]
 path = "../storage"
 version = "1.3.3"

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -14,14 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{errors::NetworkError, message::*, Cache, ConnReader, ConnWriter, Node, Receiver, Sender, State};
+use crate::{errors::NetworkError, message::*, stats, Cache, ConnReader, ConnWriter, Node, Receiver, Sender, State};
 
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::{atomic::Ordering, Arc},
-    time::Duration,
-};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use parking_lot::Mutex;
 use snarkvm_objects::Storage;
@@ -90,11 +85,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         info!("Got a connection request from {}", remote_address);
 
                         if !node_clone.can_connect() {
-                            node_clone
-                                .stats
-                                .connections
-                                .all_rejected
-                                .fetch_add(1, Ordering::Relaxed);
+                            metrics::increment_counter!(stats::CONNECTIONS_ALL_REJECTED);
                             continue;
                         }
 
@@ -147,12 +138,12 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                 Ok(Err(e)) => {
                                     error!("Failed to accept a connection request: {}", e);
                                     let _ = node.disconnect_from_peer(remote_address);
-                                    node.stats.handshakes.failures_resp.fetch_add(1, Ordering::Relaxed);
+                                    metrics::increment_counter!(stats::HANDSHAKES_FAILURES_RESP);
                                 }
                                 Err(_) => {
                                     error!("Failed to accept a connection request: the handshake timed out");
                                     let _ = node.disconnect_from_peer(remote_address);
-                                    node.stats.handshakes.timeouts_resp.fetch_add(1, Ordering::Relaxed);
+                                    metrics::increment_counter!(stats::HANDSHAKES_TIMEOUTS_RESP);
                                 }
                             }
                         });
@@ -162,11 +153,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     }
                     Err(e) => error!("Failed to accept a connection: {}", e),
                 }
-                node_clone
-                    .stats
-                    .connections
-                    .all_accepted
-                    .fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::CONNECTIONS_ALL_ACCEPTED);
             }
         });
 
@@ -236,7 +223,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     ) -> Result<(), NetworkError> {
         let Message { direction, payload } = receiver.recv().await.ok_or(NetworkError::ReceiverFailedToParse)?;
 
-        self.stats.queues.inbound.fetch_sub(1, Ordering::SeqCst);
+        metrics::decrement_gauge!(stats::QUEUES_INBOUND, 1.0);
 
         let source = if let Direction::Inbound(addr) = direction {
             self.peer_book.update_last_seen(addr);
@@ -253,21 +240,21 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
         match payload {
             Payload::Transaction(transaction) => {
-                self.stats.inbound.transactions.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_TRANSACTIONS);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_memory_pool_transaction(source, transaction).await?;
                 }
             }
             Payload::Block(block) => {
-                self.stats.inbound.blocks.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_BLOCKS);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_block(source, block, true).await?;
                 }
             }
             Payload::SyncBlock(block) => {
-                self.stats.inbound.syncblocks.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_SYNCBLOCKS);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_block(source, block, false).await?;
@@ -279,35 +266,35 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 }
             }
             Payload::GetBlocks(hashes) => {
-                self.stats.inbound.getblocks.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_GETBLOCKS);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_get_blocks(source, hashes).await?;
                 }
             }
             Payload::GetMemoryPool => {
-                self.stats.inbound.getmemorypool.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_GETMEMORYPOOL);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_get_memory_pool(source).await?;
                 }
             }
             Payload::MemoryPool(mempool) => {
-                self.stats.inbound.memorypool.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_MEMORYPOOL);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_memory_pool(mempool)?;
                 }
             }
             Payload::GetSync(getsync) => {
-                self.stats.inbound.getsync.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_GETSYNC);
 
                 if let Some(ref sync) = self.sync() {
                     sync.received_get_sync(source, getsync).await?;
                 }
             }
             Payload::Sync(sync) => {
-                self.stats.inbound.syncs.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_SYNCS);
 
                 if let Some(ref sync_handler) = self.sync() {
                     if sync.is_empty() {
@@ -322,26 +309,26 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 }
             }
             Payload::GetPeers => {
-                self.stats.inbound.getpeers.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_GETPEERS);
 
                 self.send_peers(source).await;
             }
             Payload::Peers(peers) => {
-                self.stats.inbound.peers.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_PEERS);
 
                 self.process_inbound_peers(peers);
             }
             Payload::Ping(block_height) => {
-                self.stats.inbound.pings.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_PINGS);
 
                 self.peer_book.received_ping(source, block_height);
             }
             Payload::Pong => {
-                self.stats.inbound.pongs.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_PONGS);
                 // Skip as this case is already handled with priority in Inbound::listen_for_messages
             }
             Payload::Unknown => {
-                self.stats.inbound.unknown.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_UNKNOWN);
                 warn!("Unknown payload received; this could indicate that the client you're using is out-of-date");
             }
         }
@@ -410,7 +397,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             return Err(NetworkError::InvalidHandshake);
         }
 
-        self.stats.handshakes.successes_resp.fetch_add(1, Ordering::Relaxed);
+        metrics::increment_counter!(stats::HANDSHAKES_SUCCESSES_INIT);
 
         // the remote listening address
         let remote_listener = SocketAddr::from((remote_address.ip(), peer_version.listening_port));
@@ -426,7 +413,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     pub(crate) fn route(&self, response: Message) {
         match self.inbound.sender.try_send(response) {
             Err(TrySendError::Full(msg)) => {
-                self.stats.inbound.all_failures.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::INBOUND_ALL_FAILURES);
                 error!("Failed to route a {}: the inbound channel is full", msg);
             }
             Err(TrySendError::Closed(msg)) => {
@@ -434,7 +421,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 error!("Failed to route a {}: the inbound channel is closed", msg);
             }
             Ok(_) => {
-                self.stats.queues.inbound.fetch_add(1, Ordering::SeqCst);
+                metrics::increment_gauge!(stats::QUEUES_INBOUND, 1.0);
             }
         }
     }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -397,7 +397,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             return Err(NetworkError::InvalidHandshake);
         }
 
-        metrics::increment_counter!(stats::HANDSHAKES_SUCCESSES_INIT);
+        metrics::increment_counter!(stats::HANDSHAKES_SUCCESSES_RESP);
 
         // the remote listening address
         let remote_listener = SocketAddr::from((remote_address.ip(), peer_version.listening_port));

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -26,8 +26,6 @@
 extern crate derivative;
 #[macro_use]
 extern crate tracing;
-#[macro_use]
-extern crate snarkos_metrics;
 
 pub mod config;
 pub use config::*;

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -257,10 +257,9 @@ impl PeerBook {
         }
 
         // Add the given address to the map of disconnected peers.
-        self.disconnected_peers
-            .write()
-            .entry(address)
-            .or_insert_with(|| PeerInfo::new(address));
+        self.disconnected_peers.write().insert(address, PeerInfo::new(address));
+
+        metrics::increment_gauge!(stats::CONNECTIONS_DISCONNECTED, 1.0);
 
         debug!("Added {} to the peer book", address);
     }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{message::*, ConnReader, ConnWriter, NetworkError, Node, SerializedPeerBook, Version};
+use crate::{message::*, stats, ConnReader, ConnWriter, NetworkError, Node, SerializedPeerBook, Version};
 use snarkvm_objects::Storage;
 
 use std::{
@@ -145,7 +145,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             return Err(NetworkError::PeerAlreadyConnected);
         }
 
-        self.stats.connections.all_initiated.fetch_add(1, Ordering::Relaxed);
+        metrics::increment_counter!(stats::CONNECTIONS_ALL_INITIATED);
 
         self.peer_book.set_connecting(remote_address)?;
 
@@ -206,7 +206,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             writer.write_all(&buffer[..len]).await?;
             trace!("sent s, se, psk (XX handshake part 3/3) to {}", remote_address);
 
-            node.stats.handshakes.successes_init.fetch_add(1, Ordering::Relaxed);
+            metrics::increment_counter!(stats::HANDSHAKES_SUCCESSES_INIT);
 
             let noise = Arc::new(Mutex::new(noise.into_transport_mode()?));
             let mut writer = ConnWriter::new(remote_address, writer, buffer.clone(), Arc::clone(&noise));
@@ -254,14 +254,15 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // as NetworkError::InvalidHandshake, since there's not much to salvage there
             Ok(Ok(Ok(_))) => {}
             Ok(Ok(e)) => {
+                metrics::increment_counter!(stats::HANDSHAKES_FAILURES_INIT);
                 return e;
             }
             Ok(Err(_)) => {
-                self.stats.handshakes.failures_init.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::HANDSHAKES_FAILURES_INIT);
                 return Err(NetworkError::InvalidHandshake);
             }
             Err(_) => {
-                self.stats.handshakes.timeouts_init.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::HANDSHAKES_TIMEOUTS_INIT);
                 return Err(NetworkError::HandshakeTimeout);
             }
         }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -14,7 +14,51 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use metrics::{GaugeValue, Key, Recorder, Unit};
+
+use std::{
+    borrow::Borrow,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+pub const INBOUND_ALL_SUCCESSES: &str = "snarkos_inbound_all_successes_total";
+pub const INBOUND_ALL_FAILURES: &str = "snarkos_inbound_all_failures_total";
+pub const INBOUND_BLOCKS: &str = "snarkos_inbound_blocks_total";
+pub const INBOUND_GETBLOCKS: &str = "snarkos_inbound_getblocks_total";
+pub const INBOUND_GETMEMORYPOOL: &str = "snarkos_inbound_getmemorypool_total";
+pub const INBOUND_GETPEERS: &str = "snarkos_inbound_getpeers_total";
+pub const INBOUND_GETSYNC: &str = "snarkos_inbound_getsync_total";
+pub const INBOUND_MEMORYPOOL: &str = "snarkos_inbound_memorypool_total";
+pub const INBOUND_PEERS: &str = "snarkos_inbound_peers_total";
+pub const INBOUND_PINGS: &str = "snarkos_inbound_pings_total";
+pub const INBOUND_PONGS: &str = "snarkos_inbound_pongs_total";
+pub const INBOUND_SYNCS: &str = "snarkos_inbound_syncs_total";
+pub const INBOUND_SYNCBLOCKS: &str = "snarkos_inbound_syncblocks_total";
+pub const INBOUND_TRANSACTIONS: &str = "snarkos_inbound_transactions_total";
+pub const INBOUND_UNKNOWN: &str = "snarkos_inbound_unknown_total";
+
+pub const OUTBOUND_ALL_SUCCESSES: &str = "snarkos_outbound_all_successes_total";
+pub const OUTBOUND_ALL_FAILURES: &str = "snarkos_outbound_all_failures_total";
+
+pub const CONNECTIONS_ALL_ACCEPTED: &str = "snarkos_connections_all_accepted_total";
+pub const CONNECTIONS_ALL_INITIATED: &str = "snarkos_connections_all_initiated_total";
+pub const CONNECTIONS_ALL_REJECTED: &str = "snarkos_connections_all_rejected_total";
+
+pub const HANDSHAKES_FAILURES_INIT: &str = "snarkos_handshakes_failures_init_total";
+pub const HANDSHAKES_FAILURES_RESP: &str = "snarkos_handshakes_failures_resp_total";
+pub const HANDSHAKES_SUCCESSES_INIT: &str = "snarkos_handshakes_successes_init_total";
+pub const HANDSHAKES_SUCCESSES_RESP: &str = "snarkos_handshakes_successes_resp_total";
+pub const HANDSHAKES_TIMEOUTS_INIT: &str = "snarkos_handshakes_timeouts_init_total";
+pub const HANDSHAKES_TIMEOUTS_RESP: &str = "snarkos_handshakes_timeouts_resp_total";
+
+pub const QUEUES_INBOUND: &str = "snarkos_queues_inbound_total";
+pub const QUEUES_OUTBOUND: &str = "snarkos_queues_outbound_total";
+
+pub const MISC_BLOCKS_MINED: &str = "snarkos_misc_blocks_mined_total";
+pub const MISC_DUPLICATE_BLOCKS: &str = "snarkos_misc_duplicate_blocks_total";
+pub const MISC_DUPLICATE_SYNC_BLOCKS: &str = "snarkos_misc_duplicate_sync_blocks_total";
+
+pub static NODE_STATS: Stats = Stats::new();
 
 // TODO: make members private and make gathering of stats feature-gated and possibly
 // interchangeable with prometheus metrics.
@@ -32,6 +76,19 @@ pub struct Stats {
     pub queues: QueueStats,
     /// Miscellaneous stats related to the node.
     pub misc: MiscStats,
+}
+
+impl Stats {
+    pub const fn new() -> Self {
+        Self {
+            inbound: InboundStats::new(),
+            outbound: OutboundStats::new(),
+            connections: ConnectionStats::new(),
+            handshakes: HandshakeStats::new(),
+            queues: QueueStats::new(),
+            misc: MiscStats::new(),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -69,12 +126,43 @@ pub struct InboundStats {
     pub unknown: AtomicU64,
 }
 
+impl InboundStats {
+    const fn new() -> Self {
+        Self {
+            all_successes: AtomicU64::new(0),
+            all_failures: AtomicU64::new(0),
+            blocks: AtomicU64::new(0),
+            getblocks: AtomicU64::new(0),
+            getmemorypool: AtomicU64::new(0),
+            getpeers: AtomicU64::new(0),
+            getsync: AtomicU64::new(0),
+            memorypool: AtomicU64::new(0),
+            peers: AtomicU64::new(0),
+            pings: AtomicU64::new(0),
+            pongs: AtomicU64::new(0),
+            syncs: AtomicU64::new(0),
+            syncblocks: AtomicU64::new(0),
+            transactions: AtomicU64::new(0),
+            unknown: AtomicU64::new(0),
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct OutboundStats {
     /// The number of messages successfully sent by the node.
     pub all_successes: AtomicU64,
     /// The number of messages that failed to be sent to peers.
     pub all_failures: AtomicU64,
+}
+
+impl OutboundStats {
+    const fn new() -> Self {
+        Self {
+            all_successes: AtomicU64::new(0),
+            all_failures: AtomicU64::new(0),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -85,6 +173,16 @@ pub struct ConnectionStats {
     pub all_initiated: AtomicU64,
     /// The number of rejected inbound connection requests.
     pub all_rejected: AtomicU64,
+}
+
+impl ConnectionStats {
+    const fn new() -> Self {
+        Self {
+            all_accepted: AtomicU64::new(0),
+            all_initiated: AtomicU64::new(0),
+            all_rejected: AtomicU64::new(0),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -103,20 +201,145 @@ pub struct HandshakeStats {
     pub timeouts_resp: AtomicU64,
 }
 
+impl HandshakeStats {
+    const fn new() -> Self {
+        Self {
+            failures_init: AtomicU64::new(0),
+            failures_resp: AtomicU64::new(0),
+            successes_init: AtomicU64::new(0),
+            successes_resp: AtomicU64::new(0),
+            timeouts_init: AtomicU64::new(0),
+            timeouts_resp: AtomicU64::new(0),
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct QueueStats {
     /// The number of messages queued in the common inbound channel.
-    pub inbound: AtomicU32,
+    pub inbound: AtomicU64,
     /// The number of messages queued in the individual outbound channels.
-    pub outbound: AtomicU32,
+    pub outbound: AtomicU64,
+}
+
+impl QueueStats {
+    const fn new() -> Self {
+        Self {
+            inbound: AtomicU64::new(0),
+            outbound: AtomicU64::new(0),
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct MiscStats {
     /// The number of mined blocks.
-    pub blocks_mined: AtomicU32,
+    pub blocks_mined: AtomicU64,
     /// The number of duplicate blocks received.
     pub duplicate_blocks: AtomicU64,
     /// The number of duplicate sync blocks received.
     pub duplicate_sync_blocks: AtomicU64,
+}
+
+impl MiscStats {
+    const fn new() -> Self {
+        Self {
+            blocks_mined: AtomicU64::new(0),
+            duplicate_blocks: AtomicU64::new(0),
+            duplicate_sync_blocks: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Recorder for Stats {
+    // The following are unused in Stats
+    fn register_counter(&self, _key: &Key, _unit: Option<Unit>, _desc: Option<&'static str>) {}
+
+    fn register_gauge(&self, _key: &Key, _unit: Option<Unit>, _desc: Option<&'static str>) {}
+
+    fn register_histogram(&self, _key: &Key, _unit: Option<Unit>, _desc: Option<&'static str>) {}
+
+    fn record_histogram(&self, _key: &Key, _value: f64) {}
+
+    fn increment_counter(&self, key: &Key, value: u64) {
+        if let Some(name) = key.name().parts().next() {
+            match name.borrow() {
+                // inbound
+                INBOUND_ALL_SUCCESSES => self.inbound.all_successes.fetch_add(value, Ordering::Relaxed),
+                INBOUND_ALL_FAILURES => self.inbound.all_failures.fetch_add(value, Ordering::Relaxed),
+                INBOUND_BLOCKS => self.inbound.blocks.fetch_add(value, Ordering::Relaxed),
+                INBOUND_GETBLOCKS => self.inbound.getblocks.fetch_add(value, Ordering::Relaxed),
+                INBOUND_GETMEMORYPOOL => self.inbound.getmemorypool.fetch_add(value, Ordering::Relaxed),
+                INBOUND_GETPEERS => self.inbound.getpeers.fetch_add(value, Ordering::Relaxed),
+                INBOUND_GETSYNC => self.inbound.getsync.fetch_add(value, Ordering::Relaxed),
+                INBOUND_MEMORYPOOL => self.inbound.memorypool.fetch_add(value, Ordering::Relaxed),
+                INBOUND_PEERS => self.inbound.peers.fetch_add(value, Ordering::Relaxed),
+                INBOUND_PINGS => self.inbound.pings.fetch_add(value, Ordering::Relaxed),
+                INBOUND_PONGS => self.inbound.pongs.fetch_add(value, Ordering::Relaxed),
+                INBOUND_SYNCS => self.inbound.syncs.fetch_add(value, Ordering::Relaxed),
+                INBOUND_SYNCBLOCKS => self.inbound.syncblocks.fetch_add(value, Ordering::Relaxed),
+                INBOUND_TRANSACTIONS => self.inbound.transactions.fetch_add(value, Ordering::Relaxed),
+                INBOUND_UNKNOWN => self.inbound.unknown.fetch_add(value, Ordering::Relaxed),
+                // outbound
+                OUTBOUND_ALL_SUCCESSES => self.outbound.all_successes.fetch_add(value, Ordering::Relaxed),
+                OUTBOUND_ALL_FAILURES => self.outbound.all_failures.fetch_add(value, Ordering::Relaxed),
+                // connections
+                CONNECTIONS_ALL_ACCEPTED => self.connections.all_accepted.fetch_add(value, Ordering::Relaxed),
+                CONNECTIONS_ALL_INITIATED => self.connections.all_initiated.fetch_add(value, Ordering::Relaxed),
+                CONNECTIONS_ALL_REJECTED => self.connections.all_rejected.fetch_add(value, Ordering::Relaxed),
+                // handshakes
+                HANDSHAKES_FAILURES_INIT => self.handshakes.failures_init.fetch_add(value, Ordering::Relaxed),
+                HANDSHAKES_FAILURES_RESP => self.handshakes.failures_resp.fetch_add(value, Ordering::Relaxed),
+                HANDSHAKES_SUCCESSES_INIT => self.handshakes.successes_init.fetch_add(value, Ordering::Relaxed),
+                HANDSHAKES_SUCCESSES_RESP => self.handshakes.successes_resp.fetch_add(value, Ordering::Relaxed),
+                HANDSHAKES_TIMEOUTS_INIT => self.handshakes.timeouts_init.fetch_add(value, Ordering::Relaxed),
+                HANDSHAKES_TIMEOUTS_RESP => self.handshakes.timeouts_resp.fetch_add(value, Ordering::Relaxed),
+                // misc
+                MISC_BLOCKS_MINED => self.misc.blocks_mined.fetch_add(value, Ordering::Relaxed),
+                MISC_DUPLICATE_BLOCKS => self.misc.duplicate_blocks.fetch_add(value, Ordering::Relaxed),
+                MISC_DUPLICATE_SYNC_BLOCKS => self.misc.duplicate_sync_blocks.fetch_add(value, Ordering::Relaxed),
+                _ => {
+                    error!("Metrics key {} wasn't assigned an operation and won't work!", key);
+                    0
+                }
+            };
+        } else {
+            error!("Metrics key {} wasn't assigned a name and won't work!", key);
+        }
+    }
+
+    fn update_gauge(&self, key: &Key, value: GaugeValue) {
+        if let Some(name) = key.name().parts().next() {
+            match value {
+                GaugeValue::Increment(value) => {
+                    match name.borrow() {
+                        // queues
+                        QUEUES_INBOUND => self.queues.inbound.fetch_add(value as u64, Ordering::Relaxed),
+                        QUEUES_OUTBOUND => self.queues.outbound.fetch_add(value as u64, Ordering::Relaxed),
+                        _ => {
+                            error!("Metrics key {} wasn't assigned an operation and won't work!", key);
+                            0
+                        }
+                    }
+                }
+                GaugeValue::Decrement(value) => {
+                    match name.borrow() {
+                        // queues
+                        QUEUES_INBOUND => self.queues.inbound.fetch_sub(value as u64, Ordering::Relaxed),
+                        QUEUES_OUTBOUND => self.queues.outbound.fetch_sub(value as u64, Ordering::Relaxed),
+                        _ => {
+                            error!("Metrics key {} wasn't assigned an operation and won't work!", key);
+                            0
+                        }
+                    }
+                }
+                GaugeValue::Absolute(_value) => {
+                    error!("GaugeValue::Absolute is not used!");
+                    0
+                }
+            };
+        } else {
+            error!("Metrics key {} wasn't assigned a name and won't work!", key);
+        }
+    }
 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -314,8 +314,8 @@ impl Recorder for Stats {
                 GaugeValue::Increment(value) => {
                     match name.borrow() {
                         // queues
-                        QUEUES_INBOUND => self.queues.inbound.fetch_add(value as u64, Ordering::Relaxed),
-                        QUEUES_OUTBOUND => self.queues.outbound.fetch_add(value as u64, Ordering::Relaxed),
+                        QUEUES_INBOUND => self.queues.inbound.fetch_add(value as u64, Ordering::SeqCst),
+                        QUEUES_OUTBOUND => self.queues.outbound.fetch_add(value as u64, Ordering::SeqCst),
                         _ => {
                             error!("Metrics key {} wasn't assigned an operation and won't work!", key);
                             0
@@ -325,8 +325,8 @@ impl Recorder for Stats {
                 GaugeValue::Decrement(value) => {
                     match name.borrow() {
                         // queues
-                        QUEUES_INBOUND => self.queues.inbound.fetch_sub(value as u64, Ordering::Relaxed),
-                        QUEUES_OUTBOUND => self.queues.outbound.fetch_sub(value as u64, Ordering::Relaxed),
+                        QUEUES_INBOUND => self.queues.inbound.fetch_sub(value as u64, Ordering::SeqCst),
+                        QUEUES_OUTBOUND => self.queues.outbound.fetch_sub(value as u64, Ordering::SeqCst),
                         _ => {
                             error!("Metrics key {} wasn't assigned an operation and won't work!", key);
                             0

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -43,6 +43,9 @@ pub const OUTBOUND_ALL_FAILURES: &str = "snarkos_outbound_all_failures_total";
 pub const CONNECTIONS_ALL_ACCEPTED: &str = "snarkos_connections_all_accepted_total";
 pub const CONNECTIONS_ALL_INITIATED: &str = "snarkos_connections_all_initiated_total";
 pub const CONNECTIONS_ALL_REJECTED: &str = "snarkos_connections_all_rejected_total";
+pub const CONNECTIONS_CONNECTING: &str = "snarkos_connections_connecting_total";
+pub const CONNECTIONS_CONNECTED: &str = "snarkos_connections_connected_total";
+pub const CONNECTIONS_DISCONNECTED: &str = "snarkos_connections_disconnected_total";
 
 pub const HANDSHAKES_FAILURES_INIT: &str = "snarkos_handshakes_failures_init_total";
 pub const HANDSHAKES_FAILURES_RESP: &str = "snarkos_handshakes_failures_resp_total";

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{message::*, NetworkError, Sync};
+use crate::{message::*, stats, NetworkError, Sync};
 use snarkos_consensus::error::ConsensusError;
 use snarkvm_objects::{Block, BlockHeaderHash, Storage};
 
-use std::{net::SocketAddr, sync::atomic::Ordering};
+use std::net::SocketAddr;
 
 impl<S: Storage + Send + std::marker::Sync + 'static> Sync<S> {
     ///
@@ -105,13 +105,9 @@ impl<S: Storage + Send + std::marker::Sync + 'static> Sync<S> {
 
         if let Err(ConsensusError::PreExistingBlock) = block_validity {
             if is_block_new {
-                self.node().stats.misc.duplicate_blocks.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::MISC_DUPLICATE_BLOCKS);
             } else {
-                self.node()
-                    .stats
-                    .misc
-                    .duplicate_sync_blocks
-                    .fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::MISC_DUPLICATE_SYNC_BLOCKS);
             }
         }
 

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Node, State};
+use crate::{stats, Node, State};
 use snarkos_consensus::Miner;
 use snarkvm_dpc::{base_dpc::instantiated::*, AccountAddress};
 use snarkvm_objects::Storage;
@@ -22,11 +22,7 @@ use snarkvm_objects::Storage;
 use tokio::runtime;
 use tracing::*;
 
-use std::{
-    sync::{atomic::Ordering, Arc},
-    thread,
-    time::Duration,
-};
+use std::{sync::Arc, thread, time::Duration};
 
 /// Parameters for spawning a miner that runs proof of work to find a block.
 pub struct MinerInstance<S: Storage> {
@@ -104,7 +100,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                     self.node.set_state(State::Idle);
                 }
 
-                self.node.stats.misc.blocks_mined.fetch_add(1, Ordering::Relaxed);
+                metrics::increment_counter!(stats::MISC_BLOCKS_MINED);
 
                 info!("Mined a new block: {:?}", hex::encode(block.header.get_hash().0));
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -20,7 +20,7 @@
 
 use crate::{error::RpcError, rpc_trait::RpcFunctions, rpc_types::*};
 use snarkos_consensus::{get_block_reward, memory_pool::Entry, ConsensusParameters, MemoryPool, MerkleTreeLedger};
-use snarkos_network::{Node, Sync};
+use snarkos_network::{Node, Sync, NODE_STATS};
 use snarkvm_dpc::base_dpc::{
     instantiated::{Components, Tx},
     parameters::PublicParameters,
@@ -323,52 +323,56 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     fn get_node_stats(&self) -> Result<NodeStats, RpcError> {
         Ok(NodeStats {
             inbound: NodeInboundStats {
-                all_successes: self.node.stats.inbound.all_successes.load(Ordering::Relaxed),
-                all_failures: self.node.stats.inbound.all_failures.load(Ordering::Relaxed),
+                all_successes: NODE_STATS.inbound.all_successes.load(Ordering::Relaxed),
+                all_failures: NODE_STATS.inbound.all_failures.load(Ordering::Relaxed),
 
-                blocks: self.node.stats.inbound.blocks.load(Ordering::Relaxed),
-                getblocks: self.node.stats.inbound.getblocks.load(Ordering::Relaxed),
-                getmemorypool: self.node.stats.inbound.getmemorypool.load(Ordering::Relaxed),
-                getpeers: self.node.stats.inbound.getpeers.load(Ordering::Relaxed),
-                getsync: self.node.stats.inbound.getsync.load(Ordering::Relaxed),
-                memorypool: self.node.stats.inbound.memorypool.load(Ordering::Relaxed),
-                peers: self.node.stats.inbound.peers.load(Ordering::Relaxed),
-                pings: self.node.stats.inbound.pings.load(Ordering::Relaxed),
-                pongs: self.node.stats.inbound.pongs.load(Ordering::Relaxed),
-                syncs: self.node.stats.inbound.syncs.load(Ordering::Relaxed),
-                syncblocks: self.node.stats.inbound.syncblocks.load(Ordering::Relaxed),
-                transactions: self.node.stats.inbound.transactions.load(Ordering::Relaxed),
-                unknown: self.node.stats.inbound.unknown.load(Ordering::Relaxed),
+                blocks: NODE_STATS.inbound.blocks.load(Ordering::Relaxed),
+                getblocks: NODE_STATS.inbound.getblocks.load(Ordering::Relaxed),
+                getmemorypool: NODE_STATS.inbound.getmemorypool.load(Ordering::Relaxed),
+                getpeers: NODE_STATS.inbound.getpeers.load(Ordering::Relaxed),
+                getsync: NODE_STATS.inbound.getsync.load(Ordering::Relaxed),
+                memorypool: NODE_STATS.inbound.memorypool.load(Ordering::Relaxed),
+                peers: NODE_STATS.inbound.peers.load(Ordering::Relaxed),
+                pings: NODE_STATS.inbound.pings.load(Ordering::Relaxed),
+                pongs: NODE_STATS.inbound.pongs.load(Ordering::Relaxed),
+                syncs: NODE_STATS.inbound.syncs.load(Ordering::Relaxed),
+                syncblocks: NODE_STATS.inbound.syncblocks.load(Ordering::Relaxed),
+                transactions: NODE_STATS.inbound.transactions.load(Ordering::Relaxed),
+                unknown: NODE_STATS.inbound.unknown.load(Ordering::Relaxed),
             },
             outbound: NodeOutboundStats {
-                all_successes: self.node.stats.outbound.all_successes.load(Ordering::Relaxed),
-                all_failures: self.node.stats.outbound.all_failures.load(Ordering::Relaxed),
+                all_successes: NODE_STATS.outbound.all_successes.load(Ordering::Relaxed),
+                all_failures: NODE_STATS.outbound.all_failures.load(Ordering::Relaxed),
             },
             connections: NodeConnectionStats {
-                all_accepted: self.node.stats.connections.all_accepted.load(Ordering::Relaxed),
-                all_initiated: self.node.stats.connections.all_initiated.load(Ordering::Relaxed),
-                all_rejected: self.node.stats.connections.all_rejected.load(Ordering::Relaxed),
+                all_accepted: NODE_STATS.connections.all_accepted.load(Ordering::Relaxed),
+                all_initiated: NODE_STATS.connections.all_initiated.load(Ordering::Relaxed),
+                all_rejected: NODE_STATS.connections.all_rejected.load(Ordering::Relaxed),
                 connected_peers: self.node.peer_book.number_of_connected_peers(),
                 connecting_peers: self.node.peer_book.number_of_connecting_peers(),
                 disconnected_peers: self.node.peer_book.number_of_disconnected_peers(),
             },
             handshakes: NodeHandshakeStats {
-                successes_init: self.node.stats.handshakes.successes_init.load(Ordering::Relaxed),
-                successes_resp: self.node.stats.handshakes.successes_resp.load(Ordering::Relaxed),
-                failures_init: self.node.stats.handshakes.failures_init.load(Ordering::Relaxed),
-                failures_resp: self.node.stats.handshakes.failures_resp.load(Ordering::Relaxed),
-                timeouts_init: self.node.stats.handshakes.timeouts_init.load(Ordering::Relaxed),
-                timeouts_resp: self.node.stats.handshakes.timeouts_resp.load(Ordering::Relaxed),
+                successes_init: NODE_STATS.handshakes.successes_init.load(Ordering::Relaxed),
+                successes_resp: NODE_STATS.handshakes.successes_resp.load(Ordering::Relaxed),
+                failures_init: NODE_STATS.handshakes.failures_init.load(Ordering::Relaxed),
+                failures_resp: NODE_STATS.handshakes.failures_resp.load(Ordering::Relaxed),
+                timeouts_init: NODE_STATS.handshakes.timeouts_init.load(Ordering::Relaxed),
+                timeouts_resp: NODE_STATS.handshakes.timeouts_resp.load(Ordering::Relaxed),
             },
             queues: NodeQueueStats {
-                inbound: self.node.stats.queues.inbound.load(Ordering::SeqCst),
-                outbound: self.node.stats.queues.outbound.load(Ordering::SeqCst),
+                inbound: NODE_STATS.queues.inbound.load(Ordering::SeqCst),
+                outbound: NODE_STATS.queues.outbound.load(Ordering::SeqCst),
             },
             misc: NodeMiscStats {
-                block_height: self.node.sync().map(|sync| sync.current_block_height()).unwrap_or(0),
-                blocks_mined: self.node.stats.misc.blocks_mined.load(Ordering::Relaxed),
-                duplicate_blocks: self.node.stats.misc.duplicate_blocks.load(Ordering::Relaxed),
-                duplicate_sync_blocks: self.node.stats.misc.duplicate_sync_blocks.load(Ordering::Relaxed),
+                block_height: self
+                    .node
+                    .sync()
+                    .map(|sync| sync.current_block_height() as u64)
+                    .unwrap_or(0),
+                blocks_mined: NODE_STATS.misc.blocks_mined.load(Ordering::Relaxed),
+                duplicate_blocks: NODE_STATS.misc.duplicate_blocks.load(Ordering::Relaxed),
+                duplicate_sync_blocks: NODE_STATS.misc.duplicate_sync_blocks.load(Ordering::Relaxed),
             },
         })
     }

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -234,17 +234,17 @@ pub struct NodeHandshakeStats {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeQueueStats {
     /// The number of messages queued in the common inbound channel.
-    pub inbound: u32,
+    pub inbound: u64,
     /// The number of messages queued in the individual outbound channels.
-    pub outbound: u32,
+    pub outbound: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeMiscStats {
     /// The current block height of the node.
-    pub block_height: u32,
+    pub block_height: u64,
     /// The number of blocks the node has mined.
-    pub blocks_mined: u32,
+    pub blocks_mined: u64,
     /// The number of duplicate blocks received.
     pub duplicate_blocks: u64,
     /// The number of duplicate sync blocks received.

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -111,6 +111,9 @@ fn register_metrics() {
     register_counter!(snarkos_network::CONNECTIONS_ALL_ACCEPTED);
     register_counter!(snarkos_network::CONNECTIONS_ALL_INITIATED);
     register_counter!(snarkos_network::CONNECTIONS_ALL_REJECTED);
+    register_gauge!(snarkos_network::CONNECTIONS_CONNECTING);
+    register_gauge!(snarkos_network::CONNECTIONS_CONNECTED);
+    register_gauge!(snarkos_network::CONNECTIONS_DISCONNECTED);
 
     register_counter!(snarkos_network::HANDSHAKES_FAILURES_INIT);
     register_counter!(snarkos_network::HANDSHAKES_FAILURES_RESP);

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -38,6 +38,10 @@ use snarkvm_utilities::{to_bytes, ToBytes};
 
 use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
+#[cfg(feature = "prometheus")]
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+use metrics::{register_counter, register_gauge};
 use parking_lot::Mutex;
 use tokio::runtime::{Builder, Handle};
 use tracing_subscriber::EnvFilter;
@@ -69,6 +73,60 @@ fn print_welcome(config: &Config) {
     println!("{}", render_welcome(config));
 }
 
+#[cfg(feature = "prometheus")]
+fn initialize_metrics() {
+    let builder = PrometheusBuilder::new();
+    builder
+        .install()
+        .expect("failed to install Prometheus metrics recorder");
+}
+
+#[cfg(not(feature = "prometheus"))]
+fn initialize_metrics() {
+    use snarkos_network::NODE_STATS;
+
+    metrics::set_recorder(&NODE_STATS).expect("couldn't initialize the metrics recorder!");
+}
+
+fn register_metrics() {
+    register_counter!(snarkos_network::INBOUND_ALL_SUCCESSES);
+    register_counter!(snarkos_network::INBOUND_ALL_FAILURES);
+    register_counter!(snarkos_network::INBOUND_BLOCKS);
+    register_counter!(snarkos_network::INBOUND_GETBLOCKS);
+    register_counter!(snarkos_network::INBOUND_GETMEMORYPOOL);
+    register_counter!(snarkos_network::INBOUND_GETPEERS);
+    register_counter!(snarkos_network::INBOUND_GETSYNC);
+    register_counter!(snarkos_network::INBOUND_MEMORYPOOL);
+    register_counter!(snarkos_network::INBOUND_PEERS);
+    register_counter!(snarkos_network::INBOUND_PINGS);
+    register_counter!(snarkos_network::INBOUND_PONGS);
+    register_counter!(snarkos_network::INBOUND_SYNCS);
+    register_counter!(snarkos_network::INBOUND_SYNCBLOCKS);
+    register_counter!(snarkos_network::INBOUND_TRANSACTIONS);
+    register_counter!(snarkos_network::INBOUND_UNKNOWN);
+
+    register_counter!(snarkos_network::OUTBOUND_ALL_SUCCESSES);
+    register_counter!(snarkos_network::OUTBOUND_ALL_FAILURES);
+
+    register_counter!(snarkos_network::CONNECTIONS_ALL_ACCEPTED);
+    register_counter!(snarkos_network::CONNECTIONS_ALL_INITIATED);
+    register_counter!(snarkos_network::CONNECTIONS_ALL_REJECTED);
+
+    register_counter!(snarkos_network::HANDSHAKES_FAILURES_INIT);
+    register_counter!(snarkos_network::HANDSHAKES_FAILURES_RESP);
+    register_counter!(snarkos_network::HANDSHAKES_SUCCESSES_INIT);
+    register_counter!(snarkos_network::HANDSHAKES_SUCCESSES_RESP);
+    register_counter!(snarkos_network::HANDSHAKES_TIMEOUTS_INIT);
+    register_counter!(snarkos_network::HANDSHAKES_TIMEOUTS_RESP);
+
+    register_gauge!(snarkos_network::QUEUES_INBOUND);
+    register_gauge!(snarkos_network::QUEUES_OUTBOUND);
+
+    register_counter!(snarkos_network::MISC_BLOCKS_MINED);
+    register_counter!(snarkos_network::MISC_DUPLICATE_BLOCKS);
+    register_counter!(snarkos_network::MISC_DUPLICATE_SYNC_BLOCKS);
+}
+
 ///
 /// Builds a node from configuration parameters.
 ///
@@ -82,6 +140,9 @@ fn print_welcome(config: &Config) {
 ///
 async fn start_server(config: Config, tokio_handle: Handle) -> anyhow::Result<()> {
     initialize_logger(&config);
+
+    initialize_metrics();
+    register_metrics();
 
     print_welcome(&config);
 


### PR DESCRIPTION
This PR re-implements the current atomic metrics obtainable via RPC using the `metrics` crate, and introduces a new optional feature, `prometheus`, that disables them in favor of `metrics-exporter-prometheus`.

The following screenshot was taken from a simple Grafana dashboard and using a local node running with `--features=prometheus` and connected to a few dozen synthetic nodes doing some peering and ping-pong traffic:
![Grafana](https://user-images.githubusercontent.com/3750347/118126643-ea5a9b80-b3f8-11eb-84a7-3f8a007c1739.png)

These metrics can still be extended a bit, but they are already quite usable.