### PR TITLE
Add a transaction storage verifier + fixer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "snarkvm-parameters",
  "snarkvm-utilities",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,7 @@ dependencies = [
  "snarkvm-utilities",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -246,7 +246,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None));
+        assert!(consensus1.ledger.validate(None, false));
     }
 
     #[tokio::test]
@@ -306,6 +306,6 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None));
+        assert!(consensus1.ledger.validate(None, false));
     }
 }

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -246,7 +246,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None, false));
+        // assert!(consensus1.ledger.validate(None, false));
     }
 
     #[tokio::test]
@@ -306,6 +306,6 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None, false));
+        // assert!(consensus1.ledger.validate(None, false));
     }
 }

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -246,7 +246,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        // assert!(consensus1.ledger.validate(None, false));
+        assert!(consensus1.ledger.validate(None, false));
     }
 
     #[tokio::test]
@@ -306,6 +306,6 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        // assert!(consensus1.ledger.validate(None, false));
+        assert!(consensus1.ledger.validate(None, false));
     }
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -82,5 +82,8 @@ version = "0.5.4"
 [dev-dependencies.snarkos-testing]
 path = "../testing"
 
+[dev-dependencies.tokio]
+version = "1"
+
 [dev-dependencies.tracing-subscriber]
 version = "0.2"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -81,3 +81,6 @@ version = "0.5.4"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"
+
+[dev-dependencies.tracing-subscriber]
+version = "0.2"

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -410,15 +410,15 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
 mod tests {
     use snarkos_testing::sync::TestBlocks;
 
-    #[test]
-    fn valid_storage_validates() {
-        tracing_subscriber::fmt::init();
+    #[tokio::test]
+    async fn valid_storage_validates() {
+        //tracing_subscriber::fmt::init();
 
         let consensus = snarkos_testing::sync::create_test_consensus();
 
         let blocks = TestBlocks::load(10, "test_blocks_100_1").0;
         for block in blocks {
-            consensus.receive_block(&block).unwrap();
+            consensus.receive_block(&block).await.unwrap();
         }
 
         assert!(consensus.ledger.validate(None, false));

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -82,6 +82,10 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
     /// it is likely that any issues are applicable only to the last few blocks. The `fix` argument determines whether
     /// the validation process should also attempt to fix the issues it encounters.
     pub fn validate(&self, mut limit: Option<usize>, fix: bool) -> bool {
+        if limit.is_some() && fix {
+            panic!("The validator can perform fixes only if there is no limit on the number of blocks to process");
+        }
+
         info!("Validating the storage...");
 
         let mut is_valid = true;


### PR DESCRIPTION
This PR is the fist step towards fixing https://github.com/AleoHQ/snarkOS/issues/861 and https://github.com/AleoHQ/snarkOS/issues/863; it extends the functionality of the existing block storage validator to transactions and their components, and is able to fix the storage of nodes affected by the aforementioned issues (most importantly https://github.com/AleoHQ/snarkOS/issues/861, which can completely halt the block sync process).

While I have already successfully tested it with one database (the node using it was initially stuck, and running the validator allowed it to fully sync with the chain) and it should be complete (i.e. ready for review) already, I'll still conduct a few additional tests with other databases to ensure that it has no bugs - it just currently takes a while (some performance improvements should be possible, but it's follow-up material).