### PR TITLE
Remove the sync layer from bootnodes and crawlers

### DIFF
--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -161,8 +161,8 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         }
     }
 
-    // Enable the sync layer.
-    {
+    // Enable the sync layer for only for client nodes and miners.
+    if !config.node.is_bootnode && !config.node.is_crawler {
         let memory_pool = MemoryPool::from_storage(&storage).await?;
 
         debug!("Loading Aleo parameters...");

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -161,8 +161,8 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         }
     }
 
-    // Enable the sync layer for only for client nodes and miners.
-    if !config.node.is_bootnode && !config.node.is_crawler {
+    // Enable the sync layer only for client nodes and miners.
+    if node.config.is_regular_node() {
         let memory_pool = MemoryPool::from_storage(&storage).await?;
 
         debug!("Loading Aleo parameters...");


### PR DESCRIPTION
This PR removes the sync layer from the bootnodes and the crawlers. Closes #960. 

The Aleo explorer **will** need to be pointed to a regular client node after this is merged.
