### PR TITLE
Fix path to config in the banner

### DIFF
--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -52,7 +52,7 @@ pub fn render_welcome(config: &Config) -> String {
             }
             Err(_) => {
                 output +=
-                    &"Miner not started. Please specify a valid miner address in your ~/.snarkOS/snarkOS.toml file or by using the --miner-address option in the CLI.\n\n"
+                    &"Miner not started. Please specify a valid miner address in your ~/.snarkOS/config.toml file or by using the --miner-address option in the CLI.\n\n"
                 .red().bold();
 
                 is_miner = false;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

When I originally saw the banner, it was misleading, and I've updated the wrong config file.

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

This is just a string change, so I've checked that it is still building.

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

Well, actually I did some extra things:
1) added some constants for the config file name
2) added more constants about config overwriting behaviour

but overall it looked pretty ugly and probably not worth it. Please, let me know if you want me to update the pull request with that versions.
