### PR TITLE
Dont store transaction locations of non-canon blocks

### DIFF
--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -132,18 +132,6 @@ impl<T: TransactionScheme, P: LoadableMerkleParameters, S: Storage> Ledger<T, P,
             return Err(StorageError::DuplicateMemo);
         }
 
-        for (index, transaction) in block.transactions.0.iter().enumerate() {
-            let transaction_location = TransactionLocation {
-                index: index as u32,
-                block_hash: block_hash.0,
-            };
-            database_transaction.push(Op::Insert {
-                col: COL_TRANSACTION_LOCATION,
-                key: transaction.transaction_id()?.to_vec(),
-                value: to_bytes![transaction_location]?,
-            });
-        }
-
         database_transaction.push(Op::Insert {
             col: COL_BLOCK_HEADER,
             key: block_hash.0.to_vec(),


### PR DESCRIPTION
While https://github.com/AleoHQ/snarkOS/pull/875 improved the state of stored transaction locations, it missed one possible scenario: a node can receive a side-chain block containing a transaction that had already been imported as part of a canon block; even though that side block wouldn't become canon, its insertion would still overwrite that transaction's canon location with the side chain's one, just because it was received later.

This PR removes the storage of transaction location on block insertions, leaving it only for block commits.

Cc https://github.com/AleoHQ/snarkOS/issues/863.