### PR TITLE
Remove the Result wrapper from RPC responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-types"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd69677be004820341a7bdff334b00aa6ceec45c39d75ef4afc88ff8f71633e"
+checksum = "7fbbae830dd9982663675265535efd2db328489088a05983da93b006ed6a7efd"
 dependencies = [
  "serde",
  "str-buf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,15 +1273,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-rpc2"
-version = "0.10.1"
+name = "json-rpc-types"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b49f717fad135c34796717cd5d932dc193aab2034c5c7a18caf29602f127a5"
+checksum = "4dd69677be004820341a7bdff334b00aa6ceec45c39d75ef4afc88ff8f71633e"
 dependencies = [
- "rand 0.8.3",
  "serde",
- "serde_json",
- "thiserror",
+ "str-buf",
 ]
 
 [[package]]
@@ -2783,7 +2781,7 @@ dependencies = [
  "hex",
  "hyper",
  "itertools 0.10.0",
- "json-rpc2",
+ "json-rpc-types",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -3149,6 +3147,15 @@ checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
 dependencies = [
  "libc",
  "libsodium-sys",
+ "serde",
+]
+
+[[package]]
+name = "str-buf"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66ae6a6cd930c97707cb3f1b62aadb8ddddd2fefa9df539564b3bfaa15dd31f"
+dependencies = [
  "serde",
 ]
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -70,7 +70,7 @@ features = [ "runtime", "server" ]
 version = "0.10.0"
 
 [dependencies.json-rpc-types]
-version = "1"
+version = "1.0.1"
 
 [dependencies.jsonrpc-core]
 version = "17"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -69,8 +69,8 @@ features = [ "runtime", "server" ]
 [dependencies.itertools]
 version = "0.10.0"
 
-[dependencies.json-rpc2]
-version = "0.10"
+[dependencies.json-rpc-types]
+version = "1"
 
 [dependencies.jsonrpc-core]
 version = "17"

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -32,6 +32,7 @@ use hyper::{
     Server,
 };
 use jsonrpc_core::Params;
+use serde::Serialize;
 use tokio::task;
 
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
@@ -147,20 +148,20 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
             let resp = rpc
                 .get_block(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getblockcount" => {
             let resp = rpc.get_block_count().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getbestblockhash" => {
             let resp = rpc.get_best_block_hash().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getblockhash" => match serde_json::from_value::<u32>(params.remove(0)) {
             Ok(height) => {
                 let resp = rpc.get_block_hash(height).map_err(convert_crate_err);
-                serde_json::to_value(resp).unwrap_or_default()
+                result_to_value(resp)
             }
             Err(_) => {
                 let err = json_rpc2::RpcError {
@@ -175,51 +176,51 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
             let resp = rpc
                 .get_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "gettransactioninfo" => {
             let resp = rpc
                 .get_transaction_info(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "decoderawtransaction" => {
             let resp = rpc
                 .decode_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "sendtransaction" => {
             let resp = rpc
                 .send_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "validaterawtransaction" => {
             let resp = rpc
                 .validate_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getconnectioncount" => {
             let resp = rpc.get_connection_count().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getpeerinfo" => {
             let resp = rpc.get_peer_info().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getnodeinfo" => {
             let resp = rpc.get_node_info().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getnodestats" => {
             let resp = rpc.get_node_stats().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getblocktemplate" => {
             let resp = rpc.get_block_template().map_err(convert_crate_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         // private
         "createaccount" => {
@@ -227,60 +228,60 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
                 .create_account_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "createrawtransaction" => {
             let resp = rpc
                 .create_raw_transaction_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "createtransactionkernel" => {
             let resp = rpc
                 .create_transaction_kernel_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "createtransaction" => {
             let resp = rpc
                 .create_transaction_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getrecordcommitments" => {
             let resp = rpc
                 .get_record_commitments_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "getrawrecord" => {
             let resp = rpc
                 .get_raw_record_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "decoderecord" => {
             let resp = rpc
                 .decode_record_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "decryptrecord" => {
             let resp = rpc
                 .decrypt_record_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         "disconnect" => {
             let resp = rpc.disconnect_protected(Params::Array(params), meta).await;
-            serde_json::to_value(resp).unwrap_or_default()
+            result_to_value(resp)
         }
         unknown => {
             let err = json_rpc2::RpcError {
@@ -331,5 +332,12 @@ fn convert_core_err(err: jsonrpc_core::Error) -> json_rpc2::RpcError {
         code: INTERNAL_ERROR, // as per JSON-RPC 2.0 spec
         message: err.to_string(),
         data: None,
+    }
+}
+
+fn result_to_value<T: Serialize, E: Serialize>(result: Result<T, E>) -> serde_json::Value {
+    match result {
+        Ok(res) => serde_json::to_value(&res).unwrap_or_default(),
+        Err(err) => serde_json::to_value(&err).unwrap_or_default(),
     }
 }

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -31,14 +31,12 @@ use hyper::{
     Body,
     Server,
 };
+use json_rpc_types as jrt;
 use jsonrpc_core::Params;
 use serde::Serialize;
 use tokio::task;
 
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
-
-const INTERNAL_ERROR: isize = -32603;
-const SERVER_ERROR: isize = -32000;
 
 const METHODS_EXPECTING_PARAMS: [&str; 14] = [
     // public
@@ -102,37 +100,37 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
     let data = match body.data().await {
         Some(Ok(data)) => data,
         _ => {
-            let err = json_rpc2::Error::InvalidRequest {
-                data: "Invalid request!".into(),
-            };
-            let resp: json_rpc2::Response = err.into();
+            let resp = jrt::Response::<(), ()>::error(
+                jrt::Version::V2,
+                jrt::Error::from_code(jrt::ErrorCode::ParseError),
+                None,
+            );
+            let body = serde_json::to_vec(&resp).unwrap_or_default();
 
-            return Ok(hyper::Response::new(
-                serde_json::to_vec(&resp).unwrap_or_default().into(),
-            ));
+            return Ok(hyper::Response::new(body.into()));
         }
     };
 
     // Deserialize the JSON-RPC request.
-    let mut req = match json_rpc2::from_slice(&data) {
+    let req: jrt::Request<Params> = match serde_json::from_slice(&data) {
         Ok(req) => req,
         Err(_) => {
-            let err = json_rpc2::Error::InvalidRequest {
-                data: "Invalid request!".into(),
-            };
-            let resp: json_rpc2::Response = err.into();
+            let resp = jrt::Response::<(), ()>::error(
+                jrt::Version::V2,
+                jrt::Error::from_code(jrt::ErrorCode::ParseError),
+                None,
+            );
+            let body = serde_json::to_vec(&resp).unwrap_or_default();
 
-            return Ok(hyper::Response::new(
-                serde_json::to_vec(&resp).unwrap_or_default().into(),
-            ));
+            return Ok(hyper::Response::new(body.into()));
         }
     };
 
     // Read the request params.
-    let mut params = match read_params(&mut req) {
+    let mut params = match read_params(&req) {
         Ok(params) => params,
-        Err(e) => {
-            let resp: json_rpc2::Response = (&mut req, e).into();
+        Err(err) => {
+            let resp = jrt::Response::<(), ()>::error(jrt::Version::V2, err, req.id.clone());
             let body = serde_json::to_vec(&resp).unwrap_or_default();
 
             return Ok(hyper::Response::new(body.into()));
@@ -140,81 +138,81 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
     };
 
     // Handle the request method.
-    let response = match req.method() {
+    let response = match &*req.method {
         // public
         "getblock" => {
             let result = rpc
                 .get_block(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getblockcount" => {
             let result = rpc.get_block_count().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getbestblockhash" => {
             let result = rpc.get_best_block_hash().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getblockhash" => match serde_json::from_value::<u32>(params.remove(0)) {
             Ok(height) => {
                 let result = rpc.get_block_hash(height).map_err(convert_crate_err);
-                result_to_response(&mut req, result)
+                result_to_response(&req, result)
             }
-            Err(e) => {
-                let err = json_rpc2::Error::Parse { data: e.to_string() };
-                (&mut req, err).into()
+            Err(_) => {
+                let err = jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Invalid block height!");
+                jrt::Response::error(jrt::Version::V2, err, req.id.clone())
             }
         },
         "getrawtransaction" => {
             let result = rpc
                 .get_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "gettransactioninfo" => {
             let result = rpc
                 .get_transaction_info(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "decoderawtransaction" => {
             let result = rpc
                 .decode_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "sendtransaction" => {
             let result = rpc
                 .send_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "validaterawtransaction" => {
             let result = rpc
                 .validate_raw_transaction(params[0].as_str().unwrap_or("").into())
                 .map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getconnectioncount" => {
             let result = rpc.get_connection_count().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getpeerinfo" => {
             let result = rpc.get_peer_info().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getnodeinfo" => {
             let result = rpc.get_node_info().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getnodestats" => {
             let result = rpc.get_node_stats().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getblocktemplate" => {
             let result = rpc.get_block_template().map_err(convert_crate_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         // private
         "createaccount" => {
@@ -222,67 +220,67 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
                 .create_account_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "createrawtransaction" => {
             let result = rpc
                 .create_raw_transaction_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "createtransactionkernel" => {
             let result = rpc
                 .create_transaction_kernel_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "createtransaction" => {
             let result = rpc
                 .create_transaction_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getrecordcommitments" => {
             let result = rpc
                 .get_record_commitments_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "getrawrecord" => {
             let result = rpc
                 .get_raw_record_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "decoderecord" => {
             let result = rpc
                 .decode_record_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "decryptrecord" => {
             let result = rpc
                 .decrypt_record_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
-            result_to_response(&mut req, result)
+            result_to_response(&req, result)
         }
         "disconnect" => {
-            let result = rpc.disconnect_protected(Params::Array(params), meta).await;
-            result_to_response(&mut req, result)
+            let result = rpc
+                .disconnect_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            result_to_response(&req, result)
         }
-        unknown => {
-            let err = json_rpc2::Error::MethodNotFound {
-                id: req.id().clone(),
-                name: unknown.to_owned(),
-            };
-            (&mut req, err).into()
+        _ => {
+            let err = jrt::Error::from_code(jrt::ErrorCode::MethodNotFound);
+            jrt::Response::error(jrt::Version::V2, err, req.id.clone())
         }
     };
 
@@ -294,47 +292,41 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
 }
 
 /// Ensures that the params are a non-empty (this assumption is taken advantage of later) array and returns them.
-fn read_params(req: &mut json_rpc2::Request) -> json_rpc2::Result<Vec<serde_json::Value>> {
-    if METHODS_EXPECTING_PARAMS.contains(&req.method()) {
-        match req.deserialize() {
-            Ok(Params::Array(arr)) if !arr.is_empty() => Ok(arr),
-            Ok(_) => Err(json_rpc2::Error::InvalidParams {
-                id: req.id().clone(),
-                data: "Only a non-empty array is accepted as parameters!".into(),
-            }),
-            Err(e) => Err(e),
+fn read_params(req: &jrt::Request<Params>) -> Result<Vec<serde_json::Value>, jrt::Error<()>> {
+    if METHODS_EXPECTING_PARAMS.contains(&&*req.method) {
+        match &req.params {
+            Some(Params::Array(arr)) if !arr.is_empty() => Ok(arr.clone()),
+            Some(_) => Err(jrt::Error::from_code(jrt::ErrorCode::InvalidParams)),
+            None => Err(jrt::Error::from_code(jrt::ErrorCode::InvalidParams)),
         }
     } else {
         Ok(vec![]) // unused in methods other than METHODS_EXPECTING_PARAMS
     }
 }
 
-/// Converts the crate's RpcError into a json_rpc2::RpcError
-fn convert_crate_err(err: crate::error::RpcError) -> json_rpc2::RpcError {
-    json_rpc2::RpcError {
-        code: SERVER_ERROR, // as per JSON-RPC 2.0 spec
-        message: err.to_string(),
-        data: None,
-    }
+/// Converts the crate's RpcError into a jrt::RpcError
+fn convert_crate_err(err: crate::error::RpcError) -> jrt::Error<()> {
+    let mut err = err.to_string();
+    err.truncate(31); // json-rpc-type Error length limit
+    jrt::Error::with_custom_msg(jrt::ErrorCode::ServerError(0), &err)
 }
 
-/// Converts the jsonrpc-core's Error into a json_rpc2::RpcError
-fn convert_core_err(err: jsonrpc_core::Error) -> json_rpc2::RpcError {
-    json_rpc2::RpcError {
-        code: INTERNAL_ERROR, // as per JSON-RPC 2.0 spec
-        message: err.to_string(),
-        data: None,
-    }
+/// Converts the jsonrpc-core's Error into a jrt::RpcError
+fn convert_core_err(err: jsonrpc_core::Error) -> jrt::Error<()> {
+    let mut err = err.to_string();
+    err.truncate(31); // json-rpc-type Error length limit
+    jrt::Error::with_custom_msg(jrt::ErrorCode::InternalError, &err)
 }
 
-fn result_to_response<T: Serialize, E: Serialize>(
-    request: &mut json_rpc2::Request,
-    result: Result<T, E>,
-) -> json_rpc2::Response {
-    let value = match result {
-        Ok(res) => serde_json::to_value(&res).unwrap_or_default(),
-        Err(err) => serde_json::to_value(&err).unwrap_or_default(),
-    };
-
-    (request, value).into()
+fn result_to_response<T: Serialize>(
+    request: &jrt::Request<Params>,
+    result: Result<T, jrt::Error<()>>,
+) -> jrt::Response<serde_json::Value, ()> {
+    match result {
+        Ok(res) => {
+            let result = serde_json::to_value(&res).unwrap_or_default();
+            jrt::Response::result(jrt::Version::V2, result, request.id.clone())
+        }
+        Err(err) => jrt::Response::error(jrt::Version::V2, err, request.id.clone()),
+    }
 }

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -96,7 +96,9 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     /// Returns information about a block from a block hash.
     fn get_block(&self, block_hash_string: String) -> Result<BlockInfo, RpcError> {
         let block_hash = hex::decode(&block_hash_string)?;
-        assert_eq!(block_hash.len(), 32);
+        if block_hash.len() != 32 {
+            return Err(RpcError::InvalidBlockHash(block_hash_string));
+        }
 
         let storage = &self.storage;
 


### PR DESCRIPTION
Fixes https://github.com/AleoHQ/snarkOS/issues/785 and uses a different crate with a more convenient API for RPC objects.

In addition, this PR avoids a potential panic that had been applicable to the previous implementation as well.