### PR TITLE
Basic fork detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,6 +2717,7 @@ dependencies = [
  "futures 0.3.15",
  "fxhash",
  "hex",
+ "itertools 0.10.1",
  "log",
  "metrics",
  "mpmc-map",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -87,6 +87,9 @@ version = "0.1"
 [dependencies.async-trait]
 version = "0.1"
 
+[dependencies.itertools]
+version = "0.10.1"
+
 [dependencies.nalgebra]
 version = "0.26"
 

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -64,7 +64,7 @@ impl Peer {
                 if let Some(known_network) = node.known_network() {
                     let _ = known_network
                         .sender
-                        .try_send(KnownNetworkMessage::Height((self.address, block_height)));
+                        .try_send(KnownNetworkMessage::Height(self.address, block_height));
                 }
             }
             payload => {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -22,7 +22,7 @@ use tokio::task;
 
 use snarkos_metrics::{self as metrics, connections::*};
 
-use crate::{message::*, NetworkError, Node};
+use crate::{message::*, KnownNetworkMessage, NetworkError, Node};
 
 impl<S: Storage + core::marker::Sync + Send> Node<S> {
     /// Obtain a list of addresses of connected peers for this node.
@@ -319,7 +319,9 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
             // If this node is tracking the network, record the connections. This can
             // then be used to construct the graph and query peer info from the peerbook.
 
-            let _ = known_network.sender.try_send((source, peers));
+            let _ = known_network
+                .sender
+                .try_send(KnownNetworkMessage::Peers((source, peers)));
         }
     }
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -318,10 +318,7 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
         if let Some(known_network) = self.known_network() {
             // If this node is tracking the network, record the connections. This can
             // then be used to construct the graph and query peer info from the peerbook.
-
-            let _ = known_network
-                .sender
-                .try_send(KnownNetworkMessage::Peers((source, peers)));
+            let _ = known_network.sender.try_send(KnownNetworkMessage::Peers(source, peers));
         }
     }
 

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -303,7 +303,6 @@ impl NetworkMetrics {
         }
 
         // Construct the list of nodes from the connections.
-        // FIXME: dedup?
         let mut nodes: HashSet<SocketAddr> = HashSet::new();
         for connection in connections.iter() {
             // Using a hashset guarantees uniqueness.

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -178,7 +178,8 @@ impl KnownNetwork {
             let mut nodes_g = self.nodes.write();
 
             // Remove the nodes that no longer correspond to connections.
-            nodes_g.retain(|addr, _| self.nodes_from_connections().contains(addr));
+            let nodes_from_connections = self.nodes_from_connections();
+            nodes_g.retain(|addr, _| nodes_from_connections.contains(addr));
         }
     }
 

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -567,7 +567,7 @@ mod test {
         let known_network = KnownNetwork {
             sender: tx,
             receiver: Mutex::new(rx),
-            nodes: RwLock::new(HashMap::new()),
+            nodes: Default::default(),
             connections: RwLock::new(seeded_connections),
         };
 
@@ -656,7 +656,7 @@ mod test {
                 .into_iter()
                 .collect(),
             ),
-            connections: RwLock::new(HashSet::new()),
+            connections: Default::default(),
         };
 
         let potential_forks = known_network.potential_forks();

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -231,7 +231,7 @@ impl KnownNetwork {
         let mut nodes: Vec<(SocketAddr, u32)> = self.nodes().into_iter().collect();
         nodes.sort_unstable_by_key(|&(_, height)| height);
 
-        // Find the indexes at which the split the heights.
+        // Find the indices at which to split the heights.
         let split_indexes: Vec<usize> = nodes
             .iter()
             .tuple_windows()
@@ -240,7 +240,7 @@ impl KnownNetwork {
             .map(|(i, _)| i)
             .collect();
 
-        // Create the clusters based on the indexes.
+        // Identify the clusters based on the indices.
         let mut nodes_grouped = Vec::with_capacity(nodes.len());
         for i in split_indexes.iter().rev() {
             // The index needs to be offset by one.

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -88,8 +88,10 @@ impl Connection {
 
 /// Message types passed through the `KnownNetwork` channel.
 pub enum KnownNetworkMessage {
-    Peers((SocketAddr, Vec<SocketAddr>)),
-    Height((SocketAddr, u32)),
+    /// Maps a peer address to its peers.
+    Peers(SocketAddr, Vec<SocketAddr>),
+    /// Maps a peer address to its block height.
+    Height(SocketAddr, u32),
 }
 
 /// Keeps track of crawled peers and their connections.
@@ -122,8 +124,8 @@ impl KnownNetwork {
     pub async fn update(&self) {
         if let Some(message) = self.receiver.lock().await.recv().await {
             match message {
-                KnownNetworkMessage::Peers((source, peers)) => self.update_connections(source, peers),
-                KnownNetworkMessage::Height((source, height)) => self.update_height(source, height),
+                KnownNetworkMessage::Peers(source, peers) => self.update_connections(source, peers),
+                KnownNetworkMessage::Height(source, height) => self.update_height(source, height),
             }
         }
     }

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -178,9 +178,7 @@ impl KnownNetwork {
             let mut nodes_g = self.nodes.write();
 
             // Remove the nodes that no longer correspond to connections.
-            let node_addrs: HashSet<SocketAddr> = nodes_g.keys().copied().collect();
-            let diff: HashSet<SocketAddr> = node_addrs.difference(&self.nodes_from_connections()).copied().collect();
-            nodes_g.retain(|addr, _| !diff.contains(addr));
+            nodes_g.retain(|addr, _| self.nodes_from_connections().contains(addr));
         }
     }
 

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -234,13 +234,14 @@ impl KnownNetwork {
             .tuple_windows()
             .enumerate()
             .filter(|(_i, (a, b))| b.1 - a.1 >= HEIGHT_DELTA_TOLERANCE)
-            .map(|(i, _)| i + 1)
+            .map(|(i, _)| i)
             .collect();
 
         // Create the clusters based on the indexes.
         let mut nodes_grouped = Vec::with_capacity(nodes.len());
         for i in split_indexes.iter().rev() {
-            nodes_grouped.insert(0, nodes.split_off(*i));
+            // The index needs to be offset by one.
+            nodes_grouped.insert(0, nodes.split_off(*i + 1));
         }
 
         // Don't forget the first cluster left after the `split_off` operation.

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -178,7 +178,7 @@ impl KnownNetwork {
             let mut nodes_g = self.nodes.write();
 
             // Remove the nodes that no longer correspond to connections.
-            let node_addrs: HashSet<SocketAddr> = nodes_g.iter().map(|(&addr, _)| addr).collect();
+            let node_addrs: HashSet<SocketAddr> = nodes_g.keys().copied().collect();
             let diff: HashSet<SocketAddr> = node_addrs.difference(&self.nodes_from_connections()).copied().collect();
             nodes_g.retain(|addr, _| !diff.contains(addr));
         }

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -86,6 +86,7 @@ impl Connection {
     }
 }
 
+/// Message types passed through the `KnownNetwork` channel.
 pub enum KnownNetworkMessage {
     Peers((SocketAddr, Vec<SocketAddr>)),
     Height((SocketAddr, u32)),

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -564,11 +564,12 @@ mod test {
         let known_network = KnownNetwork {
             sender: tx,
             receiver: Mutex::new(rx),
+            nodes: RwLock::new(HashMap::new()),
             connections: RwLock::new(seeded_connections),
         };
 
         // Insert two connections.
-        known_network.update_inner(addr_a, vec![addr_b, addr_c]);
+        known_network.update_connections(addr_a, vec![addr_b, addr_c]);
         assert!(
             known_network
                 .connections
@@ -596,11 +597,11 @@ mod test {
         );
 
         // Insert (a, b) connection reversed, make sure it doesn't change the list.
-        known_network.update_inner(addr_b, vec![addr_a]);
+        known_network.update_connections(addr_b, vec![addr_a]);
         assert_eq!(known_network.connections.read().len(), 3);
 
         // Insert (a, d) again and make sure the timestamp was updated.
-        known_network.update_inner(addr_a, vec![addr_d]);
+        known_network.update_connections(addr_a, vec![addr_d]);
         assert_ne!(
             old_but_valid_timestamp,
             known_network.get_connection(addr_a, addr_d).unwrap().last_seen

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -406,23 +406,12 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
         let vertices: Vec<Vertice> = network_metrics
             .centrality
             .iter()
-            .map(|(addr, node_centrality)| {
-                // Return the block height for the node if it is in the peerbook (not all crawled
-                // addresses will be), 0 indicates the height isn't known.
-
-                let block_height = match self.node.peer_book.get_disconnected_peer(*addr) {
-                    Some(peer) => peer.quality.block_height,
-                    None => 0,
-                };
-
-                Vertice {
-                    addr: *addr,
-                    block_height,
-                    is_bootnode: self.node.config.bootnodes().contains(&addr),
-                    degree_centrality: node_centrality.degree_centrality,
-                    eigenvector_centrality: node_centrality.eigenvector_centrality,
-                    fiedler_value: node_centrality.fiedler_value,
-                }
+            .map(|(addr, node_centrality)| Vertice {
+                addr: *addr,
+                is_bootnode: self.node.config.bootnodes().contains(&addr),
+                degree_centrality: node_centrality.degree_centrality,
+                eigenvector_centrality: node_centrality.eigenvector_centrality,
+                fiedler_value: node_centrality.fiedler_value,
             })
             .collect();
 
@@ -431,47 +420,6 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             .into_iter()
             .map(|(height, members)| PotentialFork { height, members })
             .collect();
-
-        //  // Sort vertices into clusters at similar heights.
-        //  let potential_forks = if !nodes.is_empty() {
-        //      use itertools::Itertools;
-        //      const HEIGHT_DELTA_TOLERANCE: u32 = 5;
-
-        //      vertices.sort_unstable_by_key(|v| v.block_height);
-
-        //      // Clone the vertices and only keep nodes that aren't at a height of `0`.
-        //      let mut nodes = vertices.clone();
-        //      nodes.retain(|node| node.block_height != 0);
-
-        //      // Find the indexes at which the split the heights.
-        //      let split_indexes: Vec<usize> = nodes
-        //          .iter()
-        //          .tuple_windows()
-        //          .enumerate()
-        //          .filter(|(_i, (a, b))| b.block_height - a.block_height >= HEIGHT_DELTA_TOLERANCE)
-        //          .map(|(i, _)| i + 1)
-        //          .collect();
-
-        //      // Create the clusters based on the indexes.
-        //      let mut nodes_grouped = Vec::with_capacity(nodes.len());
-        //      for i in split_indexes.iter().rev() {
-        //          nodes_grouped.insert(0, nodes.split_off(*i));
-        //      }
-
-        //      // Don't forget the first cluster left after the `split_off` operation.
-        //      nodes_grouped.insert(0, nodes);
-
-        //      // Remove the last cluster since it will contain the nodes even with the chain tip.
-        //      nodes_grouped.pop();
-
-        //      // Filter out any clusters smaller than three nodes, this minimises the false-positives
-        //      // as it's reasonable to assume a fork would include more than 2 members.
-        //      nodes_grouped.retain(|s| s.len() > 2);
-
-        //      nodes_grouped
-        //  } else {
-        //      vec![]
-        //  };
 
         Ok(NetworkGraph {
             node_count: network_metrics.node_count,

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -308,6 +308,7 @@ pub struct NetworkGraph {
     pub edges: Vec<Edge>,
 }
 
+/// A potential fork in the network, maps height to members.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PotentialFork {
     pub height: u32,

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -299,16 +299,26 @@ pub struct NetworkGraph {
     /// lowest.
     pub degree_centrality_delta: f64,
 
+    /// The potential forks in the network and their member nodes.
+    pub potential_forks: Vec<PotentialFork>,
+
     /// Known nodes.
     pub vertices: Vec<Vertice>,
     /// Known connections.
     pub edges: Vec<Edge>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PotentialFork {
+    pub height: u32,
+    pub members: Vec<SocketAddr>,
+}
+
 /// Metadata and measurements pertaining to a node in the graph of the known network.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Vertice {
     pub addr: SocketAddr,
+    pub block_height: u32,
     pub is_bootnode: bool,
 
     // Centrality measurements for the node.

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -318,7 +318,6 @@ pub struct PotentialFork {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Vertice {
     pub addr: SocketAddr,
-    pub block_height: u32,
     pub is_bootnode: bool,
 
     // Centrality measurements for the node.


### PR DESCRIPTION
This PR introduces a basic fork detection tool. The result is included in the output from the `getnetworkgraph` rpc endpoint.

The data can be retrieved and filtered with: 
```
curl --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getnetworkgraph", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:3030/ | jq .result.potential_forks
```
Output e.g.:
```
[
  {
    "height": 26586,
    "members": [
      "77.222.42.64:4131",
      "157.90.248.189:4131",
      "62.171.144.118:4131",
      "65.21.244.18:4131",
      "46.101.144.133:4131",
      "62.171.144.232:4131",
      "135.181.202.228:4131"
    ]
  }
]
```