### PR TITLE
Increase the default peer counts

### DIFF
--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -127,8 +127,8 @@ impl Default for Config {
                 mempool_sync_interval: 12,
                 peer_sync_interval: 15,
                 block_sync_interval: 4,
-                min_peers: 7,
-                max_peers: 25,
+                min_peers: 20,
+                max_peers: 50,
             },
         }
     }


### PR DESCRIPTION
Since there are no apparent performance/stability issues when a node is connected to 100 peers, it should be quite safe to increase the default `min-peers` and `max-peers` values. This PR changes them from `7` and `25` to `20` and `50`, which should improve the quality of the network.