### PR TITLE
Fix native-cpu flag on release builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.'cfg(any(not(target_arch = "wasm32"), feature = "noconfig"))']
+[target.'cfg(all(not(target_arch = "wasm32"), not(feature = "noconfig")))']
 rustflags = ["-C", "target-cpu=native"]
 
 [build]


### PR DESCRIPTION
This PR fixes the `noconfig` feature flag to disable native CPU targetting in release builds.