### PR TITLE
Network crawler tweaks

### DIFF
--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -199,11 +199,9 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
             let node_clone = self.clone();
 
             let known_network_task = task::spawn(async move {
+                let known_network = node_clone.known_network().unwrap();
                 loop {
-                    // Should always be present since we check for it before this block.
-                    if let Some(known_network) = node_clone.known_network() {
-                        known_network.update().await
-                    }
+                    known_network.update().await
                 }
             });
             self.register_task(known_network_task);

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -199,6 +199,7 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
             let node_clone = self.clone();
 
             let known_network_task = task::spawn(async move {
+                // Safe since we check the presence of `known_network`.
                 let known_network = node_clone.known_network().unwrap();
                 let mut receiver = known_network.take_receiver().unwrap();
 

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -200,8 +200,10 @@ impl<S: Storage + Send + core::marker::Sync + 'static> Node<S> {
 
             let known_network_task = task::spawn(async move {
                 let known_network = node_clone.known_network().unwrap();
-                loop {
-                    known_network.update().await
+                let mut receiver = known_network.take_receiver().unwrap();
+
+                while let Some(message) = receiver.recv().await {
+                    known_network.update(message);
                 }
             });
             self.register_task(known_network_task);

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -170,14 +170,12 @@ impl KnownNetwork {
             .copied()
             .collect();
 
-        // Only retain connections that aren't removed.
-        self.connections
-            .write()
-            .retain(|connection| !connections_to_remove.contains(connection));
-
         // Scope the write lock.
         {
             let mut connections_g = self.connections.write();
+
+            // Remove stale connections.
+            connections_g.retain(|connection| !connections_to_remove.contains(connection));
 
             // Insert new connections, we use replace so the last seen timestamp is overwritten.
             for new_connection in new_connections.into_iter() {

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -399,8 +399,12 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             })
             .collect();
 
-        // Compute the metrics.
-        let network_metrics = NetworkMetrics::new(connections);
+        // Compute the metrics or provide default values if there are no known connections yet.
+        let network_metrics = if !connections.is_empty() {
+            NetworkMetrics::new(connections)
+        } else {
+            NetworkMetrics::default()
+        };
 
         // Collect the vertices with the metrics.
         let vertices: Vec<Vertice> = network_metrics
@@ -421,8 +425,14 @@ impl<S: Storage + Send + core::marker::Sync + 'static> RpcFunctions for RpcImpl<
             .map(|(height, members)| PotentialFork { height, members })
             .collect();
 
+        let node_count = if network_metrics.node_count == 0 {
+            known_network.nodes().len()
+        } else {
+            network_metrics.node_count
+        };
+
         Ok(NetworkGraph {
-            node_count: network_metrics.node_count,
+            node_count,
             connection_count: network_metrics.connection_count,
             density: network_metrics.density,
             algebraic_connectivity: network_metrics.algebraic_connectivity,


### PR DESCRIPTION
This PR introduces a few crawler-related improvements:
- some code deduplication
- removal of a lock over a crawler-related `Receiver`
- removal of one call to `RwLock::write` (taking advantage of a nearby scope instead)
- providing a value for `node_count` even before any connections between peers are identified