### PR TITLE
fix: erronous check for tracking the known network

### DIFF
--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -129,7 +129,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
             master_dispatch: RwLock::new(None),
         }));
 
-        if node.config.is_bootnode() {
+        if node.config.is_crawler() {
             // Safe since this can only ever be set here.
             node.known_network.set(KnownNetwork::default()).unwrap();
         }


### PR DESCRIPTION
Follow-up to #957, re-enables tracking the known network for crawlers.
