### PR TITLE
Introduce a storage cleanup tool

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -26,6 +26,9 @@ pub use key_value::*;
 pub mod objects;
 pub use objects::*;
 
+pub mod trim;
+pub use trim::*;
+
 pub mod mem;
 #[cfg(feature = "mem_storage")]
 pub use mem::MemDb as LedgerStorage;

--- a/storage/src/trim.rs
+++ b/storage/src/trim.rs
@@ -1,0 +1,103 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    Ledger,
+    COL_BLOCK_HEADER,
+    COL_BLOCK_LOCATOR,
+    COL_BLOCK_TRANSACTIONS,
+    COL_CHILD_HASHES,
+    COL_TRANSACTION_LOCATION,
+};
+use snarkvm_algorithms::traits::LoadableMerkleParameters;
+use snarkvm_dpc::{BlockHeader, BlockHeaderHash, DatabaseTransaction, Op, Storage, StorageError, TransactionScheme};
+use snarkvm_utilities::FromBytes;
+
+use tracing::*;
+
+use std::collections::HashSet;
+
+impl<T: TransactionScheme + Send + Sync, P: LoadableMerkleParameters, S: Storage + Sync> Ledger<T, P, S> {
+    pub fn trim(&self) -> Result<(), StorageError> {
+        info!("Checking for obsolete objects in the storage...");
+
+        let locator_col = self.storage.get_col(COL_BLOCK_LOCATOR)?;
+        let canon_hashes = locator_col
+            .into_iter()
+            .filter(|(locator_key, locator_value)| locator_key.len() < locator_value.len())
+            .map(|(_block_number_bytes, block_hash)| block_hash)
+            .collect::<HashSet<_>>();
+
+        let headers_col = self.storage.get_col(COL_BLOCK_HEADER)?;
+
+        let mut database_transaction = DatabaseTransaction::new();
+
+        for (block_hash_bytes, block_header_bytes) in headers_col {
+            if !canon_hashes.contains(&block_hash_bytes) {
+                let block_hash = BlockHeaderHash::new(block_hash_bytes.to_vec());
+                let block_header = BlockHeader::read(&block_header_bytes[..])?;
+
+                trace!("Block {} is obsolete, staging its objects for removal", block_hash);
+
+                // Remove obsolete transactions
+
+                database_transaction.push(Op::Delete {
+                    col: COL_BLOCK_TRANSACTIONS,
+                    key: block_hash_bytes.to_vec(),
+                });
+                for transaction in self.get_block_transactions(&block_hash)?.0 {
+                    database_transaction.push(Op::Delete {
+                        col: COL_TRANSACTION_LOCATION,
+                        key: transaction.transaction_id()?.to_vec(),
+                    });
+                }
+
+                // Remove parent's obsolete reference
+
+                let parent_hash = &block_header.previous_block_hash;
+                let mut parent_child_hashes = self.get_child_block_hashes(parent_hash)?;
+
+                if let Some(index) = parent_child_hashes
+                    .iter()
+                    .position(|child_hash| *child_hash == block_hash)
+                {
+                    parent_child_hashes.remove(index);
+
+                    database_transaction.push(Op::Insert {
+                        col: COL_CHILD_HASHES,
+                        key: parent_hash.0.to_vec(),
+                        value: bincode::serialize(&parent_child_hashes)?,
+                    });
+                }
+
+                // Remove the obsolete header
+
+                database_transaction.push(Op::Delete {
+                    col: COL_BLOCK_HEADER,
+                    key: block_hash_bytes.into_vec(),
+                });
+            }
+        }
+
+        let num_items = database_transaction.0.len();
+        if !database_transaction.0.is_empty() {
+            self.storage.batch(database_transaction)?;
+        }
+        info!("The storage was trimmed successfully ({} items removed)!", num_items);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR introduces a (persistent) storage cleanup tool that can be run periodically in order to remove obsolete items, reducing the number of items stored - this makes it faster to query and can reduce its on-disk size (though not necessarily immediately - the database might need to run automated compaction for this to happen).

Another benefit of such a tool is the ability to measure how many blocks and transactions become non-canon.

The new functionality is not exposed to the user yet, as I'd like to test it against more databases first; initial test results across a few databases are quite positive, and the storage validator confirms that this process doesn't affect the coherence of the storage.

Cc https://github.com/AleoHQ/snarkOS/issues/826.