### PR TITLE
Fix the version of metrics-exporter-prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "envmnt"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,53 +1531,29 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53c23fff9a59f261498953cf41dc9ffc2522fd79723bdf283c1e88dc1633624"
-dependencies = [
- "metrics-macros 0.3.0",
- "proc-macro-hack",
- "t1ha",
-]
-
-[[package]]
-name = "metrics"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c0a7fa53d812d26e59d2baf7a6f77442041454ab32908eb304447f00f0dd4de"
 dependencies = [
- "metrics-macros 0.4.0",
+ "metrics-macros",
  "proc-macro-hack",
  "t1ha",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954533c2d91c118cf2405264a4ac3a5592e84efac12b1f18561400ffef0597eb"
+checksum = "423ac561fc3300388e62947ce7f944ba6d40468afe9916ce5b7774171d8b38b8"
 dependencies = [
  "hyper",
- "metrics 0.15.1",
+ "ipnet",
+ "metrics",
  "metrics-util",
  "parking_lot",
  "quanta",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22572ba9964744e261d34553568683b76db277bcd309ebf7215e28e0982505d"
-dependencies = [
- "lazy_static",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
 ]
 
 [[package]]
@@ -1590,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6586f4c52af81a3f7832cf0bc86141d2fca7207bedd09fdd3f7da60c8dcd0c4a"
+checksum = "c0c93306cf63ff153c57963151a011194af0f33c91fe30ec30faf98732350a1a"
 dependencies = [
  "aho-corasick",
  "atomic-shim",
@@ -1601,11 +1583,12 @@ dependencies = [
  "dashmap",
  "hashbrown 0.11.2",
  "indexmap",
- "metrics 0.15.1",
+ "metrics",
  "num_cpus",
  "ordered-float",
  "parking_lot",
  "quanta",
+ "radix_trie",
  "sketches-ddsketch",
  "t1ha",
 ]
@@ -1714,6 +1697,15 @@ name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nom"
@@ -2141,6 +2133,16 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -2780,7 +2782,7 @@ dependencies = [
  "fxhash",
  "hex",
  "log",
- "metrics 0.16.0",
+ "metrics",
  "metrics-exporter-prometheus",
  "nalgebra",
  "once_cell",
@@ -2845,7 +2847,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-test",
- "metrics 0.16.0",
+ "metrics",
  "parking_lot",
  "rand 0.8.3",
  "rustc_version 0.3.3",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -75,7 +75,7 @@ version = "0.4.11"
 version = "0.16"
 
 [dependencies.metrics-exporter-prometheus]
-version = "0.4"
+version = "0.5"
 optional = true
 
 [dependencies.once_cell]


### PR DESCRIPTION
https://github.com/AleoHQ/snarkOS/pull/821 accidentally (probably during a rebase) reduced the version of `metrics-exporter-prometheus` from `0.5` to `0.4`, breaking the `prometheus` feature. This PR brings it back to `0.5`, as https://github.com/AleoHQ/snarkOS/pull/815 did.