### PR TITLE
Add a private RPC to connect to multiple peers

### DIFF
--- a/rpc/documentation/private_endpoints/connect.md
+++ b/rpc/documentation/private_endpoints/connect.md
@@ -1,0 +1,20 @@
+Adds the given addresses to the node's list of peers and attempts to connect to them.
+
+### Protected Endpoint
+
+Yes
+
+### Arguments
+
+|      Parameter      |  Type  | Required |                    Description                   |
+|:-------------------:|:------:|:--------:|:------------------------------------------------ |
+| `addresses`         | array  |    Yes   | The addresses to connect to in an IP:port format |
+
+### Response
+
+null
+
+### Example
+```ignore
+curl --user username:password --data-binary '{"jsonrpc": "2.0", "id":"1", "method": "connect", "params": ["127.0.0.1:4141", "127.0.0.1:4142"] }' -H 'content-type: application/json' http://127.0.0.1:3030/
+```

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -39,7 +39,7 @@ use tokio::task;
 
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
-const METHODS_EXPECTING_PARAMS: [&str; 14] = [
+const METHODS_EXPECTING_PARAMS: [&str; 15] = [
     // public
     "getblock",
     "getblockhash",
@@ -56,6 +56,7 @@ const METHODS_EXPECTING_PARAMS: [&str; 14] = [
     "decoderecord",
     "decryptrecord",
     "disconnect",
+    "connect",
 ];
 
 #[allow(clippy::too_many_arguments)]
@@ -283,6 +284,13 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
         "disconnect" => {
             let result = rpc
                 .disconnect_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            result_to_response(&req, result)
+        }
+        "connect" => {
+            let result = rpc
+                .connect_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
             result_to_response(&req, result)

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -262,6 +262,29 @@ impl<S: Storage + Send + Sync + 'static> RpcImpl<S> {
         Ok(Value::Null)
     }
 
+    /// Connects to the given addresses
+    pub async fn connect_protected(self, params: Params, meta: Meta) -> Result<Value, JsonRPCError> {
+        self.validate_auth(meta)?;
+
+        let value = match params {
+            Params::Array(arr) => arr,
+            _ => return Err(JsonRPCError::invalid_request()),
+        };
+
+        let addresses: Vec<SocketAddr> = value
+            .into_iter()
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| JsonRPCError::invalid_params(format!("Invalid params: {}.", e)))?;
+
+        for addr in &addresses {
+            self.node.peer_book.add_peer(*addr, false).await;
+        }
+        self.node.connect_to_addresses(&addresses).await;
+
+        Ok(Value::Null)
+    }
+
     /// Expose the protected functions as RPC enpoints
     pub fn add_protected(&self, io: &mut MetaIoHandler<Meta>) {
         let mut d = IoDelegate::<Self, Meta>::new(Arc::new(self.clone()));
@@ -305,6 +328,10 @@ impl<S: Storage + Send + Sync + 'static> RpcImpl<S> {
         d.add_method_with_meta("disconnect", |rpc, params, meta| {
             let rpc = rpc.clone();
             rpc.disconnect_protected(params, meta)
+        });
+        d.add_method_with_meta("connect", |rpc, params, meta| {
+            let rpc = rpc.clone();
+            rpc.connect_protected(params, meta)
         });
 
         io.extend_with(d)
@@ -657,5 +684,15 @@ impl<S: Storage + Send + Sync + 'static> ProtectedRpcFunctions for RpcImpl<S> {
     fn disconnect(&self, address: SocketAddr) {
         let node = self.node.clone();
         tokio::spawn(async move { node.disconnect_from_peer(address).await });
+    }
+
+    fn connect(&self, addresses: Vec<SocketAddr>) {
+        let node = self.node.clone();
+        tokio::spawn(async move {
+            for addr in &addresses {
+                node.peer_book.add_peer(*addr, false).await;
+            }
+            node.connect_to_addresses(&addresses).await
+        });
     }
 }

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -155,4 +155,8 @@ pub trait ProtectedRpcFunctions {
     // todo: readd in Rust 1.54
     // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/disconnect.md"))]
     fn disconnect(&self, address: SocketAddr);
+
+    // todo: readd in Rust 1.54
+    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/connect.md"))]
+    fn connect(&self, addresses: Vec<SocketAddr>);
 }


### PR DESCRIPTION
While we already have the means to connect to given addresses at start-up, this is a bit inflexible, and the given addresses are treated as bootnodes. This PR provides us with the option to add and attempt to connect to new addresses during runtime, and the newly added peers are not treated as bootnodes, but as regular peers.