### PR TITLE
Update snarkVM to 0.6, mpmc-map to 0.2, run cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "approx"
@@ -136,9 +136,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7f7096bc256f5e5cb960f60dfc4f4ef979ca65abe7fb9d5a4f77150d3783d4"
+checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
 
 [[package]]
 name = "bincode"
@@ -274,20 +274,20 @@ checksum = "57a0c69996d49009cc837defe299dabc9bd722cfb7029837b71fe33a76bc8dd6"
 
 [[package]]
 name = "capnpc"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c8a9d317b4818641686784227e08ee161d0dbd0c2a06f0355f107df263f549"
+checksum = "b47bce811162518b5c38f746ed584bd2922ae7bb560ef64f230d2e4ee0d111fe"
 dependencies = [
  "capnp",
 ]
 
 [[package]]
 name = "cast"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -472,9 +472,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -805,6 +805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+dependencies = [
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,12 +1101,6 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -1107,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -1229,12 +1232,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1260,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1412,9 +1415,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.96"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5600b4e6efc5421841a2138a6b082e07fe12f9aaa12783d50e5d13325b26b4fc"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -1440,13 +1443,14 @@ dependencies = [
 
 [[package]]
 name = "libsodium-sys"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a685b64f837b339074115f2e7f7b431ac73681d08d75b389db7498b8892b8a58"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
+ "walkdir",
 ]
 
 [[package]]
@@ -1594,7 +1598,7 @@ dependencies = [
  "crossbeam-epoch 0.9.5",
  "crossbeam-utils 0.8.5",
  "dashmap",
- "hashbrown 0.11.2",
+ "hashbrown",
  "indexmap",
  "metrics",
  "num_cpus",
@@ -1624,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -1646,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "mpmc-map"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e950c4440703d9c82bed62ef3ff90100230150b3ae26584b1031eca39c89464"
+checksum = "f25ba43df177286c05021106ac009fc059226acafc06afdd8f8cf16d6ecd54e2"
 dependencies = [
  "arc-swap",
  "im",
@@ -1790,9 +1794,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "oorandom"
@@ -1808,9 +1812,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1828,9 +1832,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
@@ -1934,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1965,15 +1969,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
 ]
@@ -2112,14 +2116,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2139,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2153,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
 ]
@@ -2171,11 +2175,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2184,7 +2188,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2198,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "9.0.0"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
+checksum = "ca44a6969530696b262cc8d72ea432a561f3b25aebd664788cf633f826fc1a6f"
 dependencies = [
  "bitflags",
 ]
@@ -2238,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -2292,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64",
  "bytes",
@@ -2357,6 +2361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.3",
 ]
 
 [[package]]
@@ -2470,6 +2483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2585,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
+name = "signature"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+
+[[package]]
 name = "simba"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2641,7 @@ dependencies = [
  "dirs",
  "hex",
  "parking_lot",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rusty-hook",
  "self_update",
  "serde",
@@ -2644,7 +2669,7 @@ dependencies = [
  "csv",
  "derivative",
  "digest 0.7.6",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rand_xorshift",
  "rayon",
  "smallvec",
@@ -2669,7 +2694,7 @@ dependencies = [
  "criterion",
  "hex",
  "mpmc-map",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rand_xorshift",
  "snarkos-profiler",
  "snarkos-storage",
@@ -2721,7 +2746,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "peak_alloc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "serde",
  "snarkos-consensus",
  "snarkos-metrics",
@@ -2746,7 +2771,7 @@ dependencies = [
  "chrono",
  "curl",
  "hex",
- "rand 0.8.3",
+ "rand 0.8.4",
  "snarkos-consensus",
  "snarkos-storage",
  "snarkvm-algorithms",
@@ -2783,7 +2808,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-test",
  "parking_lot",
- "rand 0.8.3",
+ "rand 0.8.4",
  "serde",
  "serde_json",
  "snarkos-consensus",
@@ -2809,7 +2834,7 @@ dependencies = [
  "bincode",
  "hex",
  "parking_lot",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rayon",
  "rocksdb",
  "serde",
@@ -2835,7 +2860,7 @@ dependencies = [
  "bincode",
  "futures 0.3.15",
  "once_cell",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rand_xorshift",
  "snarkos-consensus",
  "snarkos-network",
@@ -2862,7 +2887,7 @@ dependencies = [
  "criterion",
  "getrandom 0.2.3",
  "hex",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rand_chacha 0.3.1",
  "snarkvm-algorithms",
  "snarkvm-dpc",
@@ -2874,16 +2899,19 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f603fdc7bda72382ba25aeedbc6b86e4a0b8ec84d17aa355c4ec28e7655d3b6"
+checksum = "ba6482ab4ec9170c9b8ce6c1ac9689d02aba1e112b474fa10cb72e8dda6ae0bd"
 dependencies = [
  "bitvec",
  "blake2",
+ "crossbeam-channel 0.5.1",
  "derivative",
  "digest 0.9.0",
  "itertools 0.10.1",
- "rand 0.8.3",
+ "lazy_static",
+ "once_cell",
+ "rand 0.8.4",
  "rand_chacha 0.3.1",
  "rayon",
  "sha2",
@@ -2898,12 +2926,12 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1a4b3cb0a68de48d3263a25fa63a3ae14df1f5042fdf536a207b616f1e4217"
+checksum = "29f5549929d0cc1cb8165e643f2d348f619f2f7cd5ce655201b36bf8b1aa4494"
 dependencies = [
  "derivative",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rand_xorshift",
  "rustc_version 0.3.3",
  "serde",
@@ -2914,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87c013ae803f616168939152836beb419cc7d76a12e17db3c723a0c11faa612"
+checksum = "45886a0c7a81323c267a4c2cfab1de7f0621a8f03a04fb78e2ea4f3ae5e26066"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2927,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b53fac158f2c002a0598b640a5e630cba11928399df94ec7c875545940dc77"
+checksum = "03ce3598d82ad7b3401c6d9a2a1a97dfce24eb25dba75e366389d106a62d3995"
 dependencies = [
  "anyhow",
  "base58",
@@ -2941,7 +2969,7 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "once_cell",
- "rand 0.8.3",
+ "rand 0.8.4",
  "serde",
  "sha2",
  "snarkvm-algorithms",
@@ -2957,13 +2985,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818e32f60d87abbe22e04d44ec358849e78393ae7e0a315334e3402dea909198"
+checksum = "9467325948cf839e5aeb5c91a502a2b79474d35672155a225b51b7b2c39e8e5e"
 dependencies = [
  "bincode",
  "derivative",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rand_xorshift",
  "serde",
  "snarkvm-utilities",
@@ -2972,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ada1393bd60a1f0536a6cf7acf7f5b0baea3f60c272298381b36254ee02fe86"
+checksum = "2511b5493f835f6908ee1c1411b233c1abb5de7937925dd17ca44ae6e819a186"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2992,17 +3020,17 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-marlin"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef15310b32f87802a9011d4afb6f969035b75c976469826bc66f07942954bfc2"
+checksum = "594ed731d76ede3469b3c58f6f0269dfafa1fe40212eaa071b3414cde7aa6510"
 dependencies = [
  "blake2",
  "derivative",
  "digest 0.9.0",
- "hashbrown 0.11.2",
- "rand 0.8.3",
+ "hashbrown",
+ "rand 0.8.4",
  "rand_chacha 0.3.1",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
  "rayon",
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -3016,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423de9bd2138a73ae8eb7e7962d1c392adfb3c94f51f1a0de7ad0bd955a446d9"
+checksum = "f8591a36b0a21f24394ec6a592ac3e6d669694156094771bd0a58c0c113b2d25"
 dependencies = [
  "curl",
  "hex",
@@ -3029,14 +3057,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-polycommit"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad666519a605b37c5fd6137ee293d03c9c52de65d8565886450a9cd43106d884"
+checksum = "8a3aeb9bbb5b4af050ee506e934d38f47d6216eb8c7c69b24f1c566aa7f5493c"
 dependencies = [
  "derivative",
  "digest 0.9.0",
- "hashbrown 0.11.2",
- "rand_core 0.6.2",
+ "hashbrown",
+ "rand_core 0.6.3",
  "snarkvm-algorithms",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -3048,12 +3076,12 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-posw"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1af4fd2212a3fc46589fc5956c3df9e9d70c2ce22170dfa26a47b035be955d3"
+checksum = "bf5d55735fcefc0bdcce28f71270ba2f63ab2605610dce794f74bbba5e9b6629"
 dependencies = [
  "blake2",
- "rand 0.8.3",
+ "rand 0.8.4",
  "snarkvm-algorithms",
  "snarkvm-curves",
  "snarkvm-dpc",
@@ -3070,15 +3098,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce44449083a65a43271d39db5b219bc17eaf8f21b155edf6598ba8d3eb868ad0"
+checksum = "a8892a13630b65576cd983bc69fa89bdff3f568e56466cc523a1cee783ec1513"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775650eb6ea9bec8b8b185a612ce99d91962af40579134cc9d4964902172ef51"
+checksum = "ea6805a58c986fd78be5cf474a62e40b19abf64187457874a7c93f0b8573fde6"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -3091,12 +3119,12 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c3439bd12599fcaca1d885eb9051c885f2276be2dd0e2692e5f90cc03466f1"
+checksum = "1f6dcdbf85edf6a03157aef21608e3c44835eeff97d0c2d0b3c90b3bcb869e82"
 dependencies = [
  "bincode",
- "rand 0.8.3",
+ "rand 0.8.4",
  "snarkvm-derives",
  "thiserror",
 ]
@@ -3110,8 +3138,8 @@ dependencies = [
  "blake2",
  "byteorder",
  "chacha20poly1305",
- "rand 0.8.3",
- "rand_core 0.6.2",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
  "rustc_version 0.3.3",
  "sha2",
  "sodiumoxide",
@@ -3131,10 +3159,11 @@ dependencies = [
 
 [[package]]
 name = "sodiumoxide"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
+checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
+ "ed25519",
  "libc",
  "libsodium-sys",
  "serde",
@@ -3142,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "str-buf"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66ae6a6cd930c97707cb3f1b62aadb8ddddd2fefa9df539564b3bfaa15dd31f"
+checksum = "4970bdb6571be2d30ed592d983d4ffb956d52bc2bdd64b3314a12d843e38cb2e"
 dependencies = [
  "serde",
 ]
@@ -3210,7 +3239,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -3237,18 +3266,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3301,9 +3330,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
+checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3314,6 +3343,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
@@ -3523,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,17 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-posw]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkos-consensus]
 path = "./consensus"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,22 +33,22 @@ path = "network/network.rs"
 harness = false
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-curves]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-parameters]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-posw]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -61,7 +61,7 @@ version = "0.8"
 version = "1.0"
 
 [dependencies.mpmc-map]
-version = "0.1"
+version = "0.2"
 
 [dependencies.tracing]
 default-features = false

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,19 +18,19 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-curves]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-posw]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.tokio]
 version = "1"

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -177,7 +177,7 @@ impl<T: TransactionScheme + Send + Sync + 'static> MemoryPool<T> {
             new_memory_pool.total_size_in_bytes.load(Ordering::SeqCst),
             Ordering::SeqCst,
         );
-        self.transactions.reset(new_memory_pool.transactions.inner_full());
+        self.transactions.reset(new_memory_pool.transactions.inner_full()).await;
 
         Ok(())
     }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -37,4 +37,4 @@ version = "1"
 features = [ "macros", "rt-multi-thread" ]
 
 [dev-dependencies.snarkvm-derives]
-version = "0.5.4"
+version = "0.6.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,13 +21,13 @@ edition = "2018"
 prometheus = [ "snarkos-metrics/prometheus" ]
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -145,7 +145,7 @@ version = "1.2"
 version = "0.1"
 
 [dependencies.mpmc-map]
-version = "0.1"
+version = "0.2"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -18,17 +18,17 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 default-features = false
 
 [dependencies.snarkvm-parameters]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.arc-swap]
 version = "1.2"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 default-features = false
 
 [dependencies.curl]
@@ -36,16 +36,16 @@ version = "0.4.36"
 optional = true
 
 [dev-dependencies.snarkvm-curves]
-version = "0.5.4"
+version = "0.6.0"
 
 [dev-dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dev-dependencies.snarkvm-marlin]
-version = "0.5.4"
+version = "0.6.0"
 
 [dev-dependencies.snarkvm-posw]
-version = "0.5.4"
+version = "0.6.0"
 
 [dev-dependencies.snarkos-consensus]
 path = "../consensus"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,14 +18,14 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -24,19 +24,19 @@ mem_storage = [ ]
 test = [ ]
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.parking_lot]
 version = "0.11"
 
 [dependencies.snarkvm-parameters]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkos-parameters]
 path = "../parameters"
@@ -80,7 +80,7 @@ version = "0.1"
 path = "../consensus"
 
 [dev-dependencies.snarkvm-curves]
-version = "0.5.4"
+version = "0.6.0"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -29,22 +29,22 @@ network = [
 ]
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-curves]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-parameters]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-posw]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/toolkit/Cargo.toml
+++ b/toolkit/Cargo.toml
@@ -26,17 +26,17 @@ path = "benches/account.rs"
 harness = false
 
 [dependencies.snarkvm-algorithms]
-version = "0.5.4"
+version = "0.6.0"
 default-features = false
 features = [ "wasm" ]
 
 [dependencies.snarkvm-dpc]
-version = "0.5.4"
+version = "0.6.0"
 default-features = false
 features = [ "wasm" ]
 
 [dependencies.snarkvm-utilities]
-version = "0.5.4"
+version = "0.6.0"
 
 [dependencies.anyhow]
 version = "1.0.40"


### PR DESCRIPTION
The first 2 commits update the TOML files, and the last one is a combined LOCK update after a `cargo update` run.