### PR TITLE
Faster storage validator

### DIFF
--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -247,7 +247,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None, FixMode::Nothing));
+        assert!(consensus1.ledger.validate(None, FixMode::Nothing).await);
     }
 
     #[tokio::test]
@@ -307,7 +307,7 @@ mod consensus_sidechain {
         assert_eq!(shared_height, 100);
 
         // Verify the integrity of the block storage for the first instance.
-        assert!(consensus1.ledger.validate(None, FixMode::Nothing));
+        assert!(consensus1.ledger.validate(None, FixMode::Nothing).await);
     }
 
     #[tokio::test]
@@ -350,7 +350,7 @@ mod consensus_sidechain {
         let shared_height = consensus2.ledger.get_block_number(&latest_shared_hash).unwrap();
         assert_eq!(shared_height, 10);
 
-        assert!(consensus2.ledger.validate(None, FixMode::Nothing));
+        assert!(consensus2.ledger.validate(None, FixMode::Nothing).await);
     }
 
     #[tokio::test]
@@ -378,6 +378,6 @@ mod consensus_sidechain {
         assert_eq!(consensus.ledger.get_current_block_height(), 20);
 
         // Verify the integrity of the block storage.
-        assert!(consensus.ledger.validate(None, FixMode::Nothing));
+        assert!(consensus.ledger.validate(None, FixMode::Nothing).await);
     }
 }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -121,7 +121,9 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // For extra safety, validate storage too if a trim is requested.
     if config.storage.validate || config.storage.trim {
         let now = std::time::Instant::now();
-        storage.validate(None, snarkos_storage::validator::FixMode::Everything);
+        storage
+            .validate(None, snarkos_storage::validator::FixMode::Everything)
+            .await;
         info!("Storage validated in {}ms", now.elapsed().as_millis());
         if !config.storage.trim {
             return Ok(());

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -71,6 +71,9 @@ features = [ "derive" ]
 [dependencies.thiserror]
 version = "1.0"
 
+[dependencies.tokio]
+version = "1"
+
 [dependencies.tracing]
 default-features = false
 features = [ "log" ]
@@ -84,9 +87,6 @@ version = "0.5.4"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"
-
-[dev-dependencies.tokio]
-version = "1"
 
 [dev-dependencies.tracing-subscriber]
 version = "0.2"

--- a/storage/src/rocks.rs
+++ b/storage/src/rocks.rs
@@ -43,6 +43,7 @@ impl Storage for RocksDb {
         }
     }
 
+    #[inline]
     fn get(&self, col: u32, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         self.db().get_cf(self.get_cf_ref(col), key).map_err(convert_err)
     }
@@ -88,11 +89,9 @@ impl Storage for RocksDb {
         Ok(())
     }
 
+    #[inline]
     fn exists(&self, col: u32, key: &[u8]) -> bool {
-        match self.db().get_cf(self.get_cf_ref(col), key) {
-            Ok(val) => val.is_some(),
-            Err(_) => false,
-        }
+        self.get(col, key).map(|val| val.is_some()).unwrap_or(false)
     }
 
     fn try_catch_up_with_primary(&self) -> Result<(), StorageError> {

--- a/testing/src/storage/trim.rs
+++ b/testing/src/storage/trim.rs
@@ -98,5 +98,5 @@ async fn trim_side_chain_blocks() {
     assert_eq!(consensus.ledger.get_child_block_hashes(&genesis_hash).unwrap().len(), 1);
 
     // Validate the post-trim storage.
-    assert!(consensus.ledger.validate(None, FixMode::Nothing));
+    assert!(consensus.ledger.validate(None, FixMode::Nothing).await);
 }

--- a/testing/src/storage/validator.rs
+++ b/testing/src/storage/validator.rs
@@ -29,7 +29,7 @@ async fn valid_storage_validates() {
         consensus.receive_block(&block, false).await.unwrap();
     }
 
-    assert!(consensus.ledger.validate(None, FixMode::Nothing));
+    assert!(consensus.ledger.validate(None, FixMode::Nothing).await);
 }
 
 #[tokio::test]
@@ -51,7 +51,7 @@ async fn validator_vs_a_missing_serial_number() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
     // Currently unsupported.
     // assert!(consensus.ledger.validate(None, FixMode::MissingTxComponents));
 }
@@ -75,7 +75,7 @@ async fn validator_vs_a_missing_commitment() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
     // Currently unsupported
     // assert!(consensus.ledger.validate(None, FixMode::MissingTxComponents));
 }
@@ -99,7 +99,7 @@ async fn validator_vs_a_missing_memorandum() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
     // Currently unsupported
     // assert!(consensus.ledger.validate(None, FixMode::MissingTxComponents));
 }
@@ -123,8 +123,8 @@ async fn validator_vs_a_missing_digest() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
-    assert!(consensus.ledger.validate(None, FixMode::MissingTxComponents));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
+    assert!(consensus.ledger.validate(None, FixMode::MissingTxComponents).await);
 }
 
 #[tokio::test]
@@ -151,8 +151,8 @@ async fn validator_vs_a_superfluous_serial_number() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
-    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
+    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents).await);
 }
 
 #[tokio::test]
@@ -179,8 +179,8 @@ async fn validator_vs_a_superfluous_commitment() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
-    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
+    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents).await);
 }
 
 #[tokio::test]
@@ -207,8 +207,8 @@ async fn validator_vs_a_superfluous_memorandum() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
-    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
+    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents).await);
 }
 
 #[tokio::test]
@@ -229,8 +229,8 @@ async fn validator_vs_a_superfluous_digest() {
     });
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
-    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
+    assert!(consensus.ledger.validate(None, FixMode::SuperfluousTxComponents).await);
 }
 
 #[ignore]
@@ -261,6 +261,6 @@ async fn validator_vs_a_very_broken_db() {
     consensus.ledger.storage.batch(database_transaction).unwrap();
 
     let now = std::time::Instant::now();
-    assert!(!consensus.ledger.validate(None, FixMode::Nothing));
+    assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
     tracing::info!("Storage validated in {}ms", now.elapsed().as_millis());
 }


### PR DESCRIPTION
This PR improves the performance of the storage validator; it introduces the following improvements:
- remove the locks used by the validator and `#[inline]` 2 small, widely-used database methods (a tiny improvement)
- use the `COL_BLOCK_TRANSACTIONS` column to obtain block's transactions in bulk as opposed to obtaining them individually via `Ledger::get_transaction_bytes` (~40% speed improvement for a database with a modest number of glitches, should be much more for a glitchy one)

There is still room for improvement by introducing partial transaction deserialization, but I don't know if it's viable yet; since the PR is already fairly large, I decided to open it, and further improvements - if any - will build on top of it.