### PR TITLE
Use `hash_hasher` for hash maps and sets in sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,7 @@ dependencies = [
  "defer",
  "derivative",
  "futures 0.3.16",
+ "hash_hasher",
  "hex",
  "itertools",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
+name = "hash_hasher"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2662,7 @@ dependencies = [
  "csv",
  "derivative",
  "digest 0.7.6",
+ "hash_hasher",
  "itertools",
  "rand 0.8.4",
  "rand_xorshift",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -42,6 +42,11 @@ name = "network_metrics"
 path = "network/network_metrics.rs"
 harness = false
 
+[[bench]]
+name = "hasher_hash"
+path = "network/hasher_hash.rs"
+harness = false
+
 [dependencies.snarkvm-algorithms]
 version = "=0.7.8"
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -102,3 +102,6 @@ version = "1"
 
 [dependencies.itertools]
 version = "0.10"
+
+[dependencies.hash_hasher]
+version = "2.0.3"

--- a/benchmarks/network/hasher_hash.rs
+++ b/benchmarks/network/hasher_hash.rs
@@ -1,0 +1,129 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use criterion::*;
+use hash_hasher::{HashBuildHasher, HashedMap, HashedSet};
+use rand::{thread_rng, Rng, RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
+
+use std::collections::{HashMap, HashSet};
+
+// The current applicable digest size for blocks.
+//
+// Note: `snarkos_storage::Digest` isn't implemented as a fixed size.
+type Digest = [u8; 32];
+
+fn hash_maps_insert(c: &mut Criterion) {
+    // Various HashMap uses in snarkOS:
+    //
+    // - HashMap<SocketAddr, Vec<Digest>>
+    // - HashMap<Digest, Vec<SocketAddr>>
+
+    let seed: u64 = thread_rng().gen();
+    let mut rng = XorShiftRng::seed_from_u64(seed);
+
+    let mut inputs = vec![];
+    let sizes = vec![1000, 3000, 5000, 7000];
+    for size in sizes {
+        inputs.push(generate_hashes(&mut rng, size))
+    }
+
+    let mut group = c.benchmark_group("hash_maps_insert");
+
+    for hashes in inputs {
+        let size = hashes.len();
+
+        group.bench_with_input(BenchmarkId::new("HashMap", size), &size, |b, _size| {
+            b.iter(|| {
+                let mut map: HashMap<Digest, usize> = HashMap::default();
+
+                for (i, hash) in hashes.iter().enumerate() {
+                    map.insert(*hash, i);
+                }
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("HashedMap", size), &size, |b, _size| {
+            b.iter(|| {
+                let mut map = HashedMap::with_hasher(HashBuildHasher::default());
+
+                for (i, hash) in hashes.iter().enumerate() {
+                    map.insert(*hash, i);
+                }
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn hash_sets_insert(c: &mut Criterion) {
+    // Various HashSet uses in snarkOS:
+    //
+    // - HashSet<Digest>
+    // - HashSet<Vec<u8>> for tx memos, digests, cms, etc...
+
+    let seed: u64 = thread_rng().gen();
+    let mut rng = XorShiftRng::seed_from_u64(seed);
+
+    let mut inputs = vec![];
+    let sizes = vec![1000, 3000, 5000, 7000];
+    for size in sizes {
+        inputs.push(generate_hashes(&mut rng, size))
+    }
+
+    let mut group = c.benchmark_group("hash_sets_insert");
+
+    for hashes in inputs {
+        let size = hashes.len();
+
+        group.bench_with_input(BenchmarkId::new("HashSet", size), &size, |b, _size| {
+            b.iter(|| {
+                let mut set: HashSet<[u8; 32]> = HashSet::default();
+
+                for hash in &hashes {
+                    set.insert(*hash);
+                }
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("HashedSet", size), &size, |b, _size| {
+            b.iter(|| {
+                let mut set = HashedSet::with_hasher(HashBuildHasher::default());
+
+                for hash in &hashes {
+                    set.insert(*hash);
+                }
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn generate_hashes(rng: &mut XorShiftRng, count: usize) -> Vec<Digest> {
+    (0..count)
+        .map(|_| {
+            let mut hash = [0u8; 32];
+            rng.fill_bytes(&mut hash);
+
+            hash
+        })
+        .collect()
+}
+
+criterion_group!(hash_hasher_bench, hash_maps_insert, hash_sets_insert);
+criterion_main!(hash_hasher_bench);

--- a/benchmarks/network/hasher_hash.rs
+++ b/benchmarks/network/hasher_hash.rs
@@ -68,8 +68,8 @@ fn hash_maps_get(c: &mut Criterion) {
     for hashes in inputs {
         let size = hashes.len();
 
-        let hash_map: HashMap<[u8; 32], usize> = hashes.iter().enumerate().map(|(i, &hash)| (hash, i)).collect();
-        let hashed_map: HashedMap<[u8; 32], usize> = hashes.iter().enumerate().map(|(i, &hash)| (hash, i)).collect();
+        let hash_map: HashMap<Digest, usize> = hashes.iter().enumerate().map(|(i, &hash)| (hash, i)).collect();
+        let hashed_map: HashedMap<Digest, usize> = hashes.iter().enumerate().map(|(i, &hash)| (hash, i)).collect();
 
         group.bench_with_input(BenchmarkId::new("HashMap", size), &size, |b, _size| {
             b.iter(|| {
@@ -102,7 +102,7 @@ fn hash_sets_insert(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("HashSet", size), &size, |b, _size| {
             b.iter(|| {
-                let mut set: HashSet<[u8; 32]> = HashSet::default();
+                let mut set: HashSet<Digest> = HashSet::default();
 
                 for hash in &hashes {
                     set.insert(*hash);
@@ -133,8 +133,8 @@ fn hash_sets_contains(c: &mut Criterion) {
     for hashes in inputs {
         let size = hashes.len();
 
-        let hash_set: HashSet<[u8; 32]> = hashes.iter().copied().collect();
-        let hashed_set: HashedSet<[u8; 32]> = hashes.iter().copied().collect();
+        let hash_set: HashSet<Digest> = hashes.iter().copied().collect();
+        let hashed_set: HashedSet<Digest> = hashes.iter().copied().collect();
 
         group.bench_with_input(BenchmarkId::new("HashSet", size), &size, |b, _size| {
             b.iter(|| {

--- a/benchmarks/network/syncing.rs
+++ b/benchmarks/network/syncing.rs
@@ -22,7 +22,6 @@ use snarkos_testing::{
     sync::TestBlocks,
 };
 
-// FIXME(ljedrz/nkls): gracefully shut the node and peer down once shutdown is implemented
 fn providing_sync_blocks(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -38,14 +37,16 @@ fn providing_sync_blocks(c: &mut Criterion) {
     const NUM_BLOCKS: usize = 10;
 
     let blocks = TestBlocks::load(Some(NUM_BLOCKS), "test_blocks_100_1");
+
     for block in &blocks.0 {
         assert!(rt.block_on(provider.expect_sync().consensus.receive_block(block.clone())));
     }
+
     let canon = rt.block_on(provider.storage.canon()).unwrap();
 
     assert_eq!(canon.block_height, NUM_BLOCKS);
 
-    c.bench_function("providing_sync_blocks", move |b| {
+    c.bench_function("providing_sync_blocks", |b| {
         b.to_async(&rt).iter(|| async {
             let get_sync = Payload::GetSync(vec![]);
             requester.lock().await.write_message(&get_sync).await;
@@ -54,6 +55,8 @@ fn providing_sync_blocks(c: &mut Criterion) {
             let hashes = match requester.lock().await.read_payload().await.unwrap() {
                 Payload::Sync(hashes) => hashes,
                 Payload::Ping(_) => return,
+                // ignore blocks sent before the sync request
+                Payload::SyncBlock(_) => return,
                 x => {
                     panic!("unexpected payload: {:?}", x);
                 }
@@ -74,6 +77,8 @@ fn providing_sync_blocks(c: &mut Criterion) {
             }
         })
     });
+
+    rt.block_on(provider.shut_down());
 }
 
 criterion_group!(block_sync_benches, providing_sync_blocks);

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -87,6 +87,9 @@ version = "0.1"
 [dependencies.async-trait]
 version = "0.1"
 
+[dependencies.hash_hasher]
+version = "2.0.3"
+
 [dependencies.itertools]
 version = "0.10.1"
 

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -14,15 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-    collections::{HashMap, HashSet},
-    net::SocketAddr,
-    time::Duration,
-};
+use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
 use crate::{Node, Payload, Peer};
 use anyhow::*;
 use futures::{pin_mut, select, FutureExt};
+use hash_hasher::{HashBuildHasher, HashedMap, HashedSet};
 use rand::prelude::SliceRandom;
 use snarkos_storage::Digest;
 use snarkvm_algorithms::crh::double_sha256;
@@ -198,7 +195,7 @@ impl SyncMaster {
 
     fn order_block_hashes(input: &[(SocketAddr, Vec<Digest>)]) -> Vec<Digest> {
         let mut block_order = vec![];
-        let mut seen = HashSet::<&Digest>::new();
+        let mut seen = HashedSet::<&Digest>::with_hasher(HashBuildHasher::default());
         let mut block_index = 0;
         loop {
             let mut found_row = false;

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -217,8 +217,8 @@ impl SyncMaster {
         block_order
     }
 
-    fn block_peer_map(blocks: &[(SocketAddr, Vec<Digest>)]) -> HashMap<Digest, Vec<SocketAddr>> {
-        let mut block_peer_map = HashMap::new();
+    fn block_peer_map(blocks: &[(SocketAddr, Vec<Digest>)]) -> HashedMap<Digest, Vec<SocketAddr>> {
+        let mut block_peer_map = HashedMap::with_capacity_and_hasher(blocks.len(), HashBuildHasher::default());
         for (addr, hashes) in blocks {
             for hash in hashes {
                 block_peer_map.entry(hash.clone()).or_insert_with(Vec::new).push(*addr);
@@ -231,14 +231,14 @@ impl SyncMaster {
     fn get_peer_blocks(
         &mut self,
         blocks: &[Digest],
-        block_peer_map: &HashMap<Digest, Vec<SocketAddr>>,
+        block_peer_map: &HashedMap<Digest, Vec<SocketAddr>>,
     ) -> (
         Vec<SocketAddr>,
-        HashMap<Digest, SocketAddr>,
+        HashedMap<Digest, SocketAddr>,
         HashMap<SocketAddr, Vec<Digest>>,
     ) {
         let mut peer_block_requests: HashMap<SocketAddr, Vec<Digest>> = HashMap::new();
-        let mut block_peers = HashMap::new();
+        let mut block_peers = HashedMap::with_hasher(HashBuildHasher::default());
         for block in blocks {
             let peers = block_peer_map.get(block);
             if peers.is_none() {
@@ -343,7 +343,8 @@ impl SyncMaster {
 
         self.cancel_outstanding_syncs(&peer_addresses[..]).await;
 
-        let mut blocks_by_hash: HashMap<Digest, _> = HashMap::new();
+        let mut blocks_by_hash: HashedMap<Digest, _> =
+            HashedMap::with_capacity_and_hasher(received_blocks.len(), HashBuildHasher::default());
 
         for block in received_blocks {
             let block_header = &block.block[..BlockHeader::size()];


### PR DESCRIPTION
This PR improves sync performance by leveraging `hash_hasher::HashedMap` and `HashedSet`, which work under the assumption that the data being stored is already suitably hashed for use as keys. 

I also briefly explored the use of `twox_hash::Xx3hHash`, though this turned out to be slower for maps of `<SocketAddr, Digest>` than the default SipHash 1-3 used by the std library as the keys were too small to see any speed-up. 

In addition to adding benchmarks for the relevant hash map and set operations, this PR includes a fix for the sync benchmark which was affected by the storage refactor.

Closes #1035. 