### PR TITLE
Update snarkVM to 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8db2338bd30c4f5f08f27cae89bccd9ba48b06166e1cddcc4e845de0390229f"
+checksum = "40caa98abd0a874a003d844d6a73562020fb5fa976daa14055f030d9803430b7"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2894,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a67bf9f77ce8db3e88fd58241ec7d0a0ad80097c42d0bd4e53b123106605249"
+checksum = "010ae5c95693279db519e4a8525a8a3145edc8e36198efdfaf250622f4540cc1"
 dependencies = [
  "derivative",
  "rand 0.8.4",
@@ -2910,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbe69096a11cdc3f0b069e0313d47fbcabf45532d58435ef0a03d35d2805dc5"
+checksum = "0e963ae4209f0166a619ab9266ce71c6f9228861ec55615a1b6154d673ffc158"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2923,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65b21cece03e1191989230062d8773d5dd7b848099fd0380e35d3f920b7c77e"
+checksum = "1588a3d2f38307bd64838cf1761d8cef485461e5224831c9b9df11a1fa9864e7"
 dependencies = [
  "anyhow",
  "base58",
@@ -2955,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d750651111b5d399a3b29b770fe821fdac87614335b4814ab5a0d014634bc"
+checksum = "761cb4c19d6685ac9d1d3a6eb1619600334bcf80dc6ac742cc38f4fe349ba871"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2971,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753400eccfb80757e90daaf077c37ce8988bf163816ded6eb884e725290a78f1"
+checksum = "c3b0cd11387a572f9a1c318c1d446dd46e0522c9be7681b8d6af6882d20880fd"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-marlin"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcc01851cf4cee0de8c4fda76f8096789cab813c738703ec67fe2d19d89a204"
+checksum = "206d633d6299dfb4f52640a3188567462dbf1f207de70cbb829707c07858c7e6"
 dependencies = [
  "blake2",
  "derivative",
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21f3b1fc09bff0e3a352a2e30927a3fbfbe183ef658cbb42bd2805db7d6420"
+checksum = "9f5c4d4233a623c46c483296aa24bf4d95a5f3344c669ce4f2956467fe6ea904"
 dependencies = [
  "curl",
  "hex",
@@ -3028,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-polycommit"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920e188506d5036cca0fdae46d63ad1779d3f49c671ea2339b9cda0c0ab8751a"
+checksum = "5b5ca8d560cb6f49d9de9b4a955778cc14563b0a381c56db48ea6171788f30d4"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -3047,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-posw"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d99c25a2b1702bf8136e1cb8802963087e9d767045f3237a795442c43b79391"
+checksum = "12a9c030d0d620d13dba77b4a2dcee9e651ad50082540b23f4f351e6dd6c024b"
 dependencies = [
  "blake2",
  "rand 0.8.4",
@@ -3069,15 +3069,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a060c67f5c11015465721bdbbaf71f8c5132fdc885cb2e7307f8c936dd43ca1"
+checksum = "29cb28d79c59db77774484dbc0f4e876dc8604085d8d7f43eee1b813ec0614b4"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b87182d37dc6665816e1dcd480820f6c6494d1d9604c481b756eb0771956265"
+checksum = "a12e3b7acea34af74dbe5dea056714a9f3c9b1029a9ac888595c96a6e3c676e6"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -3090,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb1462993e1d189c75f88f2482f18ae4bcccb5ea5a7a93a25de92907305af8f"
+checksum = "c0842ff685e625cb7a2f9ddc7ca1b1560d2a3e3a7220099781a28ea54564133b"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,17 +44,17 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkos-consensus]
 path = "./consensus"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -33,22 +33,22 @@ path = "network/network.rs"
 harness = false
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-curves]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,19 +18,19 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-curves]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.metrics]
 version = "0.17"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -37,4 +37,4 @@ version = "1"
 features = [ "macros", "rt-multi-thread" ]
 
 [dev-dependencies.snarkvm-derives]
-version = "=0.7.6"
+version = "=0.7.8"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,13 +21,13 @@ edition = "2018"
 prometheus = [ "snarkos-metrics/prometheus" ]
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -18,17 +18,17 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 default-features = false
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.arc-swap]
 version = "1.2"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 default-features = false
 
 [dependencies.curl]
@@ -36,16 +36,16 @@ version = "0.4.36"
 optional = true
 
 [dev-dependencies.snarkvm-curves]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dev-dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dev-dependencies.snarkvm-marlin]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dev-dependencies.snarkvm-posw]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dev-dependencies.snarkos-consensus]
 path = "../consensus"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,14 +18,14 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -24,16 +24,16 @@ mem_storage = [ ]
 test = [ ]
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkos-parameters]
 path = "../parameters"
@@ -83,7 +83,7 @@ version = "0.1"
 path = "../consensus"
 
 [dev-dependencies.snarkvm-curves]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dev-dependencies.snarkos-testing]
 path = "../testing"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -29,22 +29,22 @@ network = [
 ]
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-curves]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.6"
+version = "=0.7.8"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"


### PR DESCRIPTION
The `0.7.6` version currently used doesn't have the merkle tree initialization time improvement, making the nodes slow to start.