### PR TITLE
Fix nightly clippy errors

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -149,7 +149,7 @@ impl<S: Storage> Consensus<S> {
             // 1) The block is a genesis block, or
             // 2) The block is unknown and does not correspond with the canon chain.
             if crate::is_genesis(&block.header) && self.ledger.is_empty() {
-                self.process_block(&block)?;
+                self.process_block(block)?;
             } else {
                 self.ledger.insert_only(block)?;
             }
@@ -194,7 +194,7 @@ impl<S: Storage> Consensus<S> {
                         if !side_chain_path.path.is_empty() {
                             for block_hash in side_chain_path.path {
                                 if block_hash == block.header.get_hash() {
-                                    self.process_block(&block)?
+                                    self.process_block(block)?
                                 } else {
                                     let new_block = self.ledger.get_block(&block_hash)?;
                                     self.process_block(&new_block)?;

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -158,7 +158,7 @@ impl<T: TransactionScheme> MemoryPool<T> {
         let mut new_memory_pool = Self::new();
 
         for (_, entry) in self.clone().transactions.iter() {
-            new_memory_pool.insert(&storage, entry.clone())?;
+            new_memory_pool.insert(storage, entry.clone())?;
         }
 
         self.total_size_in_bytes = new_memory_pool.total_size_in_bytes;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -19,8 +19,8 @@
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Documentation
-#![cfg_attr(nightly, feature(doc_cfg, external_doc))]
-#![cfg_attr(nightly, doc(include = "../documentation/concepts/network_server.md"))]
+#![cfg_attr(nightly, feature(doc_cfg))]
+#![cfg_attr(nightly, doc = include_str!("../documentation/concepts/network_server.md"))]
 
 #[macro_use]
 extern crate derivative;

--- a/network/src/message/message.rs
+++ b/network/src/message/message.rs
@@ -62,29 +62,29 @@ impl fmt::Display for Message {
 /// The actual message transmitted over the network.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Payload {
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/block.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/block.md"))]
     Block(Vec<u8>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_blocks.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/get_blocks.md"))]
     GetBlocks(Vec<BlockHeaderHash>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_memory_pool.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/get_memory_pool.md"))]
     GetMemoryPool,
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_peers.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/get_peers.md"))]
     GetPeers,
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_sync.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/get_sync.md"))]
     GetSync(Vec<BlockHeaderHash>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/memory_pool.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/memory_pool.md"))]
     MemoryPool(Vec<Vec<u8>>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/peers.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/peers.md"))]
     Peers(Vec<SocketAddr>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/ping.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/ping.md"))]
     Ping(BlockHeight),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/pong.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/pong.md"))]
     Pong,
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/sync.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/sync.md"))]
     Sync(Vec<BlockHeaderHash>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/sync_block.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/sync_block.md"))]
     SyncBlock(Vec<u8>),
-    #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/transaction.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/transaction.md"))]
     Transaction(Vec<u8>),
 
     // a placeholder indicating the introduction of a new payload type; used for forward compatibility

--- a/network/src/message/serialization.rs
+++ b/network/src/message/serialization.rs
@@ -106,7 +106,7 @@ impl Payload {
             match self {
                 Payload::Block(bytes) => {
                     let mut builder = builder.init_block();
-                    builder.set_data(&bytes);
+                    builder.set_data(bytes);
                 }
                 Payload::GetBlocks(hashes) => {
                     let mut builder = builder.init_get_blocks(hashes.len() as u32);
@@ -181,11 +181,11 @@ impl Payload {
                 }
                 Payload::SyncBlock(bytes) => {
                     let mut builder = builder.init_sync_block();
-                    builder.set_data(&bytes);
+                    builder.set_data(bytes);
                 }
                 Payload::Transaction(bytes) => {
                     let mut builder = builder.init_transaction();
-                    builder.set_data(&bytes);
+                    builder.set_data(bytes);
                 }
                 _ => unreachable!(),
             }
@@ -215,7 +215,7 @@ fn deserialize_block_hashes(hashes: BlockHashes<'_>) -> capnp::Result<Vec<BlockH
     for hash in hashes.iter() {
         let bytes = hash.get_hash()?;
         let mut block_hash = [0u8; 32];
-        block_hash.copy_from_slice(&bytes);
+        block_hash.copy_from_slice(bytes);
         vec.push(BlockHeaderHash(block_hash));
     }
 

--- a/network/src/message/version.rs
+++ b/network/src/message/version.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#[cfg_attr(nightly, doc(include = "../../documentation/network_messages/version.md"))]
+#[cfg_attr(nightly, doc = include_str!("../../documentation/network_messages/version.md"))]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Version {
     /// The version number of the sender's node server.

--- a/network/src/outbound/outbound.rs
+++ b/network/src/outbound/outbound.rs
@@ -88,7 +88,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
 
     pub fn send_ping(&self, remote_address: SocketAddr) {
         // Consider peering tests that don't use the sync layer.
-        let current_block_height = if let Some(ref sync) = self.sync() {
+        let current_block_height = if let Some(sync) = self.sync() {
             sync.current_block_height()
         } else {
             0

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -383,7 +383,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         trace!("Broadcasting `Ping` messages");
 
         // Consider peering tests that don't use the sync layer.
-        let current_block_height = if let Some(ref sync) = self.sync() {
+        let current_block_height = if let Some(sync) = self.sync() {
             sync.current_block_height()
         } else {
             0
@@ -412,7 +412,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         let serialized_peer_book = bincode::serialize(&SerializedPeerBook::from(&self.peer_book))?;
 
         // TODO: the peer book should be stored outside of sync
-        if let Some(ref sync) = self.sync() {
+        if let Some(sync) = self.sync() {
             // Save the serialized peer book to storage.
             sync.storage().save_peer_book_to_storage(serialized_peer_book)?;
         }

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -136,7 +136,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
                 transaction,
             };
 
-            if let Ok(Some(txid)) = memory_pool.insert(&storage, entry) {
+            if let Ok(Some(txid)) = memory_pool.insert(storage, entry) {
                 debug!(
                     "Transaction added to memory pool with txid: {:?}",
                     hex::encode(txid.clone())
@@ -147,11 +147,11 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         // Cleanse and store transactions once batch has been received.
         debug!("Cleansing memory pool transactions in database");
         memory_pool
-            .cleanse(&storage)
+            .cleanse(storage)
             .unwrap_or_else(|error| debug!("Failed to cleanse memory pool transactions in database {}", error));
         debug!("Storing memory pool transactions in database");
         memory_pool
-            .store(&storage)
+            .store(storage)
             .unwrap_or_else(|error| debug!("Failed to store memory pool transaction in database {}", error));
 
         Ok(())

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -18,9 +18,9 @@
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Documentation
-#![cfg_attr(nightly, feature(doc_cfg, external_doc))]
+#![cfg_attr(nightly, feature(doc_cfg))]
 // #![cfg_attr(nightly, warn(missing_docs))]
-#![cfg_attr(nightly, doc(include = "../documentation/concepts/rpc_server.md"))]
+#![cfg_attr(nightly, doc = include_str!("../documentation/concepts/rpc_server.md"))]
 
 #[macro_use]
 extern crate derivative;

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -272,7 +272,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                     transaction,
                 };
 
-                if let Ok(inserted) = self.memory_pool()?.lock().insert(&storage, entry) {
+                if let Ok(inserted) = self.memory_pool()?.lock().insert(storage, entry) {
                     if inserted.is_some() {
                         info!("Transaction added to the memory pool.");
                         // TODO(ljedrz): checks if needs to be propagated to the network; if need be, this could
@@ -398,7 +398,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
         let full_transactions = self
             .memory_pool()?
             .lock()
-            .get_candidates(&storage, self.consensus_parameters()?.max_block_size)?;
+            .get_candidates(storage, self.consensus_parameters()?.max_block_size)?;
 
         let transaction_strings = full_transactions.serialize_as_str()?;
 

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -497,8 +497,8 @@ impl<S: Storage + Send + Sync + 'static> ProtectedRpcFunctions for RpcImpl<S> {
             .iter()
             .zip_eq(&transaction_input.old_account_private_keys)
         {
-            let record = Record::from_str(&record_string)?;
-            let private_key = PrivateKey::from_str(&private_key_string)?;
+            let record = Record::from_str(record_string)?;
+            let private_key = PrivateKey::from_str(private_key_string)?;
 
             builder = builder.add_input(private_key, record)?;
         }

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -87,10 +87,10 @@ pub trait RpcFunctions {
 
 /// Definition of private RPC endpoints that require authentication.
 pub trait ProtectedRpcFunctions {
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/createaccount.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/createaccount.md"))]
     fn create_account(&self) -> Result<RpcAccount, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/createrawtransaction.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/createrawtransaction.md"))]
     fn create_raw_transaction(
         &self,
         transaction_input: TransactionInputs,
@@ -98,31 +98,31 @@ pub trait ProtectedRpcFunctions {
 
     #[cfg_attr(
         nightly,
-        doc(include = "../documentation/private_endpoints/createtransactionkernel.md")
+        doc = include_str!("../documentation/private_endpoints/createtransactionkernel.md")
     )]
     fn create_transaction_kernel(&self, transaction_input: TransactionInputs) -> Result<String, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/createtransaction.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/createtransaction.md"))]
     fn create_transaction(&self, transaction_kernel: String) -> Result<CreateRawTransactionOuput, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/getrecordcommitments.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/getrecordcommitments.md"))]
     fn get_record_commitments(&self) -> Result<Vec<String>, RpcError>;
 
     #[cfg_attr(
         nightly,
-        doc(include = "../documentation/private_endpoints/getrecordcommitmentcount.md")
+        doc = include_str!("../documentation/private_endpoints/getrecordcommitmentcount.md")
     )]
     fn get_record_commitment_count(&self) -> Result<usize, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/getrawrecord.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/getrawrecord.md"))]
     fn get_raw_record(&self, record_commitment: String) -> Result<String, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/decoderecord.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/decoderecord.md"))]
     fn decode_record(&self, record_bytes: String) -> Result<RecordInfo, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/decryptrecord.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/decryptrecord.md"))]
     fn decrypt_record(&self, decryption_input: DecryptRecordInput) -> Result<String, RpcError>;
 
-    #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/disconnect.md"))]
+    #[cfg_attr(nightly, doc = include_str!("../documentation/private_endpoints/disconnect.md"))]
     fn disconnect(&self, address: SocketAddr);
 }

--- a/storage/src/key_value.rs
+++ b/storage/src/key_value.rs
@@ -69,7 +69,7 @@ impl FromBytes for TransactionLocation {
 
 pub fn bytes_to_u32(bytes: &[u8]) -> u32 {
     let mut num_bytes = [0u8; 4];
-    num_bytes.copy_from_slice(&bytes);
+    num_bytes.copy_from_slice(bytes);
 
     u32::from_le_bytes(num_bytes)
 }

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -171,7 +171,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
 
                 let genesis_block: Block<T> = FromBytes::read(GenesisBlock::load_bytes().as_slice())?;
 
-                let ledger_storage = Self::new(Some(&path.as_ref()), ledger_parameters, genesis_block)
+                let ledger_storage = Self::new(Some(path.as_ref()), ledger_parameters, genesis_block)
                     .expect("Ledger could not be instantiated");
 
                 // If there did not exist a primary ledger at the path,

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -310,7 +310,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         // If the block does not exist in the storage
         if !self.block_hash_exists(&block_hash) {
             // Insert it first
-            self.insert_only(&block)?;
+            self.insert_only(block)?;
         }
         // Commit it
         self.commit(block)

--- a/storage/src/objects/ledger_scheme.rs
+++ b/storage/src/objects/ledger_scheme.rs
@@ -123,6 +123,6 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> LedgerScheme
         cm: &Self::Commitment,
         witness: &Self::MerklePath,
     ) -> bool {
-        witness.verify(&digest, cm).unwrap()
+        witness.verify(digest, cm).unwrap()
     }
 }

--- a/storage/src/objects/records.rs
+++ b/storage/src/objects/records.rs
@@ -44,7 +44,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
 
     /// Get a transaction bytes given the transaction id.
     pub fn get_record<R: RecordScheme>(&self, record_commitment: &[u8]) -> Result<Option<R>, StorageError> {
-        match self.storage.get(COL_RECORDS, &record_commitment)? {
+        match self.storage.get(COL_RECORDS, record_commitment)? {
             Some(record_bytes) => {
                 let record: R = FromBytes::read(&record_bytes[..])?;
                 Ok(Some(record))

--- a/storage/src/objects/transaction.rs
+++ b/storage/src/objects/transaction.rs
@@ -26,7 +26,7 @@ use snarkvm_utilities::{
 impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
     /// Returns a transaction location given the transaction ID if it exists. Returns `None` otherwise.
     pub fn get_transaction_location(&self, transaction_id: &[u8]) -> Result<Option<TransactionLocation>, StorageError> {
-        match self.storage.get(COL_TRANSACTION_LOCATION, &transaction_id)? {
+        match self.storage.get(COL_TRANSACTION_LOCATION, transaction_id)? {
             Some(transaction_locator) => {
                 let transaction_location = TransactionLocation::read(&transaction_locator[..])?;
                 Ok(Some(transaction_location))
@@ -37,7 +37,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
 
     /// Returns a transaction given the transaction ID if it exists. Returns `None` otherwise.
     pub fn get_transaction(&self, transaction_id: &[u8]) -> Result<Option<T>, StorageError> {
-        match self.get_transaction_location(&transaction_id)? {
+        match self.get_transaction_location(transaction_id)? {
             Some(transaction_location) => {
                 let block_transactions =
                     self.get_block_transactions(&BlockHeaderHash(transaction_location.block_hash))?;

--- a/toolkit/src/dpc/transaction_kernel_builder.rs
+++ b/toolkit/src/dpc/transaction_kernel_builder.rs
@@ -281,7 +281,7 @@ impl TransactionKernel {
                 &parameters.account_signature,
                 &parameters.account_commitment,
                 &parameters.account_encryption,
-                &private_key,
+                private_key,
             )?;
 
             assert_eq!(&address, record.owner());

--- a/toolkit/src/record/record.rs
+++ b/toolkit/src/record/record.rs
@@ -60,7 +60,7 @@ impl Record {
 
     /// Return the serial number that corresponds to the record.
     pub fn to_serial_number(&self, private_key: &PrivateKey) -> Result<Vec<u8>, RecordError> {
-        let address = Address::from(&private_key)?;
+        let address = Address::from(private_key)?;
 
         // Check that the private key corresponds with the owner of the record
         if self.record.owner() != &address.address {


### PR DESCRIPTION
This PR fixes the nightly `clippy` errors and some warnings as a drive-by; not all the warnings could be fixed yet,as the `#[rpc]` attribute seems to conflict with the new way of including external docs.