### PR TITLE
Tweak the block_initiator_side sync test

### DIFF
--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -90,8 +90,9 @@ async fn block_initiator_side() {
     peer.write_message(&block_2).await;
 
     // check the blocks have been added to the node's chain
-    wait_until!(1, node.expect_sync().storage().block_hash_exists(&block_1_header_hash));
-    wait_until!(1, node.expect_sync().storage().block_hash_exists(&block_2_header_hash));
+    let node_storage = node.expect_sync().storage();
+    wait_until!(5, node_storage.block_hash_exists(&block_1_header_hash));
+    wait_until!(1, node_storage.block_hash_exists(&block_2_header_hash));
 }
 
 #[tokio::test]


### PR DESCRIPTION
While I don't see any apparent issues with this test, we might just be running out of time due to other tests being executed at the same time; let's just increase the first time limit and see if it helps.