### PR TITLE
Restore the remaining storage validator tests

### DIFF
--- a/storage/src/key_value/agent/mod.rs
+++ b/storage/src/key_value/agent/mod.rs
@@ -168,7 +168,7 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
     }
 
     #[cfg(feature = "test")]
-    fn remove_key(&mut self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
+    fn delete_item(&mut self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
         self.inner().delete(col, &key)
     }
 
@@ -220,7 +220,7 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
             Message::Validate(limit, fix_mode) => Box::new(self.validate(limit, fix_mode)),
             Message::StoreInitDigest(digest) => Box::new(self.wrap(move |f| f.store_init_digest(digest))),
             #[cfg(feature = "test")]
-            Message::RemoveKey(col, key) => Box::new(self.wrap(move |f| f.remove_key(col, key))),
+            Message::DeleteItem(col, key) => Box::new(self.wrap(move |f| f.delete_item(col, key))),
         }
     }
 

--- a/storage/src/key_value/agent/mod.rs
+++ b/storage/src/key_value/agent/mod.rs
@@ -168,6 +168,11 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
     }
 
     #[cfg(feature = "test")]
+    fn store_item(&mut self, col: KeyValueColumn, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        self.inner().store(col, &key, &value)
+    }
+
+    #[cfg(feature = "test")]
     fn delete_item(&mut self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
         self.inner().delete(col, &key)
     }
@@ -219,6 +224,8 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
             Message::GetBlockHashes(limit, filter) => Box::new(self.get_block_hashes(limit, filter)),
             Message::Validate(limit, fix_mode) => Box::new(self.validate(limit, fix_mode)),
             Message::StoreInitDigest(digest) => Box::new(self.wrap(move |f| f.store_init_digest(digest))),
+            #[cfg(feature = "test")]
+            Message::StoreItem(col, key, value) => Box::new(self.wrap(move |f| f.store_item(col, key, value))),
             #[cfg(feature = "test")]
             Message::DeleteItem(col, key) => Box::new(self.wrap(move |f| f.delete_item(col, key))),
         }

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -94,6 +94,8 @@ enum Message {
     GetBlockHashes(Option<u32>, BlockFilter),
     Validate(Option<u32>, FixMode),
     StoreInitDigest(Digest),
+    #[cfg(feature = "test")]
+    RemoveKey(KeyValueColumn, Vec<u8>),
 }
 
 impl fmt::Display for Message {
@@ -144,6 +146,8 @@ impl fmt::Display for Message {
             Message::GetBlockHashes(limit, filter) => write!(f, "GetBlockHashes({:?}, {:?})", limit, filter),
             Message::Validate(limit, fix_mode) => write!(f, "Validate({:?}, {:?})", limit, fix_mode),
             Message::StoreInitDigest(digest) => write!(f, "StoreInitDigest({})", digest),
+            #[cfg(feature = "test")]
+            Message::RemoveKey(col, key) => write!(f, "RemoveKey({:?}, {:?})", col, key),
         }
     }
 }

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -95,7 +95,7 @@ enum Message {
     Validate(Option<u32>, FixMode),
     StoreInitDigest(Digest),
     #[cfg(feature = "test")]
-    RemoveKey(KeyValueColumn, Vec<u8>),
+    DeleteItem(KeyValueColumn, Vec<u8>),
 }
 
 impl fmt::Display for Message {
@@ -147,7 +147,7 @@ impl fmt::Display for Message {
             Message::Validate(limit, fix_mode) => write!(f, "Validate({:?}, {:?})", limit, fix_mode),
             Message::StoreInitDigest(digest) => write!(f, "StoreInitDigest({})", digest),
             #[cfg(feature = "test")]
-            Message::RemoveKey(col, key) => write!(f, "RemoveKey({:?}, {:?})", col, key),
+            Message::DeleteItem(col, key) => write!(f, "DeleteItem({:?}, {:?})", col, key),
         }
     }
 }

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -95,6 +95,8 @@ enum Message {
     Validate(Option<u32>, FixMode),
     StoreInitDigest(Digest),
     #[cfg(feature = "test")]
+    StoreItem(KeyValueColumn, Vec<u8>, Vec<u8>),
+    #[cfg(feature = "test")]
     DeleteItem(KeyValueColumn, Vec<u8>),
 }
 
@@ -146,6 +148,8 @@ impl fmt::Display for Message {
             Message::GetBlockHashes(limit, filter) => write!(f, "GetBlockHashes({:?}, {:?})", limit, filter),
             Message::Validate(limit, fix_mode) => write!(f, "Validate({:?}, {:?})", limit, fix_mode),
             Message::StoreInitDigest(digest) => write!(f, "StoreInitDigest({})", digest),
+            #[cfg(feature = "test")]
+            Message::StoreItem(col, key, value) => write!(f, "StoreItem({:?}, {:?}, {:?})", col, key, value),
             #[cfg(feature = "test")]
             Message::DeleteItem(col, key) => write!(f, "DeleteItem({:?}, {:?})", col, key),
         }

--- a/storage/src/key_value/storage.rs
+++ b/storage/src/key_value/storage.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "test")]
+use crate::key_value::KeyValueColumn;
 use crate::{
     BlockFilter,
     BlockStatus,
@@ -148,5 +150,10 @@ impl Storage for KeyValueStore {
 
     async fn store_init_digest(&self, digest: Digest) -> Result<()> {
         self.send(Message::StoreInitDigest(digest)).await
+    }
+
+    #[cfg(feature = "test")]
+    async fn remove_key(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
+        self.send(Message::RemoveKey(col, key)).await
     }
 }

--- a/storage/src/key_value/storage.rs
+++ b/storage/src/key_value/storage.rs
@@ -153,6 +153,11 @@ impl Storage for KeyValueStore {
     }
 
     #[cfg(feature = "test")]
+    async fn store_item(&self, col: KeyValueColumn, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        self.send(Message::StoreItem(col, key, value)).await
+    }
+
+    #[cfg(feature = "test")]
     async fn delete_item(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
         self.send(Message::DeleteItem(col, key)).await
     }

--- a/storage/src/key_value/storage.rs
+++ b/storage/src/key_value/storage.rs
@@ -153,7 +153,7 @@ impl Storage for KeyValueStore {
     }
 
     #[cfg(feature = "test")]
-    async fn remove_key(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
-        self.send(Message::RemoveKey(col, key)).await
+    async fn delete_item(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()> {
+        self.send(Message::DeleteItem(col, key)).await
     }
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -171,7 +171,7 @@ pub trait Storage: Send + Sync {
 
     /// Removes the given key from the given column.
     #[cfg(feature = "test")]
-    async fn remove_key(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()>;
+    async fn delete_item(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()>;
 }
 
 /// A wrapper over storage implementations

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -169,7 +169,11 @@ pub trait Storage: Send + Sync {
     /// Performs low-level storage validation; it's mostly intended for test purposes, as there is a lower level `KeyValueStorage` interface available outside of them.
     async fn validate(&self, limit: Option<u32>, fix_mode: FixMode) -> bool;
 
-    /// Removes the given key from the given column.
+    /// Stores the given key+value pair in the given column.
+    #[cfg(feature = "test")]
+    async fn store_item(&self, col: KeyValueColumn, key: Vec<u8>, value: Vec<u8>) -> Result<()>;
+
+    /// Removes the given key and its corresponding value from the given column.
     #[cfg(feature = "test")]
     async fn delete_item(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()>;
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -17,6 +17,8 @@
 use anyhow::*;
 use std::sync::Arc;
 
+#[cfg(feature = "test")]
+use crate::key_value::KeyValueColumn;
 use crate::{Digest, FixMode, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction, TransactionLocation};
 
 /// Current state of a block in storage
@@ -166,6 +168,10 @@ pub trait Storage: Send + Sync {
 
     /// Performs low-level storage validation; it's mostly intended for test purposes, as there is a lower level `KeyValueStorage` interface available outside of them.
     async fn validate(&self, limit: Option<u32>, fix_mode: FixMode) -> bool;
+
+    /// Removes the given key from the given column.
+    #[cfg(feature = "test")]
+    async fn remove_key(&self, col: KeyValueColumn, key: Vec<u8>) -> Result<()>;
 }
 
 /// A wrapper over storage implementations

--- a/testing/src/storage/validator.rs
+++ b/testing/src/storage/validator.rs
@@ -47,7 +47,7 @@ async fn validator_vs_a_missing_serial_number() {
     let random_sn = &stored_sns.choose(&mut thread_rng()).unwrap().0;
     consensus
         .storage
-        .remove_key(KeyValueColumn::SerialNumber, random_sn.to_vec())
+        .delete_item(KeyValueColumn::SerialNumber, random_sn.to_vec())
         .await
         .unwrap();
 
@@ -70,7 +70,7 @@ async fn validator_vs_a_missing_commitment() {
     let random_cm = &stored_cms.choose(&mut thread_rng()).unwrap().0;
     consensus
         .storage
-        .remove_key(KeyValueColumn::Commitment, random_cm.to_vec())
+        .delete_item(KeyValueColumn::Commitment, random_cm.to_vec())
         .await
         .unwrap();
 
@@ -93,7 +93,7 @@ async fn validator_vs_a_missing_memorandum() {
     let random_memo = &stored_memos.choose(&mut thread_rng()).unwrap().0;
     consensus
         .storage
-        .remove_key(KeyValueColumn::Memo, random_memo.to_vec())
+        .delete_item(KeyValueColumn::Memo, random_memo.to_vec())
         .await
         .unwrap();
 
@@ -116,7 +116,7 @@ async fn validator_vs_a_missing_digest() {
     let random_digest = &stored_digests.choose(&mut thread_rng()).unwrap().0;
     consensus
         .storage
-        .remove_key(KeyValueColumn::DigestIndex, random_digest.to_vec())
+        .delete_item(KeyValueColumn::DigestIndex, random_digest.to_vec())
         .await
         .unwrap();
 


### PR DESCRIPTION
~This PR builds on top of https://github.com/AleoHQ/snarkOS/pull/1042, only the last 5 commits are new ([diff](https://github.com/AleoHQ/snarkOS/pull/1045/files/de47a954ec5d8de62fc8652af5cb059083bd7741..15446b96f7c0990ba5e414450079e1425cac1eb9)).~

In order to re-enable the remaining storage validator tests, 2 new, low-level, test-only methods are added to `Storage`. All the restored tests pass.