### PR TITLE
Allow the users to specify the IP of the RPC server

### DIFF
--- a/rpc/src/rpc_server.rs
+++ b/rpc/src/rpc_server.rs
@@ -35,14 +35,12 @@ use std::{net::SocketAddr, sync::Arc};
 /// This may be changed in the future to give the node more control of the rpc server.
 #[allow(clippy::too_many_arguments)]
 pub fn start_rpc_server<S: Storage + Send + Sync + 'static>(
-    rpc_port: u16,
+    rpc_addr: SocketAddr,
     secondary_storage: Arc<MerkleTreeLedger<S>>,
     node_server: Node<S>,
     username: Option<String>,
     password: Option<String>,
 ) -> task::JoinHandle<()> {
-    let rpc_server: SocketAddr = format!("0.0.0.0:{}", rpc_port).parse().unwrap();
-
     let credentials = match (username, password) {
         (Some(username), Some(password)) => Some(RpcCredentials { username, password }),
         _ => None,
@@ -65,7 +63,7 @@ pub fn start_rpc_server<S: Storage + Send + Sync + 'static>(
             Meta { auth }
         })
         .threads(1)
-        .start_http(&rpc_server)
+        .start_http(&rpc_addr)
         .expect("couldn't start the RPC server!");
 
     tokio::task::spawn(async move {

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -62,6 +62,7 @@ pub struct Aleo {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JsonRPC {
     pub json_rpc: bool,
+    pub ip: String,
     pub port: u16,
     pub username: Option<String>,
     pub password: Option<String>,
@@ -113,6 +114,7 @@ impl Default for Config {
             },
             rpc: JsonRPC {
                 json_rpc: true,
+                ip: "0.0.0.0".into(),
                 port: 3030,
                 // TODO (raychu86) Establish a random username and password for the node operator by default
                 username: Some("Username".into()),
@@ -209,6 +211,7 @@ impl Config {
             "network" => self.network(clap::value_t!(arguments.value_of(*option), u8).ok()),
             "path" => self.path(arguments.value_of(option)),
             "port" => self.port(clap::value_t!(arguments.value_of(*option), u16).ok()),
+            "rpc-ip" => self.rpc_ip(arguments.value_of(option)),
             "rpc-port" => self.rpc_port(clap::value_t!(arguments.value_of(*option), u16).ok()),
             "rpc-username" => self.rpc_username(arguments.value_of(option)),
             "rpc-password" => self.rpc_password(arguments.value_of(option)),
@@ -305,6 +308,12 @@ impl Config {
         }
     }
 
+    fn rpc_ip(&mut self, argument: Option<&str>) {
+        if let Some(ip) = argument {
+            self.rpc.ip = ip.to_string();
+        }
+    }
+
     fn rpc_port(&mut self, argument: Option<u16>) {
         if let Some(rpc_port) = argument {
             self.rpc.port = rpc_port;
@@ -369,6 +378,7 @@ impl CLI for ConfigCli {
         option::MIN_PEERS,
         option::MAX_PEERS,
         option::NETWORK,
+        option::RPC_IP,
         option::RPC_PORT,
         option::RPC_USERNAME,
         option::RPC_PASSWORD,
@@ -392,6 +402,7 @@ impl CLI for ConfigCli {
             "mempool-interval",
             "min-peers",
             "max-peers",
+            "rpc-ip",
             "rpc-port",
             "rpc-username",
             "rpc-password",

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -175,8 +175,12 @@ async fn start_server(config: Config, tokio_handle: Handle) -> anyhow::Result<()
             Arc::new(MerkleTreeLedger::open_secondary_at_path(path.clone())?)
         };
 
+        let rpc_address = format!("{}:{}", config.rpc.ip, config.rpc.port)
+            .parse()
+            .expect("Invalid RPC server address!");
+
         let rpc_handle = start_rpc_server(
-            config.rpc.port,
+            rpc_address,
             secondary_storage,
             node.clone(),
             config.rpc.username,

--- a/snarkos/parameters/option.rs
+++ b/snarkos/parameters/option.rs
@@ -79,6 +79,13 @@ pub const NETWORK: OptionType = (
     &[],
 );
 
+pub const RPC_IP: OptionType = (
+    "[rpc-ip] -i --rpc-ip=[rpc-ip] 'Specify the ip of the RPC server'",
+    &[],
+    &[],
+    &[],
+);
+
 pub const RPC_PORT: OptionType = (
     "[rpc-port] --rpc-port=[rpc-port] 'Specify the port the json rpc server is run on'",
     &["no_jsonrpc"],


### PR DESCRIPTION
Currently only the port of the RPC server can be specified by the user; this PR adds a new param, `--rpc-ip` which allows the IP to be selected instead of the default `0.0.0.0` as well.

It was successfully tested using a loopback and local network address.

Cc @damons 