### PR TITLE
Merkle tree parallelize integration + upgrade to snarkVM 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adba2012502267c1fdde381e0e3acc44bf8be96b2f7d455089dcc2c8ad2f67bd"
+checksum = "003cb79c1c6d1c93344c7e1201bb51c2148f24ec2bd9c253709d6b2efb796515"
 dependencies = [
  "curl-sys",
  "libc",
@@ -665,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.43+curl-7.76.0"
+version = "0.4.44+curl-7.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a802c7a9828b7d139efaed1bc92471ab6681ed86d19a105605f5eadcb0837d11"
+checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
 dependencies = [
  "cc",
  "libc",
@@ -841,6 +853,12 @@ name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
+
+[[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futures"
@@ -2095,6 +2113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,6 +2699,12 @@ dependencies = [
  "snarkos-network",
  "snarkos-profiler",
  "snarkos-testing",
+ "snarkvm-algorithms",
+ "snarkvm-curves",
+ "snarkvm-dpc",
+ "snarkvm-objects",
+ "snarkvm-parameters",
+ "snarkvm-posw",
  "snarkvm-utilities",
  "tokio",
 ]
@@ -2889,10 +2919,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f8349fad4f4e9a05ab4fde6baa99aad8542fcaf10320128114fdc26798a0ad"
+checksum = "c3fd86a876b0e2962c39c2983bcea5f37b6d9baf3a9f02ae55cca25fd70a4d15"
 dependencies = [
+ "bitvec",
  "blake2",
  "derivative",
  "digest 0.9.0",
@@ -2912,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8f71e6243e588507a7935512bcd79e28906ad89553671151eaf721e42b1513"
+checksum = "7a00e4d17d5f5057e82a378ae26865d796ad646af242d9f27097c6f63b2bc464"
 dependencies = [
  "derivative",
  "rand 0.8.3",
@@ -2928,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b3ad83bcd981531a29e8e70bac4cf34126b1031f42bc529975a46e49100383"
+checksum = "769aa9c2a57b7541cce8b8c253b07f6cef992caa08c62621195e6a5d3766d83c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2941,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54268e972e18e7a1508418f29fe3f64201f86acf2131ed28b1bc9f8891fc1bbb"
+checksum = "c7b114c7f0127022978b7c1921e6f5cf97bf93777392404b725cacd5618ca6a3"
 dependencies = [
  "anyhow",
  "base58",
@@ -2967,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b885226e300d6a237905038fba681eaa2a851e5cb45a22b685c0bc87c574b6"
+checksum = "c903a05e20795aa94edca58c3de6fddb00eed2b9ca598293128059eb4dd251bd"
 dependencies = [
  "bincode",
  "derivative",
@@ -2982,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0322e4fd5fe0b0b7499a6b1dbd47d20cf65e0904a23094ba087662253ed60ff0"
+checksum = "854f74c19907673be7a5ca9f0a0e2e42d205dcdfeac2de1dd186c8333577cee8"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2999,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-marlin"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed42c68a04bb52f8c6b170e5ec67872f5a362598b1e3d52375416bfea581a5e"
+checksum = "c2879ed32355696c92807ef70a3e4cab49c1d865a10e8261d8d3f7c59f76cf89"
 dependencies = [
  "blake2",
  "derivative",
@@ -3024,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-nonnative"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d1660301b12d5cd2573b706850a61f160cdf70fd1658a5ac370a5313151e4f"
+checksum = "dd2a1cef36501a3cc0094bf295a9f966aab0e52ba537d6ec18d405b8d6a18dc7"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -3041,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-objects"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b2dd86a3d036d09608e7493c7a14bf17a59648e567cd08414d2520a627d07"
+checksum = "7ce78b7202f4498be7963486f864a26507fd5838ae1861687141718093029fc2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3062,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7932c7d7fd7b9572a1acaad3c9622f6849c414e5ac8bdb599a504ef4330bb857"
+checksum = "fca43707d4b2948e79ce87c58996dd44feecb0b73f9972bf1b3537d051803784"
 dependencies = [
  "curl",
  "hex",
@@ -3075,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-polycommit"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf6181064236b9eb63e6ea2b770be926480533b74d7e13234bf28c551c3ea3a"
+checksum = "e486f7e318f90cbda578dbe4e8532a5d0901ce135af2715b179b489701d1ab8b"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -3095,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-posw"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20358d7f6c523d0706f21593470f14bd2e69b2463c29d6c4263650e5615dabbe"
+checksum = "e5424334a358ab43a1c5a669e773b937b63a0805408b227d224aeacef387c0e7"
 dependencies = [
  "blake2",
  "rand 0.8.3",
@@ -3117,15 +3148,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877f7ee215903aa4da2343f6d82fd5ec7426210a33f4773770ab35dbdddd3bd9"
+checksum = "4fd3e8f4794714aeb37d11632f071c2878e2fcbd4b959863a536edaec10d1604"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5695a57009b1b79f32df22d88f5d5dabf7a84f6a953280896ae4edb8b9db76d"
+checksum = "bbdbad98b7148a7493b3bec301648887102ca2d8a01d385df9ca738a42fb1700"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -3138,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996ba23293c9288d983003c224450db8a6acd875f9fe7f6d839ab91897023b5b"
+checksum = "1e310ff5659e2fcc721103b0221d6bc4c2fd01d0a65b1b4c2bb317eb71522e55"
 dependencies = [
  "bincode",
  "rand 0.8.3",
@@ -3242,6 +3273,12 @@ dependencies = [
  "num-traits",
  "rustc_version 0.2.3",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3849,6 +3886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,11 +19,11 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "once_cell",
  "version_check",
 ]
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
@@ -258,18 +258,18 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
+checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 dependencies = [
  "jobserver",
 ]
@@ -447,9 +447,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f508f5ff4df34cfd12172af9f98f5c307db8b36ceb0c63264eccb43be5ed635"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]
@@ -532,7 +532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -553,8 +553,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.4",
- "crossbeam-utils 0.8.4",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
- "memoffset 0.6.3",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -609,11 +609,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -726,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.13"
+version = "0.99.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
+checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1012,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1139,15 +1138,15 @@ checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1394,9 +1393,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "libloading"
@@ -1517,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -1572,8 +1571,8 @@ checksum = "6586f4c52af81a3f7832cf0bc86141d2fca7207bedd09fdd3f7da60c8dcd0c4a"
 dependencies = [
  "aho-corasick",
  "atomic-shim",
- "crossbeam-epoch 0.9.4",
- "crossbeam-utils 0.8.4",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
  "dashmap",
  "hashbrown 0.11.2",
  "indexmap",
@@ -1829,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.2.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8919aecb97e5ee9aceef27e24f39c46b11831130f4a6b7b091ec5de0de12"
+checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
 dependencies = [
  "num-traits",
 ]
@@ -1940,9 +1939,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2029,9 +2028,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -2178,7 +2177,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -2225,9 +2224,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque 0.8.0",
@@ -2237,13 +2236,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
 ]
@@ -2263,7 +2262,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "redox_syscall",
 ]
 
@@ -2904,7 +2903,7 @@ version = "1.3.6"
 dependencies = [
  "anyhow",
  "criterion",
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "hex",
  "rand 0.8.3",
  "rand_chacha 0.3.0",
@@ -3296,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
@@ -3315,18 +3314,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3379,9 +3378,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3396,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3417,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3441,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3608,9 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
 dependencies = [
  "tinyvec",
 ]
@@ -3668,9 +3667,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,20 +45,20 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-posw]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-consensus]
 path = "./consensus"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -23,12 +23,35 @@ path = "syncing/syncing.rs"
 harness = false
 
 [[bench]]
+name = "merkle"
+path = "merkle/merkle.rs"
+harness = false
+
+[[bench]]
 name = "network"
 path = "network/network.rs"
 harness = false
 
+[dependencies.snarkvm-algorithms]
+version = "0.4.0"
+
+[dependencies.snarkvm-curves]
+version = "0.4.0"
+
+[dependencies.snarkvm-dpc]
+version = "0.4.0"
+
+[dependencies.snarkvm-objects]
+version = "0.4.0"
+
+[dependencies.snarkvm-parameters]
+version = "0.4.0"
+
+[dependencies.snarkvm-posw]
+version = "0.4.0"
+
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/benchmarks/merkle/merkle.rs
+++ b/benchmarks/merkle/merkle.rs
@@ -18,10 +18,8 @@ use std::sync::Arc;
 
 use criterion::*;
 use rand::Rng;
-use snarkvm_algorithms::{CRH, MerkleParameters, merkle_tree::MerkleTree};
-use snarkvm_dpc::{
-    base_dpc::instantiated::*,
-};
+use snarkvm_algorithms::{merkle_tree::MerkleTree, MerkleParameters, CRH};
+use snarkvm_dpc::base_dpc::instantiated::*;
 use snarkvm_parameters::{LedgerMerkleTreeParameters, Parameter};
 use snarkvm_utilities::bytes::FromBytes;
 
@@ -30,7 +28,8 @@ fn merkle_build(c: &mut Criterion) {
         <MerkleTreeCRH as CRH>::Parameters::read(&LedgerMerkleTreeParameters::load_bytes().unwrap()[..])
             .expect("read bytes as hash for MerkleParameters in ledger");
     let merkle_tree_hash_parameters = <CommitmentMerkleParameters as MerkleParameters>::H::from(crh_parameters);
-    let ledger_merkle_tree_parameters: Arc<CommitmentMerkleParameters> = Arc::new(From::from(merkle_tree_hash_parameters));
+    let ledger_merkle_tree_parameters: Arc<CommitmentMerkleParameters> =
+        Arc::new(From::from(merkle_tree_hash_parameters));
 
     let mut commitments = Vec::with_capacity(10000);
     for _ in 0..10000 {
@@ -39,9 +38,7 @@ fn merkle_build(c: &mut Criterion) {
         commitments.push(buf);
     }
 
-
     c.bench_function("merkle_build", move |b| {
-
         b.iter(|| {
             MerkleTree::new(ledger_merkle_tree_parameters.clone(), &commitments[..]).unwrap();
         });

--- a/benchmarks/merkle/merkle.rs
+++ b/benchmarks/merkle/merkle.rs
@@ -1,0 +1,57 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use criterion::*;
+use rand::Rng;
+use snarkvm_algorithms::{CRH, MerkleParameters, merkle_tree::MerkleTree};
+use snarkvm_dpc::{
+    base_dpc::instantiated::*,
+};
+use snarkvm_parameters::{LedgerMerkleTreeParameters, Parameter};
+use snarkvm_utilities::bytes::FromBytes;
+
+fn merkle_build(c: &mut Criterion) {
+    let crh_parameters =
+        <MerkleTreeCRH as CRH>::Parameters::read(&LedgerMerkleTreeParameters::load_bytes().unwrap()[..])
+            .expect("read bytes as hash for MerkleParameters in ledger");
+    let merkle_tree_hash_parameters = <CommitmentMerkleParameters as MerkleParameters>::H::from(crh_parameters);
+    let ledger_merkle_tree_parameters: Arc<CommitmentMerkleParameters> = Arc::new(From::from(merkle_tree_hash_parameters));
+
+    let mut commitments = Vec::with_capacity(10000);
+    for _ in 0..10000 {
+        let mut buf = [0u8; 32];
+        rand::thread_rng().fill(&mut buf[..]);
+        commitments.push(buf);
+    }
+
+
+    c.bench_function("merkle_build", move |b| {
+
+        b.iter(|| {
+            MerkleTree::new(ledger_merkle_tree_parameters.clone(), &commitments[..]).unwrap();
+        });
+    });
+}
+
+criterion_group! {
+    name = merkle;
+    config = Criterion::default().sample_size(10);
+    targets = merkle_build
+}
+
+criterion_main!(merkle);

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,22 +18,22 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-posw]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -36,7 +36,7 @@ features = [ "macros", "rt-multi-thread" ]
 version = "0.3"
 
 [dev-dependencies.snarkvm-derives]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.serial_test]
 version = "0.5.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -18,16 +18,16 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -18,14 +18,14 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [dependencies.snarkvm-parameters]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [dependencies.curl]
@@ -33,19 +33,19 @@ version = "0.4.36"
 optional = true
 
 [dev-dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.snarkvm-marlin]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.snarkvm-posw]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.snarkos-consensus]
 path = "../consensus"

--- a/parameters/examples/generate_transaction.rs
+++ b/parameters/examples/generate_transaction.rs
@@ -57,7 +57,7 @@ fn empty_ledger<T: Transaction, P: LoadableMerkleParameters, S: Storage>(
         .map_err(|err| LedgerError::Message(err.to_string()))?;
 
     let leaves: &[[u8; 32]] = &[];
-    let cm_merkle_tree = MerkleTree::<P>::new(parameters.clone(), leaves.iter())?;
+    let cm_merkle_tree = MerkleTree::<P>::new(parameters.clone(), &leaves[..])?;
 
     Ok(Ledger {
         current_block_height: Default::default(),

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,17 +18,17 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -24,19 +24,19 @@ mem_storage = [ ]
 test = [ ] # enables database deletion for tests; used by snarkos-testing
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-parameters]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-parameters]
 path = "../parameters"
@@ -72,7 +72,7 @@ version = "1.0"
 path = "../consensus"
 
 [dev-dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.4.0"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -134,7 +134,9 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
 
                 let mut cm_and_indices = vec![];
 
-                for (commitment_key, index_value) in storage.get_col(COL_COMMITMENT)? {
+                let cms = storage.get_col(COL_COMMITMENT)?;
+
+                for (commitment_key, index_value) in cms {
                     let commitment: T::Commitment = FromBytes::read(&commitment_key[..])?;
                     let index = bytes_to_u32(&index_value) as usize;
 
@@ -142,9 +144,9 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
                 }
 
                 cm_and_indices.sort_by(|&(_, i), &(_, j)| i.cmp(&j));
-                let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm);
+                let commitments = cm_and_indices.into_iter().map(|(cm, _)| cm).collect::<Vec<_>>();
 
-                let merkle_tree = MerkleTree::new(ledger_parameters.clone(), commitments)?;
+                let merkle_tree = MerkleTree::new(ledger_parameters.clone(), &commitments[..])?;
 
                 Ok(Self {
                     current_block_height: AtomicU32::new(bytes_to_u32(&val)),

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -120,9 +120,9 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         new_cm_and_indices.sort_by(|&(_, i), &(_, j)| i.cmp(&j));
 
         let old_commitments = old_cm_and_indices.into_iter().map(|(cm, _)| cm);
-        let new_commitments = new_cm_and_indices.into_iter().map(|(cm, _)| cm);
+        let new_commitments = new_cm_and_indices.into_iter().map(|(cm, _)| cm).collect::<Vec<_>>();
 
-        let new_tree = { self.cm_merkle_tree.read().rebuild(old_commitments, new_commitments)? };
+        let new_tree = { self.cm_merkle_tree.read().rebuild(old_commitments, &new_commitments[..])? };
         *self.cm_merkle_tree.write() = new_tree;
 
         Ok(())

--- a/storage/src/objects/dpc_state.rs
+++ b/storage/src/objects/dpc_state.rs
@@ -122,7 +122,11 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
         let old_commitments = old_cm_and_indices.into_iter().map(|(cm, _)| cm);
         let new_commitments = new_cm_and_indices.into_iter().map(|(cm, _)| cm).collect::<Vec<_>>();
 
-        let new_tree = { self.cm_merkle_tree.read().rebuild(old_commitments, &new_commitments[..])? };
+        let new_tree = {
+            self.cm_merkle_tree
+                .read()
+                .rebuild(old_commitments, &new_commitments[..])?
+        };
         *self.cm_merkle_tree.write() = new_tree;
 
         Ok(())

--- a/storage/src/objects/ledger_scheme.rs
+++ b/storage/src/objects/ledger_scheme.rs
@@ -56,7 +56,7 @@ impl<T: Transaction, P: LoadableMerkleParameters, S: Storage> LedgerScheme for L
         }
 
         let leaves: &[[u8; 32]] = &[];
-        let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), leaves.iter())?;
+        let empty_cm_merkle_tree = MerkleTree::<Self::MerkleParameters>::new(parameters.clone(), leaves)?;
 
         let ledger_storage = Self {
             current_block_height: Default::default(),

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -29,25 +29,25 @@ network = [
 ]
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-parameters]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-posw]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/toolkit/Cargo.toml
+++ b/toolkit/Cargo.toml
@@ -26,20 +26,20 @@ path = "benches/account.rs"
 harness = false
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 features = [ "wasm" ]
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [dependencies.snarkvm-objects]
-version = "0.3.1"
+version = "0.4.0"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies.anyhow]
 version = "1.0.40"


### PR DESCRIPTION
This PR integrated snarkVM 0.4.0 which adds merkle tree parallel building and partial parallel rebuilding.