### PR TITLE
ref: remove obsolete async

### DIFF
--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -83,7 +83,6 @@ impl<S: Storage + Send + Sync + 'static> Node<S> {
                             match node_clone
                                 .peer_book
                                 .receive_connection(node_clone.clone(), remote_address, stream)
-                                .await
                             {
                                 Ok(_) => (),
                                 Err(e) => {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -112,7 +112,7 @@ impl<S: Storage + core::marker::Sync + Send + 'static> Node<S> {
 
 impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
     /// Creates a new instance of `Node`.
-    pub async fn new(config: Config) -> Result<Self, NetworkError> {
+    pub fn new(config: Config) -> Result<Self, NetworkError> {
         let node = Self(Arc::new(InnerNode {
             id: thread_rng().gen(),
             state: Default::default(),

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -149,7 +149,7 @@ impl PeerBook {
         self.pending_connections.load(Ordering::SeqCst)
     }
 
-    pub async fn receive_connection<S: Storage + Send + Sync + 'static>(
+    pub fn receive_connection<S: Storage + Send + Sync + 'static>(
         &self,
         node: Node<S>,
         address: SocketAddr,

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -77,7 +77,7 @@ impl<S: Storage + Send + Sync + 'static> SyncMaster<S> {
         interesting_peers
     }
 
-    async fn block_locator_hashes(&mut self) -> Vec<BlockHeaderHash> {
+    fn block_locator_hashes(&mut self) -> Vec<BlockHeaderHash> {
         match self.node.expect_sync().storage().get_block_locator_hashes() {
             Ok(block_locator_hashes) => block_locator_hashes,
             _ => {
@@ -91,7 +91,7 @@ impl<S: Storage + Send + Sync + 'static> SyncMaster<S> {
         let sync_nodes = self.find_sync_nodes().await;
 
         info!("requested block information from {} peers", sync_nodes.len());
-        let block_locator_hashes = self.block_locator_hashes().await;
+        let block_locator_hashes = self.block_locator_hashes();
         let mut future_set = vec![];
         for peer in sync_nodes.iter() {
             if let Some(handle) = self.node.peer_book.get_peer_handle(peer.address) {

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -35,7 +35,7 @@ async fn test_nodes(n: usize, setup: TestSetup) -> Vec<Node<LedgerStorage>> {
 
     for _ in 0..n {
         let environment = test_config(setup.clone());
-        let node = Node::new(environment).await.unwrap();
+        let node = Node::new(environment).unwrap();
 
         node.listen().await.unwrap();
         nodes.push(node);
@@ -61,7 +61,7 @@ async fn spawn_nodes_in_a_line() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Line).await;
+    connect_nodes(&mut nodes, Topology::Line);
     start_nodes(&nodes).await;
 
     // First and Last nodes should have 1 connected peer.
@@ -82,7 +82,7 @@ async fn spawn_nodes_in_a_ring() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Ring).await;
+    connect_nodes(&mut nodes, Topology::Ring);
     start_nodes(&nodes).await;
 
     for node in &nodes {
@@ -98,7 +98,7 @@ async fn spawn_nodes_in_a_star() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Star).await;
+    connect_nodes(&mut nodes, Topology::Star);
     start_nodes(&nodes).await;
 
     let hub = nodes.first().unwrap();
@@ -115,7 +115,7 @@ async fn spawn_nodes_in_a_mesh() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Mesh).await;
+    connect_nodes(&mut nodes, Topology::Mesh);
     start_nodes(&nodes).await;
 
     // Set the sleep interval to 200ms to avoid locking issues.
@@ -147,7 +147,7 @@ async fn line_converges_to_mesh() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Line).await;
+    connect_nodes(&mut nodes, Topology::Line);
     start_nodes(&nodes).await;
 
     wait_until!(10, network_density(&nodes) >= 0.1, 200);
@@ -169,7 +169,7 @@ async fn ring_converges_to_mesh() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Ring).await;
+    connect_nodes(&mut nodes, Topology::Ring);
     start_nodes(&nodes).await;
 
     wait_until!(10, network_density(&nodes) >= 0.1, 200);
@@ -191,7 +191,7 @@ async fn star_converges_to_mesh() {
         ..Default::default()
     };
     let mut nodes = test_nodes(N, setup).await;
-    connect_nodes(&mut nodes, Topology::Star).await;
+    connect_nodes(&mut nodes, Topology::Star);
     start_nodes(&nodes).await;
 
     wait_until!(15, network_density(&nodes) >= 0.1, 200);
@@ -217,8 +217,8 @@ async fn binary_star_contact() {
     };
     let environment_a = test_config(bootnode_setup.clone());
     let environment_b = test_config(bootnode_setup.clone());
-    let bootnode_a = Node::new(environment_a).await.unwrap();
-    let bootnode_b = Node::new(environment_b).await.unwrap();
+    let bootnode_a = Node::new(environment_a).unwrap();
+    let bootnode_b = Node::new(environment_b).unwrap();
 
     bootnode_a.listen().await.unwrap();
     bootnode_b.listen().await.unwrap();
@@ -242,8 +242,8 @@ async fn binary_star_contact() {
     star_b_nodes.insert(0, bootnode_b);
 
     // Create the star topologies.
-    connect_nodes(&mut star_a_nodes, Topology::Star).await;
-    connect_nodes(&mut star_b_nodes, Topology::Star).await;
+    connect_nodes(&mut star_a_nodes, Topology::Star);
+    connect_nodes(&mut star_b_nodes, Topology::Star);
 
     // Start the services. The two meshes should still be disconnected.
     start_nodes(&star_a_nodes).await;

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -79,7 +79,7 @@ mod protected_rpc_tests {
         };
 
         let environment = test_config(TestSetup::default());
-        let mut node = Node::new(environment).await.unwrap();
+        let mut node = Node::new(environment).unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::sync::create_test_consensus_from_ledger(ledger.clone()));
 

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -37,7 +37,7 @@ mod rpc_tests {
 
     async fn initialize_test_rpc(ledger: Arc<MerkleTreeLedger<LedgerStorage>>) -> Rpc {
         let environment = test_config(TestSetup::default());
-        let mut node = Node::new(environment).await.unwrap();
+        let mut node = Node::new(environment).unwrap();
         let consensus_setup = ConsensusSetup::default();
         let consensus = Arc::new(snarkos_testing::sync::create_test_consensus_from_ledger(ledger.clone()));
 

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -104,7 +104,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (miner, RPC) needs to use it.
-    let mut node = Node::new(node_config).await?;
+    let mut node = Node::new(node_config)?;
 
     let is_storage_in_memory = LedgerStorage::IN_MEMORY;
 

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -177,7 +177,7 @@ pub fn test_config(setup: TestSetup) -> Config {
 pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
     let is_miner = setup.consensus_setup.as_ref().map(|c| c.is_miner) == Some(true);
     let config = test_config(setup.clone());
-    let mut node = Node::new(config).await.unwrap();
+    let mut node = Node::new(config).unwrap();
 
     if let Some(consensus_setup) = setup.consensus_setup {
         let consensus = test_consensus(consensus_setup);

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -36,21 +36,21 @@ pub enum Topology {
 /// started yet, as it uses the bootnodes to establish the connections between nodes.
 ///
 /// When connecting in a `Star`, the first node in the `nodes` will be used as the hub.
-pub async fn connect_nodes(nodes: &mut Vec<Node<LedgerStorage>>, topology: Topology) {
+pub fn connect_nodes(nodes: &mut Vec<Node<LedgerStorage>>, topology: Topology) {
     if nodes.len() < 2 {
         panic!("Can't connect less than two nodes");
     }
 
     match topology {
-        Topology::Line => line(nodes).await,
-        Topology::Ring => ring(nodes).await,
-        Topology::Mesh => mesh(nodes).await,
-        Topology::Star => star(nodes).await,
+        Topology::Line => line(nodes),
+        Topology::Ring => ring(nodes),
+        Topology::Mesh => mesh(nodes),
+        Topology::Star => star(nodes),
     }
 }
 
 /// Connects the network nodes in a line topology.
-async fn line(nodes: &mut Vec<Node<LedgerStorage>>) {
+fn line(nodes: &mut Vec<Node<LedgerStorage>>) {
     let mut prev_node: Option<SocketAddr> = None;
 
     // Start each node with the previous as a bootnode.
@@ -67,9 +67,9 @@ async fn line(nodes: &mut Vec<Node<LedgerStorage>>) {
 }
 
 /// Connects the network nodes in a ring topology.
-async fn ring(nodes: &mut Vec<Node<LedgerStorage>>) {
+fn ring(nodes: &mut Vec<Node<LedgerStorage>>) {
     // Set the nodes up in a line.
-    line(nodes).await;
+    line(nodes);
 
     // Connect the first to the last.
     let first_addr = nodes.first().unwrap().local_address().unwrap();
@@ -81,7 +81,7 @@ async fn ring(nodes: &mut Vec<Node<LedgerStorage>>) {
 
 /// Connects the network nodes in a mesh topology. The inital peers are selected at random based on the
 /// minimum number of connected peers value.
-async fn mesh(nodes: &mut Vec<Node<LedgerStorage>>) {
+fn mesh(nodes: &mut Vec<Node<LedgerStorage>>) {
     let local_addresses: Vec<SocketAddr> = nodes.iter().map(|node| node.local_address().unwrap()).collect();
 
     for node in nodes {
@@ -98,7 +98,7 @@ async fn mesh(nodes: &mut Vec<Node<LedgerStorage>>) {
 }
 
 /// Connects the network nodes in a star topology.
-async fn star(nodes: &mut Vec<Node<LedgerStorage>>) {
+fn star(nodes: &mut Vec<Node<LedgerStorage>>) {
     // Setup the hub.
     let hub_address = nodes.first().unwrap().local_address().unwrap();
 


### PR DESCRIPTION
A quick pass on `snarkOS` to remove `async` functions in favour of synchronous versions where possible; this doesn't change any functionality.