### PR TITLE
Don't omit the first 2 operations in decommit_latest_block

### DIFF
--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -157,4 +157,41 @@ mod consensus_sidechain {
 
         assert_eq!(old_block_height, new_block_height);
     }
+
+    #[test]
+    fn decommit() {
+        let consensus = snarkos_testing::sync::create_test_consensus();
+
+        // Introduce one block.
+        let block_1 = Block::<Tx>::read(&BLOCK_1[..]).unwrap();
+        consensus.receive_block(&block_1).unwrap();
+
+        // Verify that the best block number is the same as the block height.
+        let mut block_height = consensus.ledger.get_current_block_height();
+        let mut best_block_number = consensus.ledger.get_best_block_number().unwrap();
+        assert_eq!(best_block_number, block_height);
+
+        // Introduce another block.
+        let block_2 = Block::<Tx>::read(&BLOCK_2[..]).unwrap();
+        consensus.receive_block(&block_2).unwrap();
+
+        // Verify that the best block number is the same as the block height.
+        block_height = consensus.ledger.get_current_block_height();
+        best_block_number = consensus.ledger.get_best_block_number().unwrap();
+        assert_eq!(best_block_number, block_height);
+
+        // Check if the locator hashes can be found.
+        assert!(consensus.ledger.get_block_locator_hashes().is_ok());
+
+        // Decommit a block.
+        consensus.ledger.decommit_latest_block().unwrap();
+
+        // Verify that the best block number is the same as the block height.
+        block_height = consensus.ledger.get_current_block_height();
+        best_block_number = consensus.ledger.get_best_block_number().unwrap();
+        assert_eq!(best_block_number, block_height);
+
+        // Check if the locator hashes can still be found.
+        assert!(consensus.ledger.get_block_locator_hashes().is_ok());
+    }
 }

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -89,6 +89,16 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         self.get_current_block_height() + 1
     }
 
+    /// Get the height of the best block on the chain.
+    pub fn get_best_block_number(&self) -> Result<BlockHeight, StorageError> {
+        let best_block_number_bytes = self
+            .storage
+            .get(COL_META, KEY_BEST_BLOCK_NUMBER.as_bytes())?
+            .ok_or_else(|| StorageError::Message("Can't obtain the best block's number".into()))?;
+
+        Ok(bytes_to_u32(&best_block_number_bytes))
+    }
+
     /// Get the stored old connected peers.
     pub fn get_peer_book(&self) -> Result<Option<Vec<u8>>, StorageError> {
         self.storage.get(COL_META, &KEY_PEER_BOOK.as_bytes().to_vec())
@@ -177,11 +187,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     pub fn catch_up_secondary(&self, update_merkle_tree: bool) -> Result<(), StorageError> {
         // Sync the secondary and primary instances
         if self.storage.try_catch_up_with_primary().is_ok() {
-            let current_block_height_bytes = self
-                .storage
-                .get(COL_META, &KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec())?
-                .ok_or_else(|| StorageError::Message("can't determine current block height".into()))?;
-            let new_current_block_height = bytes_to_u32(&current_block_height_bytes);
+            let new_current_block_height = self.get_best_block_number()?;
             let current_block_height = self.get_current_block_height();
 
             // If the new block height is greater than the stored block height,

--- a/storage/src/objects/block.rs
+++ b/storage/src/objects/block.rs
@@ -182,8 +182,6 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         let mut cm_index = self.current_cm_index()?;
         let mut memo_index = self.current_memo_index()?;
 
-        let mut database_transaction = DatabaseTransaction::new();
-
         for transaction in self.get_block_transactions(&block_hash)?.0 {
             for sn in transaction.old_serial_numbers() {
                 database_transaction.push(Op::Delete {

--- a/storage/src/objects/block.rs
+++ b/storage/src/objects/block.rs
@@ -162,7 +162,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
             return Err(StorageError::InvalidBlockDecommit);
         }
 
-        let update_best_block_num = current_block_height - 1;
+        let new_best_block_number = current_block_height - 1;
         let block_hash: BlockHeaderHash = self.get_block_hash(current_block_height)?;
 
         let mut database_transaction = DatabaseTransaction::new();
@@ -170,7 +170,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         database_transaction.push(Op::Insert {
             col: COL_META,
             key: KEY_BEST_BLOCK_NUMBER.as_bytes().to_vec(),
-            value: update_best_block_num.to_le_bytes().to_vec(),
+            value: new_best_block_number.to_le_bytes().to_vec(),
         });
 
         database_transaction.push(Op::Delete {
@@ -238,7 +238,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
 
         self.current_block_height.fetch_sub(1, Ordering::SeqCst);
 
-        self.update_merkle_tree()?;
+        self.update_merkle_tree(new_best_block_number)?;
 
         Ok(block_hash)
     }

--- a/storage/src/objects/block_path.rs
+++ b/storage/src/objects/block_path.rs
@@ -44,10 +44,14 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     pub fn get_block_path(&self, block_header: &BlockHeader) -> Result<BlockPath, StorageError> {
         let block_hash = block_header.get_hash();
 
-        // The given block header already exists
+        /*  The given block header already exists; temporarily disable this check, as it can cause issues
+            when decommitting blocks, or rather when sync blocks are received after that process - since
+            this check is done in COL_BLOCK_HEADER, a sync block that could become canonical would be rejected
+            as a duplicate
         if self.block_hash_exists(&block_hash) {
             return Ok(BlockPath::ExistingBlock);
         }
+        */
 
         // The given block header is valid on the canon chain
         if self.get_latest_block()?.header.get_hash() == block_header.previous_block_hash {


### PR DESCRIPTION
This PR fixes a logic error found while investigating https://github.com/AleoHQ/snarkOS/issues/780. When a node detects that it's on a non-canon fork and decides to decommit one or more of its latest blocks, it currently doesn't include 2 operations, as the database transaction is erroneously started twice in the `Ledger::decommit_latest_block` method.

Cc https://github.com/AleoHQ/snarkOS/issues/780; additional fixes might be needed.