### PR TITLE
Include the node's listening address in the getnodeinfo RPC

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -26,7 +26,7 @@ use std::{
 /// A core data structure containing the pre-configured parameters for the node.
 pub struct Config {
     /// The pre-configured desired address of this node.
-    pub desired_address: Option<SocketAddr>,
+    pub desired_address: SocketAddr,
     /// The minimum number of peers required to maintain connections with.
     minimum_number_of_connected_peers: u16,
     /// The maximum number of peers permitted to maintain connections with.
@@ -44,7 +44,7 @@ impl Config {
     /// Creates a new instance of `Environment`.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        desired_address: Option<SocketAddr>,
+        desired_address: SocketAddr,
         minimum_number_of_connected_peers: u16,
         maximum_number_of_connected_peers: u16,
         bootnodes_addresses: Vec<String>,

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -64,14 +64,9 @@ impl Inbound {
 impl<S: Storage + Send + Sync + 'static> Node<S> {
     /// This method handles new inbound connection requests.
     pub async fn listen(&self) -> Result<(), NetworkError> {
-        let (listener_address, listener) = if let Some(addr) = self.config.desired_address {
-            let listener = TcpListener::bind(&addr).await?;
-            (listener.local_addr()?, listener)
-        } else {
-            let listener = TcpListener::bind("0.0.0.0:0").await?;
-            let listener_address = listener.local_addr()?;
-            (listener_address, listener)
-        };
+        let listener = TcpListener::bind(&self.config.desired_address).await?;
+        let listener_address = listener.local_addr()?;
+
         self.set_local_address(listener_address);
         info!("Initializing listener for node ({:x})", self.id);
 

--- a/rpc/documentation/public_endpoints/getnodeinfo.md
+++ b/rpc/documentation/public_endpoints/getnodeinfo.md
@@ -6,13 +6,14 @@ None
 
 ### Response
 
-|   Parameter   |     Type      |                  Description                  |
-|:-------------:|:-------------:|:---------------------------------------------:|
-| `is_bootnode` | bool          | Flag indicating if the node is a bootnode     |
-| `is_miner`    | bool          | Flag indicating if the node is a miner        |
-| `is_syncing`  | bool          | Flag indicating if the node currently syncing |
-| `launched`    | DateTime<Utc> | The timestamp of when the node was launched   |
-| `version`     | String        | The version of the client binary              |
+|     Parameter    |     Type      |                  Description                  |
+|:----------------:|:-------------:|:---------------------------------------------:|
+| `is_bootnode`    | bool          | Flag indicating if the node is a bootnode     |
+| `is_miner`       | bool          | Flag indicating if the node is a miner        |
+| `is_syncing`     | bool          | Flag indicating if the node currently syncing |
+| `launched`       | DateTime<Utc> | The timestamp of when the node was launched   |
+| `listening_addr` | SocketAddr    | The configured listening address of the node  |
+| `version`        | String        | The version of the client binary              |
 
 ### Example
 ```ignore

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -311,6 +311,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     /// Returns data about the node.
     fn get_node_info(&self) -> Result<NodeInfo, RpcError> {
         Ok(NodeInfo {
+            listening_addr: self.node.config.desired_address,
             is_bootnode: self.node.config.is_bootnode(),
             is_miner: self.sync_handler()?.is_miner(),
             is_syncing: self.sync_handler()?.is_syncing_blocks(),

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -123,6 +123,9 @@ pub struct DecryptRecordInput {
 /// Returned value for the `getnodeinfo` rpc call
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeInfo {
+    /// The configured listening address of the node.
+    pub listening_addr: SocketAddr,
+
     /// Flag indicating if the node is a bootnode
     pub is_bootnode: bool,
 

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -150,14 +150,14 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     print_welcome(&config);
 
-    let address = format! {"{}:{}", config.node.ip, config.node.port};
+    let address = format!("{}:{}", config.node.ip, config.node.port);
     let desired_address = address.parse::<SocketAddr>()?;
 
     let mut path = config.node.dir;
     path.push(&config.node.db);
 
     let node_config = NodeConfig::new(
-        Some(desired_address),
+        desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,
         config.p2p.bootnodes.clone(),

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -100,7 +100,7 @@ impl Default for ConsensusSetup {
 #[derive(Clone)]
 pub struct TestSetup {
     pub node_id: u64,
-    pub socket_address: Option<SocketAddr>,
+    pub socket_address: SocketAddr,
     pub consensus_setup: Option<ConsensusSetup>,
     pub peer_sync_interval: u64,
     pub min_peers: u16,
@@ -113,7 +113,7 @@ pub struct TestSetup {
 impl TestSetup {
     pub fn new(
         node_id: u64,
-        socket_address: Option<SocketAddr>,
+        socket_address: SocketAddr,
         consensus_setup: Option<ConsensusSetup>,
         peer_sync_interval: u64,
         min_peers: u16,
@@ -140,7 +140,7 @@ impl Default for TestSetup {
     fn default() -> Self {
         Self {
             node_id: u64::MAX,
-            socket_address: "127.0.0.1:0".parse().ok(),
+            socket_address: "127.0.0.1:0".parse().unwrap(),
             consensus_setup: Some(Default::default()),
             peer_sync_interval: 600,
             min_peers: 1,


### PR DESCRIPTION
In addition, make the `desired_address` field in node's `Config` non-optional, as it's always present in the current setup.