### PR TITLE
A range of tweaks and fixes around storage and its verifier

### DIFF
--- a/benchmarks/syncing/syncing.rs
+++ b/benchmarks/syncing/syncing.rs
@@ -37,7 +37,7 @@ fn providing_sync_blocks(c: &mut Criterion) {
 
     const NUM_BLOCKS: usize = 10;
 
-    let blocks = TestBlocks::load(NUM_BLOCKS, "test_blocks_100_1");
+    let blocks = TestBlocks::load(Some(NUM_BLOCKS), "test_blocks_100_1");
     for block in &blocks.0 {
         rt.block_on(provider.expect_sync().consensus.receive_block(&block))
             .unwrap()

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -205,13 +205,13 @@ mod consensus_sidechain {
         let consensus2 = snarkos_testing::sync::create_test_consensus();
 
         // Consensus 1 imports a random number of blocks lower than consensus 2.
-        let blocks_1 = TestBlocks::load(rng.gen_range(0..=50), "test_blocks_100_1").0;
+        let blocks_1 = TestBlocks::load(Some(rng.gen_range(0..=50)), "test_blocks_100_1").0;
         for block in blocks_1 {
             consensus1.receive_block(&block).await.unwrap();
         }
 
         // Consensus 2 imports 100 blocks.
-        let blocks_2 = TestBlocks::load(100, "test_blocks_100_2").0;
+        let blocks_2 = TestBlocks::load(Some(100), "test_blocks_100_2").0;
         for block in &blocks_2 {
             consensus2.receive_block(block).await.unwrap();
         }
@@ -257,8 +257,8 @@ mod consensus_sidechain {
         let consensus1 = snarkos_testing::sync::create_test_consensus();
         let consensus2 = snarkos_testing::sync::create_test_consensus();
 
-        let blocks1 = TestBlocks::load(50, "test_blocks_100_1").0; // side chain blocks
-        let blocks2 = TestBlocks::load(100, "test_blocks_100_2").0; // canon blocks
+        let blocks1 = TestBlocks::load(Some(50), "test_blocks_100_1").0; // side chain blocks
+        let blocks2 = TestBlocks::load(Some(100), "test_blocks_100_2").0; // canon blocks
 
         // Consensus 2 imports 100 blocks.
         for block in &blocks2 {

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod consensus_sidechain {
+    use snarkos_storage::validator::FixMode;
     use snarkos_testing::sync::*;
     use snarkvm_dpc::{testnet1::instantiated::Tx, Block};
     use snarkvm_utilities::bytes::FromBytes;
@@ -246,7 +247,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None, false));
+        assert!(consensus1.ledger.validate(None, FixMode::Everything));
     }
 
     #[tokio::test]
@@ -306,7 +307,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None, false));
+        assert!(consensus1.ledger.validate(None, FixMode::Everything));
     }
 
     #[tokio::test]
@@ -349,6 +350,6 @@ mod consensus_sidechain {
         let shared_height = consensus2.ledger.get_block_number(&latest_shared_hash).unwrap();
         assert_eq!(shared_height, 10);
 
-        assert!(consensus2.ledger.validate(None, false));
+        assert!(consensus2.ledger.validate(None, FixMode::Everything));
     }
 }

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -223,7 +223,9 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
         let transaction_id = transaction.transaction_id()?;
         let storage = &self.storage;
         let block_number = match storage.get_transaction_location(&transaction_id.to_vec())? {
-            Some(block_location) => Some(storage.get_block_number(&BlockHeaderHash(block_location.block_hash))?),
+            Some(block_location) => storage
+                .get_block_number(&BlockHeaderHash(block_location.block_hash))
+                .ok(),
             None => None,
         };
 

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -135,7 +135,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         for (index, transaction) in block.transactions.0.iter().enumerate() {
             let transaction_location = TransactionLocation {
                 index: index as u32,
-                block_hash: block.header.get_hash().0,
+                block_hash: block_hash.0,
             };
             database_transaction.push(Op::Insert {
                 col: COL_TRANSACTION_LOCATION,
@@ -151,7 +151,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         });
         database_transaction.push(Op::Insert {
             col: COL_BLOCK_TRANSACTIONS,
-            key: block.header.get_hash().0.to_vec(),
+            key: block_hash.0.to_vec(),
             value: to_bytes![block.transactions]?.to_vec(),
         });
 

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -167,12 +167,6 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
             });
         }
 
-        database_transaction.push(Op::Insert {
-            col: COL_BLOCK_TRANSACTIONS,
-            key: block.header.get_hash().0.to_vec(),
-            value: to_bytes![block.transactions]?.to_vec(),
-        });
-
         self.storage.batch(database_transaction)?;
 
         Ok(())

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -110,7 +110,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         let mut transaction_memos = Vec::with_capacity(block.transactions.0.len());
 
         for transaction in &block.transactions.0 {
-            transaction_serial_numbers.push(transaction.transaction_id()?);
+            transaction_serial_numbers.push(transaction.old_serial_numbers());
             transaction_commitments.push(transaction.new_commitments());
             transaction_memos.push(transaction.memorandum());
         }
@@ -188,7 +188,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         let mut transaction_memos = Vec::with_capacity(block.transactions.0.len());
 
         for transaction in &block.transactions.0 {
-            transaction_serial_numbers.push(transaction.transaction_id()?);
+            transaction_serial_numbers.push(transaction.old_serial_numbers());
             transaction_commitments.push(transaction.new_commitments());
             transaction_memos.push(transaction.memorandum());
         }

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -264,13 +264,13 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
 
         database_transaction.push(Op::Insert {
             col: COL_BLOCK_LOCATOR,
-            key: block.header.get_hash().0.to_vec(),
+            key: block_header_hash.0.to_vec(),
             value: new_best_block_number.to_le_bytes().to_vec(),
         });
         database_transaction.push(Op::Insert {
             col: COL_BLOCK_LOCATOR,
             key: new_best_block_number.to_le_bytes().to_vec(),
-            value: block.header.get_hash().0.to_vec(),
+            value: block_header_hash.0.to_vec(),
         });
 
         // Rebuild the new commitment merkle tree

--- a/storage/src/objects/transaction.rs
+++ b/storage/src/objects/transaction.rs
@@ -41,7 +41,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
             Some(transaction_location) => {
                 let block_transactions =
                     self.get_block_transactions(&BlockHeaderHash(transaction_location.block_hash))?;
-                Ok(Some(block_transactions.0[transaction_location.index as usize].clone()))
+                Ok(block_transactions.0.get(transaction_location.index as usize).cloned())
             }
             None => Ok(None),
         }

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -416,7 +416,7 @@ mod tests {
 
         let consensus = snarkos_testing::sync::create_test_consensus();
 
-        let blocks = TestBlocks::load(10, "test_blocks_100_1").0;
+        let blocks = TestBlocks::load(Some(10), "test_blocks_100_1").0;
         for block in blocks {
             consensus.receive_block(&block).await.unwrap();
         }

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -28,7 +28,7 @@ macro_rules! validate_tx_components {
         fn $fn_name(
             &self,
             tx_entries: &HashSet<Vec<u8>>,
-            database_fix: &mut Option<DatabaseTransaction>,
+            db_ops: &mut Option<DatabaseTransaction>,
             is_storage_valid: &mut bool,
         ) {
             let storage_entries_and_indices = match self.storage.get_col($component_col) {
@@ -55,10 +55,10 @@ macro_rules! validate_tx_components {
                     $component_name
                 );
 
-                if let Some(ref mut fix) = database_fix {
+                if let Some(ref mut ops) = db_ops {
                     for superfluous_item in superfluous_items {
                         trace!("Staging a {} for deletion", $component_name);
-                        fix.push(Op::Delete {
+                        ops.push(Op::Delete {
                             col: $component_col,
                             key: superfluous_item.to_vec(),
                         });
@@ -69,6 +69,18 @@ macro_rules! validate_tx_components {
             }
         }
     };
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum FixMode {
+    /// Don't fix anything in the storage.
+    Nothing,
+    /// Update transaction locations if need be.
+    TxLocations,
+    /// Remove transaction serial numbers, commitments and memorandums for missing transactions.
+    TxComponents,
+    /// Apply all the available fixes.
+    Everything,
 }
 
 impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P, S> {
@@ -83,9 +95,11 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
     /// stored in the database is coherent. The optional limit restricts the number of blocks to check, as
     /// it is likely that any issues are applicable only to the last few blocks. The `fix` argument determines whether
     /// the validation process should also attempt to fix the issues it encounters.
-    pub fn validate(&self, mut limit: Option<usize>, fix: bool) -> bool {
-        if limit.is_some() && fix {
-            panic!("The validator can perform fixes only if there is no limit on the number of blocks to process");
+    pub fn validate(&self, mut limit: Option<usize>, fix_mode: FixMode) -> bool {
+        if limit.is_some() && [FixMode::TxComponents, FixMode::Everything].contains(&fix_mode) {
+            panic!(
+                "The validator can perform the specified fixes only if there is no limit on the number of blocks to process"
+            );
         }
 
         info!("Validating the storage...");
@@ -98,7 +112,11 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
             return is_valid;
         }
 
-        let mut database_fix = if fix { Some(DatabaseTransaction::new()) } else { None };
+        let mut db_ops = if fix_mode != FixMode::Nothing {
+            Some(DatabaseTransaction::new())
+        } else {
+            None
+        };
 
         let mut current_height = self.get_current_block_height();
 
@@ -189,7 +207,8 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
                 &mut tx_memos,
                 &mut tx_sns,
                 &mut tx_cms,
-                &mut database_fix,
+                &mut db_ops,
+                fix_mode,
                 &mut is_valid,
             );
 
@@ -250,14 +269,16 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
             current_hash = previous_hash;
         }
 
-        self.validate_transaction_memos(&tx_memos, &mut database_fix, &mut is_valid);
-        self.validate_transaction_sns(&tx_sns, &mut database_fix, &mut is_valid);
-        self.validate_transaction_cms(&tx_cms, &mut database_fix, &mut is_valid);
+        if [FixMode::TxComponents, FixMode::Everything].contains(&fix_mode) {
+            self.validate_transaction_memos(&tx_memos, &mut db_ops, &mut is_valid);
+            self.validate_transaction_sns(&tx_sns, &mut db_ops, &mut is_valid);
+            self.validate_transaction_cms(&tx_cms, &mut db_ops, &mut is_valid);
+        }
 
-        if let Some(fix) = database_fix {
-            if !fix.0.is_empty() {
-                info!("Fixing the storage issues");
-                if let Err(e) = self.storage.batch(fix) {
+        if let Some(ops) = db_ops {
+            if !ops.0.is_empty() {
+                info!("Fixing the detected storage issues ({} fixes)", ops.0.len());
+                if let Err(e) = self.storage.batch(ops) {
                     error!("Couldn't fix the storage issues: {}", e);
                 }
             }
@@ -281,6 +302,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         tx_sns: &mut HashSet<Vec<u8>>,
         tx_cms: &mut HashSet<Vec<u8>>,
         database_fix: &mut Option<DatabaseTransaction>,
+        fix_mode: FixMode,
         is_storage_valid: &mut bool,
     ) {
         for (block_tx_idx, tx) in block.transactions.iter().enumerate() {
@@ -369,24 +391,28 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
                             BlockHeaderHash(tx_location.block_hash)
                         );
 
-                        if let Some(ref mut fix) = database_fix {
-                            let corrected_location = TransactionLocation {
-                                index: block_tx_idx as u32,
-                                block_hash: block.header.get_hash().0,
-                            };
+                        if let Some(ref mut db_ops) = database_fix {
+                            if [FixMode::TxLocations, FixMode::Everything].contains(&fix_mode) {
+                                let corrected_location = TransactionLocation {
+                                    index: block_tx_idx as u32,
+                                    block_hash: block.header.get_hash().0,
+                                };
 
-                            match to_bytes!(corrected_location) {
-                                Ok(location_bytes) => {
-                                    fix.push(Op::Insert {
-                                        col: COL_TRANSACTION_LOCATION,
-                                        key: tx_id.to_vec(),
-                                        value: location_bytes,
-                                    });
+                                match to_bytes!(corrected_location) {
+                                    Ok(location_bytes) => {
+                                        db_ops.push(Op::Insert {
+                                            col: COL_TRANSACTION_LOCATION,
+                                            key: tx_id.to_vec(),
+                                            value: location_bytes,
+                                        });
+                                    }
+                                    Err(e) => {
+                                        error!("Can't create a block locator fix for tx {}: {}", hex::encode(tx_id), e);
+                                        *is_storage_valid = false;
+                                    }
                                 }
-                                Err(e) => {
-                                    error!("Can't create a block locator fix for tx {}: {}", hex::encode(tx_id), e);
-                                    *is_storage_valid = false;
-                                }
+                            } else {
+                                *is_storage_valid = false;
                             }
                         } else {
                             *is_storage_valid = false;
@@ -403,24 +429,5 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use snarkos_testing::sync::TestBlocks;
-
-    #[tokio::test]
-    async fn valid_storage_validates() {
-        //tracing_subscriber::fmt::init();
-
-        let consensus = snarkos_testing::sync::create_test_consensus();
-
-        let blocks = TestBlocks::load(Some(10), "test_blocks_100_1").0;
-        for block in blocks {
-            consensus.receive_block(&block).await.unwrap();
-        }
-
-        assert!(consensus.ledger.validate(None, false));
     }
 }

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -184,7 +184,7 @@ async fn block_two_node() {
 
     const NUM_BLOCKS: usize = 100;
 
-    let blocks = crate::sync::TestBlocks::load(NUM_BLOCKS, "test_blocks_100_1").0;
+    let blocks = crate::sync::TestBlocks::load(Some(NUM_BLOCKS), "test_blocks_100_1").0;
     assert_eq!(blocks.len(), NUM_BLOCKS);
 
     for block in blocks {


### PR DESCRIPTION
This PR contains a set of fixes and adjustments detected or driven by the storage verifier.

The list of changes, in commit order:
- a new test of a ledger that forks many times back and forth, plus an adjustment to the `TestBlocks` API
- remove a duplicate database operation (within a single method / database transaction)
- reuse the `block_header_hash` variable (a refactoring)
- more fine-grained fix options for the storage validator
- actually check for duplicates among serial numbers (as opposed to transaction ids)
- make `Ledger::get_transaction` safer (by using `get` instead of indexing)
- make the `decoderawtransaction` and `gettransactioninfo` RPCs not fail if block number can't be found
- update the transaction's location when committing it

Fixes https://github.com/AleoHQ/snarkOS/issues/863, https://github.com/AleoHQ/snarkOS/issues/872.