### PR TITLE
Lower invalid block error message verbosity

### DIFF
--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -67,7 +67,14 @@ impl ConsensusInner {
                         response.send(Box::new(true)).ok();
                     }
                     Err(e) => {
-                        error!("failed receiving block: {:?}", e);
+                        match e {
+                            ConsensusError::InvalidBlock(e) => {
+                                debug!("failed receiving block: {:?}", e);
+                            }
+                            e => {
+                                warn!("failed receiving block: {:?}", e);
+                            }
+                        }
                         response.send(Box::new(false)).ok();
                     }
                 },

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -139,13 +139,13 @@ impl ConsensusInner {
     ) -> Result<(), ConsensusError> {
         match self.storage.get_block_state(hash).await? {
             BlockStatus::Committed(_) => return Ok(()),
-            BlockStatus::Unknown => return Err(ConsensusError::InvalidBlock(hash.0.to_vec())),
+            BlockStatus::Unknown => return Err(ConsensusError::InvalidBlock(hash.clone())),
             BlockStatus::Uncommitted => (),
         }
 
         // 1. Verify that the block valid
         if !self.verify_block(block).await? {
-            return Err(ConsensusError::InvalidBlock(hash.0.to_vec()));
+            return Err(ConsensusError::InvalidBlock(hash.clone()));
         }
 
         // 2. Insert/canonize block

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use snarkos_storage::Digest;
 use snarkvm_algorithms::errors::CRHError;
 use snarkvm_dpc::{BlockError, DPCError, ProgramError, RecordError, StorageError, TransactionError};
 use snarkvm_posw::error::PoswError;
@@ -54,7 +55,7 @@ pub enum ConsensusError {
     FuturisticTimestamp(i64, i64),
 
     #[error("invalid block {:?}", _0)]
-    InvalidBlock(Vec<u8>),
+    InvalidBlock(Digest),
 
     #[error("invalid coinbase transaction")]
     InvalidCoinbaseTransaction,


### PR DESCRIPTION
* error => warn generally for invalid blocks
* warn => debug for `InvalidBlock` errors
* used a `Digest` for `InvalidBlock` errors to get a nicer display.