### PR TITLE
Add a protected shutdown RPC

### DIFF
--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -329,6 +329,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         for handle in self.tasks.lock().drain(..).rev() {
             handle.abort();
         }
+
+        info!("The node can be shut down now");
     }
 
     pub fn register_task(&self, handle: task::JoinHandle<()>) {

--- a/rpc/documentation/private_endpoints/shutdown.md
+++ b/rpc/documentation/private_endpoints/shutdown.md
@@ -1,0 +1,18 @@
+Shuts the node down gracefully.
+
+### Protected Endpoint
+
+Yes
+
+### Arguments
+
+None
+
+### Response
+
+null
+
+### Example
+```ignore
+curl --user username:password --data-binary '{"jsonrpc": "2.0", "id":"1", "method": "shutdown" }' -H 'content-type: application/json' http://127.0.0.1:3030/
+```

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -281,6 +281,13 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
                 .map_err(convert_core_err);
             result_to_response(&req, result)
         }
+        "shutdown" => {
+            let result = rpc
+                .shutdown_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            result_to_response(&req, result)
+        }
         _ => {
             let err = jrt::Error::from_code(jrt::ErrorCode::MethodNotFound);
             jrt::Response::error(jrt::Version::V2, err, req.id.clone())

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -262,6 +262,15 @@ impl<S: Storage + Send + Sync + 'static> RpcImpl<S> {
         Ok(Value::Null)
     }
 
+    /// Gracefully shuts the node down
+    pub async fn shutdown_protected(self, _params: Params, meta: Meta) -> Result<Value, JsonRPCError> {
+        self.validate_auth(meta)?;
+
+        self.node.shut_down();
+
+        Ok(Value::Null)
+    }
+
     /// Expose the protected functions as RPC enpoints
     pub fn add_protected(&self, io: &mut MetaIoHandler<Meta>) {
         let mut d = IoDelegate::<Self, Meta>::new(Arc::new(self.clone()));
@@ -305,6 +314,10 @@ impl<S: Storage + Send + Sync + 'static> RpcImpl<S> {
         d.add_method_with_meta("disconnect", |rpc, params, meta| {
             let rpc = rpc.clone();
             rpc.disconnect_protected(params, meta)
+        });
+        d.add_method_with_meta("shutdown", |rpc, params, meta| {
+            let rpc = rpc.clone();
+            rpc.shutdown_protected(params, meta)
         });
 
         io.extend_with(d)


### PR DESCRIPTION
The node doesn't currently have a "clean" way of getting shut down. This RPC endpoint provides us with one.