### PR TITLE
feat: distinguish crawler nodes and bootnodes

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -37,6 +37,8 @@ pub struct Config {
     /// If `true`, initializes this node as a bootnode and forgoes connecting
     /// to the default bootnodes or saved peers in the peer book.
     is_bootnode: bool,
+    /// If `true`, initializes this node as a crawler.
+    is_crawler: bool,
     /// The interval between each peer sync.
     peer_sync_interval: Duration,
 }
@@ -50,6 +52,7 @@ impl Config {
         maximum_number_of_connected_peers: u16,
         bootnodes_addresses: Vec<String>,
         is_bootnode: bool,
+        is_crawler: bool,
         peer_sync_interval: Duration,
     ) -> Result<Self, NetworkError> {
         // Convert the given bootnodes into socket addresses.
@@ -66,6 +69,7 @@ impl Config {
             maximum_number_of_connected_peers,
             bootnodes: ArcSwap::new(Arc::new(bootnodes)),
             is_bootnode,
+            is_crawler,
             peer_sync_interval,
         })
     }
@@ -80,6 +84,11 @@ impl Config {
     #[inline]
     pub fn is_bootnode(&self) -> bool {
         self.is_bootnode
+    }
+
+    #[inline]
+    pub fn is_crawler(&self) -> bool {
+        self.is_crawler
     }
 
     /// Returns the minimum number of peers this node maintains a connection with.

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -402,6 +402,10 @@ impl Config {
             return Err(CliError::MinerBootstrapper);
         }
 
+        if self.node.is_bootnode && self.node.is_crawler {
+            return Err(CliError::CrawlerBootstrapper);
+        }
+
         // TODO (howardwu): Check the memory pool interval.
 
         Ok(())

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -73,6 +73,7 @@ pub struct Node {
     pub dir: PathBuf,
     pub db: String,
     pub is_bootnode: bool,
+    pub is_crawler: bool,
     pub ip: String,
     pub port: u16,
     pub verbose: u8,
@@ -118,6 +119,7 @@ impl Default for Config {
                 dir: Self::snarkos_dir(),
                 db: "snarkos_testnet1".into(),
                 is_bootnode: false,
+                is_crawler: false,
                 ip: "0.0.0.0".into(),
                 port: 4131,
                 verbose: 2,
@@ -220,6 +222,7 @@ impl Config {
             // Flags
             "is-bootnode" => self.is_bootnode(arguments.is_present(option)),
             "is-miner" => self.is_miner(arguments.is_present(option)),
+            "is-crawler" => self.is_crawler(arguments.is_present(option)),
             "no-jsonrpc" => self.no_jsonrpc(arguments.is_present(option)),
             "trim-storage" => self.trim_storage(arguments.is_present(option)),
             "validate-storage" => self.validate_storage(arguments.is_present(option)),
@@ -286,6 +289,10 @@ impl Config {
 
     fn is_miner(&mut self, argument: bool) {
         self.miner.is_miner = argument;
+    }
+
+    fn is_crawler(&mut self, argument: bool) {
+        self.node.is_crawler = argument;
     }
 
     fn ip(&mut self, argument: Option<&str>) {
@@ -412,6 +419,7 @@ impl CLI for ConfigCli {
         flag::NO_JSONRPC,
         flag::IS_BOOTNODE,
         flag::IS_MINER,
+        flag::IS_CRAWLER,
         flag::TRIM_STORAGE,
         flag::VALIDATE_STORAGE,
     ];
@@ -446,6 +454,7 @@ impl CLI for ConfigCli {
             "import-canon-blocks",
             "is-bootnode",
             "is-miner",
+            "is-crawler",
             "ip",
             "port",
             "path",

--- a/snarkos/errors/cli.rs
+++ b/snarkos/errors/cli.rs
@@ -31,6 +31,9 @@ pub enum CliError {
     #[error("The node can't be a bootstrapper and a miner at the same time")]
     MinerBootstrapper,
 
+    #[error("The node can't be a bootstrapper and a crawler at the same time")]
+    CrawlerBootstrapper,
+
     #[error("The minimum or maximum value for peer count is invalid")]
     PeerCountInvalid,
 

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -97,6 +97,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         config.p2p.max_peers,
         config.p2p.bootnodes.clone(),
         config.node.is_bootnode,
+        config.node.is_crawler,
         // Set sync intervals for peers, blocks and transactions (memory pool).
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/snarkos/parameters/flag.rs
+++ b/snarkos/parameters/flag.rs
@@ -23,6 +23,8 @@ pub const IS_BOOTNODE: &str =
 
 pub const IS_MINER: &str = "[is-miner] --is-miner 'Start mining blocks from this node'";
 
+pub const IS_CRAWLER: &str = "[is-crawler] --is-crawler 'Run this node as a network crawler'";
+
 pub const LIST: &str = "[list] -l --list 'List all available releases of snarkOS'";
 
 pub const TRIM_STORAGE: &str = "[trim-storage] --trim-storage 'Remove non-canon items from the node's storage'";

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -102,6 +102,7 @@ pub struct TestSetup {
     pub min_peers: u16,
     pub max_peers: u16,
     pub is_bootnode: bool,
+    pub is_crawler: bool,
     pub bootnodes: Vec<String>,
     pub tokio_handle: Option<runtime::Handle>,
 }
@@ -116,6 +117,7 @@ impl TestSetup {
         min_peers: u16,
         max_peers: u16,
         is_bootnode: bool,
+        is_crawler: bool,
         bootnodes: Vec<String>,
         tokio_handle: Option<runtime::Handle>,
     ) -> Self {
@@ -127,6 +129,7 @@ impl TestSetup {
             min_peers,
             max_peers,
             is_bootnode,
+            is_crawler,
             bootnodes,
             tokio_handle,
         }
@@ -143,6 +146,7 @@ impl Default for TestSetup {
             min_peers: 1,
             max_peers: 100,
             is_bootnode: false,
+            is_crawler: false,
             bootnodes: vec![],
             tokio_handle: None,
         }
@@ -168,6 +172,7 @@ pub fn test_config(setup: TestSetup) -> Config {
         setup.max_peers,
         setup.bootnodes,
         setup.is_bootnode,
+        setup.is_crawler,
         Duration::from_secs(setup.peer_sync_interval),
     )
     .unwrap()


### PR DESCRIPTION
Considering bootnodes currently still implement a sync layer and are run in decent numbers on the testnet, this PR introduces a command line flag to distinguish between crawler nodes and bootnodes. Bootnodes generally disconnect down to 80% of their peering capacity to ensure high availability to nodes joining the network and don't connect to any peers on their own (other than their bootnode list if they have `0` connections). 

Merging these changes would also pave the way for crawler nodes to operate in support of a cluster of bootnodes, providing them with peers they could then pass on to new peers joining the network. 

This new distinction would also allow us to remove the sync layer from either the bootnodes or the crawlers (whichever isn't used by aleo.network). 

