### PR TITLE
RocksDb test cleanups

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -204,61 +204,61 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             Payload::Transaction(transaction) => {
                 metrics::increment_counter!(stats::INBOUND_TRANSACTIONS);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_memory_pool_transaction(source, transaction)?;
+                if self.sync().is_some() {
+                    self.received_memory_pool_transaction(source, transaction)?;
                 }
             }
             Payload::Block(block) => {
                 metrics::increment_counter!(stats::INBOUND_BLOCKS);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_block(source, block, true)?;
+                if self.sync().is_some() {
+                    self.received_block(source, block, true)?;
                 }
             }
             Payload::SyncBlock(block) => {
                 metrics::increment_counter!(stats::INBOUND_SYNCBLOCKS);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_block(source, block, false)?;
+                if self.sync().is_some() {
+                    self.received_block(source, block, false)?;
 
                     // Update the peer and possibly finish the sync process.
                     if self.peer_book.got_sync_block(source) {
-                        sync.finished_syncing_blocks();
+                        self.finished_syncing_blocks();
                     }
                 }
             }
             Payload::GetBlocks(hashes) => {
                 metrics::increment_counter!(stats::INBOUND_GETBLOCKS);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_get_blocks(source, hashes)?;
+                if self.sync().is_some() {
+                    self.received_get_blocks(source, hashes)?;
                 }
             }
             Payload::GetMemoryPool => {
                 metrics::increment_counter!(stats::INBOUND_GETMEMORYPOOL);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_get_memory_pool(source);
+                if self.sync().is_some() {
+                    self.received_get_memory_pool(source);
                 }
             }
             Payload::MemoryPool(mempool) => {
                 metrics::increment_counter!(stats::INBOUND_MEMORYPOOL);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_memory_pool(mempool)?;
+                if self.sync().is_some() {
+                    self.received_memory_pool(mempool)?;
                 }
             }
             Payload::GetSync(getsync) => {
                 metrics::increment_counter!(stats::INBOUND_GETSYNC);
 
-                if let Some(ref sync) = self.sync() {
-                    sync.received_get_sync(source, getsync)?;
+                if self.sync().is_some() {
+                    self.received_get_sync(source, getsync)?;
                 }
             }
             Payload::Sync(sync) => {
                 metrics::increment_counter!(stats::INBOUND_SYNCS);
 
-                if let Some(ref sync_handler) = self.sync() {
+                if self.sync().is_some() {
                     if sync.is_empty() {
                         // An empty `Sync` is unexpected, as `GetSync` requests are only
                         // sent to peers that declare a greater block height.
@@ -266,7 +266,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                         warn!("{} doesn't have sync blocks to share", source);
                     } else if self.peer_book.expecting_sync_blocks(source, sync.len()) {
                         trace!("Received {} sync block hashes from {}", sync.len(), source);
-                        sync_handler.received_sync(source, sync);
+                        self.received_sync(source, sync);
                     }
                 }
             }

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -110,7 +110,7 @@ impl<S: Storage + Send + Sync + 'static> MinerInstance<S> {
                     continue;
                 };
 
-                self.node.expect_sync().propagate_block(serialized_block, local_address);
+                self.node.propagate_block(serialized_block, local_address);
             }
         });
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -316,7 +316,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             listening_addr: self.node.config.desired_address,
             is_bootnode: self.node.config.is_bootnode(),
             is_miner: self.sync_handler()?.is_miner(),
-            is_syncing: self.sync_handler()?.is_syncing_blocks(),
+            is_syncing: self.node.is_syncing_blocks(),
             launched: self.node.launched,
             version: env!("CARGO_PKG_VERSION").into(),
         })

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -84,7 +84,6 @@ mod protected_rpc_tests {
         let consensus = Arc::new(snarkos_testing::sync::create_test_consensus_from_ledger(ledger.clone()));
 
         let node_consensus = snarkos_network::Sync::new(
-            node.clone(),
             consensus.clone(),
             consensus_setup.is_miner,
             Duration::from_secs(consensus_setup.block_sync_interval),

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -43,7 +43,6 @@ mod rpc_tests {
         let consensus = Arc::new(snarkos_testing::sync::create_test_consensus_from_ledger(ledger.clone()));
 
         let node_consensus = snarkos_network::Sync::new(
-            node.clone(),
             consensus.clone(),
             consensus_setup.is_miner,
             Duration::from_secs(consensus_setup.block_sync_interval),

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -218,7 +218,6 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         });
 
         let sync = Sync::new(
-            node.clone(),
             consensus,
             config.miner.is_miner,
             Duration::from_secs(config.p2p.block_sync_interval.into()),

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2018"
 default = [ "rocksdb_storage" ]
 rocksdb_storage = [ "rocksdb" ]
 mem_storage = [ ]
+test = [ ] # enables database deletion for tests; used by snarkos-testing
 
 [dependencies.snarkvm-algorithms]
 version = "0.3.1"

--- a/storage/src/rocks.rs
+++ b/storage/src/rocks.rs
@@ -110,7 +110,7 @@ impl Drop for RocksDb {
         drop(db);
 
         // destroy the database in test conditions
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "test")]
         {
             let _ = DB::destroy(&Options::default(), _path);
         }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -66,6 +66,7 @@ version = "1.3.6"
 path = "../storage"
 version = "1.3.6"
 default-features = false
+features = [ "test" ]
 
 [dependencies.anyhow]
 version = "1.0.40"

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -152,11 +152,10 @@ impl Default for TestSetup {
     }
 }
 
-pub fn test_consensus(setup: ConsensusSetup, node: Node<LedgerStorage>) -> Sync<LedgerStorage> {
+pub fn test_consensus(setup: ConsensusSetup) -> Sync<LedgerStorage> {
     let consensus = Arc::new(crate::sync::create_test_consensus());
 
     Sync::new(
-        node,
         consensus,
         setup.is_miner,
         Duration::from_secs(setup.block_sync_interval),
@@ -184,7 +183,7 @@ pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
     let mut node = Node::new(config).await.unwrap();
 
     if let Some(consensus_setup) = setup.consensus_setup {
-        let consensus = test_consensus(consensus_setup, node.clone());
+        let consensus = test_consensus(consensus_setup);
         node.set_sync(consensus);
     }
 


### PR DESCRIPTION
The reason why the auto-cleanup of the `rocksdb` temporary files was not kicking in was two-fold:
1. there was an extra `Arc` reference to the `InnerNode` which caused the `Drop` impl for it to not be triggered when it went out of scope - this is fixed by removing the `Node` member from `Sync` and refactoring the related code
2. the `cfg` attributes don't work too well accross workspaces (cargo doesn't currently support it) - the typical workaround is to utilize a dedicated `test` feature instead; since the extra objects were produced only by `snarkos-testing`, it can just use that new, non-default feature of `snarkos-storage` automatically, as it only contains tests

Fixes https://github.com/AleoHQ/snarkOS/issues/794.