### PR TITLE
Add a ledgercommitmentproofs RPC

### DIFF
--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -39,7 +39,7 @@ use tokio::task;
 
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
-const METHODS_EXPECTING_PARAMS: [&str; 14] = [
+const METHODS_EXPECTING_PARAMS: [&str; 15] = [
     // public
     "getblock",
     "getblockhash",
@@ -56,6 +56,7 @@ const METHODS_EXPECTING_PARAMS: [&str; 14] = [
     "decryptrecord",
     "disconnect",
     "connect",
+    "ledgercommitmentproofs",
 ];
 
 #[allow(clippy::too_many_arguments)]
@@ -283,6 +284,13 @@ async fn handle_rpc<S: Storage + Send + Sync + 'static>(
         "connect" => {
             let result = rpc
                 .connect_protected(Params::Array(params), meta)
+                .await
+                .map_err(convert_core_err);
+            result_to_response(&req, result)
+        }
+        "ledgercommitmentproofs" => {
+            let result = rpc
+                .ledger_commitment_proofs_protected(Params::Array(params), meta)
                 .await
                 .map_err(convert_core_err);
             result_to_response(&req, result)

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -49,6 +49,9 @@ pub enum RpcError {
     #[error("invalid metadata: {}", _0)]
     InvalidMetadata(String),
 
+    #[error("invalid number of commitments: {} instead of {}", _0, _1)]
+    InvalidCommitmentCount(usize, usize),
+
     #[error("{}", _0)]
     Message(String),
 

--- a/rpc/src/rpc_trait.rs
+++ b/rpc/src/rpc_trait.rs
@@ -18,6 +18,10 @@
 
 use crate::{error::RpcError, rpc_types::*};
 use snarkos_metrics::snapshots::NodeStats;
+use snarkvm::{
+    algorithms::merkle_tree::MerkleTreeDigest,
+    dpc::{testnet1::Testnet1Parameters, Parameters},
+};
 
 use jsonrpc_derive::rpc;
 
@@ -159,4 +163,15 @@ pub trait ProtectedRpcFunctions {
     // todo: readd in Rust 1.54
     // #[cfg_attr(nightly, doc(include = "../documentation/private_endpoints/connect.md"))]
     fn connect(&self, addresses: Vec<SocketAddr>);
+
+    fn ledger_commitment_proofs(
+        &self,
+        commitments: Vec<<Testnet1Parameters as Parameters>::RecordCommitment>,
+    ) -> Result<
+        (
+            MerkleTreeDigest<<Testnet1Parameters as Parameters>::RecordCommitmentTreeParameters>,
+            Vec<LeanMerklePath>,
+        ),
+        RpcError,
+    >;
 }

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -21,6 +21,11 @@ use jsonrpc_core::Metadata;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
+use snarkvm::{
+    algorithms::{merkle_tree::MerklePath as ParametrizedMerklePath, traits::MerkleParameters},
+    prelude::ToBytes,
+};
+
 /// Defines the authentication format for accessing private endpoints on the RPC server
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RpcCredentials {
@@ -321,4 +326,21 @@ pub struct Vertice {
 pub struct Edge {
     pub source: SocketAddr,
     pub target: SocketAddr,
+}
+
+// A rendition of snarkvm_dpc::algorithms::MerklePath without parameters and with the path in its
+// serialized (ToBytes::to_bytes_le + hex::encode) form.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LeanMerklePath {
+    pub path: String,
+    pub leaf_index: usize,
+}
+
+impl<P: MerkleParameters> From<ParametrizedMerklePath<P>> for LeanMerklePath {
+    fn from(full_path: ParametrizedMerklePath<P>) -> Self {
+        Self {
+            path: hex::encode(full_path.path.to_bytes_le().unwrap()), // safe, in-memory
+            leaf_index: full_path.leaf_index,
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces a new RPC, `ledgercommitmentproofs`, which expects a list of commitments as an argument and returns a pair of values: the current ledger digest and the Merkle paths for the provided values.

note: due to the fact that all `MerklePath` objects contain the same parameters, they were omitted from them; also, since `MerkleTreeDigest` is not easily serializable with `Serde` (it's an alias of `CRH::Output` which, in order to be serializable, would require all `Affine` values to impl `Serialize` too), the `MerklePath` values are returned in a serialized (`ToBytes::to_bytes_le` + `hex::encode`) form, which is easily reversible.