### PR TITLE
Update metrics-related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "envmnt"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53c23fff9a59f261498953cf41dc9ffc2522fd79723bdf283c1e88dc1633624"
+checksum = "9c0a7fa53d812d26e59d2baf7a6f77442041454ab32908eb304447f00f0dd4de"
 dependencies = [
  "metrics-macros",
  "proc-macro-hack",
@@ -1536,11 +1542,12 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954533c2d91c118cf2405264a4ac3a5592e84efac12b1f18561400ffef0597eb"
+checksum = "423ac561fc3300388e62947ce7f944ba6d40468afe9916ce5b7774171d8b38b8"
 dependencies = [
  "hyper",
+ "ipnet",
  "metrics",
  "metrics-util",
  "parking_lot",
@@ -1551,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-macros"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22572ba9964744e261d34553568683b76db277bcd309ebf7215e28e0982505d"
+checksum = "caa72e4a3d157986dd2565c82ecbddcc23941513669a3766b938f6b72eb87f3f"
 dependencies = [
  "lazy_static",
  "proc-macro-hack",
@@ -1565,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6586f4c52af81a3f7832cf0bc86141d2fca7207bedd09fdd3f7da60c8dcd0c4a"
+checksum = "c0c93306cf63ff153c57963151a011194af0f33c91fe30ec30faf98732350a1a"
 dependencies = [
  "aho-corasick",
  "atomic-shim",
@@ -1581,6 +1588,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "quanta",
+ "radix_trie",
  "sketches-ddsketch",
  "t1ha",
 ]
@@ -1689,6 +1697,15 @@ name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nom"
@@ -2116,6 +2133,16 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,10 +93,10 @@ version = "3.0.2"
 version = "0.4.1"
 
 [dependencies.metrics]
-version = "0.15"
+version = "0.16"
 
 [dependencies.metrics-exporter-prometheus]
-version = "0.4"
+version = "0.5"
 optional = true
 
 [dependencies.parking_lot]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -72,7 +72,7 @@ version = "0.4.2"
 version = "0.4.11"
 
 [dependencies.metrics]
-version = "0.15"
+version = "0.16"
 
 [dependencies.once_cell]
 version = "1.5.2"

--- a/network/src/stats.rs
+++ b/network/src/stats.rs
@@ -16,10 +16,7 @@
 
 use metrics::{GaugeValue, Key, Recorder, Unit};
 
-use std::{
-    borrow::Borrow,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 pub const INBOUND_ALL_SUCCESSES: &str = "snarkos_inbound_all_successes_total";
 pub const INBOUND_ALL_FAILURES: &str = "snarkos_inbound_all_failures_total";
@@ -270,90 +267,82 @@ impl Recorder for Stats {
     fn record_histogram(&self, _key: &Key, _value: f64) {}
 
     fn increment_counter(&self, key: &Key, value: u64) {
-        if let Some(name) = key.name().parts().next() {
-            match name.borrow() {
-                // inbound
-                INBOUND_ALL_SUCCESSES => self.inbound.all_successes.fetch_add(value, Ordering::Relaxed),
-                INBOUND_ALL_FAILURES => self.inbound.all_failures.fetch_add(value, Ordering::Relaxed),
-                INBOUND_BLOCKS => self.inbound.blocks.fetch_add(value, Ordering::Relaxed),
-                INBOUND_GETBLOCKS => self.inbound.getblocks.fetch_add(value, Ordering::Relaxed),
-                INBOUND_GETMEMORYPOOL => self.inbound.getmemorypool.fetch_add(value, Ordering::Relaxed),
-                INBOUND_GETPEERS => self.inbound.getpeers.fetch_add(value, Ordering::Relaxed),
-                INBOUND_GETSYNC => self.inbound.getsync.fetch_add(value, Ordering::Relaxed),
-                INBOUND_MEMORYPOOL => self.inbound.memorypool.fetch_add(value, Ordering::Relaxed),
-                INBOUND_PEERS => self.inbound.peers.fetch_add(value, Ordering::Relaxed),
-                INBOUND_PINGS => self.inbound.pings.fetch_add(value, Ordering::Relaxed),
-                INBOUND_PONGS => self.inbound.pongs.fetch_add(value, Ordering::Relaxed),
-                INBOUND_SYNCS => self.inbound.syncs.fetch_add(value, Ordering::Relaxed),
-                INBOUND_SYNCBLOCKS => self.inbound.syncblocks.fetch_add(value, Ordering::Relaxed),
-                INBOUND_TRANSACTIONS => self.inbound.transactions.fetch_add(value, Ordering::Relaxed),
-                INBOUND_UNKNOWN => self.inbound.unknown.fetch_add(value, Ordering::Relaxed),
-                // outbound
-                OUTBOUND_ALL_SUCCESSES => self.outbound.all_successes.fetch_add(value, Ordering::Relaxed),
-                OUTBOUND_ALL_FAILURES => self.outbound.all_failures.fetch_add(value, Ordering::Relaxed),
-                // connections
-                CONNECTIONS_ALL_ACCEPTED => self.connections.all_accepted.fetch_add(value, Ordering::Relaxed),
-                CONNECTIONS_ALL_INITIATED => self.connections.all_initiated.fetch_add(value, Ordering::Relaxed),
-                CONNECTIONS_ALL_REJECTED => self.connections.all_rejected.fetch_add(value, Ordering::Relaxed),
-                // handshakes
-                HANDSHAKES_FAILURES_INIT => self.handshakes.failures_init.fetch_add(value, Ordering::Relaxed),
-                HANDSHAKES_FAILURES_RESP => self.handshakes.failures_resp.fetch_add(value, Ordering::Relaxed),
-                HANDSHAKES_SUCCESSES_INIT => self.handshakes.successes_init.fetch_add(value, Ordering::Relaxed),
-                HANDSHAKES_SUCCESSES_RESP => self.handshakes.successes_resp.fetch_add(value, Ordering::Relaxed),
-                HANDSHAKES_TIMEOUTS_INIT => self.handshakes.timeouts_init.fetch_add(value, Ordering::Relaxed),
-                HANDSHAKES_TIMEOUTS_RESP => self.handshakes.timeouts_resp.fetch_add(value, Ordering::Relaxed),
-                // misc
-                MISC_BLOCK_HEIGHT => 0, // obtained ad-hoc for the purposes of RPC metrics
-                MISC_BLOCKS_MINED => self.misc.blocks_mined.fetch_add(value, Ordering::Relaxed),
-                MISC_DUPLICATE_BLOCKS => self.misc.duplicate_blocks.fetch_add(value, Ordering::Relaxed),
-                MISC_DUPLICATE_SYNC_BLOCKS => self.misc.duplicate_sync_blocks.fetch_add(value, Ordering::Relaxed),
-                MISC_RPC_REQUESTS => self.misc.rpc_requests.fetch_add(value, Ordering::Relaxed),
-                _ => {
-                    error!("Metrics key {} wasn't assigned an operation and won't work!", key);
-                    0
-                }
-            };
-        } else {
-            error!("Metrics key {} wasn't assigned a name and won't work!", key);
-        }
+        match key.name() {
+            // inbound
+            INBOUND_ALL_SUCCESSES => self.inbound.all_successes.fetch_add(value, Ordering::Relaxed),
+            INBOUND_ALL_FAILURES => self.inbound.all_failures.fetch_add(value, Ordering::Relaxed),
+            INBOUND_BLOCKS => self.inbound.blocks.fetch_add(value, Ordering::Relaxed),
+            INBOUND_GETBLOCKS => self.inbound.getblocks.fetch_add(value, Ordering::Relaxed),
+            INBOUND_GETMEMORYPOOL => self.inbound.getmemorypool.fetch_add(value, Ordering::Relaxed),
+            INBOUND_GETPEERS => self.inbound.getpeers.fetch_add(value, Ordering::Relaxed),
+            INBOUND_GETSYNC => self.inbound.getsync.fetch_add(value, Ordering::Relaxed),
+            INBOUND_MEMORYPOOL => self.inbound.memorypool.fetch_add(value, Ordering::Relaxed),
+            INBOUND_PEERS => self.inbound.peers.fetch_add(value, Ordering::Relaxed),
+            INBOUND_PINGS => self.inbound.pings.fetch_add(value, Ordering::Relaxed),
+            INBOUND_PONGS => self.inbound.pongs.fetch_add(value, Ordering::Relaxed),
+            INBOUND_SYNCS => self.inbound.syncs.fetch_add(value, Ordering::Relaxed),
+            INBOUND_SYNCBLOCKS => self.inbound.syncblocks.fetch_add(value, Ordering::Relaxed),
+            INBOUND_TRANSACTIONS => self.inbound.transactions.fetch_add(value, Ordering::Relaxed),
+            INBOUND_UNKNOWN => self.inbound.unknown.fetch_add(value, Ordering::Relaxed),
+            // outbound
+            OUTBOUND_ALL_SUCCESSES => self.outbound.all_successes.fetch_add(value, Ordering::Relaxed),
+            OUTBOUND_ALL_FAILURES => self.outbound.all_failures.fetch_add(value, Ordering::Relaxed),
+            // connections
+            CONNECTIONS_ALL_ACCEPTED => self.connections.all_accepted.fetch_add(value, Ordering::Relaxed),
+            CONNECTIONS_ALL_INITIATED => self.connections.all_initiated.fetch_add(value, Ordering::Relaxed),
+            CONNECTIONS_ALL_REJECTED => self.connections.all_rejected.fetch_add(value, Ordering::Relaxed),
+            // handshakes
+            HANDSHAKES_FAILURES_INIT => self.handshakes.failures_init.fetch_add(value, Ordering::Relaxed),
+            HANDSHAKES_FAILURES_RESP => self.handshakes.failures_resp.fetch_add(value, Ordering::Relaxed),
+            HANDSHAKES_SUCCESSES_INIT => self.handshakes.successes_init.fetch_add(value, Ordering::Relaxed),
+            HANDSHAKES_SUCCESSES_RESP => self.handshakes.successes_resp.fetch_add(value, Ordering::Relaxed),
+            HANDSHAKES_TIMEOUTS_INIT => self.handshakes.timeouts_init.fetch_add(value, Ordering::Relaxed),
+            HANDSHAKES_TIMEOUTS_RESP => self.handshakes.timeouts_resp.fetch_add(value, Ordering::Relaxed),
+            // misc
+            MISC_BLOCK_HEIGHT => 0, // obtained ad-hoc for the purposes of RPC metrics
+            MISC_BLOCKS_MINED => self.misc.blocks_mined.fetch_add(value, Ordering::Relaxed),
+            MISC_DUPLICATE_BLOCKS => self.misc.duplicate_blocks.fetch_add(value, Ordering::Relaxed),
+            MISC_DUPLICATE_SYNC_BLOCKS => self.misc.duplicate_sync_blocks.fetch_add(value, Ordering::Relaxed),
+            MISC_RPC_REQUESTS => self.misc.rpc_requests.fetch_add(value, Ordering::Relaxed),
+            _ => {
+                error!("Metrics key {} wasn't assigned an operation and won't work!", key);
+                0
+            }
+        };
     }
 
     fn update_gauge(&self, key: &Key, value: GaugeValue) {
-        if let Some(name) = key.name().parts().next() {
-            match value {
-                GaugeValue::Increment(value) => {
-                    match name.borrow() {
-                        // queues
-                        QUEUES_INBOUND => self.queues.inbound.fetch_add(value as u64, Ordering::SeqCst),
-                        QUEUES_OUTBOUND => self.queues.outbound.fetch_add(value as u64, Ordering::SeqCst),
-                        // obtained ad-hoc for the purposes of RPC metrics
-                        CONNECTIONS_CONNECTING | CONNECTIONS_CONNECTED | CONNECTIONS_DISCONNECTED => 0,
-                        _ => {
-                            error!("Metrics key {} wasn't assigned an operation and won't work!", key);
-                            0
-                        }
+        match value {
+            GaugeValue::Increment(value) => {
+                match key.name() {
+                    // queues
+                    QUEUES_INBOUND => self.queues.inbound.fetch_add(value as u64, Ordering::SeqCst),
+                    QUEUES_OUTBOUND => self.queues.outbound.fetch_add(value as u64, Ordering::SeqCst),
+                    // obtained ad-hoc for the purposes of RPC metrics
+                    CONNECTIONS_CONNECTING | CONNECTIONS_CONNECTED | CONNECTIONS_DISCONNECTED => 0,
+                    _ => {
+                        error!("Metrics key {} wasn't assigned an operation and won't work!", key);
+                        0
                     }
                 }
-                GaugeValue::Decrement(value) => {
-                    match name.borrow() {
-                        // queues
-                        QUEUES_INBOUND => self.queues.inbound.fetch_sub(value as u64, Ordering::SeqCst),
-                        QUEUES_OUTBOUND => self.queues.outbound.fetch_sub(value as u64, Ordering::SeqCst),
-                        // obtained ad-hoc for the purposes of RPC metrics
-                        CONNECTIONS_CONNECTING | CONNECTIONS_CONNECTED | CONNECTIONS_DISCONNECTED => 0,
-                        _ => {
-                            error!("Metrics key {} wasn't assigned an operation and won't work!", key);
-                            0
-                        }
+            }
+            GaugeValue::Decrement(value) => {
+                match key.name() {
+                    // queues
+                    QUEUES_INBOUND => self.queues.inbound.fetch_sub(value as u64, Ordering::SeqCst),
+                    QUEUES_OUTBOUND => self.queues.outbound.fetch_sub(value as u64, Ordering::SeqCst),
+                    // obtained ad-hoc for the purposes of RPC metrics
+                    CONNECTIONS_CONNECTING | CONNECTIONS_CONNECTED | CONNECTIONS_DISCONNECTED => 0,
+                    _ => {
+                        error!("Metrics key {} wasn't assigned an operation and won't work!", key);
+                        0
                     }
                 }
-                GaugeValue::Absolute(_value) => {
-                    error!("GaugeValue::Absolute is not used!");
-                    0
-                }
-            };
-        } else {
-            error!("Metrics key {} wasn't assigned a name and won't work!", key);
-        }
+            }
+            GaugeValue::Absolute(_value) => {
+                error!("GaugeValue::Absolute is not used!");
+                0
+            }
+        };
     }
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -82,7 +82,7 @@ version = "17"
 version = "17"
 
 [dependencies.metrics]
-version = "0.15"
+version = "0.16"
 
 [dependencies.parking_lot]
 version = "0.11.1"


### PR DESCRIPTION
This PR updates the `metrics`-related dependencies.

Obviates https://github.com/AleoHQ/snarkOS/pull/761 and https://github.com/AleoHQ/snarkOS/pull/763.