### PR TITLE
Connect to fewer, randomized bootnodes

### DIFF
--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -258,7 +258,7 @@ async fn handshake_timeout_initiator_side() {
     let node = test_node(setup).await;
 
     // the node should start connecting to all the configured bootnodes
-    wait_until!(3, node.peer_book.get_active_peer_count() == NUM_BOOTSTRAPPERS as u32);
+    wait_until!(3, node.peer_book.get_active_peer_count() != 0);
 
     // but since they won't reply, it should drop them after the handshake deadline
     wait_until!(


### PR DESCRIPTION
As discussed during the community call, we can reduce the connection strain on the bootnodes by making nodes without peers connect to only 2 of them at once, and picking them from the configured list at random.