### PR TITLE
Only catch up the secondary storage if the block height is behind the primary one

### DIFF
--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -111,7 +111,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
 
         let storage = &self.storage;
 
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
 
         let block_header_hash = BlockHeaderHash::new(block_hash);
         let height = match storage.get_block_number(&block_header_hash) {
@@ -153,17 +154,17 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
         }
     }
 
-    /// Returns the number of blocks in the canonical chain.
+    /// Returns the number of blocks in the canonical chain, including the genesis.
     fn get_block_count(&self) -> Result<u32, RpcError> {
-        let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
-        Ok(storage.get_block_count())
+        let primary_height = self.sync_handler()?.current_block_height();
+        Ok(primary_height + 1)
     }
 
     /// Returns the block hash of the head of the canonical chain.
     fn get_best_block_hash(&self) -> Result<String, RpcError> {
         let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
         let best_block_hash = storage.get_block_hash(storage.get_current_block_height())?;
 
         Ok(hex::encode(&best_block_hash.0))
@@ -172,7 +173,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     /// Returns the block hash of the index specified if it exists in the canonical chain.
     fn get_block_hash(&self, block_height: u32) -> Result<String, RpcError> {
         let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
         let block_hash = storage.get_block_hash(block_height)?;
 
         Ok(hex::encode(&block_hash.0))
@@ -181,7 +183,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     /// Returns the hex encoded bytes of a transaction from its transaction id.
     fn get_raw_transaction(&self, transaction_id: String) -> Result<String, RpcError> {
         let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
         Ok(hex::encode(
             &storage.get_transaction_bytes(&hex::decode(transaction_id)?)?,
         ))
@@ -195,7 +198,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
 
     /// Returns information about a transaction from serialized transaction bytes.
     fn decode_raw_transaction(&self, transaction_bytes: String) -> Result<TransactionInfo, RpcError> {
-        self.storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        self.storage.catch_up_secondary(false, primary_height)?;
         let transaction_bytes = hex::decode(transaction_bytes)?;
         let transaction = Tx::read(&transaction_bytes[..])?;
 
@@ -265,7 +269,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
 
         let storage = &self.storage;
 
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
 
         if !self.sync_handler()?.consensus.verify_transaction(&transaction)? {
             // TODO (raychu86) Add more descriptive message. (e.g. tx already exists)
@@ -310,7 +315,8 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
 
         let storage = &self.storage;
 
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
 
         Ok(self.sync_handler()?.consensus.verify_transaction(&transaction)?)
     }
@@ -364,7 +370,9 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
     /// Returns the current mempool and sync information known by this node.
     fn get_block_template(&self) -> Result<BlockTemplate, RpcError> {
         let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
+
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
 
         let block_height = storage.get_current_block_height();
         let block = storage.get_block_from_block_number(block_height)?;

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -572,7 +572,9 @@ impl<S: Storage + Send + Sync + 'static> ProtectedRpcFunctions for RpcImpl<S> {
     /// Returns the number of record commitments that are stored on the full node.
     fn get_record_commitment_count(&self) -> Result<usize, RpcError> {
         let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
+
         let record_commitments = storage.get_record_commitments(None)?;
 
         Ok(record_commitments.len())
@@ -581,7 +583,9 @@ impl<S: Storage + Send + Sync + 'static> ProtectedRpcFunctions for RpcImpl<S> {
     /// Returns a list of record commitments that are stored on the full node.
     fn get_record_commitments(&self) -> Result<Vec<String>, RpcError> {
         let storage = &self.storage;
-        storage.catch_up_secondary(false)?;
+        let primary_height = self.sync_handler()?.current_block_height();
+        storage.catch_up_secondary(false, primary_height)?;
+
         let record_commitments = storage.get_record_commitments(Some(100))?;
         let record_commitment_strings: Vec<String> = record_commitments.iter().map(hex::encode).collect();
 


### PR DESCRIPTION
While investigating https://github.com/AleoHQ/snarkOS/issues/900, I ruled out primary storage coherence issues and was not able to reproduce (using the script by @e-nikolov) the bug when the secondary storage instance normally used for RPC purposes was disabled (i.e. only the primary instance was used).

While the ultimate solution would be not to use the secondary storage altogether (which might not be viable yet, as it hasn't yet been determined if it wouldn't lead to degraded performance), I was able to greatly reduce the number of times `Ledger::catch_up_secondary` is called by limiting it to the times when the secondary storage's block height is actually behind the primary one. With this change in place, I haven't been able to reproduce the issue.

Fixes https://github.com/AleoHQ/snarkOS/issues/900.