### PR TITLE
Temporary custom rpc server impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -192,12 +192,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -316,7 +310,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -380,7 +374,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -395,7 +389,7 @@ dependencies = [
  "regex",
  "terminal_size",
  "unicode-width",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -472,7 +466,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio 1.5.0",
+ "tokio",
  "walkdir",
 ]
 
@@ -656,8 +650,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.0",
- "winapi 0.3.9",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
@@ -672,7 +666,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -756,7 +750,7 @@ checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -838,22 +832,6 @@ name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -950,7 +928,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1025,45 +1003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "globset"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
-dependencies = [
- "aho-corasick",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
-
-[[package]]
-name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1071,8 +1016,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.5.0",
- "tokio-util 0.6.6",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1105,7 +1050,7 @@ checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64",
  "bitflags",
- "bytes 1.0.1",
+ "bytes",
  "headers-core",
  "http",
  "mime",
@@ -1143,19 +1088,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-dependencies = [
- "bytes 0.5.6",
- "http",
 ]
 
 [[package]]
@@ -1164,9 +1099,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1177,39 +1112,9 @@ checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "httpdate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
-
-[[package]]
-name = "hyper"
-version = "0.13.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.2.7",
- "http",
- "http-body 0.3.1",
- "httparse",
- "httpdate 0.3.2",
- "itoa",
- "pin-project",
- "socket2 0.3.19",
- "tokio 0.2.25",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -1217,19 +1122,19 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.3",
+ "h2",
  "http",
- "http-body 0.4.2",
+ "http-body",
  "httparse",
- "httpdate 1.0.0",
+ "httpdate",
  "itoa",
  "pin-project",
- "socket2 0.4.0",
- "tokio 1.5.0",
+ "socket2",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1241,10 +1146,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.1",
- "hyper 0.14.7",
+ "bytes",
+ "hyper",
  "native-tls",
- "tokio 1.5.0",
+ "tokio",
  "tokio-native-tls",
 ]
 
@@ -1298,7 +1203,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
 ]
 
 [[package]]
@@ -1308,15 +1213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1365,6 +1261,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-rpc2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b49f717fad135c34796717cd5d932dc193aab2034c5c7a18caf29602f127a5"
+dependencies = [
+ "rand 0.8.3",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1419,22 +1327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-http-server"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2303c4f0562afcbd2dae75e3e21815095f8994749a80fbcd365877e44ed64"
-dependencies = [
- "futures 0.3.15",
- "hyper 0.13.10",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "net2",
- "parking_lot",
- "unicase",
-]
-
-[[package]]
 name = "jsonrpc-pubsub"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,23 +1342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-server-utils"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4207cce738bf713a82525065b750a008f28351324f438f56b33d698ada95bb4"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.15",
- "globset",
- "jsonrpc-core",
- "lazy_static",
- "log",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
- "unicase",
-]
-
-[[package]]
 name = "jsonrpc-test"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,16 +1353,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -1515,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1642,13 +1507,13 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "954533c2d91c118cf2405264a4ac3a5592e84efac12b1f18561400ffef0597eb"
 dependencies = [
- "hyper 0.14.7",
+ "hyper",
  "metrics",
  "metrics-util",
  "parking_lot",
  "quanta",
  "thiserror",
- "tokio 1.5.0",
+ "tokio",
 ]
 
 [[package]]
@@ -1715,46 +1580,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1763,7 +1597,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1803,17 +1637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,7 +1658,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1955,7 +1778,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2010,12 +1833,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -2182,7 +1999,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2385,7 +2202,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2395,13 +2212,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
 dependencies = [
  "base64",
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body 0.4.2",
- "hyper 0.14.7",
+ "http-body",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2410,11 +2227,11 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.5.0",
+ "tokio",
  "tokio-native-tls",
  "url 2.2.2",
  "wasm-bindgen",
@@ -2497,7 +2314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2543,7 +2360,7 @@ checksum = "6fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c"
 dependencies = [
  "either",
  "flate2",
- "hyper 0.14.7",
+ "hyper",
  "indicatif",
  "log",
  "quick-xml",
@@ -2750,7 +2567,7 @@ dependencies = [
  "snarkvm-posw",
  "snarkvm-utilities",
  "thiserror",
- "tokio 1.5.0",
+ "tokio",
  "toml",
  "tracing",
  "tracing-futures",
@@ -2773,7 +2590,7 @@ dependencies = [
  "snarkos-profiler",
  "snarkos-testing",
  "snarkvm-utilities",
- "tokio 1.5.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2809,7 +2626,7 @@ dependencies = [
  "prometheus",
  "serial_test",
  "snarkvm-derives",
- "tokio 1.5.0",
+ "tokio",
  "warp",
 ]
 
@@ -2844,7 +2661,7 @@ dependencies = [
  "snarkvm-utilities",
  "snow",
  "thiserror",
- "tokio 1.5.0",
+ "tokio",
  "tracing",
  "tracing-futures",
 ]
@@ -2886,11 +2703,12 @@ dependencies = [
  "chrono",
  "derivative",
  "hex",
+ "hyper",
  "itertools 0.10.0",
+ "json-rpc2",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "jsonrpc-http-server",
  "jsonrpc-test",
  "parking_lot",
  "rand 0.8.3",
@@ -2907,7 +2725,7 @@ dependencies = [
  "snarkvm-objects",
  "snarkvm-utilities",
  "thiserror",
- "tokio 1.5.0",
+ "tokio",
  "tracing",
 ]
 
@@ -2956,7 +2774,7 @@ dependencies = [
  "snarkvm-posw",
  "snarkvm-utilities",
  "snow",
- "tokio 1.5.0",
+ "tokio",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -3237,23 +3055,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3325,7 +3132,7 @@ dependencies = [
  "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3335,7 +3142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3383,7 +3190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3413,36 +3220,18 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.23",
- "num_cpus",
- "pin-project-lite 0.1.12",
- "slab",
-]
-
-[[package]]
-name = "tokio"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
- "mio 0.7.11",
+ "mio",
  "num_cpus",
  "parking_lot",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "tokio-macros",
 ]
 
@@ -3464,7 +3253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.5.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3474,8 +3263,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.6",
- "tokio 1.5.0",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3487,22 +3276,8 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project",
- "tokio 1.5.0",
+ "tokio",
  "tungstenite",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.12",
- "tokio 0.2.25",
 ]
 
 [[package]]
@@ -3511,12 +3286,12 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.6",
- "tokio 1.5.0",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3542,7 +3317,7 @@ checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.6",
+ "pin-project-lite",
  "tracing-core",
 ]
 
@@ -3622,7 +3397,7 @@ checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
 dependencies = [
  "base64",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "http",
  "httparse",
  "input_buffer",
@@ -3757,7 +3532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -3777,11 +3552,11 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures 0.3.15",
  "headers",
  "http",
- "hyper 0.14.7",
+ "hyper",
  "log",
  "mime",
  "mime_guess",
@@ -3792,10 +3567,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.5.0",
+ "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.6",
+ "tokio-util",
  "tower-service",
  "tracing",
 ]
@@ -3916,12 +3691,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3929,12 +3698,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3948,7 +3711,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3963,17 +3726,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -62,8 +62,15 @@ version = "2"
 [dependencies.hex]
 version = "0.4.2"
 
+[dependencies.hyper]
+version = "0.14"
+features = [ "runtime", "server" ]
+
 [dependencies.itertools]
 version = "0.10.0"
+
+[dependencies.json-rpc2]
+version = "0.10"
 
 [dependencies.jsonrpc-core]
 version = "17"
@@ -72,9 +79,6 @@ version = "17"
 version = "17"
 
 [dependencies.jsonrpc-derive]
-version = "17"
-
-[dependencies.jsonrpc-http-server]
 version = "17"
 
 [dependencies.parking_lot]

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -1,0 +1,335 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Logic for instantiating the RPC server.
+
+use crate::{
+    rpc_trait::RpcFunctions,
+    rpc_types::{Meta, RpcCredentials},
+    RpcImpl,
+};
+use snarkos_consensus::MerkleTreeLedger;
+use snarkos_network::Node;
+use snarkvm_objects::Storage;
+
+use hyper::{
+    body::HttpBody,
+    service::{make_service_fn, service_fn},
+    Body,
+    Server,
+};
+use jsonrpc_core::Params;
+use tokio::task;
+
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+
+const INTERNAL_ERROR: isize = -32603;
+const METHOD_NOT_FOUND: isize = -32601;
+const PARSE_ERROR: isize = -32700;
+const SERVER_ERROR: isize = -32000;
+
+const METHODS_EXPECTING_PARAMS: [&str; 14] = [
+    // public
+    "getblock",
+    "getblockhash",
+    "getrawtransaction",
+    "gettransactioninfo",
+    "decoderawtransaction",
+    "sendtransaction",
+    "validaterawtransaction",
+    // private
+    "createrawtransaction",
+    "createtransactionkernel",
+    "createtransaction",
+    "getrawrecord",
+    "decoderecord",
+    "decryptrecord",
+    "disconnect",
+];
+
+#[allow(clippy::too_many_arguments)]
+pub fn start_rpc_server<S: Storage + Send + Sync + 'static>(
+    rpc_addr: SocketAddr,
+    secondary_storage: Arc<MerkleTreeLedger<S>>,
+    node_server: Node<S>,
+    username: Option<String>,
+    password: Option<String>,
+) -> task::JoinHandle<()> {
+    let credentials = match (username, password) {
+        (Some(username), Some(password)) => Some(RpcCredentials { username, password }),
+        _ => None,
+    };
+
+    let rpc_impl = RpcImpl::new(secondary_storage, credentials, node_server);
+
+    let service = make_service_fn(move |_conn| {
+        let rpc = rpc_impl.clone();
+        async move { Ok::<_, Infallible>(service_fn(move |req| handle_rpc(rpc.clone(), req))) }
+    });
+
+    let server = Server::bind(&rpc_addr).serve(service);
+
+    task::spawn(async move {
+        server.await.expect("The RPC server couldn't be started!");
+    })
+}
+
+async fn handle_rpc<S: Storage + Send + Sync + 'static>(
+    rpc: RpcImpl<S>,
+    req: hyper::Request<Body>,
+) -> Result<hyper::Response<Body>, Infallible> {
+    // Obtain the username and password, if present.
+    let auth = req
+        .headers()
+        .get(hyper::header::AUTHORIZATION)
+        .map(|h| h.to_str().unwrap_or("").to_owned());
+    let meta = Meta { auth };
+
+    // Ready the body of the request
+    let mut body = req.into_body();
+    let data = match body.data().await {
+        Some(Ok(data)) => data,
+        _ => {
+            let err = json_rpc2::Error::InvalidRequest {
+                data: "Invalid request!".into(),
+            };
+            let resp: json_rpc2::Response = err.into();
+
+            return Ok(hyper::Response::new(
+                serde_json::to_vec(&resp).unwrap_or_default().into(),
+            ));
+        }
+    };
+
+    // Deserialize the JSON-RPC request.
+    let mut req = match json_rpc2::from_slice(&data) {
+        Ok(req) => req,
+        Err(_) => {
+            let err = json_rpc2::Error::InvalidRequest {
+                data: "Invalid request!".into(),
+            };
+            let resp: json_rpc2::Response = err.into();
+
+            return Ok(hyper::Response::new(
+                serde_json::to_vec(&resp).unwrap_or_default().into(),
+            ));
+        }
+    };
+
+    // Read the request params.
+    let mut params = match read_params(&mut req) {
+        Ok(params) => params,
+        Err(e) => {
+            let resp: json_rpc2::Response = (&mut req, e).into();
+            let body = serde_json::to_vec(&resp).unwrap_or_default();
+
+            return Ok(hyper::Response::new(body.into()));
+        }
+    };
+
+    // Handle the request method.
+    let value = match req.method() {
+        // public
+        "getblock" => {
+            let resp = rpc
+                .get_block(params[0].as_str().unwrap_or("").into())
+                .map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getblockcount" => {
+            let resp = rpc.get_block_count().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getbestblockhash" => {
+            let resp = rpc.get_best_block_hash().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getblockhash" => match serde_json::from_value::<u32>(params.remove(0)) {
+            Ok(height) => {
+                let resp = rpc.get_block_hash(height).map_err(convert_crate_err);
+                serde_json::to_value(resp).unwrap_or_default()
+            }
+            Err(_) => {
+                let err = json_rpc2::RpcError {
+                    code: PARSE_ERROR, // as per JSON-RPC 2.0 spec
+                    message: "The request can't be parsed: invalid block height!".into(),
+                    data: None,
+                };
+                serde_json::to_value(&err).unwrap_or_default()
+            }
+        },
+        "getrawtransaction" => {
+            let resp = rpc
+                .get_raw_transaction(params[0].as_str().unwrap_or("").into())
+                .map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "gettransactioninfo" => {
+            let resp = rpc
+                .get_transaction_info(params[0].as_str().unwrap_or("").into())
+                .map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "decoderawtransaction" => {
+            let resp = rpc
+                .decode_raw_transaction(params[0].as_str().unwrap_or("").into())
+                .map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "sendtransaction" => {
+            let resp = rpc
+                .send_raw_transaction(params[0].as_str().unwrap_or("").into())
+                .map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "validaterawtransaction" => {
+            let resp = rpc
+                .validate_raw_transaction(params[0].as_str().unwrap_or("").into())
+                .map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getconnectioncount" => {
+            let resp = rpc.get_connection_count().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getpeerinfo" => {
+            let resp = rpc.get_peer_info().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getnodeinfo" => {
+            let resp = rpc.get_node_info().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getnodestats" => {
+            let resp = rpc.get_node_stats().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getblocktemplate" => {
+            let resp = rpc.get_block_template().map_err(convert_crate_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        // private
+        "createaccount" => {
+            let resp = rpc
+                .create_account_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "createrawtransaction" => {
+            let resp = rpc
+                .create_raw_transaction_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "createtransactionkernel" => {
+            let resp = rpc
+                .create_transaction_kernel_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "createtransaction" => {
+            let resp = rpc
+                .create_transaction_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getrecordcommitments" => {
+            let resp = rpc
+                .get_record_commitments_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "getrawrecord" => {
+            let resp = rpc
+                .get_raw_record_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "decoderecord" => {
+            let resp = rpc
+                .decode_record_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "decryptrecord" => {
+            let resp = rpc
+                .decrypt_record_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        "disconnect" => {
+            let resp = rpc.disconnect_protected(Params::Array(params), meta).await;
+            serde_json::to_value(resp).unwrap_or_default()
+        }
+        unknown => {
+            let err = json_rpc2::RpcError {
+                code: METHOD_NOT_FOUND, // as per JSON-RPC 2.0 spec
+                message: format!("Unknown method!: \"{}\"", unknown),
+                data: None,
+            };
+            serde_json::to_value(&err).unwrap_or_default()
+        }
+    };
+
+    // Create and serialize the response object.
+    let resp = json_rpc2::Response::from((&mut req, value));
+    let body = serde_json::to_vec(&resp).unwrap_or_default();
+
+    // Send the HTTP response.
+    Ok(hyper::Response::new(body.into()))
+}
+
+/// Ensures that the params are a non-empty (this assumption is taken advantage of later) array and returns them.
+fn read_params(req: &mut json_rpc2::Request) -> json_rpc2::Result<Vec<serde_json::Value>> {
+    if METHODS_EXPECTING_PARAMS.contains(&req.method()) {
+        match req.deserialize() {
+            Ok(Params::Array(arr)) if !arr.is_empty() => Ok(arr),
+            Ok(_) => Err(json_rpc2::Error::InvalidParams {
+                id: req.id().clone(),
+                data: "Only a non-empty array is accepted as parameters!".into(),
+            }),
+            Err(e) => Err(e),
+        }
+    } else {
+        Ok(vec![]) // unused in methods other than METHODS_EXPECTING_PARAMS
+    }
+}
+
+/// Converts the crate's RpcError into a json_rpc2::RpcError
+fn convert_crate_err(err: crate::error::RpcError) -> json_rpc2::RpcError {
+    json_rpc2::RpcError {
+        code: SERVER_ERROR, // as per JSON-RPC 2.0 spec
+        message: err.to_string(),
+        data: None,
+    }
+}
+
+/// Converts the jsonrpc-core's Error into a json_rpc2::RpcError
+fn convert_core_err(err: jsonrpc_core::Error) -> json_rpc2::RpcError {
+    json_rpc2::RpcError {
+        code: INTERNAL_ERROR, // as per JSON-RPC 2.0 spec
+        message: err.to_string(),
+        data: None,
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -27,6 +27,10 @@ extern crate derivative;
 #[macro_use]
 extern crate thiserror;
 
+pub mod custom_rpc_server;
+#[doc(inline)]
+pub use custom_rpc_server::*;
+
 pub mod error;
 
 pub mod rpc_impl;
@@ -36,11 +40,11 @@ pub use rpc_impl::*;
 pub mod rpc_impl_protected;
 #[doc(inline)]
 pub use rpc_impl_protected::*;
-
+/*
 pub mod rpc_server;
 #[doc(inline)]
 pub use rpc_server::*;
-
+*/
 pub mod rpc_trait;
 #[doc(inline)]
 pub use rpc_trait::*;

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -50,7 +50,7 @@ use snarkvm_utilities::{
 };
 
 use itertools::Itertools;
-use jsonrpc_http_server::jsonrpc_core::{IoDelegate, MetaIoHandler, Params, Value};
+use jsonrpc_core::{IoDelegate, MetaIoHandler, Params, Value};
 use rand::{thread_rng, Rng};
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
@@ -257,7 +257,7 @@ impl<S: Storage + Send + Sync + 'static> RpcImpl<S> {
         let address: SocketAddr = serde_json::from_value(value[0].clone())
             .map_err(|e| JsonRPCError::invalid_params(format!("Invalid params: {}.", e)))?;
 
-        self.node.disconnect_from_peer(address);
+        self.disconnect(address);
 
         Ok(Value::Null)
     }
@@ -648,5 +648,9 @@ impl<S: Storage + Send + Sync + 'static> ProtectedRpcFunctions for RpcImpl<S> {
             commitment,
             commitment_randomness,
         })
+    }
+
+    fn disconnect(&self, address: SocketAddr) {
+        self.node.disconnect_from_peer(address);
     }
 }

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -20,6 +20,8 @@ use crate::{error::RpcError, rpc_types::*};
 
 use jsonrpc_derive::rpc;
 
+use std::net::SocketAddr;
+
 /// Definition of public RPC endpoints.
 #[rpc]
 pub trait RpcFunctions {
@@ -120,4 +122,7 @@ pub trait ProtectedRpcFunctions {
 
     #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/decryptrecord.md"))]
     fn decrypt_record(&self, decryption_input: DecryptRecordInput) -> Result<String, RpcError>;
+
+    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/disconnect.md"))]
+    fn disconnect(&self, address: SocketAddr);
 }

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -17,7 +17,7 @@
 //! Structures for RPC endpoint requests and responses.
 
 use chrono::{DateTime, Utc};
-use jsonrpc_http_server::jsonrpc_core::Metadata;
+use jsonrpc_core::Metadata;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 


### PR DESCRIPTION
We are currently using a deprecated crate for our JSON-RPC server implementation, which is very sub-optimal, as it carries plenty of old dependencies (mostly due to it depending on `tokio 0.2`), makes us unable to `await` in the RPC methods, and makes reasoning about resources very tricky.

This PR introduces an alternative JSON-RPC server implementation which is compatible with all the existing calls; it's built on `hyper` (like the current version) and is fully compatible with the rest of our setup.

Once the successor to the `jsonrpc-*` crates (`jsonrpsee`) is ready, we'll be able to use it instead. But for now, a custom implementation is a far better option than a mismatch in async executors.

note: as a small drive-by, the `disconnect` RPC is slightly refactored so that its implementation is aligned with all the other protected calls.

Cc https://github.com/AleoHQ/snarkOS/issues/754