### PR TITLE
Fix metrics

### DIFF
--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -63,6 +63,7 @@ pub mod queues {
 pub mod misc {
     pub const BLOCK_HEIGHT: &str = "snarkos_misc_block_height_total";
     pub const BLOCKS_MINED: &str = "snarkos_misc_blocks_mined_total";
+    pub const CHAIN_BLOCK_HEIGHT: &str = "snarkos_misc_chain_block_height_total";
     pub const DUPLICATE_BLOCKS: &str = "snarkos_misc_duplicate_blocks_total";
     pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_misc_duplicate_sync_blocks_total";
     pub const RPC_REQUESTS: &str = "snarkos_misc_rpc_requests_total";

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -119,6 +119,8 @@ pub struct NodeQueueStats {
 pub struct NodeMiscStats {
     /// The current block height of the node.
     pub block_height: u64,
+    /// The current block height of the chain.
+    pub chain_block_height: u64,
     /// The number of blocks the node has mined.
     pub blocks_mined: u64,
     /// The number of duplicate blocks received.

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -272,6 +272,7 @@ impl QueueStats {
 
 pub struct MiscStats {
     block_height: DiscreteGauge,
+    chain_block_height: DiscreteGauge,
     /// The number of mined blocks.
     blocks_mined: Counter,
     /// The number of duplicate blocks received.
@@ -286,6 +287,7 @@ impl MiscStats {
     const fn new() -> Self {
         Self {
             block_height: DiscreteGauge::new(),
+            chain_block_height: DiscreteGauge::new(),
             blocks_mined: Counter::new(),
             duplicate_blocks: Counter::new(),
             duplicate_sync_blocks: Counter::new(),
@@ -296,6 +298,7 @@ impl MiscStats {
     pub fn snapshot(&self) -> NodeMiscStats {
         NodeMiscStats {
             block_height: self.block_height.read(),
+            chain_block_height: self.chain_block_height.read(),
             blocks_mined: self.blocks_mined.read(),
             duplicate_blocks: self.duplicate_blocks.read(),
             duplicate_sync_blocks: self.duplicate_sync_blocks.read(),
@@ -365,6 +368,7 @@ impl Recorder for Stats {
             queues::OUTBOUND => &self.queues.outbound,
             // misc
             misc::BLOCK_HEIGHT => &self.misc.block_height,
+            misc::CHAIN_BLOCK_HEIGHT => &self.misc.chain_block_height,
             // connections
             connections::CONNECTING => &self.connections.connecting_peers,
             connections::CONNECTED => &self.connections.connected_peers,

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -302,6 +302,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
         // The node can already be at some non-zero height.
         if let Some(sync) = self.sync() {
             metrics::counter!(misc::BLOCK_HEIGHT, sync.current_block_height() as u64);
+            metrics::counter!(misc::CHAIN_BLOCK_HEIGHT, sync.current_block_height() as u64);
         }
     }
 

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -137,6 +137,11 @@ impl<S: Storage + Send + std::marker::Sync + 'static> Node<S> {
             }
         }
 
+        metrics::gauge!(
+            CHAIN_BLOCK_HEIGHT,
+            self.expect_sync().consensus.ledger.get_current_block_height() as f64
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Fix #964 

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

I have tested it locally (by introducing a new metrics), it works:

```
$ curl 127.0.0.1:9000 | grep block_height | grep -v TYPE
snarkos_misc_chain_block_height_total 344264
snarkos_misc_block_height_total 356358
$ curl -s --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getnodestats", "params": [] }' -H 'content-type: application/json' http://localhost:3030/ | jq '.[].misc?.
block_height?';
344264
```

