### PR TITLE
Adjust the storage validator to the new storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -1793,6 +1793,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2c8fd66061a707503d515639b8af10fd3807a5b5ee6959f7ff1bd303634bd5"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474fd1d096da3ad17084694eebed40ba09c4a36c5255cd772bd8b98859cc562e"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +2033,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -2835,6 +2867,7 @@ dependencies = [
  "futures 0.3.16",
  "hex",
  "indexmap",
+ "num_enum",
  "rand 0.8.4",
  "rocksdb",
  "serde",
@@ -2930,7 +2963,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e963ae4209f0166a619ab9266ce71c6f9228861ec55615a1b6154d673ffc158"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -28,6 +28,10 @@ impl ConsensusInner {
             let hash = self.public.genesis_block.header.hash();
             let block = self.public.genesis_block.clone();
             self.storage.insert_block(&block).await?;
+
+            let init_digest = self.ledger.extend(&[], &[], &[])?;
+            self.storage.store_init_digest(init_digest).await?;
+
             self.commit_block(&hash, &block).await?;
         }
         // info!("rebuilding canon");

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -25,7 +25,15 @@ use crate::{
     MemoryPool,
 };
 use anyhow::*;
-use snarkos_storage::{BlockStatus, Digest, ForkDescription, SerialBlock, SerialTransaction, Storage, VMTransaction};
+use snarkos_storage::{
+    BlockStatus,
+    Digest,
+    DynStorage,
+    ForkDescription,
+    SerialBlock,
+    SerialTransaction,
+    VMTransaction,
+};
 use snarkvm_dpc::{
     testnet1::{instantiated::Components, Record as DPCRecord, TransactionKernel},
     DPCScheme,
@@ -47,7 +55,7 @@ pub struct ConsensusInner {
     pub public: Arc<Consensus>,
     pub ledger: DynLedger,
     pub memory_pool: MemoryPool,
-    pub storage: Arc<dyn Storage>,
+    pub storage: DynStorage,
 }
 
 struct LedgerData {

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod consensus_sidechain {
-    // use snarkos_storage::validator::FixMode;
+    use snarkos_storage::validator::FixMode;
     use snarkos_testing::sync::*;
 
     use rand::{seq::IteratorRandom, thread_rng, Rng};
@@ -251,7 +251,7 @@ mod consensus_sidechain {
         assert!(consensus2_sync_blocks.is_empty());
 
         // Verify the integrity of the block storage for the first instance.
-        // todo: assert!(consensus1.ledger.validate(None, FixMode::Nothing).await);
+        assert!(consensus1.storage.validate(None, FixMode::Nothing).await);
     }
 
     #[tokio::test]
@@ -319,7 +319,7 @@ mod consensus_sidechain {
         assert!(consensus2_sync_blocks.is_empty());
 
         // Verify the integrity of the block storage for the first instance.
-        // todo: assert!(consensus1.ledger.validate(None, FixMode::Nothing).await);
+        assert!(consensus1.storage.validate(None, FixMode::Nothing).await);
     }
 
     #[tokio::test]
@@ -362,7 +362,7 @@ mod consensus_sidechain {
             .unwrap();
         assert!(sync_blocks.is_empty());
 
-        // todo: assert!(consensus2.ledger.validate(None, FixMode::Nothing).await);
+        assert!(consensus2.storage.validate(None, FixMode::Nothing).await);
     }
 
     #[tokio::test]
@@ -387,6 +387,6 @@ mod consensus_sidechain {
         assert_eq!(consensus.storage.canon().await.unwrap().block_height, 20);
 
         // Verify the integrity of the block storage.
-        // todo: assert!(consensus.ledger.validate(None, FixMode::Nothing).await);
+        assert!(consensus.storage.validate(None, FixMode::Nothing).await);
     }
 }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -121,7 +121,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // For extra safety, validate storage too if a trim is requested.
     let storage = if config.storage.validate || config.storage.trim {
         let now = std::time::Instant::now();
-        let moved_storage = storage
+        let (_, moved_storage) = storage
             .validate(None, snarkos_storage::validator::FixMode::Everything)
             .await;
         info!("Storage validated in {}ms", now.elapsed().as_millis());

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -26,7 +26,15 @@ use snarkos::{
 use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
 use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, Sync};
 use snarkos_rpc::start_rpc_server;
-use snarkos_storage::{export_canon_blocks, key_value::KeyValueStore, RocksDb, SerialBlock, Storage, VMBlock};
+use snarkos_storage::{
+    export_canon_blocks,
+    key_value::KeyValueStore,
+    RocksDb,
+    SerialBlock,
+    Storage,
+    VMBlock,
+    Validator,
+};
 use snarkvm_algorithms::{MerkleParameters, CRH, SNARK};
 use snarkvm_dpc::{
     testnet1::{

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -64,6 +64,9 @@ version = "1.6"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.rayon]
+version = "1"
+
 [dependencies.rocksdb]
 version = "0.17.0"
 optional = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -64,9 +64,6 @@ version = "1.6"
 [dependencies.rand]
 version = "0.8"
 
-[dependencies.rayon]
-version = "1"
-
 [dependencies.rocksdb]
 version = "0.17.0"
 optional = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -61,6 +61,9 @@ version = "0.4.2"
 [dependencies.indexmap]
 version = "1.6"
 
+[dependencies.num_enum]
+version = "0.5"
+
 [dependencies.rand]
 version = "0.8"
 

--- a/storage/src/key_value/column.rs
+++ b/storage/src/key_value/column.rs
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use num_enum::TryFromPrimitive;
+
 #[repr(u32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
 pub enum KeyValueColumn {
     Meta = 0,          // MISC Values
     BlockHeader,       // Block hash -> block header
@@ -29,26 +31,6 @@ pub enum KeyValueColumn {
     Records,           // commitment -> record bytes
     ChildHashes,       // block hash -> vector of potential child hashes
     End,               // psuedo-column to signify count of columns
-}
-
-impl From<u32> for KeyValueColumn {
-    fn from(id: u32) -> Self {
-        match id {
-            0 => KeyValueColumn::Meta,
-            1 => KeyValueColumn::BlockHeader,
-            2 => KeyValueColumn::BlockTransactions,
-            3 => KeyValueColumn::BlockIndex,
-            4 => KeyValueColumn::TransactionLookup,
-            5 => KeyValueColumn::Commitment,
-            6 => KeyValueColumn::SerialNumber,
-            7 => KeyValueColumn::Memo,
-            8 => KeyValueColumn::DigestIndex,
-            9 => KeyValueColumn::Records,
-            10 => KeyValueColumn::ChildHashes,
-            11 => KeyValueColumn::End,
-            _ => unreachable!(),
-        }
-    }
 }
 
 pub const KEY_BEST_BLOCK_NUMBER: &str = "BEST_BLOCK_NUMBER";

--- a/storage/src/key_value/column.rs
+++ b/storage/src/key_value/column.rs
@@ -31,6 +31,26 @@ pub enum KeyValueColumn {
     End,               // psuedo-column to signify count of columns
 }
 
+impl From<u32> for KeyValueColumn {
+    fn from(id: u32) -> Self {
+        match id {
+            0 => KeyValueColumn::Meta,
+            1 => KeyValueColumn::BlockHeader,
+            2 => KeyValueColumn::BlockTransactions,
+            3 => KeyValueColumn::BlockIndex,
+            4 => KeyValueColumn::TransactionLookup,
+            5 => KeyValueColumn::Commitment,
+            6 => KeyValueColumn::SerialNumber,
+            7 => KeyValueColumn::Memo,
+            8 => KeyValueColumn::DigestIndex,
+            9 => KeyValueColumn::Records,
+            10 => KeyValueColumn::ChildHashes,
+            11 => KeyValueColumn::End,
+            _ => unreachable!(),
+        }
+    }
+}
+
 pub const KEY_BEST_BLOCK_NUMBER: &str = "BEST_BLOCK_NUMBER";
 pub const KEY_MEMORY_POOL: &str = "MEMORY_POOL";
 pub const KEY_CURR_CM_INDEX: &str = "CURRENT_CM_INDEX";

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -33,13 +33,13 @@ use agent::Agent;
 pub type Value<'a> = Cow<'a, [u8]>;
 
 pub trait KeyValueStorage {
-    fn get<'a>(&'a self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>>;
+    fn get<'a>(&'a mut self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>>;
 
-    fn exists(&self, column: KeyValueColumn, key: &[u8]) -> Result<bool>;
+    fn exists(&mut self, column: KeyValueColumn, key: &[u8]) -> Result<bool>;
 
-    fn get_column_keys<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<Value<'a>>>;
+    fn get_column_keys<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<Value<'a>>>;
 
-    fn get_column<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>>;
+    fn get_column<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>>;
 
     fn store(&mut self, column: KeyValueColumn, key: &[u8], value: &[u8]) -> Result<()>;
 

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -93,6 +93,7 @@ enum Message {
     GetCanonBlocks(Option<u32>),
     GetBlockHashes(Option<u32>, BlockFilter),
     Validate(Option<u32>, FixMode),
+    StoreInitDigest(Digest),
 }
 
 impl fmt::Display for Message {
@@ -142,6 +143,7 @@ impl fmt::Display for Message {
             Message::GetCanonBlocks(limit) => write!(f, "GetCanonBlocks({:?})", limit),
             Message::GetBlockHashes(limit, filter) => write!(f, "GetBlockHashes({:?}, {:?})", limit, filter),
             Message::Validate(limit, fix_mode) => write!(f, "Validate({:?}, {:?})", limit, fix_mode),
+            Message::StoreInitDigest(digest) => write!(f, "StoreInitDigest({})", digest),
         }
     }
 }

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -45,6 +45,8 @@ pub trait KeyValueStorage {
 
     fn delete(&mut self, column: KeyValueColumn, key: &[u8]) -> Result<()>;
 
+    fn in_transaction(&self) -> bool;
+
     fn begin(&mut self) -> Result<()>;
 
     fn abort(&mut self) -> Result<()>;

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -33,13 +33,13 @@ use agent::Agent;
 pub type Value<'a> = Cow<'a, [u8]>;
 
 pub trait KeyValueStorage {
-    fn get<'a>(&'a mut self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>>;
+    fn get<'a>(&'a self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>>;
 
-    fn exists(&mut self, column: KeyValueColumn, key: &[u8]) -> Result<bool>;
+    fn exists(&self, column: KeyValueColumn, key: &[u8]) -> Result<bool>;
 
-    fn get_column_keys<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<Value<'a>>>;
+    fn get_column_keys<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<Value<'a>>>;
 
-    fn get_column<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>>;
+    fn get_column<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>>;
 
     fn store(&mut self, column: KeyValueColumn, key: &[u8], value: &[u8]) -> Result<()>;
 

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -18,7 +18,7 @@ use std::{any::Any, borrow::Cow, fmt};
 
 use tokio::sync::{mpsc, oneshot};
 
-use crate::{BlockFilter, Digest, SerialBlock, SerialRecord};
+use crate::{BlockFilter, Digest, FixMode, SerialBlock, SerialRecord};
 use anyhow::*;
 
 mod storage;
@@ -92,6 +92,7 @@ enum Message {
     ResetLedger(Vec<Digest>, Vec<Digest>, Vec<Digest>, Vec<Digest>),
     GetCanonBlocks(Option<u32>),
     GetBlockHashes(Option<u32>, BlockFilter),
+    Validate(Option<u32>, FixMode),
 }
 
 impl fmt::Display for Message {
@@ -140,6 +141,7 @@ impl fmt::Display for Message {
             Message::ResetLedger(_, _, _, _) => write!(f, "ResetLedger(..)"),
             Message::GetCanonBlocks(limit) => write!(f, "GetCanonBlocks({:?})", limit),
             Message::GetBlockHashes(limit, filter) => write!(f, "GetBlockHashes({:?}, {:?})", limit, filter),
+            Message::Validate(limit, fix_mode) => write!(f, "Validate({:?}, {:?})", limit, fix_mode),
         }
     }
 }

--- a/storage/src/key_value/storage.rs
+++ b/storage/src/key_value/storage.rs
@@ -19,6 +19,7 @@ use crate::{
     BlockStatus,
     CanonData,
     Digest,
+    FixMode,
     ForkDescription,
     SerialBlock,
     SerialBlockHeader,
@@ -139,5 +140,9 @@ impl Storage for KeyValueStore {
 
     async fn get_block_hashes(&self, limit: Option<u32>, filter: BlockFilter) -> Result<Vec<Digest>> {
         self.send(Message::GetBlockHashes(limit, filter)).await
+    }
+
+    async fn validate(&self, limit: Option<u32>, fix_mode: FixMode) -> bool {
+        self.send(Message::Validate(limit, fix_mode)).await
     }
 }

--- a/storage/src/key_value/storage.rs
+++ b/storage/src/key_value/storage.rs
@@ -145,4 +145,8 @@ impl Storage for KeyValueStore {
     async fn validate(&self, limit: Option<u32>, fix_mode: FixMode) -> bool {
         self.send(Message::Validate(limit, fix_mode)).await
     }
+
+    async fn store_init_digest(&self, digest: Digest) -> Result<()> {
+        self.send(Message::StoreInitDigest(digest)).await
+    }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -42,8 +42,8 @@ mod rocks;
 #[cfg(feature = "rocksdb_storage")]
 pub use rocks::RocksDb;
 
-// pub mod validator;
-// pub use validator::*;
+pub mod validator;
+pub use validator::*;
 
 /// The number of block hashes that are returned by the `Ledger::get_block_locator_hashes` call.
 pub const NUM_LOCATOR_HASHES: u32 = 64;

--- a/storage/src/mem.rs
+++ b/storage/src/mem.rs
@@ -96,8 +96,12 @@ impl KeyValueStorage for MemDb {
         Ok(())
     }
 
+    fn in_transaction(&self) -> bool {
+        self.transaction.is_some()
+    }
+
     fn begin(&mut self) -> Result<()> {
-        if self.transaction.is_some() {
+        if self.in_transaction() {
             return Err(anyhow!("attempted to restart a transaction"));
         }
         self.transaction = Some(self.entries.clone());
@@ -105,7 +109,7 @@ impl KeyValueStorage for MemDb {
     }
 
     fn abort(&mut self) -> Result<()> {
-        if self.transaction.is_none() {
+        if !self.in_transaction() {
             return Err(anyhow!("attempted to abort when not in a transaction"));
         }
         self.transaction = None;
@@ -113,7 +117,7 @@ impl KeyValueStorage for MemDb {
     }
 
     fn commit(&mut self) -> Result<()> {
-        if self.transaction.is_none() {
+        if !self.in_transaction() {
             return Err(anyhow!("attempted to commit when not in a transaction"));
         }
         self.entries = self.transaction.take().unwrap();

--- a/storage/src/mem.rs
+++ b/storage/src/mem.rs
@@ -41,11 +41,7 @@ impl MemDb {
         }
     }
 
-    fn column(&self, column: KeyValueColumn) -> Option<&IndexMap<Vec<u8>, Vec<u8>>> {
-        self.entries.get(&column)
-    }
-
-    fn column_mut(&mut self, column: KeyValueColumn) -> &mut IndexMap<Vec<u8>, Vec<u8>> {
+    fn column(&mut self, column: KeyValueColumn) -> &mut IndexMap<Vec<u8>, Vec<u8>> {
         self.entries.entry(column).or_insert_with(IndexMap::new)
     }
 
@@ -59,33 +55,27 @@ impl MemDb {
 }
 
 impl KeyValueStorage for MemDb {
-    fn get<'a>(&'a self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>> {
-        match self.column(column).and_then(|col| col.get(key)) {
+    fn get<'a>(&'a mut self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>> {
+        match self.column(column).get(key) {
             Some(value) => Ok(Some(Cow::Borrowed(&value[..]))),
             None => Ok(None),
         }
     }
 
-    fn exists(&self, column: KeyValueColumn, key: &[u8]) -> Result<bool> {
-        Ok(self.column(column).map(|col| col.contains_key(key)).unwrap_or(false))
+    fn exists(&mut self, column: KeyValueColumn, key: &[u8]) -> Result<bool> {
+        Ok(self.column(column).contains_key(key))
     }
 
-    fn get_column_keys<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<Value<'a>>> {
-        Ok(self
-            .column(column)
-            .map(|col| col.keys().map(|x| Cow::Borrowed(&x[..])).collect())
-            .unwrap_or_default())
+    fn get_column_keys<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<Value<'a>>> {
+        Ok(self.column(column).keys().map(|x| Cow::Borrowed(&x[..])).collect())
     }
 
-    fn get_column<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>> {
+    fn get_column<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>> {
         Ok(self
             .column(column)
-            .map(|col| {
-                col.iter()
-                    .map(|(key, value)| (Cow::Borrowed(&key[..]), Cow::Borrowed(&value[..])))
-                    .collect()
-            })
-            .unwrap_or_default())
+            .iter()
+            .map(|(key, value)| (Cow::Borrowed(&key[..]), Cow::Borrowed(&value[..])))
+            .collect())
     }
 
     fn store(&mut self, column: KeyValueColumn, key: &[u8], value: &[u8]) -> Result<()> {
@@ -93,7 +83,7 @@ impl KeyValueStorage for MemDb {
             column.insert(key.to_vec(), value.to_vec());
             return Ok(());
         }
-        self.column_mut(column).insert(key.to_vec(), value.to_vec());
+        self.column(column).insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
@@ -102,7 +92,7 @@ impl KeyValueStorage for MemDb {
             column.remove(key);
             return Ok(());
         }
-        self.column_mut(column).remove(key);
+        self.column(column).remove(key);
         Ok(())
     }
 

--- a/storage/src/rocks.rs
+++ b/storage/src/rocks.rs
@@ -40,17 +40,17 @@ pub struct RocksDb {
 }
 
 impl KeyValueStorage for RocksDb {
-    fn get<'a>(&'a mut self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>> {
+    fn get<'a>(&'a self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>> {
         let out = self.db().get_cf(self.get_cf_ref(column as u32), key)?;
         Ok(out.map(Cow::Owned))
     }
 
-    fn exists(&mut self, column: KeyValueColumn, key: &[u8]) -> Result<bool> {
+    fn exists(&self, column: KeyValueColumn, key: &[u8]) -> Result<bool> {
         let out = self.db().get_cf(self.get_cf_ref(column as u32), key)?;
         Ok(out.is_some())
     }
 
-    fn get_column<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>> {
+    fn get_column<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>> {
         Ok(self
             .db()
             .iterator_cf(self.get_cf_ref(column as u32), IteratorMode::Start)
@@ -58,7 +58,7 @@ impl KeyValueStorage for RocksDb {
             .collect())
     }
 
-    fn get_column_keys<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<Value<'a>>> {
+    fn get_column_keys<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<Value<'a>>> {
         Ok(self
             .db()
             .iterator_cf(self.get_cf_ref(column as u32), IteratorMode::Start)

--- a/storage/src/rocks.rs
+++ b/storage/src/rocks.rs
@@ -40,17 +40,17 @@ pub struct RocksDb {
 }
 
 impl KeyValueStorage for RocksDb {
-    fn get<'a>(&'a self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>> {
+    fn get<'a>(&'a mut self, column: KeyValueColumn, key: &[u8]) -> Result<Option<Value<'a>>> {
         let out = self.db().get_cf(self.get_cf_ref(column as u32), key)?;
         Ok(out.map(Cow::Owned))
     }
 
-    fn exists(&self, column: KeyValueColumn, key: &[u8]) -> Result<bool> {
+    fn exists(&mut self, column: KeyValueColumn, key: &[u8]) -> Result<bool> {
         let out = self.db().get_cf(self.get_cf_ref(column as u32), key)?;
         Ok(out.is_some())
     }
 
-    fn get_column<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>> {
+    fn get_column<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<(Value<'a>, Value<'a>)>> {
         Ok(self
             .db()
             .iterator_cf(self.get_cf_ref(column as u32), IteratorMode::Start)
@@ -58,7 +58,7 @@ impl KeyValueStorage for RocksDb {
             .collect())
     }
 
-    fn get_column_keys<'a>(&'a self, column: KeyValueColumn) -> Result<Vec<Value<'a>>> {
+    fn get_column_keys<'a>(&'a mut self, column: KeyValueColumn) -> Result<Vec<Value<'a>>> {
         Ok(self
             .db()
             .iterator_cf(self.get_cf_ref(column as u32), IteratorMode::Start)

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -17,7 +17,7 @@
 use anyhow::*;
 use std::sync::Arc;
 
-use crate::{Digest, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction, TransactionLocation};
+use crate::{Digest, FixMode, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction, TransactionLocation};
 
 /// Current state of a block in storage
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -160,6 +160,9 @@ pub trait Storage: Send + Sync {
 
     /// Similar to `Storage::get_canon_blocks`, gets hashes of all blocks subject to `filter` and `limit` in block-number ascending order. A maintenance function, not intended for general use.
     async fn get_block_hashes(&self, limit: Option<u32>, filter: BlockFilter) -> Result<Vec<Digest>>;
+
+    /// Performs low-level storage validation; it's mostly intended for test purposes, as there is a lower level `KeyValueStorage` interface available outside of them.
+    async fn validate(&self, limit: Option<u32>, fix_mode: FixMode) -> bool;
 }
 
 /// A wrapper over storage implementations

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -123,6 +123,9 @@ pub trait Storage: Send + Sync {
         }
     }
 
+    /// Stores the "pre-genesis" digest; only applicable to the genesis block txs.
+    async fn store_init_digest(&self, digest: Digest) -> Result<()>;
+
     // miner convenience record management functions
 
     /// Gets a list of stored record commitments subject to `limit`.

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -502,12 +502,19 @@ async fn validate_block_transactions(
             );
 
             if [FixMode::MissingTestnet1TxComponents, FixMode::Everything].contains(&fix_mode) {
-                let db_op = Op::Insert {
+                let block_height_bytes = block_height.to_le_bytes().to_vec();
+                let db_op1 = Op::Insert {
                     col: DigestIndex as u32,
                     key: tx_digest.clone(),
-                    value: block_height.to_le_bytes().to_vec(),
+                    value: block_height_bytes.clone(),
                 };
-                component_sender.send(ValidatorAction::QueueDatabaseOp(db_op)).unwrap();
+                let db_op2 = Op::Insert {
+                    col: DigestIndex as u32,
+                    key: block_height_bytes,
+                    value: tx_digest.clone(),
+                };
+                component_sender.send(ValidatorAction::QueueDatabaseOp(db_op1)).unwrap();
+                component_sender.send(ValidatorAction::QueueDatabaseOp(db_op2)).unwrap();
             } else {
                 is_storage_valid.store(false, Ordering::SeqCst);
             }

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -480,7 +480,7 @@ async fn validate_block_transactions(
         }
 
         let tx_digest = to_bytes_le![tx.ledger_digest].unwrap();
-        let found = db_lookup(Commitment, Exists(tx_digest.clone()), lookup_sender).await;
+        let found = db_lookup(DigestIndex, Exists(tx_digest.clone()), lookup_sender).await;
         if !matches!(found, LookupResponse::Found(true)) {
             warn!(
                 "Transaction {} doesn't have the ledger digest stored",

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -48,6 +48,8 @@ macro_rules! check_for_superfluous_tx_components {
                 }
             };
 
+            debug!("there are {} {}s stored", storage_keys.len(), $component_name);
+
             let superfluous_items = storage_keys.difference(tx_entries).collect::<Vec<_>>();
 
             if !superfluous_items.is_empty() {

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -285,11 +285,12 @@ impl RocksDb {
 
         if fix_mode != FixMode::Nothing && !db_ops.is_empty() {
             info!("Fixing the detected storage issues");
+
             storage.begin().unwrap();
             for op in db_ops {
                 if let Err(e) = match op {
-                    Op::Insert { col, key, value } => storage.store(KeyValueColumn::from(col), &key, &value),
-                    Op::Delete { col, key } => storage.delete(KeyValueColumn::from(col), &key),
+                    Op::Insert { col, key, value } => storage.store(col.try_into().unwrap(), &key, &value),
+                    Op::Delete { col, key } => storage.delete(col.try_into().unwrap(), &key),
                 } {
                     error!("Couldn't fix a storage issue: {}", e);
                 }

--- a/testing/src/storage/mod.rs
+++ b/testing/src/storage/mod.rs
@@ -20,8 +20,8 @@ pub mod exporter;
 #[cfg(test)]
 pub mod trim;
 
-// #[cfg(test)]
-// pub mod validator;
+#[cfg(test)]
+pub mod validator;
 
 // pub use snarkos_storage::validator::FixMode;
 use snarkos_consensus::{DynLedger, MerkleLedger};

--- a/testing/src/storage/validator.rs
+++ b/testing/src/storage/validator.rs
@@ -22,16 +22,17 @@ use rand::prelude::*;
 
 #[tokio::test]
 async fn valid_storage_validates() {
+    tracing_subscriber::fmt::init();
     let consensus = create_test_consensus().await;
 
     let blocks = TestBlocks::load(Some(5), "test_blocks_100_1").0;
     for block in blocks {
-        consensus.receive_block(&block, false).await.unwrap();
+        consensus.receive_block(block).await;
     }
 
-    assert!(consensus.ledger.validate(None, FixMode::Nothing).await);
+    assert!(consensus.storage.validate(None, FixMode::Nothing).await);
 }
-
+/*
 #[tokio::test]
 async fn validator_vs_a_missing_serial_number() {
     let consensus = create_test_consensus().await;
@@ -289,3 +290,4 @@ async fn validator_vs_a_very_broken_db() {
     assert!(!consensus.ledger.validate(None, FixMode::Nothing).await);
     tracing::info!("Storage validated in {}ms", now.elapsed().as_millis());
 }
+*/


### PR DESCRIPTION
This PR re-enables the storage validator tool after the recent storage revamp.

Even though it appears to work, the PR is still a draft, as I'm still not sure if I used the best APIs, and due to the fact the validator-related tests are still disabled (as they are incompatible with the validator now).

My intention is for the validator to be as low-level as possible and to remain snappy ~(hence the `KeyValueStorage` API tweaks)~.