### PR TITLE
Make the outbound metric not grow with time

### DIFF
--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -65,6 +65,10 @@ impl PeerBookRef {
                 }
                 PeerEventData::Disconnect(peer, status) => {
                     self.connected_peers.remove(peer.address).await;
+
+                    let queued_outbound_message_count = peer.queued_outbound_message_count.swap(0, Ordering::SeqCst);
+                    metrics::decrement_gauge!(snarkos_metrics::queues::OUTBOUND, queued_outbound_message_count as f64);
+
                     if self.disconnected_peers.insert(peer.address, peer).await.is_none() {
                         metrics::increment_gauge!(DISCONNECTED, 1.0);
                     }


### PR DESCRIPTION
In some disconnect-intensive scenarios (e.g. a network crawler node), the queued outbound message count metric would gradually retain some entries with time. This PR "tightens" the way this metric is modified, and appears to solve the issue when tested with a crawler over an extended period of time.