### PR TITLE
Fix the inbound::ALL_SUCCESSES metric

### DIFF
--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -52,11 +52,13 @@ impl Peer {
                     self.fail();
                 }
                 metrics::increment_counter!(PONGS);
+                metrics::increment_counter!(ALL_SUCCESSES);
             }
             Payload::Ping(block_height) => {
                 network.write_payload(&Payload::Pong).await?;
                 self.quality.block_height = block_height;
                 metrics::increment_counter!(PINGS);
+                metrics::increment_counter!(ALL_SUCCESSES);
 
                 // Relay the height to the known network.
                 if let Some(known_network) = node.known_network() {


### PR DESCRIPTION
Ping/Pong messages were forgotten in the metric as they are handled seperately.

Closes #1025. 
