### PR TITLE
Fix the block height metric

### DIFF
--- a/consensus/src/consensus/utility.rs
+++ b/consensus/src/consensus/utility.rs
@@ -57,7 +57,7 @@ impl Consensus {
         let mut old_records = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
         let mut joint_serial_numbers = vec![];
 
-        for i in 0..Components::NUM_INPUT_RECORDS {
+        for old_account_private_key in old_account_private_keys.iter().take(Components::NUM_INPUT_RECORDS) {
             let sn_nonce_input: [u8; 4] = rng.gen();
 
             let old_sn_nonce = <Components as DPCComponents>::SerialNumberNonceCRH::hash(
@@ -78,10 +78,8 @@ impl Consensus {
                 &mut rng,
             )?;
 
-            let (sn, _) = old_record.to_serial_number(
-                &self.dpc.system_parameters.account_signature,
-                &old_account_private_keys[i],
-            )?;
+            let (sn, _) =
+                old_record.to_serial_number(&self.dpc.system_parameters.account_signature, old_account_private_key)?;
             joint_serial_numbers.extend_from_slice(&to_bytes_le![sn]?);
 
             old_records.push(old_record.serialize()?);

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -120,14 +120,9 @@ impl Node {
         // Verify the block and insert it into the storage.
         let block_validity = self.expect_sync().consensus.receive_block(block_struct).await;
 
-        if block_validity {
+        if block_validity && is_block_new {
             // This is a non-sync Block, send it to our peers.
-            if is_block_new {
-                self.propagate_block(block, remote_address);
-            } else {
-                // If it's a valid SyncBlock, bump block height.
-                metrics::increment_counter!(BLOCK_HEIGHT);
-            }
+            self.propagate_block(block, remote_address);
         }
 
         Ok(())

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -24,7 +24,6 @@ use snarkvm_dpc::{
 };
 
 use snarkos_consensus::error::ConsensusError;
-use snarkos_metrics::{self as metrics, misc::*};
 
 use crate::{master::SyncInbound, message::*, NetworkError, Node};
 use anyhow::*;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -24,8 +24,6 @@
 
 #[macro_use]
 extern crate thiserror;
-#[macro_use]
-extern crate tracing;
 
 pub mod custom_rpc_server;
 #[doc(inline)]

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -590,7 +590,7 @@ impl ProtectedRpcFunctions for RpcImpl {
         // Decode the private keys
         let mut old_private_keys = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
         for private_key in private_keys.iter() {
-            old_private_keys.push(PrivateKey::<Components>::from_str(&private_key)?.into());
+            old_private_keys.push(PrivateKey::<Components>::from_str(private_key)?.into());
         }
 
         // Decode the transaction kernel


### PR DESCRIPTION
Fixes the block height metric by moving its update next to the block commit. The value is also fully overwritten instead of incrementing by 1 (which could lead the value to being offset). 
