### PR TITLE
Make the connection buffers grow on demand

### DIFF
--- a/network/src/peers/peer/handshake.rs
+++ b/network/src/peers/peer/handshake.rs
@@ -34,7 +34,7 @@ use crate::{
 pub struct HandshakeData {
     pub version: Version,
     pub noise: TransportState,
-    pub buffer: Box<[u8]>,
+    pub buffer: Vec<u8>,
     pub noise_buffer: Box<[u8]>,
 }
 
@@ -53,7 +53,7 @@ async fn responder_handshake<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
     let static_key = builder.generate_keypair()?.private;
     let noise_builder = builder.local_private_key(&static_key).psk(3, crate::HANDSHAKE_PSK);
     let mut noise = noise_builder.build_responder()?;
-    let mut buffer: Box<[u8]> = vec![0u8; crate::MAX_MESSAGE_SIZE + 4096].into();
+    let mut buffer: Vec<u8> = vec![0u8; crate::NOISE_BUF_LEN];
     let mut noise_buffer: Box<[u8]> = vec![0u8; crate::NOISE_BUF_LEN].into();
     // <- e
     reader.read_exact(&mut buffer[..1]).await?;
@@ -115,7 +115,7 @@ async fn initiator_handshake<W: AsyncWrite + Unpin, R: AsyncRead + Unpin>(
     let static_key = builder.generate_keypair()?.private;
     let noise_builder = builder.local_private_key(&static_key).psk(3, crate::HANDSHAKE_PSK);
     let mut noise = noise_builder.build_initiator()?;
-    let mut buffer: Box<[u8]> = vec![0u8; crate::MAX_MESSAGE_SIZE + 4096].into();
+    let mut buffer: Vec<u8> = vec![0u8; crate::NOISE_BUF_LEN];
     let mut noise_buffer: Box<[u8]> = vec![0u8; crate::NOISE_BUF_LEN].into();
     // -> e
     let len = noise.write_message(&[], &mut buffer)?;

--- a/testing/src/network/encryption.rs
+++ b/testing/src/network/encryption.rs
@@ -24,8 +24,8 @@ use rand::{distributions::Standard, thread_rng, Rng};
 async fn encrypt_and_decrypt_a_big_payload() {
     let (mut node0, mut node1) = spawn_2_fake_nodes().await;
 
-    // account for the overhead of serialization and noise tags
-    let block_size = snarkos_network::MAX_MESSAGE_SIZE / 2;
+    // account for some overhead of serialization and noise tags
+    let block_size = snarkos_network::MAX_MESSAGE_SIZE / 4 * 3;
 
     // create a big block containing random data
     let fake_block_bytes: Vec<u8> = (&mut thread_rng()).sample_iter(Standard).take(block_size).collect();

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -212,11 +212,7 @@ impl FakeNode {
         let mut network = PeerIOHandle {
             reader: Some(reader),
             writer,
-            cipher: Cipher::new(
-                noise,
-                vec![0u8; MAX_MESSAGE_SIZE + 4096].into(),
-                vec![0u8; NOISE_BUF_LEN].into(),
-            ),
+            cipher: Cipher::new(noise, vec![0u8; NOISE_BUF_LEN], vec![0u8; NOISE_BUF_LEN].into()),
         };
 
         let reader = network.take_reader();


### PR DESCRIPTION
This will significantly reduce memory use for nodes with many connections until/unless a message with the maximum network message size is processed (at which point the buffers will be allocated to their maximum capacity). The cost of extra arithmetic ops is negligible.