### PR TITLE
Fix block_on node hanging

### DIFF
--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -358,7 +358,7 @@ mod consensus_sidechain {
         //tracing_subscriber::fmt::init();
 
         let consensus = snarkos_testing::sync::create_test_consensus();
-        let blocks = TestBlocks::load(20, "test_blocks_100_1").0;
+        let blocks = TestBlocks::load(Some(20), "test_blocks_100_1").0;
 
         // Consensus imports 20 blocks.
         for block in &blocks {
@@ -378,6 +378,6 @@ mod consensus_sidechain {
         assert_eq!(consensus.ledger.get_current_block_height(), 20);
 
         // Verify the integrity of the block storage.
-        assert!(consensus.ledger.validate(None, false));
+        assert!(consensus.ledger.validate(None, FixMode::Nothing));
     }
 }

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -283,7 +283,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                             }
                             Ok(None) => (),
                             Err(e) => {
-                                error!("failed to insert into memory pool: {:?}", e);
+                                error!("Failed to insert into memory pool: {:?}", e);
                             }
                         },
                         Err(e) => {

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -287,7 +287,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                             }
                         },
                         Err(e) => {
-                            error!("failed to fetch memory pool: {:?}", e);
+                            error!("Failed to fetch memory pool: {:?}", e);
                         }
                     }
                 });

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -277,15 +277,13 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
                 let self_clone = self.clone();
                 tokio::spawn(async move {
                     match self_clone.memory_pool() {
-                        Ok(pool) => {
-                            match pool.insert(&self_clone.storage, entry).await {
-                                Ok(Some(_)) => {
-                                    info!("Transaction added to the memory pool.");
-                                },
-                                Ok(None) => (),
-                                Err(e) => {
-                                    error!("failed to insert into memory pool: {:?}", e);
-                                }
+                        Ok(pool) => match pool.insert(&self_clone.storage, entry).await {
+                            Ok(Some(_)) => {
+                                info!("Transaction added to the memory pool.");
+                            }
+                            Ok(None) => (),
+                            Err(e) => {
+                                error!("failed to insert into memory pool: {:?}", e);
                             }
                         },
                         Err(e) => {


### PR DESCRIPTION
This PR fixes a bug introduced by lockless that causes nodes to hang after a certain number of calls to `send_raw_transaction`. Currently running on `us-testnet1` and seems to have fixed the problem.