### PR TITLE
Relink external md docs where possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
 jobs:
   rust-stable:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: 2xlarge
     steps:
       - checkout
@@ -78,7 +78,7 @@ jobs:
 
   snarkos-consensus:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -93,7 +93,7 @@ jobs:
 
   snarkos-metrics:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -108,7 +108,7 @@ jobs:
 
   snarkos-network:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -123,7 +123,7 @@ jobs:
 
   snarkos-parameters:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -138,7 +138,7 @@ jobs:
 
   snarkos-profiler:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -153,7 +153,7 @@ jobs:
 
   snarkos-rpc:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -168,7 +168,7 @@ jobs:
 
   snarkos-storage:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout
@@ -183,7 +183,7 @@ jobs:
 
   snarkos-testing:
     docker:
-      - image: cimg/rust:1.53.0
+      - image: cimg/rust:1.54.0
     resource_class: xlarge
     steps:
       - checkout

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -19,8 +19,7 @@
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Documentation
-// todo: readd in Rust 1.54
-// #![doc = include_str!("../documentation/concepts/network_server.md")]
+#![doc = include_str!("../documentation/concepts/network_server.md")]
 
 #[macro_use]
 extern crate derivative;

--- a/network/src/message/message.rs
+++ b/network/src/message/message.rs
@@ -61,41 +61,29 @@ impl fmt::Display for Message {
 /// The actual message transmitted over the network.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Payload {
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/block.md"))]
+    #[doc = include_str!("../../documentation/network_messages/block.md")]
     Block(Vec<u8>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_blocks.md"))]
+    #[doc = include_str!("../../documentation/network_messages/get_blocks.md")]
     GetBlocks(Vec<BlockHeaderHash>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_memory_pool.md"))]
+    #[doc = include_str!("../../documentation/network_messages/get_memory_pool.md")]
     GetMemoryPool,
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_peers.md"))]
+    #[doc = include_str!("../../documentation/network_messages/get_peers.md")]
     GetPeers,
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/get_sync.md"))]
+    #[doc = include_str!("../../documentation/network_messages/get_sync.md")]
     GetSync(Vec<BlockHeaderHash>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/memory_pool.md"))]
+    #[doc = include_str!("../../documentation/network_messages/memory_pool.md")]
     MemoryPool(Vec<Vec<u8>>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/peers.md"))]
+    #[doc = include_str!("../../documentation/network_messages/peers.md")]
     Peers(Vec<SocketAddr>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/ping.md"))]
+    #[doc = include_str!("../../documentation/network_messages/ping.md")]
     Ping(u32),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/pong.md"))]
+    #[doc = include_str!("../../documentation/network_messages/pong.md")]
     Pong,
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/sync.md"))]
+    #[doc = include_str!("../../documentation/network_messages/sync.md")]
     Sync(Vec<BlockHeaderHash>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/sync_block.md"))]
+    #[doc = include_str!("../../documentation/network_messages/sync_block.md")]
     SyncBlock(Vec<u8>),
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/transaction.md"))]
+    #[doc = include_str!("../../documentation/network_messages/transaction.md")]
     Transaction(Vec<u8>),
 
     // a placeholder indicating the introduction of a new payload type; used for forward compatibility

--- a/network/src/message/version.rs
+++ b/network/src/message/version.rs
@@ -14,8 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-// todo: readd in Rust 1.54
-// #[cfg_attr(nightly, doc(include = "../../documentation/network_messages/version.md"))]
+#[doc = include_str!("../../documentation/network_messages/version.md")]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Version {
     /// The version number of the sender's node server.

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -18,9 +18,8 @@
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
 // Documentation
-// #![cfg_attr(nightly, warn(missing_docs))]
-// todo: readd in Rust 1.54
-// #![cfg_attr(nightly, doc(include = "../documentation/concepts/rpc_server.md"))]
+// #![warn(missing_docs)]
+#![doc = include_str!("../documentation/concepts/rpc_server.md")]
 
 #[macro_use]
 extern crate thiserror;

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -24,47 +24,47 @@ use std::net::SocketAddr;
 /// Definition of public RPC endpoints.
 #[async_trait::async_trait]
 pub trait RpcFunctions {
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getblock.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getblock.md")]
     // #[rpc(name = "getblock")]
     async fn get_block(&self, block_hash_string: String) -> Result<BlockInfo, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getblockcount.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getblockcount.md")]
     // #[rpc(name = "getblockcount")]
     async fn get_block_count(&self) -> Result<u32, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getbestblockhash.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getbestblockhash.md")]
     // #[rpc(name = "getbestblockhash")]
     async fn get_best_block_hash(&self) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getblockhash.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getblockhash.md")]
     // #[rpc(name = "getblockhash")]
     async fn get_block_hash(&self, block_height: u32) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getrawtransaction.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getrawtransaction.md")]
     // #[rpc(name = "getrawtransaction")]
     async fn get_raw_transaction(&self, transaction_id: String) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/gettransactioninfo.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/gettransactioninfo.md")]
     // #[rpc(name = "gettransactioninfo")]
     async fn get_transaction_info(&self, transaction_id: String) -> Result<TransactionInfo, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/decoderawtransaction.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/decoderawtransaction.md")]
     // #[rpc(name = "decoderawtransaction")]
     async fn decode_raw_transaction(&self, transaction_bytes: String) -> Result<TransactionInfo, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/sendtransaction.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/sendtransaction.md")]
     // #[rpc(name = "sendtransaction")]
     async fn send_raw_transaction(&self, transaction_bytes: String) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
     // #[cfg_attr(
     //     nightly,
     //     doc(include = "../documentation/public_endpoints/validaterawtransaction.md")
@@ -72,33 +72,33 @@ pub trait RpcFunctions {
     // #[rpc(name = "validaterawtransaction")]
     async fn validate_raw_transaction(&self, transaction_bytes: String) -> Result<bool, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getconnectioncount.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getconnectioncount.md")]
     // #[rpc(name = "getconnectioncount")]
     async fn get_connection_count(&self) -> Result<usize, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getpeerinfo.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getpeerinfo.md")]
     // #[rpc(name = "getpeerinfo")]
     async fn get_peer_info(&self) -> Result<PeerInfo, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getnodeinfo.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getnodeinfo.md")]
     // #[rpc(name = "getnodeinfo")]
     async fn get_node_info(&self) -> Result<NodeInfo, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getnodestats.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getnodestats.md")]
     // #[rpc(name = "getnodestats")]
     async fn get_node_stats(&self) -> Result<NodeStats, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/public_endpoints/getblocktemplate.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getblocktemplate.md")]
     // #[rpc(name = "getblocktemplate")]
     async fn get_block_template(&self) -> Result<BlockTemplate, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include ="../documentation/public_endpoints/getnetworkgraph.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/public_endpoints/getnetworkgraph.md")]
     // #[rpc(name = "getnetworkgraph")]
     async fn get_network_graph(&self) -> Result<NetworkGraph, RpcError>;
 }
@@ -106,60 +106,60 @@ pub trait RpcFunctions {
 /// Definition of private RPC endpoints that require authentication.
 #[async_trait::async_trait]
 pub trait ProtectedRpcFunctions {
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/createaccount.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/createaccount.md")]
     async fn create_account(&self) -> Result<RpcAccount, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/createrawtransaction.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/createrawtransaction.md")]
     async fn create_raw_transaction(
         &self,
         transaction_input: TransactionInputs,
     ) -> Result<CreateRawTransactionOuput, RpcError>;
 
-    // todo: readd in Rust 1.54
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
     // #[cfg_attr(
     //     nightly,
     //     doc(include = "../documentation/private_endpoints/createtransactionkernel.md")
     // )]
     async fn create_transaction_kernel(&self, transaction_input: TransactionInputs) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/createtransaction.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/createtransaction.md")]
     async fn create_transaction(
         &self,
         private_keys: [String; 2], // TODO (howardwu): Genericize this.
         transaction_kernel: String,
     ) -> Result<CreateRawTransactionOuput, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/getrecordcommitments.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/getrecordcommitments.md")]
     async fn get_record_commitments(&self) -> Result<Vec<String>, RpcError>;
 
-    // todo: readd in Rust 1.54
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
     // #[cfg_attr(
     //     nightly,
     //     doc(include = "../documentation/private_endpoints/getrecordcommitmentcount.md")
     // )]
     async fn get_record_commitment_count(&self) -> Result<usize, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/getrawrecord.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/getrawrecord.md")]
     async fn get_raw_record(&self, record_commitment: String) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/decoderecord.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/decoderecord.md")]
     async fn decode_record(&self, record_bytes: String) -> Result<RecordInfo, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/decryptrecord.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/decryptrecord.md")]
     async fn decrypt_record(&self, decryption_input: DecryptRecordInput) -> Result<String, RpcError>;
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/disconnect.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/disconnect.md")]
     async fn disconnect(&self, address: SocketAddr);
 
-    // todo: readd in Rust 1.54
-    // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/connect.md"))]
+    // todo: readd, this attr still doesn't play nice in this trait in Rust 1.54.
+    // #[doc = include_str!("../documentation/private_endpoints/connect.md")]
     async fn connect(&self, addresses: Vec<SocketAddr>);
 }


### PR DESCRIPTION
Rust 1.54 stabilises `#[doc = include_str!()]` for external documentation. This PR reintroduces a decent portion of the external documentation. Builds on #1006. 

Unfortunately this didn't seem to play nice with the rpc trait functions, not sure why yet (hence the draft). `#[rpc]` over the `RpcFunctions` trait is likely to blame.