### PR TITLE
Revert the removal of the check for duplicate blocks

### DIFF
--- a/storage/src/objects/block_path.rs
+++ b/storage/src/objects/block_path.rs
@@ -44,14 +44,10 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
     pub fn get_block_path(&self, block_header: &BlockHeader) -> Result<BlockPath, StorageError> {
         let block_hash = block_header.get_hash();
 
-        /*  The given block header already exists; temporarily disable this check, as it can cause issues
-            when decommitting blocks, or rather when sync blocks are received after that process - since
-            this check is done in COL_BLOCK_HEADER, a sync block that could become canonical would be rejected
-            as a duplicate
+        // The given block header already exists
         if self.block_hash_exists(&block_hash) {
             return Ok(BlockPath::ExistingBlock);
         }
-        */
 
         // The given block header is valid on the canon chain
         if self.get_latest_block()?.header.get_hash() == block_header.previous_block_hash {


### PR DESCRIPTION
As requested by @howardwu; even with the stack overflow issue being fixed with https://github.com/AleoHQ/snarkOS/pull/847, the node can still be slowed down significantly if it repeatedly enters the path that applies after the check for duplicate block entries that was commented out in https://github.com/AleoHQ/snarkOS/pull/781 (as it could interfere with post-forking syncing). Since we can still receive batches of duplicate sync blocks under certain conditions, it is safer to restore the previous behavior until a long-term fix is found.