### PR TITLE
feat: expose centrality measurements via rpc

### DIFF
--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -14,14 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-// Network crawler:
-// Start a crawler task (similar to the peers task) which updates state. Only one peer would be
-// connected at a time to start and would be queried for peers. It would then select on peer at
-// random to continue the crawl.
-//
-// Q: extend the network protocol to include statistics or node metadata?
-// Q: when to perform centrality computation?
-
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashSet},

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -179,34 +179,31 @@ impl KnownNetwork {
 #[derive(Debug)]
 pub struct NetworkMetrics {
     /// The total node count of the network.
-    node_count: usize,
+    pub node_count: usize,
     /// The total connection count for the network.
-    connection_count: usize,
+    pub connection_count: usize,
     /// The network density.
     ///
     /// This is defined as actual connections divided by the total number of possible connections.
-    density: f64,
+    pub density: f64,
     /// The algebraic connectivity of the network.
     ///
     /// This is the value of the Fiedler eigenvalue, the second-smallest eigenvalue of the network's
     /// Laplacian matrix.
-    algebraic_connectivity: f64,
+    pub algebraic_connectivity: f64,
     /// The difference between the node with the largest connection count and the node with the
     /// lowest.
-    degree_centrality_delta: f64,
+    pub degree_centrality_delta: f64,
     /// Node centrality measurements mapped to each node's address.
     ///
     /// Includes degree centrality, eigenvector centrality (the relative importance of a node in
     /// the network) and Fiedler vector (describes a possible partitioning of the network).
-    centrality: BTreeMap<SocketAddr, NodeCentrality>,
+    pub centrality: BTreeMap<SocketAddr, NodeCentrality>,
 }
 
 impl NetworkMetrics {
     /// Returns the network metrics for the state described by the connections list.
-    pub fn new(known_network: &KnownNetwork) -> Self {
-        // Copy the connections as the data must not change throughout the metrics computation.
-        let connections: HashSet<Connection> = known_network.connections();
-
+    pub fn new(connections: HashSet<Connection>) -> Self {
         // Construct the list of nodes from the connections.
         let mut nodes: HashSet<SocketAddr> = HashSet::new();
         for connection in connections.iter() {
@@ -263,20 +260,20 @@ impl NetworkMetrics {
 
 /// Centrality measurements of a node.
 #[derive(Debug)]
-struct NodeCentrality {
+pub struct NodeCentrality {
     /// Connection count of the node.
-    degree_centrality: u16,
+    pub degree_centrality: u16,
     /// A measure of the relative importance of the node in the network.
     ///
     /// Summing the values of each node adds up to the number of nodes in the network. This was
     /// done to allow comparison between different network topologies irrespective of node count.
-    eigenvector_centrality: f64,
+    pub eigenvector_centrality: f64,
     /// This value is extracted from the Fiedler eigenvector corresponding to the second smallest
     /// eigenvalue of the Laplacian matrix of the network.
     ///
     /// The network can be partitioned on the basis of these values (positive, negative and when
     /// relevant close to zero).
-    fiedler_value: f64,
+    pub fiedler_value: f64,
 }
 
 impl NodeCentrality {

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -176,7 +176,7 @@ impl KnownNetwork {
 }
 
 /// Network topology measurements.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NetworkMetrics {
     /// The total node count of the network.
     pub node_count: usize,
@@ -204,6 +204,12 @@ pub struct NetworkMetrics {
 impl NetworkMetrics {
     /// Returns the network metrics for the state described by the connections list.
     pub fn new(connections: HashSet<Connection>) -> Self {
+        // Don't compute the metrics for an empty set of connections.
+        if connections.is_empty() {
+            // Returns all metrics set to `0`.
+            return Self::default();
+        }
+
         // Construct the list of nodes from the connections.
         let mut nodes: HashSet<SocketAddr> = HashSet::new();
         for connection in connections.iter() {

--- a/rpc/documentation/public_endpoints/getnetworkgraph.md
+++ b/rpc/documentation/public_endpoints/getnetworkgraph.md
@@ -6,14 +6,22 @@ None
 
 ### Response
 
-| Parameter                 | Type       | Description                               |
-| :-----------------------: | :--------: | :---------------------------------------: |
-| `edges`                   | array      | The list of connections known by the node |
-| `vertices`                | array      | The list of nodes known by the node       |
-| `edges[i].source`         | SocketAddr | One side of the crawled connection        |
-| `edges[i].target`         | SocketAddr | The other side of the crawled connection  |
-| `vertices[i].addr`        | SocketAddr | The recorded address of the crawled node  |
-| `vertices[i].is_bootnode` | bool       | Indicates whether the node is a bootnode  |
+| Parameter                            | Type       | Description                                                                               |
+| :----------------------------------: | :--------: | :---------------------------------------------------------------------------------------: |
+| `node_count`                         | usize      | The number of nodes known by the node                                                     |
+| `connection_count`                   | usize      | The number of connection known by the node                                                |
+| `density`                            | f64        | The density of the known network                                                          |
+| `algebraic_connectivity`             | f64        | The algebraic connectivity, aka the fiedler eigenvalue of the known network               |
+| `degree_centrality_delta`            | f64        | The difference between the largest and the smallest peer count in the network             |
+| `edges`                              | array      | The list of connections known by the node                                                 |
+| `vertices`                           | array      | The list of nodes known by the node                                                       |
+| `edges[i].source`                    | SocketAddr | One side of the crawled connection                                                        |
+| `edges[i].target`                    | SocketAddr | The other side of the crawled connection                                                  |
+| `vertices[i].addr`                   | SocketAddr | The recorded address of the crawled node                                                  |
+| `vertices[i].is_bootnode`            | bool       | Indicates whether the node is a bootnode                                                  |
+| `vertices[i].degree_centrality`      | u16        | The node's degree centrality, aka its connection count                                    |
+| `vertices[i].eigenvector_centrality` | f64        | The node's eigenvector centrality, indicates its relative importance in the network       |
+| `vertices[i].fiedler_value`          | f64        | The node's fiedler value, can be used to partition the network graph                      |
 
 ### Example
 ```ignore

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -39,7 +39,7 @@ use snarkvm_utilities::{
 
 use chrono::Utc;
 
-use std::{collections::HashSet, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
 /// Implements JSON-RPC HTTP endpoint functions for a node.
 /// The constructor is given Arc::clone() copies of all needed node components.

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -21,7 +21,7 @@
 use crate::{error::RpcError, rpc_trait::RpcFunctions, rpc_types::*};
 use snarkos_consensus::{get_block_reward, memory_pool::Entry, ConsensusParameters, MemoryPool, MerkleTreeLedger};
 use snarkos_metrics::{snapshots::NodeStats, stats::NODE_STATS};
-use snarkos_network::{KnownNetwork, Node, Sync};
+use snarkos_network::{KnownNetwork, NetworkMetrics, Node, Sync};
 use snarkvm_dpc::{
     testnet1::{
         instantiated::{Components, Tx},
@@ -378,27 +378,42 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     }
 
     fn get_network_graph(&self) -> Result<NetworkGraph, RpcError> {
-        let mut vertices = HashSet::new();
-        let edges: HashSet<Edge> = self
-            .known_network()?
-            .connections()
+        // Copy the connections as the data must not change throughout the metrics computation.
+        let connections = self.known_network()?.connections();
+
+        // Collect the edges.
+        let edges = connections
             .iter()
-            .map(|connection| {
-                let (source, target) = (connection.source, connection.target);
-
-                vertices.insert(Vertice {
-                    addr: source,
-                    is_bootnode: self.node.config.bootnodes().contains(&source),
-                });
-                vertices.insert(Vertice {
-                    addr: target,
-                    is_bootnode: self.node.config.bootnodes().contains(&target),
-                });
-
-                Edge { source, target }
+            .map(|connection| Edge {
+                source: connection.source,
+                target: connection.target,
             })
             .collect();
 
-        Ok(NetworkGraph { vertices, edges })
+        // Compute the metrics.
+        let network_metrics = NetworkMetrics::new(connections);
+
+        // Collect the vertices with the metrics.
+        let vertices = network_metrics
+            .centrality
+            .iter()
+            .map(|(addr, node_centrality)| Vertice {
+                addr: *addr,
+                is_bootnode: self.node.config.bootnodes().contains(&addr),
+                degree_centrality: node_centrality.degree_centrality,
+                eigenvector_centrality: node_centrality.eigenvector_centrality,
+                fiedler_value: node_centrality.fiedler_value,
+            })
+            .collect();
+
+        Ok(NetworkGraph {
+            node_count: network_metrics.node_count,
+            connection_count: network_metrics.connection_count,
+            density: network_metrics.density,
+            algebraic_connectivity: network_metrics.algebraic_connectivity,
+            degree_centrality_delta: network_metrics.degree_centrality_delta,
+            vertices,
+            edges,
+        })
     }
 }

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -19,7 +19,7 @@
 use chrono::{DateTime, Utc};
 use jsonrpc_core::Metadata;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, net::SocketAddr};
+use std::net::SocketAddr;
 
 /// Defines the authentication format for accessing private endpoints on the RPC server
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -283,19 +283,42 @@ pub struct TransactionRecipient {
     pub amount: u64,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+/// The crawled known network and measurements.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NetworkGraph {
-    pub vertices: HashSet<Vertice>,
-    pub edges: HashSet<Edge>,
+    /// The number of nodes in the known network.
+    pub node_count: usize,
+    /// The number of connections in the known network.
+    pub connection_count: usize,
+    /// The density of the network: actual connections divided by the number of possible
+    /// connections.
+    pub density: f64,
+    /// The fiedler eigenvalue.
+    pub algebraic_connectivity: f64,
+    /// The difference between the node with the largest connection count and the node with the
+    /// lowest.
+    pub degree_centrality_delta: f64,
+
+    /// Known nodes.
+    pub vertices: Vec<Vertice>,
+    /// Known connections.
+    pub edges: Vec<Edge>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+/// Metadata and measurements pertaining to a node in the graph of the known network.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Vertice {
     pub addr: SocketAddr,
     pub is_bootnode: bool,
+
+    // Centrality measurements for the node.
+    pub degree_centrality: u16,
+    pub eigenvector_centrality: f64,
+    pub fiedler_value: f64,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+/// A connection in the graph of the known network.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Edge {
     pub source: SocketAddr,
     pub target: SocketAddr,


### PR DESCRIPTION
Exposes the network centrality measurements through the `getnetworkgraph` rpc endpoint. Note, the computation of said measurements only occures at the time of the rpc call. Though the computation hasn't yet been benchmarked, it's reasonably fast for current testnet sizes (i.e. ~`1000` nodes). 
