### PR TITLE
Longer RPC error responses

### DIFF
--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -105,7 +105,7 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
         _ => {
             let resp = jrt::Response::<(), ()>::error(
                 jrt::Version::V2,
-                jrt::Error::from_code(jrt::ErrorCode::ParseError),
+                jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Couldn't read the RPC body"),
                 None,
             );
             let body = serde_json::to_vec(&resp).unwrap_or_default();
@@ -120,7 +120,7 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
         Err(_) => {
             let resp = jrt::Response::<(), ()>::error(
                 jrt::Version::V2,
-                jrt::Error::from_code(jrt::ErrorCode::ParseError),
+                jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Couldn't parse the RPC body"),
                 None,
             );
             let body = serde_json::to_vec(&resp).unwrap_or_default();

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -308,23 +308,21 @@ fn read_params(req: &jrt::Request<Params>) -> Result<Vec<serde_json::Value>, jrt
 }
 
 /// Converts the crate's RpcError into a jrt::RpcError
-fn convert_crate_err(err: crate::error::RpcError) -> jrt::Error<()> {
-    let mut err = err.to_string();
-    err.truncate(31); // json-rpc-type Error length limit
-    jrt::Error::with_custom_msg(jrt::ErrorCode::ServerError(0), &err)
+fn convert_crate_err(err: crate::error::RpcError) -> jrt::Error<String> {
+    let error = jrt::Error::with_custom_msg(jrt::ErrorCode::ServerError(-32000), "internal error");
+    error.set_data(err.to_string())
 }
 
 /// Converts the jsonrpc-core's Error into a jrt::RpcError
-fn convert_core_err(err: jsonrpc_core::Error) -> jrt::Error<()> {
-    let mut err = err.to_string();
-    err.truncate(31); // json-rpc-type Error length limit
-    jrt::Error::with_custom_msg(jrt::ErrorCode::InternalError, &err)
+fn convert_core_err(err: jsonrpc_core::Error) -> jrt::Error<String> {
+    let error = jrt::Error::with_custom_msg(jrt::ErrorCode::InternalError, "JSONRPC server error");
+    error.set_data(err.to_string())
 }
 
 fn result_to_response<T: Serialize>(
     request: &jrt::Request<Params>,
-    result: Result<T, jrt::Error<()>>,
-) -> jrt::Response<serde_json::Value, ()> {
+    result: Result<T, jrt::Error<String>>,
+) -> jrt::Response<serde_json::Value, String> {
     match result {
         Ok(res) => {
             let result = serde_json::to_value(&res).unwrap_or_default();


### PR DESCRIPTION
This PR does 3 things:
- provides non-truncated error details in `error.data` (compliant with the JSONRPC 2.0 spec)
- provides a bit more error details for some errors in the `error.message` field
- uses a spec-compliant numeric value for the server errors

Note: the "Internal Error" and "Server Error" categories in the JSONRPC spec are a bit misleading:

code | message | meaning
-- | -- | --
-32603 | Internal error | Internal JSON-RPC error.
-32000 to -32099 | Server error | Reserved for implementation-defined server-errors.

I decided to report "internal error" for the `ServerError` code (as it's for errors internal to the node) and "JSONRPC server error" for the `InternalError` code, as it is internal to the JSON-RPC implementation (we're still using some components of the `jsonrpc` crate).

Closes https://github.com/AleoHQ/snarkOS/issues/876.