### PR TITLE
Fix syncing which involves previously known blocks

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -167,8 +167,13 @@ impl<S: Storage> Consensus<S> {
                     // Attempt to fast forward the block state if the node already stores
                     // the children of the new canon block.
                     let child_path = self.ledger.longest_child_path(block.header.get_hash())?;
-                    for child_block_hash in child_path {
+                    for child_block_hash in child_path.into_iter().skip(1) {
                         let new_block = self.ledger.get_block(&child_block_hash)?;
+
+                        debug!(
+                            "Fast-forwarding using the block's children. Height {}",
+                            self.ledger.get_current_block_height() + 1
+                        );
                         self.process_block(&new_block).await?;
                     }
                 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -167,11 +167,19 @@ impl<S: Storage> Consensus<S> {
                     // Attempt to fast forward the block state if the node already stores
                     // the children of the new canon block.
                     let child_path = self.ledger.longest_child_path(block.header.get_hash())?;
+
+                    if child_path.len() > 1 {
+                        debug!(
+                            "Attempting to canonize the descendants of block at height {}.",
+                            block_height
+                        );
+                    }
+
                     for child_block_hash in child_path.into_iter().skip(1) {
                         let new_block = self.ledger.get_block(&child_block_hash)?;
 
                         debug!(
-                            "Fast-forwarding using the block's children. Height {}",
+                            "Processing the next known descendant. Height {}",
                             self.ledger.get_current_block_height() + 1
                         );
                         self.process_block(&new_block).await?;

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -160,7 +160,7 @@ mod consensus_sidechain {
     }
 
     #[tokio::test]
-    async fn decommit() {
+    async fn decommit_one_block() {
         let consensus = snarkos_testing::sync::create_test_consensus();
 
         // Introduce one block.
@@ -307,5 +307,33 @@ mod consensus_sidechain {
 
         // Verify the integrity of the block storage for the first instance.
         assert!(consensus1.ledger.validate(None, false));
+    }
+
+    #[tokio::test]
+    async fn decommit_many_and_reimport() {
+        //tracing_subscriber::fmt::init();
+
+        let consensus = snarkos_testing::sync::create_test_consensus();
+        let blocks = TestBlocks::load(20, "test_blocks_100_1").0;
+
+        // Consensus imports 20 blocks.
+        for block in &blocks {
+            consensus.receive_block(block).await.unwrap();
+        }
+
+        // Consensus decommits 10 blocks.
+        for _ in 0..10 {
+            consensus.ledger.decommit_latest_block().unwrap();
+        }
+
+        // Consensus re-imports 10 blocks.
+        for block in &blocks[10..] {
+            consensus.receive_block(block).await.unwrap();
+        }
+
+        assert_eq!(consensus.ledger.get_current_block_height(), 20);
+
+        // Verify the integrity of the block storage.
+        assert!(consensus.ledger.validate(None, false));
     }
 }

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -326,10 +326,10 @@ mod consensus_sidechain {
             consensus.ledger.decommit_latest_block().unwrap();
         }
 
-        // Consensus re-imports 10 blocks.
-        for block in &blocks[10..] {
-            consensus.receive_block(block).await.unwrap();
-        }
+        assert_eq!(consensus.ledger.get_current_block_height(), 10);
+
+        // Consensus re-imports 1 block, the rest get fast-forwarded.
+        consensus.receive_block(&blocks[10]).await.unwrap();
 
         assert_eq!(consensus.ledger.get_current_block_height(), 20);
 

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -299,10 +299,7 @@ impl<S: Storage + Send + Sync + 'static> SyncMaster<S> {
         let early_blocks_count = early_blocks.len();
 
         let ledger = &self.node.expect_sync().consensus.ledger;
-        let block_order: Vec<BlockHeaderHash> = early_blocks
-            .into_iter()
-            .filter(|x| !ledger.block_hash_exists(x))
-            .collect();
+        let block_order: Vec<BlockHeaderHash> = early_blocks.into_iter().filter(|x| !ledger.is_canon(x)).collect();
 
         info!(
             "requesting {} blocks for sync, received headers for {} known blocks",

--- a/storage/src/objects/block.rs
+++ b/storage/src/objects/block.rs
@@ -158,6 +158,9 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
     /// De-commit the latest block and return its header hash.
     pub fn decommit_latest_block(&self) -> Result<BlockHeaderHash, StorageError> {
         let current_block_height = self.get_current_block_height();
+
+        tracing::debug!("Decommitting block at height {}", current_block_height);
+
         if current_block_height == 0 {
             return Err(StorageError::InvalidBlockDecommit);
         }

--- a/storage/src/objects/block_path.rs
+++ b/storage/src/objects/block_path.rs
@@ -45,7 +45,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         let block_hash = block_header.get_hash();
 
         // The given block header already exists
-        if self.block_hash_exists(&block_hash) {
+        if self.is_canon(&block_hash) {
             return Ok(BlockPath::ExistingBlock);
         }
 


### PR DESCRIPTION
This is slightly affected by https://github.com/AleoHQ/snarkOS/issues/856, but the node doesn't get blocked anymore. Also, since we're no longer requesting duplicate blocks (this PR changes this restriction to canon blocks, so that previously known blocks can become canon), that issue is way less severe than before, and takes a while only when there are a lot of pre-existing blocks to fast-forward to.

The test added by this PR fails without the `fix` commit.

Fixes https://github.com/AleoHQ/snarkOS/issues/870.

Cc https://github.com/AleoHQ/snarkOS/issues/822