### PR TITLE
Update the node cleanup test

### DIFF
--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -266,6 +266,10 @@ impl PeerBook {
         debug!("Added {} to the peer book", address);
     }
 
+    pub async fn remove_peer(&self, address: SocketAddr) -> Option<Peer> {
+        self.disconnected_peers.remove(address).await
+    }
+
     ///
     /// Returns the `SocketAddr` of the last seen peer to be used as a sync node, or `None`.
     ///

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -266,7 +266,10 @@ impl PeerBook {
         debug!("Added {} to the peer book", address);
     }
 
-    pub async fn remove_peer(&self, address: SocketAddr) -> Option<Peer> {
+    /// Removes the peer by address from the disconnected peers in this `PeerBook`.
+    ///
+    /// Note: this is currently only used in testing.
+    pub async fn remove_disconnected_peer(&self, address: SocketAddr) -> Option<Peer> {
         self.disconnected_peers.remove(address).await
     }
 

--- a/network/tests/cleanup.rs
+++ b/network/tests/cleanup.rs
@@ -72,8 +72,9 @@ async fn check_inactive_conn_cleanup() {
 }
 
 #[tokio::test]
-#[ignore]
-async fn check_node_cleanup() {
+async fn check_node_connections_cleanup() {
+    // The test checks for memory leaks surrounding the node's connection handling.
+
     #[global_allocator]
     static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
@@ -115,7 +116,7 @@ async fn check_node_cleanup() {
 
         // Remove the peer from the peer book, to avoid heap growth from disconnected peer
         // tracking.
-        assert!(node.peer_book.remove_peer(addr).await.is_some());
+        assert!(node.peer_book.remove_disconnected_peer(addr).await.is_some());
 
         // Register the current heap size, after the connection has been dropped.
         let current_heap_size = PEAK_ALLOC.current_usage() - mem_deduction;
@@ -152,4 +153,6 @@ async fn check_node_cleanup() {
     println!("average use: {}kB", avg_heap_use / 1000);
     println!("maximum use: {}kB", PEAK_ALLOC.peak_usage() / 1000);
     println!("growth:      {}B, {:.2}%", heap_growth, growth_percentage);
+
+    assert_eq!(heap_growth, 0);
 }

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -201,12 +201,13 @@ pub async fn test_node(setup: TestSetup) -> Node<LedgerStorage> {
 }
 
 pub struct FakeNode {
+    pub addr: SocketAddr,
     network: PeerIOHandle,
     reader: PeerReader<OwnedReadHalf>,
 }
 
 impl FakeNode {
-    pub fn new(stream: TcpStream, _peer_addr: SocketAddr, noise: snow::TransportState) -> Self {
+    pub fn new(stream: TcpStream, addr: SocketAddr, noise: snow::TransportState) -> Self {
         let (reader, writer) = stream.into_split();
 
         let mut network = PeerIOHandle {
@@ -221,7 +222,7 @@ impl FakeNode {
 
         let reader = network.take_reader();
 
-        Self { network, reader }
+        Self { addr, network, reader }
     }
 
     pub async fn read_payload(&mut self) -> Result<Payload, NetworkError> {


### PR DESCRIPTION
This PR updates the test checking leaks in the node's connection handling.

Results: 
```
---- heap use summary ----

before node setup:     56kB
after node setup:      105kB
after 32 connections:  123kB
after 256 connections: 123kB

average use: 122kB
maximum use: 25501kB
growth:      0B, 0.00%
```
