### PR TITLE
Tweak the storage validator, expose the storage trim tool

### DIFF
--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -104,6 +104,10 @@ pub struct Storage {
     pub import: Option<PathBuf>,
     /// If `true`, checks the node's storage for inconsistencies and attempts to fix any encountered issues.
     pub validate: bool,
+    /// If `true`, deletes any superfluous (non-canon) items from the node's storage. Note: it can temporarily increase
+    /// the size of the database files, but they will become smaller after a while, when the database has run its
+    /// automated maintenance.
+    pub trim: bool,
 }
 
 impl Default for Config {
@@ -144,6 +148,7 @@ impl Default for Config {
             storage: Storage {
                 export: None,
                 import: None,
+                trim: false,
                 validate: false,
             },
         }
@@ -216,6 +221,7 @@ impl Config {
             "is-bootnode" => self.is_bootnode(arguments.is_present(option)),
             "is-miner" => self.is_miner(arguments.is_present(option)),
             "no-jsonrpc" => self.no_jsonrpc(arguments.is_present(option)),
+            "trim-storage" => self.trim_storage(arguments.is_present(option)),
             "validate-storage" => self.validate_storage(arguments.is_present(option)),
             // Options
             "connect" => self.connect(arguments.value_of(option)),
@@ -360,6 +366,10 @@ impl Config {
         }
     }
 
+    fn trim_storage(&mut self, argument: bool) {
+        self.storage.trim = argument;
+    }
+
     fn validate_storage(&mut self, argument: bool) {
         self.storage.validate = argument;
     }
@@ -402,6 +412,7 @@ impl CLI for ConfigCli {
         flag::NO_JSONRPC,
         flag::IS_BOOTNODE,
         flag::IS_MINER,
+        flag::TRIM_STORAGE,
         flag::VALIDATE_STORAGE,
     ];
     const NAME: NameType = "snarkOS";
@@ -447,6 +458,7 @@ impl CLI for ConfigCli {
             "rpc-port",
             "rpc-username",
             "rpc-password",
+            "trim-storage",
             "validate-storage",
             "verbose",
         ]);

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -127,7 +127,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     if config.storage.trim {
         let now = std::time::Instant::now();
-        // There shouldn't be issues after validation, but if there are, ignore them,.
+        // There shouldn't be issues after validation, but if there are, ignore them.
         let _ = storage.trim();
         info!("Storage trimmed in {}ms", now.elapsed().as_millis());
     }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -118,10 +118,18 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     };
     info!("Storage finished loading");
 
-    if config.storage.validate {
+    // For extra safety, validate storage too if a trim is requested.
+    if config.storage.validate || config.storage.trim {
         let now = std::time::Instant::now();
         storage.validate(None, snarkos_storage::validator::FixMode::Everything);
         info!("Storage validated in {}ms", now.elapsed().as_millis());
+    }
+
+    if config.storage.trim {
+        let now = std::time::Instant::now();
+        // There shouldn't be issues after validation, but if there are, ignore them,.
+        let _ = storage.trim();
+        info!("Storage trimmed in {}ms", now.elapsed().as_millis());
     }
 
     if let Some(limit) = config.storage.export {

--- a/snarkos/parameters/flag.rs
+++ b/snarkos/parameters/flag.rs
@@ -25,4 +25,6 @@ pub const IS_MINER: &str = "[is-miner] --is-miner 'Start mining blocks from this
 
 pub const LIST: &str = "[list] -l --list 'List all available releases of snarkOS'";
 
+pub const TRIM_STORAGE: &str = "[trim-storage] --trim-storage 'Remove non-canon items from the node's storage'";
+
 pub const VALIDATE_STORAGE: &str = "[validate-storage] --validate-storage 'Check the integrity of the node's storage and attempt to fix encountered issues'";

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -75,7 +75,6 @@ macro_rules! check_for_superfluous_tx_components {
                 if let Some(ref mut ops) = &mut *db_ops.lock() {
                     if [FixMode::SuperfluousTxComponents, FixMode::Everything].contains(&fix_mode) {
                         for superfluous_item in superfluous_items {
-                            trace!("Staging a {} for deletion", $component_name);
                             ops.push(Op::Delete {
                                 col: $component_col,
                                 key: superfluous_item.to_vec(),
@@ -273,7 +272,8 @@ impl<T: TransactionScheme + Send + Sync, P: LoadableMerkleParameters, S: Storage
 
         let block_hash = block.header.get_hash();
 
-        trace!("Validating block at height {} ({})", block_height, block_hash);
+        // This is extremely verbose and shouldn't be used outside of debugging.
+        // trace!("Validating block at height {} ({})", block_height, block_hash);
 
         if !self.block_hash_exists(&block_hash) {
             is_storage_valid.store(false, Ordering::SeqCst);

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -465,19 +465,11 @@ impl<T: TransactionScheme + Send + Sync, P: LoadableMerkleParameters, S: Storage
                                     block_hash: block.header.get_hash().0,
                                 };
 
-                                match to_bytes!(corrected_location) {
-                                    Ok(location_bytes) => {
-                                        db_ops.push(Op::Insert {
-                                            col: COL_TRANSACTION_LOCATION,
-                                            key: tx_id.to_vec(),
-                                            value: location_bytes,
-                                        });
-                                    }
-                                    Err(e) => {
-                                        error!("Can't create a block locator fix for tx {}: {}", hex::encode(tx_id), e);
-                                        is_storage_valid.store(false, Ordering::SeqCst);
-                                    }
-                                }
+                                db_ops.push(Op::Insert {
+                                    col: COL_TRANSACTION_LOCATION,
+                                    key: tx_id.to_vec(),
+                                    value: to_bytes!(corrected_location).unwrap(), // to_bytes can't fail
+                                });
                             } else {
                                 is_storage_valid.store(false, Ordering::SeqCst);
                             }

--- a/testing/src/storage/validator.rs
+++ b/testing/src/storage/validator.rs
@@ -232,3 +232,35 @@ async fn validator_vs_a_superfluous_digest() {
     assert!(!consensus.ledger.validate(None, FixMode::Nothing));
     assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents));
 }
+
+#[ignore]
+#[tokio::test]
+async fn validator_vs_a_very_broken_db() {
+    tracing_subscriber::fmt::init();
+
+    let consensus = create_test_consensus();
+
+    let blocks = TestBlocks::load(Some(10), "test_blocks_100_1").0;
+    for block in blocks {
+        consensus.receive_block(&block, false).await.unwrap();
+    }
+
+    let mut database_transaction = DatabaseTransaction::new();
+
+    // Delete all tx-related items.
+    for col in [COL_SERIAL_NUMBER, COL_COMMITMENT, COL_MEMO, COL_DIGEST].iter() {
+        let stored_col = consensus.ledger.storage.get_col(*col).unwrap();
+        for key in stored_col.into_iter().map(|(key, _val)| key) {
+            database_transaction.push(Op::Delete {
+                col: *col,
+                key: key.into_vec(),
+            });
+        }
+    }
+
+    consensus.ledger.storage.batch(database_transaction).unwrap();
+
+    let now = std::time::Instant::now();
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
+    tracing::info!("Storage validated in {}ms", now.elapsed().as_millis());
+}


### PR DESCRIPTION
This PR introduces a few minor tweaks to the storage validator and an ignored test for dev purposes, and exposes the storage trim utility to the users as `--trim-storage`.