### PR TITLE
Refactor the forking tiebreaker to use aggregated difficulty, instead of chain length

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -393,9 +393,11 @@ impl<S: Storage> Consensus<S> {
         let mut aggregate_difficulty = 0u128;
 
         for i in 0..path_size {
-            let block = self.ledger.get_block_from_block_number(current_block_height - i)?;
+            let block_header = self
+                .ledger
+                .get_block_header(&self.ledger.get_block_hash(current_block_height - i)?)?;
 
-            aggregate_difficulty += block.header.difficulty_target as u128;
+            aggregate_difficulty += block_header.difficulty_target as u128;
         }
 
         Ok(aggregate_difficulty)

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -187,8 +187,6 @@ impl<S: Storage> Consensus<S> {
                     // perform a fork to the side chain.
                     let canon_difficulty =
                         self.get_canon_difficulty_from_height(side_chain_path.shared_block_number)?;
-                    println!("{}", canon_difficulty);
-                    println!("{}", side_chain_path.aggregate_difficulty);
 
                     if side_chain_path.aggregate_difficulty > canon_difficulty {
                         debug!(

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -34,6 +34,7 @@ use snarkvm_dpc::{
     DPCScheme,
     LedgerScheme,
     Storage,
+    StorageError,
     Transactions as DPCTransactions,
 };
 use snarkvm_posw::txids_to_roots;
@@ -191,11 +192,14 @@ impl<S: Storage> Consensus<S> {
                         side_chain_path.new_block_number
                     );
 
-                    // If the side chain is now longer than the canon chain,
+                    // If the side chain is now heavier than the canon chain,
                     // perform a fork to the side chain.
-                    if side_chain_path.new_block_number > self.ledger.get_current_block_height() {
+                    let canon_difficulty =
+                        self.get_canon_difficulty_from_height(side_chain_path.shared_block_number)?;
+
+                    if side_chain_path.aggregate_difficulty > canon_difficulty {
                         debug!(
-                            "Determined side chain is longer than canon chain by {} blocks",
+                            "Determined side chain is heavier than canon chain by {} blocks",
                             side_chain_path.new_block_number - self.ledger.get_current_block_height()
                         );
                         warn!("A valid fork has been detected. Performing a fork to the side chain.");
@@ -381,5 +385,19 @@ impl<S: Storage> Consensus<S> {
             memo,
             rng,
         )
+    }
+
+    fn get_canon_difficulty_from_height(&self, height: u32) -> Result<u128, StorageError> {
+        let current_block_height = self.ledger.get_current_block_height();
+        let path_size = current_block_height - height;
+        let mut aggregate_difficulty = 0u128;
+
+        for i in 0..path_size {
+            let block = self.ledger.get_block_from_block_number(current_block_height - i)?;
+
+            aggregate_difficulty += block.header.difficulty_target as u128;
+        }
+
+        Ok(aggregate_difficulty)
     }
 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -25,8 +25,17 @@ use snarkvm_dpc::{
         transaction::amount::AleoAmount,
         Record as DPCRecord,
     },
-    Account, AccountAddress, AccountPrivateKey, AccountScheme, Block, DPCComponents, DPCScheme, LedgerScheme, Storage,
-    StorageError, Transactions as DPCTransactions,
+    Account,
+    AccountAddress,
+    AccountPrivateKey,
+    AccountScheme,
+    Block,
+    DPCComponents,
+    DPCScheme,
+    LedgerScheme,
+    Storage,
+    StorageError,
+    Transactions as DPCTransactions,
 };
 use snarkvm_posw::txids_to_roots;
 use snarkvm_utilities::{to_bytes, ToBytes};
@@ -190,8 +199,8 @@ impl<S: Storage> Consensus<S> {
 
                     if side_chain_path.aggregate_difficulty > canon_difficulty {
                         debug!(
-                            "Determined side chain is heavier than canon chain by {} blocks",
-                            side_chain_path.new_block_number - self.ledger.get_current_block_height()
+                            "Determined side chain is heavier than canon chain by {}%",
+                            get_delta_percentage(side_chain_path.aggregate_difficulty, canon_difficulty)
                         );
                         warn!("A valid fork has been detected. Performing a fork to the side chain.");
 
@@ -354,10 +363,11 @@ impl<S: Storage> Consensus<S> {
 
         let new_record_owners = vec![recipient; Components::NUM_OUTPUT_RECORDS];
         let new_is_dummy_flags = [vec![false], vec![true; Components::NUM_OUTPUT_RECORDS - 1]].concat();
-        let new_values = [
-            vec![total_value_balance.0 as u64],
-            vec![0; Components::NUM_OUTPUT_RECORDS - 1],
-        ]
+        let new_values = [vec![total_value_balance.0 as u64], vec![
+            0;
+            Components::NUM_OUTPUT_RECORDS
+                - 1
+        ]]
         .concat();
         let new_payloads = vec![RecordPayload::default(); NUM_OUTPUT_RECORDS];
 
@@ -390,4 +400,9 @@ impl<S: Storage> Consensus<S> {
 
         Ok(aggregate_difficulty)
     }
+}
+
+fn get_delta_percentage(side_chain_diff: u128, canon_diff: u128) -> f64 {
+    let delta = side_chain_diff - canon_diff;
+    (delta as f64 / canon_diff as f64) * 100.0
 }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -25,17 +25,8 @@ use snarkvm_dpc::{
         transaction::amount::AleoAmount,
         Record as DPCRecord,
     },
-    Account,
-    AccountAddress,
-    AccountPrivateKey,
-    AccountScheme,
-    Block,
-    DPCComponents,
-    DPCScheme,
-    LedgerScheme,
-    Storage,
-    StorageError,
-    Transactions as DPCTransactions,
+    Account, AccountAddress, AccountPrivateKey, AccountScheme, Block, DPCComponents, DPCScheme, LedgerScheme, Storage,
+    StorageError, Transactions as DPCTransactions,
 };
 use snarkvm_posw::txids_to_roots;
 use snarkvm_utilities::{to_bytes, ToBytes};
@@ -196,6 +187,8 @@ impl<S: Storage> Consensus<S> {
                     // perform a fork to the side chain.
                     let canon_difficulty =
                         self.get_canon_difficulty_from_height(side_chain_path.shared_block_number)?;
+                    println!("{}", canon_difficulty);
+                    println!("{}", side_chain_path.aggregate_difficulty);
 
                     if side_chain_path.aggregate_difficulty > canon_difficulty {
                         debug!(
@@ -363,11 +356,10 @@ impl<S: Storage> Consensus<S> {
 
         let new_record_owners = vec![recipient; Components::NUM_OUTPUT_RECORDS];
         let new_is_dummy_flags = [vec![false], vec![true; Components::NUM_OUTPUT_RECORDS - 1]].concat();
-        let new_values = [vec![total_value_balance.0 as u64], vec![
-            0;
-            Components::NUM_OUTPUT_RECORDS
-                - 1
-        ]]
+        let new_values = [
+            vec![total_value_balance.0 as u64],
+            vec![0; Components::NUM_OUTPUT_RECORDS - 1],
+        ]
         .concat();
         let new_payloads = vec![RecordPayload::default(); NUM_OUTPUT_RECORDS];
 

--- a/storage/src/objects/block_path.rs
+++ b/storage/src/objects/block_path.rs
@@ -73,7 +73,7 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
                     // Add all the difficulty targets associated with the longest_path,
                     // skipping the first element (which is the hash associated to
                     // `block_header`).
-                    for hash in longest_path[1..].iter() {
+                    for hash in longest_path.iter().skip(1) {
                         let block_header = self.get_block_header(hash)?;
                         side_chain_diff += block_header.difficulty_target as u128;
                     }


### PR DESCRIPTION
## Motivation

This change should reduce the length of orphan chains, and reduce the number of nodes that sync onto orphan chains and get stuck there. As an orphaned chain uses less computing power than the main one, its difficulty will drastically drop as it is extended. After a while, and with a bit of luck, this can cause an orphaned miner to keep going on its own route and always stay ahead of the main chain in terms of raw numbers. However, his aggregated difficulty will diminish severely as time goes on, due to the low computing power used. Thus, this change should make sure orphaned miners are brought back to the main chain quicker than before, and it should also ensure that syncing nodes will re-org to the main chain if they start going down an orphaned block path.

## Test Plan

The fix has been tested on my personal node by syncing from scratch 3 times. All 3 times, the node successfully managed to sync its way to the tip of the chain without getting stuck on an orphan chain. The node was observed, from time to time, to be syncing its way into an orphan chain, but then forking back to the main chain, after noticing a side path with a difficulty many times higher than what it was currently on - indicating that it is now able to successfully identify the chain on which the most work is done.

The next step will be to roll this out on a wider scale. As this merges on staging, there will be a few nodes already using this fix, which will give us further indication of the feasibility of this fix.