### PR TITLE
Improve metrics + cleanups

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -124,7 +124,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                     trace!("Connected to {} (listener: {})", remote_address, remote_listener);
 
                                     // Immediately send a ping to provide the peer with our block height.
-                                    node.send_ping(remote_listener).await;
+                                    node.send_ping(remote_listener);
 
                                     if let Ok(ref peer) = node.peer_book.get_peer(remote_listener) {
                                         peer.register_task(peer_reading_task, true);
@@ -200,8 +200,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 // Handle Ping/Pong messages immediately in order not to skew latency calculation.
                 match &message.payload {
                     Payload::Ping(..) => {
-                        self.send_request(Message::new(Direction::Outbound(reader.addr), Payload::Pong))
-                            .await;
+                        self.send_request(Message::new(Direction::Outbound(reader.addr), Payload::Pong));
                     }
                     Payload::Pong => {
                         self.peer_book.received_pong(reader.addr);
@@ -243,21 +242,21 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 metrics::increment_counter!(stats::INBOUND_TRANSACTIONS);
 
                 if let Some(ref sync) = self.sync() {
-                    sync.received_memory_pool_transaction(source, transaction).await?;
+                    sync.received_memory_pool_transaction(source, transaction)?;
                 }
             }
             Payload::Block(block) => {
                 metrics::increment_counter!(stats::INBOUND_BLOCKS);
 
                 if let Some(ref sync) = self.sync() {
-                    sync.received_block(source, block, true).await?;
+                    sync.received_block(source, block, true)?;
                 }
             }
             Payload::SyncBlock(block) => {
                 metrics::increment_counter!(stats::INBOUND_SYNCBLOCKS);
 
                 if let Some(ref sync) = self.sync() {
-                    sync.received_block(source, block, false).await?;
+                    sync.received_block(source, block, false)?;
 
                     // Update the peer and possibly finish the sync process.
                     if self.peer_book.got_sync_block(source) {
@@ -269,14 +268,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 metrics::increment_counter!(stats::INBOUND_GETBLOCKS);
 
                 if let Some(ref sync) = self.sync() {
-                    sync.received_get_blocks(source, hashes).await?;
+                    sync.received_get_blocks(source, hashes)?;
                 }
             }
             Payload::GetMemoryPool => {
                 metrics::increment_counter!(stats::INBOUND_GETMEMORYPOOL);
 
                 if let Some(ref sync) = self.sync() {
-                    sync.received_get_memory_pool(source).await?;
+                    sync.received_get_memory_pool(source);
                 }
             }
             Payload::MemoryPool(mempool) => {
@@ -290,7 +289,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 metrics::increment_counter!(stats::INBOUND_GETSYNC);
 
                 if let Some(ref sync) = self.sync() {
-                    sync.received_get_sync(source, getsync).await?;
+                    sync.received_get_sync(source, getsync)?;
                 }
             }
             Payload::Sync(sync) => {
@@ -304,14 +303,14 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         warn!("{} doesn't have sync blocks to share", source);
                     } else if self.peer_book.expecting_sync_blocks(source, sync.len()) {
                         trace!("Received {} sync block hashes from {}", sync.len(), source);
-                        sync_handler.received_sync(source, sync).await;
+                        sync_handler.received_sync(source, sync);
                     }
                 }
             }
             Payload::GetPeers => {
                 metrics::increment_counter!(stats::INBOUND_GETPEERS);
 
-                self.send_peers(source).await;
+                self.send_peers(source);
             }
             Payload::Peers(peers) => {
                 metrics::increment_counter!(stats::INBOUND_PEERS);

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -226,11 +226,12 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         metrics::decrement_gauge!(stats::QUEUES_INBOUND, 1.0);
 
         let source = if let Direction::Inbound(addr) = direction {
-            self.peer_book.update_last_seen(addr);
             addr
         } else {
             unreachable!("All messages processed sent to the inbound receiver are Inbound");
         };
+
+        self.peer_book.register_message(source);
 
         // Check if the message hasn't already been processed recently if it's a `Block`.
         // The node should also reject them while syncing, as it is bound to receive them later.

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -127,8 +127,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                     node.send_ping(remote_listener).await;
 
                                     if let Ok(ref peer) = node.peer_book.get_peer(remote_listener) {
-                                        peer.register_task(peer_reading_task);
-                                        peer.register_task(peer_writing_task);
+                                        peer.register_task(peer_reading_task, true);
+                                        peer.register_task(peer_writing_task, false);
                                     } else {
                                         // If the related peer is not found, it means it's already been dropped.
                                         peer_reading_task.abort();

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -181,7 +181,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     // Determine if we should send a disconnect message.
                     match disconnect_from_peer {
                         true => {
-                            // TODO (howardwu): Implement a handler so the node does not lose state of undetected disconnects.
                             warn!("Disconnecting from {} (unreliable)", reader.addr);
                             let _ = self.disconnect_from_peer(reader.addr);
                             // The error has been handled and reported, we may now safely break.

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -137,12 +137,12 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                                 }
                                 Ok(Err(e)) => {
                                     error!("Failed to accept a connection request: {}", e);
-                                    let _ = node.disconnect_from_peer(remote_address);
+                                    node.disconnect_from_peer(remote_address);
                                     metrics::increment_counter!(stats::HANDSHAKES_FAILURES_RESP);
                                 }
                                 Err(_) => {
                                     error!("Failed to accept a connection request: the handshake timed out");
-                                    let _ = node.disconnect_from_peer(remote_address);
+                                    node.disconnect_from_peer(remote_address);
                                     metrics::increment_counter!(stats::HANDSHAKES_TIMEOUTS_RESP);
                                 }
                             }
@@ -182,7 +182,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     match disconnect_from_peer {
                         true => {
                             warn!("Disconnecting from {} (unreliable)", reader.addr);
-                            let _ = self.disconnect_from_peer(reader.addr);
+                            self.disconnect_from_peer(reader.addr);
                             // The error has been handled and reported, we may now safely break.
                             break;
                         }

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -195,9 +195,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
             loop {
                 info!("Updating peers");
 
-                if let Err(e) = node_clone.update_peers().await {
-                    error!("Peer update error: {}", e);
-                }
+                node_clone.update_peers();
+
                 sleep(peer_sync_interval).await;
             }
         });
@@ -249,7 +248,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
                             sync_node = sync_clone.node().peer_book.last_seen();
                         }
 
-                        sync_clone.update_memory_pool(sync_node).await;
+                        sync_clone.update_memory_pool(sync_node);
                     }
 
                     sleep(mempool_sync_interval).await;
@@ -305,7 +304,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
 
                             // Begin a new sync attempt.
                             sync_clone.register_block_sync_attempt();
-                            sync_clone.update_blocks(*sync_node).await;
+                            sync_clone.update_blocks(*sync_node);
                         }
                     }
 

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -320,7 +320,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         debug!("Shutting down");
 
         for addr in self.connected_peers() {
-            let _ = self.disconnect_from_peer(addr);
+            self.disconnect_from_peer(addr);
         }
 
         for handle in self.threads.lock().drain(..).rev() {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -79,7 +79,8 @@ impl<S: Storage> Drop for InnerNode<S> {
         // also, the connections are going to be broken automatically, so we only need to
         // take care of the associated tasks here
         for peer_info in self.peer_book.connected_peers().values() {
-            for handle in peer_info.tasks.lock().drain(..).rev() {
+            for (handle, _abortable) in peer_info.tasks.lock().drain(..).rev() {
+                // We're already shutting down, so always abort.
                 handle.abort();
             }
         }

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -56,7 +56,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// and attempts to send the given request to it.
     ///
     #[inline]
-    pub async fn send_request(&self, request: Message) {
+    pub fn send_request(&self, request: Message) {
         let target_addr = request.receiver();
         // Fetch the outbound channel.
         match self.outbound.outbound_channel(target_addr) {
@@ -86,7 +86,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         }
     }
 
-    pub async fn send_ping(&self, remote_address: SocketAddr) {
+    pub fn send_ping(&self, remote_address: SocketAddr) {
         // Consider peering tests that don't use the sync layer.
         let current_block_height = if let Some(ref sync) = self.sync() {
             sync.current_block_height()
@@ -99,8 +99,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         self.send_request(Message::new(
             Direction::Outbound(remote_address),
             Payload::Ping(current_block_height),
-        ))
-        .await;
+        ));
     }
 
     /// This method handles new outbound messages to a single connected node.

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -329,9 +329,10 @@ impl PeerBook {
     /// Updates the last seen timestamp of this peer to the current time.
     ///
     #[inline]
-    pub fn update_last_seen(&self, addr: SocketAddr) {
-        if let Some(ref quality) = self.peer_quality(addr) {
+    pub fn register_message(&self, addr: SocketAddr) {
+        if let Some(quality) = self.peer_quality(addr) {
             *quality.last_seen.write() = Some(chrono::Utc::now());
+            quality.num_messages_received.fetch_add(1, Ordering::Relaxed);
         } else {
             trace!("Tried updating state of a peer that's not connected: {}", addr);
         }

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -54,6 +54,8 @@ pub struct PeerQuality {
     pub failures: AtomicU32,
     /// The number of remaining blocks to sync with.
     pub remaining_sync_blocks: AtomicU32,
+    /// The number of messages received from the peer.
+    pub num_messages_received: AtomicU64,
 }
 
 impl PeerQuality {

--- a/network/src/peers/peer_info.rs
+++ b/network/src/peers/peer_info.rs
@@ -140,14 +140,6 @@ impl PeerInfo {
     }
 
     ///
-    /// Returns the timestamp of the first seen instance of this peer.
-    ///
-    #[inline]
-    pub fn first_seen(&self) -> Option<DateTime<Utc>> {
-        self.first_seen
-    }
-
-    ///
     /// Returns the timestamp of the last seen instance of this peer.
     ///
     #[inline]
@@ -188,6 +180,9 @@ impl PeerInfo {
             self.status = PeerStatus::Connected;
 
             let now = Utc::now();
+            if self.first_seen.is_none() {
+                self.first_seen = Some(now);
+            }
             self.last_connected = Some(now);
             *self.quality.last_seen.write() = Some(now);
             self.connected_count += 1;

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -404,18 +404,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         for remote_address in self.connected_peers() {
             self.send_request(Message::new(Direction::Outbound(remote_address), Payload::GetPeers))
                 .await;
-
-            // // Fetch the connection channel.
-            // if let Some(channel) = self.get_channel(&remote_address) {
-            //     // Broadcast the message over the channel.
-            //     if let Err(_) = channel.write(&GetPeers).await {
-            //         // Disconnect from the peer if the message fails to send.
-            //         self.disconnect_from_peer(&remote_address).await?;
-            //     }
-            // } else {
-            //     // Disconnect from the peer if the channel is not active.
-            //     self.disconnect_from_peer(&remote_address).await?;
-            // }
         }
     }
 
@@ -479,8 +467,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     }
 
     pub(crate) async fn send_peers(&self, remote_address: SocketAddr) {
-        // TODO (howardwu): Simplify this and parallelize this with Rayon.
-        // Broadcast the sanitized list of connected peers back to requesting peer.
+        // Broadcast the sanitized list of connected peers back to the requesting peer.
         let peers = self
             .peer_book
             .connected_peers()
@@ -498,9 +485,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// Add all new/updated addresses to our disconnected.
     /// The connection handler will be responsible for sending out handshake requests to them.
     pub(crate) fn process_inbound_peers(&self, peers: Vec<SocketAddr>) {
-        // TODO (howardwu): Simplify this and parallelize this with Rayon.
-        // Process all of the peers sent in the message,
-        // by informing the peer book of that we found peers.
         let local_address = self.local_address().unwrap(); // the address must be known by now
 
         for peer_address in peers.into_iter().filter(|&peer_addr| peer_addr != local_address) {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -467,17 +467,15 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// as disconnected from this node server.
     ///
     #[inline]
-    pub fn disconnect_from_peer(&self, remote_address: SocketAddr) -> Result<(), NetworkError> {
+    pub fn disconnect_from_peer(&self, remote_address: SocketAddr) {
         // Set the peer as disconnected in the peer book.
-        let result = self.peer_book.set_disconnected(remote_address);
+        let was_connected = self.peer_book.set_disconnected(remote_address);
 
         // If the peer was truly disconnected, remove its channel and advise.
-        if let Ok(true) = result {
+        if was_connected {
             self.outbound.channels.write().remove(&remote_address);
             trace!("Disconnected from {}", remote_address);
         }
-
-        result.map(|_| ())
     }
 
     pub(crate) async fn send_peers(&self, remote_address: SocketAddr) {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -235,8 +235,8 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             node.peer_book.set_connected(remote_address, None);
 
             if let Ok(ref peer) = node.peer_book.get_peer(remote_address) {
-                peer.register_task(conn_reading_task);
-                peer.register_task(conn_writing_task);
+                peer.register_task(conn_reading_task, true);
+                peer.register_task(conn_writing_task, false);
             } else {
                 // if the related peer is not found, it means it's already been dropped
                 conn_reading_task.abort();

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -73,7 +73,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                 || peer_quality.is_inactive(now)
             {
                 warn!("Peer {} has a low quality score; disconnecting.", addr);
-                let _ = self.disconnect_from_peer(addr);
+                self.disconnect_from_peer(addr);
             }
         }
 
@@ -112,7 +112,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
             for _ in 0..number_to_disconnect {
                 if let Some((addr, _)) = connected.pop() {
-                    let _ = self.disconnect_from_peer(addr);
+                    self.disconnect_from_peer(addr);
                 }
             }
         }
@@ -310,7 +310,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     }
                     Err(e) => {
                         warn!("Couldn't connect to bootnode {}: {}", bootnode_address, e);
-                        let _ = node.disconnect_from_peer(bootnode_address);
+                        node.disconnect_from_peer(bootnode_address);
                     }
                     Ok(_) => {}
                 }
@@ -376,7 +376,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                     }
                     Err(e) => {
                         warn!("Couldn't connect to peer {}: {}", remote_address, e);
-                        let _ = node.disconnect_from_peer(remote_address);
+                        node.disconnect_from_peer(remote_address);
                     }
                     Ok(_) => {}
                 }

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -57,6 +57,7 @@ pub const HANDSHAKES_TIMEOUTS_RESP: &str = "snarkos_handshakes_timeouts_resp_tot
 pub const QUEUES_INBOUND: &str = "snarkos_queues_inbound_total";
 pub const QUEUES_OUTBOUND: &str = "snarkos_queues_outbound_total";
 
+pub const MISC_BLOCK_HEIGHT: &str = "snarkos_misc_block_height_total";
 pub const MISC_BLOCKS_MINED: &str = "snarkos_misc_blocks_mined_total";
 pub const MISC_DUPLICATE_BLOCKS: &str = "snarkos_misc_duplicate_blocks_total";
 pub const MISC_DUPLICATE_SYNC_BLOCKS: &str = "snarkos_misc_duplicate_sync_blocks_total";

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -257,7 +257,7 @@ impl<S: Storage + Send + Sync + 'static> RpcImpl<S> {
         let address: SocketAddr = serde_json::from_value(value[0].clone())
             .map_err(|e| JsonRPCError::invalid_params(format!("Invalid params: {}.", e)))?;
 
-        let _ = self.node.disconnect_from_peer(address);
+        self.node.disconnect_from_peer(address);
 
         Ok(Value::Null)
     }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -125,6 +125,7 @@ fn register_metrics() {
     register_gauge!(snarkos_network::QUEUES_INBOUND);
     register_gauge!(snarkos_network::QUEUES_OUTBOUND);
 
+    register_counter!(snarkos_network::MISC_BLOCK_HEIGHT);
     register_counter!(snarkos_network::MISC_BLOCKS_MINED);
     register_counter!(snarkos_network::MISC_DUPLICATE_BLOCKS);
     register_counter!(snarkos_network::MISC_DUPLICATE_SYNC_BLOCKS);
@@ -222,6 +223,9 @@ async fn start_server(config: Config, tokio_handle: Handle) -> anyhow::Result<()
             Duration::from_secs(config.p2p.block_sync_interval.into()),
             Duration::from_secs(config.p2p.mempool_sync_interval.into()),
         );
+
+        // The node can already be at some non-zero height.
+        metrics::counter!(snarkos_network::MISC_BLOCK_HEIGHT, sync.current_block_height() as u64);
 
         node.set_sync(sync);
     }

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -192,9 +192,8 @@ pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
     node.start_services().await;
 
     if is_miner {
-        let tokio_handle = setup.tokio_handle.unwrap();
         let miner_address = FIXTURE.test_accounts[0].address.clone();
-        MinerInstance::new(miner_address, node.clone()).spawn(tokio_handle);
+        MinerInstance::new(miner_address, node.clone()).spawn();
     }
 
     node


### PR DESCRIPTION
This PR:
- extends the Prometheus metrics with the block height
- fixes outbound metric calculation in case of abrupt disconnects
- counts inbound messages per peer
- performs a range of cleanups