### PR TITLE
Make network crawlers disregard their connection count when requesting peer lists

### DIFF
--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -86,9 +86,16 @@ impl Config {
         self.is_bootnode
     }
 
+    /// Returns `true` if this node is a crawler. Otherwise, returns `false`.
     #[inline]
     pub fn is_crawler(&self) -> bool {
         self.is_crawler
+    }
+
+    /// Returns `true` if this node is a plain node. Otherwise, returns `false`.
+    #[inline]
+    pub fn is_regular_node(&self) -> bool {
+        !(self.is_bootnode() || self.is_crawler())
     }
 
     /// Returns the minimum number of peers this node maintains a connection with.


### PR DESCRIPTION
When the crawler functionality was separated from the bootnodes, one spot was omitted where a bootnode-specific behavior was desirable for network crawlers; this PR accounts for crawlers there now, and provides a new method, `Config::is_regular_node`, which makes handling bootnode+crawler-specific (or regular-node-only) behavior easier.

In addition, the bootnodes and crawlers no longer periodically disconnect from semi-random peers, but from the oldest ones, in order to cycle their peers better. A few comments were also tweaked for better readability.

@howardwu the new release hasn't been tagged or pushed to [crates.io](https://crates.io) yet, correct? If not, then it would be a good idea to include this change in it.