### PR TITLE
Add fork points to sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   ubuntu:
     name: Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -34,9 +34,8 @@ impl ConsensusInner {
 
             self.commit_block(&hash, &block).await?;
         }
-        // info!("rebuilding canon");
-        // self.diff_canon().await?;
-        // self.recommit_canon().await?; // TODO: DEFINITELY REMOVE
+
+        // scan for forks
         let forks = self.scan_forks().await?;
         for (canon, fork_child) in forks {
             let canon_height = match self.storage.get_block_state(&canon).await? {
@@ -53,7 +52,7 @@ impl ConsensusInner {
                 fork_blocks.last().unwrap()
             );
         }
-        // info!("rebuilt canon");
+
         if let Err(e) = self.try_to_fast_forward().await {
             match e {
                 ConsensusError::InvalidBlock(e) => debug!("invalid block in initial fast-forward: {}", e),

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -25,7 +25,17 @@ use crate::{
     MemoryPool,
 };
 use anyhow::*;
-use snarkos_storage::{BlockFilter, BlockOrder, BlockStatus, Digest, DynStorage, ForkDescription, SerialBlock, SerialTransaction, VMTransaction};
+use snarkos_storage::{
+    BlockFilter,
+    BlockOrder,
+    BlockStatus,
+    Digest,
+    DynStorage,
+    ForkDescription,
+    SerialBlock,
+    SerialTransaction,
+    VMTransaction,
+};
 use snarkvm_dpc::{
     testnet1::{instantiated::Components, Record as DPCRecord, TransactionKernel},
     DPCScheme,

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -151,7 +151,7 @@ impl Consensus {
     }
 
     /// Diagnostic function to scan for valid forks
-    pub async fn scan_forks(&self) -> Result<()> {
+    pub async fn scan_forks(&self) -> Result<Vec<(Digest, Digest)>> {
         self.send(ConsensusMessage::ScanForks()).await
     }
 

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -15,12 +15,8 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod consensus_sidechain {
-<<<<<<< HEAD
-    use snarkos_storage::validator::FixMode;
-=======
     use snarkos_consensus::OLDEST_FORK_THRESHOLD;
-    // use snarkos_storage::validator::FixMode;
->>>>>>> 3a24d6cb... wip dynamic syncing
+    use snarkos_storage::validator::FixMode;
     use snarkos_testing::sync::*;
 
     use rand::{seq::IteratorRandom, thread_rng, Rng};

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -15,7 +15,12 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod consensus_sidechain {
+<<<<<<< HEAD
     use snarkos_storage::validator::FixMode;
+=======
+    use snarkos_consensus::OLDEST_FORK_THRESHOLD;
+    // use snarkos_storage::validator::FixMode;
+>>>>>>> 3a24d6cb... wip dynamic syncing
     use snarkos_testing::sync::*;
 
     use rand::{seq::IteratorRandom, thread_rng, Rng};
@@ -183,7 +188,13 @@ mod consensus_sidechain {
         assert_eq!(best_block_number, block_height);
 
         // Check if the locator hashes can be found.
-        assert!(consensus.storage.get_block_locator_hashes().await.is_ok());
+        assert!(
+            consensus
+                .storage
+                .get_block_locator_hashes(vec![], snarkos_consensus::OLDEST_FORK_THRESHOLD)
+                .await
+                .is_ok()
+        );
 
         // Decommit a block.
         let canon_hash = consensus.storage.canon().await.unwrap().hash;
@@ -195,7 +206,13 @@ mod consensus_sidechain {
         assert_eq!(best_block_number, block_height);
 
         // Check if the locator hashes can still be found.
-        assert!(consensus.storage.get_block_locator_hashes().await.is_ok());
+        assert!(
+            consensus
+                .storage
+                .get_block_locator_hashes(vec![], snarkos_consensus::OLDEST_FORK_THRESHOLD)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -219,7 +236,11 @@ mod consensus_sidechain {
         }
 
         // There is no overlap between the 2 instances.
-        let consensus1_locator_hashes = consensus1.storage.get_block_locator_hashes().await.unwrap();
+        let consensus1_locator_hashes = consensus1
+            .storage
+            .get_block_locator_hashes(vec![], OLDEST_FORK_THRESHOLD)
+            .await
+            .unwrap();
         let consensus2_sync_blocks = consensus2
             .storage
             .find_sync_blocks(&consensus1_locator_hashes, 64)
@@ -242,7 +263,11 @@ mod consensus_sidechain {
         }
 
         // The blocks should fully overlap between the 2 instances now.
-        let consensus1_locator_hashes = consensus1.storage.get_block_locator_hashes().await.unwrap();
+        let consensus1_locator_hashes = consensus1
+            .storage
+            .get_block_locator_hashes(vec![], OLDEST_FORK_THRESHOLD)
+            .await
+            .unwrap();
         let consensus2_sync_blocks = consensus2
             .storage
             .find_sync_blocks(&consensus1_locator_hashes, 64)
@@ -277,7 +302,11 @@ mod consensus_sidechain {
         let overlap_height = consensus1.storage.canon().await.unwrap().block_height;
 
         // There is some initial overlap between the 2 instances.
-        let consensus1_locator_hashes = consensus1.storage.get_block_locator_hashes().await.unwrap();
+        let consensus1_locator_hashes = consensus1
+            .storage
+            .get_block_locator_hashes(vec![], OLDEST_FORK_THRESHOLD)
+            .await
+            .unwrap();
         let consensus2_sync_blocks = consensus2
             .storage
             .find_sync_blocks(&consensus1_locator_hashes, 64)
@@ -310,7 +339,11 @@ mod consensus_sidechain {
         }
 
         // The blocks should fully overlap between the 2 instances now.
-        let consensus1_locator_hashes = consensus1.storage.get_block_locator_hashes().await.unwrap();
+        let consensus1_locator_hashes = consensus1
+            .storage
+            .get_block_locator_hashes(vec![], OLDEST_FORK_THRESHOLD)
+            .await
+            .unwrap();
         let consensus2_sync_blocks = consensus2
             .storage
             .find_sync_blocks(&consensus1_locator_hashes, 64)
@@ -354,7 +387,11 @@ mod consensus_sidechain {
         }
 
         // The blocks should fully overlap between the 2 instances now.
-        let consensus1_locator_hashes = consensus1.storage.get_block_locator_hashes().await.unwrap();
+        let consensus1_locator_hashes = consensus1
+            .storage
+            .get_block_locator_hashes(vec![], OLDEST_FORK_THRESHOLD)
+            .await
+            .unwrap();
         let sync_blocks = consensus2
             .storage
             .find_sync_blocks(&consensus1_locator_hashes, 64)

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -49,7 +49,7 @@ pub mod topology;
 pub use topology::*;
 
 /// The maximum number of block hashes that can be requested or provided in a single batch.
-pub const MAX_BLOCK_SYNC_COUNT: u32 = snarkos_storage::NUM_LOCATOR_HASHES;
+pub const MAX_BLOCK_SYNC_COUNT: u32 = snarkos_storage::NUM_LOCATOR_HASHES * 2;
 /// The maximum amount of time allowed to process a single batch of sync blocks. It should be aligned
 /// with `MAX_BLOCK_SYNC_COUNT`.
 pub const BLOCK_SYNC_EXPIRATION_SECS: u8 = 30;

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -84,6 +84,10 @@ impl SyncMaster {
         let blocks_of_interest: Vec<Digest> = forks_of_interest.into_iter().map(|(_canon, fork)| fork).collect();
         let mut tips_of_blocks_of_interest: Vec<Digest> = Vec::with_capacity(blocks_of_interest.len());
         for block in blocks_of_interest {
+            if tips_of_blocks_of_interest.len() > crate::MAX_BLOCK_SYNC_COUNT as usize {
+                debug!("reached limit of blocks of interest in sync block locator hashes");
+                continue;
+            }
             let mut fork_path = self.node.storage.longest_child_path(&block).await?;
             if fork_path.len() < 2 {
                 // a minor fork, we probably don't care

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -86,7 +86,7 @@ impl SyncMaster {
         for block in blocks_of_interest {
             if tips_of_blocks_of_interest.len() > crate::MAX_BLOCK_SYNC_COUNT as usize {
                 debug!("reached limit of blocks of interest in sync block locator hashes");
-                continue;
+                break;
             }
             let mut fork_path = self.node.storage.longest_child_path(&block).await?;
             if fork_path.len() < 2 {

--- a/storage/src/key_value/agent/block.rs
+++ b/storage/src/key_value/agent/block.rs
@@ -413,7 +413,7 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
                 match order {
                     BlockOrder::Ascending => values.into_iter().map(|x| x.0).collect(),
                     BlockOrder::Descending => values.into_iter().rev().map(|x| x.0).collect(),
-                    BlockOrder::Unordered => unimplemented!(),
+                    BlockOrder::Unordered => unreachable!(),
                 }
             }
             BlockFilter::NonCanonOnly => {

--- a/storage/src/key_value/agent/block_commit.rs
+++ b/storage/src/key_value/agent/block_commit.rs
@@ -24,7 +24,7 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
         let header = self.get_block_header(hash)?;
         let canon_height = self.canon_height()?;
         let mut parent_hash = header.previous_block_hash;
-        for _ in 0..=90000 {
+        for _ in 0..=oldest_fork_threshold {
             // check if the part is part of the canon chain
             match self.get_block_state(&parent_hash)? {
                 // This is a canon parent

--- a/storage/src/key_value/agent/mod.rs
+++ b/storage/src/key_value/agent/mod.rs
@@ -197,8 +197,11 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
             }
             Message::DecommitBlocks(hash) => Box::new(self.wrap(move |f| f.decommit_blocks(&hash))),
             Message::Canon() => Box::new(self.canon()),
+            Message::GetBlockChildren(hash) => Box::new(self.get_child_block_hashes(&hash)),
             Message::LongestChildPath(hash) => Box::new(self.longest_child_path(&hash)),
-            Message::GetBlockLocatorHashes() => Box::new(self.get_block_locator_hashes()),
+            Message::GetBlockLocatorHashes(points_of_interest, oldest_fork_threshold) => {
+                Box::new(self.get_block_locator_hashes(points_of_interest, oldest_fork_threshold))
+            }
             Message::FindSyncBlocks(hashes, block_count) => Box::new(self.find_sync_blocks(hashes, block_count)),
             Message::GetTransactionLocation(transaction_id) => Box::new(self.get_transaction_location(&transaction_id)),
             Message::GetRecordCommitments(limit) => Box::new(self.get_record_commitments(limit)),

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -79,7 +79,8 @@ enum Message {
     DecommitBlocks(Digest),
     Canon(),
     LongestChildPath(Digest),
-    GetBlockLocatorHashes(),
+    GetBlockChildren(Digest),
+    GetBlockLocatorHashes(Vec<Digest>, usize), // points of interest, oldest_fork_threshold
     FindSyncBlocks(Vec<Digest>, usize),
     GetTransactionLocation(Digest),
     GetRecordCommitments(Option<usize>),
@@ -117,7 +118,12 @@ impl fmt::Display for Message {
             Message::DecommitBlocks(hash) => write!(f, "DecommitBlocks({})", hash),
             Message::Canon() => write!(f, "Canon()"),
             Message::LongestChildPath(hash) => write!(f, "LongestChildPath({})", hash),
-            Message::GetBlockLocatorHashes() => write!(f, "GetBlockLocatorHashes()"),
+            Message::GetBlockChildren(hash) => write!(f, "GetBlockChildren({})", hash),
+            Message::GetBlockLocatorHashes(canon_depth_limit, oldest_fork_threshold) => write!(
+                f,
+                "GetBlockLocatorHashes({:?}, {})",
+                canon_depth_limit, oldest_fork_threshold
+            ),
             Message::FindSyncBlocks(hashes, max_block_count) => {
                 write!(f, "FindSyncBlocks(")?;
                 for hash in hashes {

--- a/storage/src/key_value/storage.rs
+++ b/storage/src/key_value/storage.rs
@@ -82,8 +82,20 @@ impl Storage for KeyValueStore {
         self.send(Message::LongestChildPath(block_hash.clone())).await
     }
 
-    async fn get_block_locator_hashes(&self) -> Result<Vec<Digest>> {
-        self.send(Message::GetBlockLocatorHashes()).await
+    async fn get_block_children(&self, block_hash: &Digest) -> Result<Vec<Digest>> {
+        self.send(Message::GetBlockChildren(block_hash.clone())).await
+    }
+
+    async fn get_block_locator_hashes(
+        &self,
+        points_of_interest: Vec<Digest>,
+        oldest_fork_threshold: usize,
+    ) -> Result<Vec<Digest>> {
+        self.send(Message::GetBlockLocatorHashes(
+            points_of_interest,
+            oldest_fork_threshold,
+        ))
+        .await
     }
 
     async fn find_sync_blocks(&self, block_locator_hashes: &[Digest], block_count: usize) -> Result<Vec<Digest>> {

--- a/testing/examples/test_blocks.rs
+++ b/testing/examples/test_blocks.rs
@@ -17,90 +17,14 @@
 #[macro_use]
 extern crate tracing;
 
-use snarkos_consensus::{error::ConsensusError, Consensus, CreateTransactionRequest, MineContext, TransactionResponse};
-use snarkos_storage::{PrivateKey, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction};
-use snarkos_testing::sync::*;
-use snarkvm_dpc::{
-    testnet1::{instantiated::*, record::payload::Payload as RecordPayload},
-    Account,
-    Address,
-    AleoAmount,
-    DPCComponents,
+use snarkos_consensus::{error::ConsensusError, MineContext, TransactionResponse};
+use snarkos_testing::{
+    mining::{mine_block, send},
+    sync::*,
 };
 use tracing_subscriber::EnvFilter;
 
 use std::{fs::File, path::PathBuf};
-
-async fn mine_block(
-    miner: &MineContext,
-    transactions: Vec<SerialTransaction>,
-    parent_block_header: &SerialBlockHeader,
-) -> Result<(SerialBlock, Vec<SerialRecord>), ConsensusError> {
-    info!("Mining block!");
-
-    let (transactions, coinbase_records) = miner.establish_block(transactions).await?;
-
-    let header = miner.find_block(&transactions, parent_block_header)?;
-
-    let block = SerialBlock { header, transactions };
-
-    let old_block_height = miner.consensus.storage.canon().await?.block_height;
-
-    // Duplicate blocks dont do anything
-    miner.consensus.receive_block(block.clone()).await; // throws a duplicate error -- seemingly intentional
-
-    let new_block_height = miner.consensus.storage.canon().await?.block_height;
-    assert_eq!(old_block_height + 1, new_block_height);
-
-    Ok((block, coinbase_records))
-}
-
-/// Spends some value from inputs owned by the sender, to the receiver,
-/// and pays back whatever we are left with.
-#[allow(clippy::too_many_arguments)]
-async fn send(
-    consensus: &Consensus,
-    from: &Account<Components>,
-    inputs: Vec<SerialRecord>,
-    receiver: &Address<Components>,
-    amount: i64,
-    memo: [u8; 32],
-) -> Result<TransactionResponse, ConsensusError> {
-    let mut sum = 0;
-    for inp in &inputs {
-        sum += inp.value.0;
-    }
-    assert!(sum >= amount, "not enough balance in inputs");
-    let change = sum - amount;
-
-    let to = vec![receiver.clone(), from.address.clone()];
-    let values = vec![amount, change];
-
-    let from: Vec<PrivateKey> = vec![from.private_key.clone(); Components::NUM_INPUT_RECORDS]
-        .into_iter()
-        .map(Into::into)
-        .collect();
-
-    let joint_serial_numbers = consensus.calculate_joint_serial_numbers(&inputs[..], &from[..])?;
-    let mut new_records = vec![];
-    for j in 0..Components::NUM_OUTPUT_RECORDS as u8 {
-        new_records.push(consensus.make_dummy_record(
-            &joint_serial_numbers[..],
-            j,
-            to[j as usize].clone().into(),
-            AleoAmount(values[j as usize]),
-            RecordPayload::default(),
-        )?);
-    }
-    consensus
-        .create_transaction(CreateTransactionRequest {
-            old_records: inputs,
-            old_account_private_keys: from,
-            new_records,
-            memo,
-        })
-        .await
-}
 
 async fn mine_blocks(n: u32) -> Result<TestBlocks, ConsensusError> {
     info!("Creating test account");

--- a/testing/examples/test_data.rs
+++ b/testing/examples/test_data.rs
@@ -14,20 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_consensus::{error::ConsensusError, Consensus, CreateTransactionRequest, MineContext, TransactionResponse};
-use snarkos_storage::{PrivateKey, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction};
-use snarkos_testing::sync::*;
-use snarkvm_dpc::{
-    testnet1::{instantiated::*, payload::Payload as RecordPayload},
-    Account,
-    Address,
-    AleoAmount,
-    DPCComponents,
+use snarkos_consensus::{MineContext, TransactionResponse};
+use snarkos_testing::{
+    mining::{mine_block, send},
+    sync::*,
 };
 
 use snarkvm_utilities::ToBytes;
 use std::{fs::File, path::PathBuf};
-use tracing::info;
 
 async fn setup_test_data() -> TestData {
     let [miner_acc, acc_1, _] = FIXTURE.test_accounts.clone();
@@ -87,77 +81,6 @@ async fn setup_test_data() -> TestData {
         alternative_block_1_header,
         alternative_block_2_header,
     }
-}
-
-async fn mine_block(
-    miner: &MineContext,
-    transactions: Vec<SerialTransaction>,
-    parent_block_header: &SerialBlockHeader,
-) -> Result<(SerialBlock, Vec<SerialRecord>), ConsensusError> {
-    info!("Mining block!");
-
-    let (transactions, coinbase_records) = miner.establish_block(transactions).await?;
-
-    let header = miner.find_block(&transactions, parent_block_header)?;
-
-    let block = SerialBlock { header, transactions };
-
-    let old_block_height = miner.consensus.storage.canon().await?.block_height;
-
-    // Duplicate blocks dont do anything
-    miner.consensus.receive_block(block.clone()).await; // throws a duplicate error -- seemingly intentional
-
-    let new_block_height = miner.consensus.storage.canon().await?.block_height;
-    assert_eq!(old_block_height + 1, new_block_height);
-
-    Ok((block, coinbase_records))
-}
-
-/// Spends some value from inputs owned by the sender, to the receiver,
-/// and pays back whatever we are left with.
-#[allow(clippy::too_many_arguments)]
-async fn send(
-    consensus: &Consensus,
-    from: &Account<Components>,
-    inputs: Vec<SerialRecord>,
-    receiver: &Address<Components>,
-    amount: i64,
-    memo: [u8; 32],
-) -> Result<TransactionResponse, ConsensusError> {
-    let mut sum = 0;
-    for inp in &inputs {
-        sum += inp.value.0;
-    }
-    assert!(sum >= amount, "not enough balance in inputs");
-    let change = sum - amount;
-
-    let to = vec![receiver.clone(), from.address.clone()];
-    let values = vec![amount, change];
-
-    let from: Vec<PrivateKey> = vec![from.private_key.clone(); Components::NUM_INPUT_RECORDS]
-        .into_iter()
-        .map(Into::into)
-        .collect();
-
-    let joint_serial_numbers = consensus.calculate_joint_serial_numbers(&inputs[..], &from[..])?;
-    let mut new_records = vec![];
-    for j in 0..Components::NUM_OUTPUT_RECORDS as u8 {
-        new_records.push(consensus.make_dummy_record(
-            &joint_serial_numbers[..],
-            j,
-            to[j as usize].clone().into(),
-            AleoAmount(values[j as usize]),
-            RecordPayload::default(),
-        )?);
-    }
-    consensus
-        .create_transaction(CreateTransactionRequest {
-            old_records: inputs,
-            old_account_private_keys: from,
-            new_records,
-            memo,
-        })
-        .await
 }
 
 #[tokio::main]

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 
 pub mod dpc;
+pub mod mining;
 #[cfg(feature = "network")]
 pub mod network;
 pub mod storage;

--- a/testing/src/mining/mod.rs
+++ b/testing/src/mining/mod.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkos_consensus::{error::ConsensusError, Consensus, CreateTransactionRequest, MineContext, TransactionResponse};
+use snarkos_storage::{PrivateKey, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction};
+use snarkvm_dpc::{
+    testnet1::{instantiated::*, record::payload::Payload as RecordPayload},
+    Account,
+    Address,
+    AleoAmount,
+    DPCComponents,
+};
+
+pub async fn mine_block(
+    miner: &MineContext,
+    transactions: Vec<SerialTransaction>,
+    parent_block_header: &SerialBlockHeader,
+) -> Result<(SerialBlock, Vec<SerialRecord>), ConsensusError> {
+    let (transactions, coinbase_records) = miner.establish_block(transactions).await?;
+
+    let header = miner.find_block(&transactions, parent_block_header)?;
+
+    let block = SerialBlock { header, transactions };
+
+    let old_block_height = miner.consensus.storage.canon().await?.block_height;
+
+    // Duplicate blocks dont do anything
+    miner.consensus.receive_block(block.clone()).await; // throws a duplicate error -- seemingly intentional
+
+    let new_block_height = miner.consensus.storage.canon().await?.block_height;
+    assert_eq!(old_block_height + 1, new_block_height);
+
+    Ok((block, coinbase_records))
+}
+
+/// Spends some value from inputs owned by the sender, to the receiver,
+/// and pays back whatever we are left with.
+#[allow(clippy::too_many_arguments)]
+pub async fn send(
+    consensus: &Consensus,
+    from: &Account<Components>,
+    inputs: Vec<SerialRecord>,
+    receiver: &Address<Components>,
+    amount: i64,
+    memo: [u8; 32],
+) -> Result<TransactionResponse, ConsensusError> {
+    let mut sum = 0;
+    for inp in &inputs {
+        sum += inp.value.0;
+    }
+    assert!(sum >= amount, "not enough balance in inputs");
+    let change = sum - amount;
+
+    let to = vec![receiver.clone(), from.address.clone()];
+    let values = vec![amount, change];
+
+    let from: Vec<PrivateKey> = vec![from.private_key.clone(); Components::NUM_INPUT_RECORDS]
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    let joint_serial_numbers = consensus.calculate_joint_serial_numbers(&inputs[..], &from[..])?;
+    let mut new_records = vec![];
+    for j in 0..Components::NUM_OUTPUT_RECORDS as u8 {
+        new_records.push(consensus.make_dummy_record(
+            &joint_serial_numbers[..],
+            j,
+            to[j as usize].clone().into(),
+            AleoAmount(values[j as usize]),
+            RecordPayload::default(),
+        )?);
+    }
+    consensus
+        .create_transaction(CreateTransactionRequest {
+            old_records: inputs,
+            old_account_private_keys: from,
+            new_records,
+            memo,
+        })
+        .await
+}


### PR DESCRIPTION
Fixes #979.

This PR adds the tip of forks near canon tip to block locator hashes. This avoids the issues outlined in #979.

Future work may include doing more than just tip of forks, but this is sufficient in current testing and has minimal impact for an initial rollout.

Tested to tip canon tip twice and over a few days in local testing, no issues.