### PR TITLE
Fix individual compilation of the network crate

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -104,6 +104,7 @@ version = "1.0"
 
 [dependencies.tokio]
 version = "1"
+features = [ "io-util", "parking_lot", "macros", "net", "rt-multi-thread", "sync", "time" ]
 
 [dependencies.tracing]
 default-features = false


### PR DESCRIPTION
This appears to fix the individual compilation of all crates that depend on `snarkos-network` as well.