### PR TITLE
Safer block decommits

### DIFF
--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -203,7 +203,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
                 // the secondary instance requires it.
                 if update_merkle_tree {
                     // Update the Merkle tree of the secondary instance.
-                    self.rebuild_merkle_tree(vec![])?;
+                    self.rebuild_merkle_tree(Default::default(), vec![])?;
                 }
             }
         }

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -280,7 +280,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
         });
 
         // Rebuild the new commitment merkle tree
-        self.rebuild_merkle_tree(transaction_cms)?;
+        self.rebuild_merkle_tree(Default::default(), transaction_cms)?;
         let tree = self.cm_merkle_tree.load();
         let new_digest = tree.root();
 


### PR DESCRIPTION
This PR makes the block decommit process safer by performing all the related database operations within a single transaction. This should have the side effect of making it slightly faster as well.

Note: while it is technically possible to perform multiple decommits in a single batch, we don't need to optimize for it, as it is not the usual path.