### PR TITLE
chore: clippy lints

### DIFF
--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -311,7 +311,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // The peer book will determine if we have seen the peer before,
             // and include the peer if it is new.
             self.peer_book
-                .add_peer(*peer_address, self.config.bootnodes().contains(&peer_address))
+                .add_peer(*peer_address, self.config.bootnodes().contains(peer_address))
                 .await;
         }
 

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -154,7 +154,7 @@ impl KnownNetwork {
         // Only retain connections that aren't removed.
         self.connections
             .write()
-            .retain(|connection| !connections_to_remove.contains(&connection));
+            .retain(|connection| !connections_to_remove.contains(connection));
 
         // Scope the write lock.
         {

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -283,13 +283,13 @@ impl<T: TransactionScheme + Send + Sync, P: LoadableMerkleParameters, S: Storage
         self.validate_block_transactions(
             &block,
             block_height,
-            &tx_memos,
-            &tx_sns,
-            &tx_cms,
-            &tx_digests,
-            &database_fix,
+            tx_memos,
+            tx_sns,
+            tx_cms,
+            tx_digests,
+            database_fix,
             fix_mode,
-            &is_storage_valid,
+            is_storage_valid,
         );
 
         // The genesis block has no parent.


### PR DESCRIPTION
Fixes a few needless borrow lints.

In addition some of the lints are caused by false positives: rust-lang/rust-clippy#7422, these should be fixed in the next `nightly` release. 
