### PR TITLE
Send block height within Block and SyncBlock messages

### DIFF
--- a/benchmarks/network/block_cache.rs
+++ b/benchmarks/network/block_cache.rs
@@ -36,7 +36,7 @@ fn block_cache_perf(c: &mut Criterion) {
             let mut random_bytes = vec![0u8; block_size];
             rng.fill(&mut random_bytes[..]);
 
-            let test_block = Payload::Block(random_bytes);
+            let test_block = Payload::Block(random_bytes, None);
 
             let _check = cache.contains(&test_block);
         })

--- a/benchmarks/network/messaging.rs
+++ b/benchmarks/network/messaging.rs
@@ -35,7 +35,7 @@ fn send_small_messages(c: &mut Criterion) {
     c.bench_function("send_small_messages", move |b| {
         b.to_async(&rt).iter(|| async {
             let block_size: u16 = thread_rng().gen();
-            let big_block = Payload::Block(fake_block_bytes[..block_size as usize].to_vec());
+            let big_block = Payload::Block(fake_block_bytes[..block_size as usize].to_vec(), Some(1));
 
             // send it from node0 to node1
             node0.lock().await.write_message(&big_block).await;

--- a/benchmarks/network/syncing.rs
+++ b/benchmarks/network/syncing.rs
@@ -65,7 +65,7 @@ fn providing_sync_blocks(c: &mut Criterion) {
             let mut sync_blocks_count = 0;
             loop {
                 let payload = requester.lock().await.read_payload().await.unwrap();
-                if let Payload::SyncBlock(_) = payload {
+                if let Payload::SyncBlock(..) = payload {
                     sync_blocks_count += 1;
                 }
                 if sync_blocks_count == NUM_BLOCKS {

--- a/network/src/inbound/cache.rs
+++ b/network/src/inbound/cache.rs
@@ -33,7 +33,7 @@ impl Default for Cache {
 
 impl Cache {
     pub fn contains(&mut self, payload: &Payload) -> bool {
-        let hash = if let Payload::Block(bytes) = payload {
+        let hash = if let Payload::Block(bytes, _) = payload {
             hash64(bytes)
         } else {
             unreachable!("Only blocks are cached for now");

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -142,18 +142,18 @@ impl Node {
                     self.received_memory_pool_transaction(source, transaction).await?;
                 }
             }
-            Payload::Block(block) => {
+            Payload::Block(block, height) => {
                 // The BLOCKS metric was already updated during the block dedup cache lookup.
 
                 if self.sync().is_some() {
-                    self.received_block(source, block, true).await?;
+                    self.received_block(source, block, height, true).await?;
                 }
             }
-            Payload::SyncBlock(block) => {
+            Payload::SyncBlock(block, height) => {
                 metrics::increment_counter!(inbound::SYNCBLOCKS);
 
                 if self.sync().is_some() {
-                    self.received_block(source, block, false).await?;
+                    self.received_block(source, block, height, false).await?;
 
                     // Update the peer and possibly finish the sync process.
                     if let Some(peer) = self.peer_book.get_peer_handle(source) {

--- a/network/src/message/message.rs
+++ b/network/src/message/message.rs
@@ -62,7 +62,7 @@ impl fmt::Display for Message {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Payload {
     #[doc = include_str!("../../documentation/network_messages/block.md")]
-    Block(Vec<u8>),
+    Block(Vec<u8>, Option<u32>),
     #[doc = include_str!("../../documentation/network_messages/get_blocks.md")]
     GetBlocks(Vec<BlockHeaderHash>),
     #[doc = include_str!("../../documentation/network_messages/get_memory_pool.md")]
@@ -82,7 +82,7 @@ pub enum Payload {
     #[doc = include_str!("../../documentation/network_messages/sync.md")]
     Sync(Vec<BlockHeaderHash>),
     #[doc = include_str!("../../documentation/network_messages/sync_block.md")]
-    SyncBlock(Vec<u8>),
+    SyncBlock(Vec<u8>, Option<u32>),
     #[doc = include_str!("../../documentation/network_messages/transaction.md")]
     Transaction(Vec<u8>),
 

--- a/network/src/message/payload.capnp
+++ b/network/src/message/payload.capnp
@@ -37,6 +37,7 @@ struct Transaction {
 
 struct Block {
     data @0 :Data;
+    height @1 :UInt32;
 }
 
 struct Ping {

--- a/network/src/message/payload_capnp.rs
+++ b/network/src/message/payload_capnp.rs
@@ -1215,6 +1215,10 @@ pub mod block {
     pub fn has_data(&self) -> bool {
       !self.reader.get_pointer_field(0).is_null()
     }
+    #[inline]
+    pub fn get_height(self) -> u32 {
+      self.reader.get_data_field::<u32>(0)
+    }
   }
 
   pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
@@ -1280,6 +1284,14 @@ pub mod block {
     pub fn has_data(&self) -> bool {
       !self.builder.get_pointer_field(0).is_null()
     }
+    #[inline]
+    pub fn get_height(self) -> u32 {
+      self.builder.get_data_field::<u32>(0)
+    }
+    #[inline]
+    pub fn set_height(&mut self, value: u32)  {
+      self.builder.set_data_field::<u32>(0, value);
+    }
   }
 
   pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
@@ -1292,7 +1304,7 @@ pub mod block {
   }
   mod _private {
     use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 0, pointers: 1 };
+    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 1, pointers: 1 };
     pub const TYPE_ID: u64 = 0xd0ca_0d5d_1257_f5d7;
   }
 }

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -33,7 +33,7 @@ impl Peer {
 
         // If message is a `SyncBlock` message, log it as a trace.
         match payload {
-            Payload::SyncBlock(_) => trace!("Received a '{}' message from {}", payload, self.address),
+            Payload::SyncBlock(..) => trace!("Received a '{}' message from {}", payload, self.address),
             _ => debug!("Received a '{}' message from {}", payload, self.address),
         }
 

--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -116,7 +116,7 @@ impl Peer {
                 metrics::decrement_gauge!(OUTBOUND, 1.0);
 
                 match &message {
-                    Payload::SyncBlock(_) => trace!("Sent a '{}' message to {}", &message, self.address),
+                    Payload::SyncBlock(..) => trace!("Sent a '{}' message to {}", &message, self.address),
                     _ => debug!("Sent a '{}' message to {}", &message, self.address),
                 }
                 Ok(PeerResponse::None)

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -31,7 +31,7 @@ use tokio::{sync::mpsc, time::Instant};
 
 pub enum SyncInbound {
     BlockHashes(SocketAddr, Vec<BlockHeaderHash>),
-    Block(SocketAddr, Vec<u8>),
+    Block(SocketAddr, Vec<u8>, Option<u32>),
 }
 
 pub struct SyncMaster {
@@ -42,6 +42,7 @@ pub struct SyncMaster {
 struct SyncBlock {
     address: SocketAddr,
     block: Vec<u8>,
+    height: Option<u32>,
 }
 
 impl SyncMaster {
@@ -152,7 +153,7 @@ impl SyncMaster {
                 SyncInbound::BlockHashes(addr, hashes) => {
                     received_block_hashes.insert(addr, hashes.into_iter().map(|x| -> Digest { x.0.into() }).collect());
                 }
-                SyncInbound::Block(_, _) => {
+                SyncInbound::Block(..) => {
                     warn!("received sync block prematurely");
                 }
             }
@@ -183,8 +184,8 @@ impl SyncMaster {
                 SyncInbound::BlockHashes(_, _) => {
                     // late, ignored
                 }
-                SyncInbound::Block(address, block) => {
-                    blocks.push(SyncBlock { address, block });
+                SyncInbound::Block(address, block, height) => {
+                    blocks.push(SyncBlock { address, block, height });
                 }
             }
             blocks.len() >= block_count
@@ -357,7 +358,7 @@ impl SyncMaster {
         for (i, hash) in block_order.iter().enumerate() {
             if let Some(block) = blocks_by_hash.remove(hash) {
                 self.node
-                    .process_received_block(block.address, block.block, false)
+                    .process_received_block(block.address, block.block, block.height, false)
                     .await?;
             } else {
                 warn!(

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -108,8 +108,13 @@ impl MinerInstance {
                 info!("Mined a new block: {:?}", hex::encode(block.header.hash().0));
 
                 let serialized_block = block.serialize();
+                let node_clone = self.node.clone();
+                let new_height = futures::executor::block_on(async move {
+                    node_clone.storage.canon().await.map(|c| c.block_height as u32)
+                })
+                .ok();
 
-                self.node.propagate_block(serialized_block, local_address);
+                self.node.propagate_block(serialized_block, new_height, local_address);
             }
         }))
     }

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -334,6 +334,7 @@ async fn fuzzing_corrupted_payloads_with_bodies_pre_handshake() {
     let mut rng = thread_rng();
     let random_len: usize = rng.gen_range(1..(64 * 1024));
     let blob: Vec<u8> = rng.sample_iter(Standard).take(random_len).collect();
+    let height = Some(1);
 
     let addrs: Vec<SocketAddr> = [
         "0.0.0.0:0",
@@ -348,9 +349,9 @@ async fn fuzzing_corrupted_payloads_with_bodies_pre_handshake() {
     .collect();
 
     for payload in &[
-        Payload::Block(blob.clone()),
+        Payload::Block(blob.clone(), height),
         Payload::MemoryPool(vec![blob.clone(); 10]),
-        Payload::SyncBlock(blob.clone()),
+        Payload::SyncBlock(blob.clone(), height),
         Payload::Transaction(blob.clone()),
         Payload::Peers(addrs.clone()),
         Payload::Ping(thread_rng().gen()),
@@ -398,6 +399,7 @@ async fn fuzzing_corrupted_payloads_with_bodies_post_handshake() {
     let mut rng = thread_rng();
     let random_len: usize = rng.gen_range(1..(64 * 1024));
     let blob: Vec<u8> = rng.sample_iter(Standard).take(random_len).collect();
+    let height = None;
 
     let addrs: Vec<SocketAddr> = [
         "0.0.0.0:0",
@@ -412,9 +414,9 @@ async fn fuzzing_corrupted_payloads_with_bodies_post_handshake() {
     .collect();
 
     for payload in &[
-        Payload::Block(blob.clone()),
+        Payload::Block(blob.clone(), height),
         Payload::MemoryPool(vec![blob.clone(); 10]),
-        Payload::SyncBlock(blob.clone()),
+        Payload::SyncBlock(blob.clone(), height),
         Payload::Transaction(blob.clone()),
         Payload::Peers(addrs.clone()),
         Payload::Ping(thread_rng().gen()),

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -210,13 +210,15 @@ async fn reject_non_version_messages_before_handshake() {
     // Block
     let mut peer_stream = TcpStream::connect(node.local_address().unwrap()).await.unwrap();
     let block = vec![0u8, 10];
-    write_message_to_stream(Payload::Block(block), &mut peer_stream).await;
+    let height = None;
+    write_message_to_stream(Payload::Block(block, height), &mut peer_stream).await;
     assert_node_rejected_message(&node, &mut peer_stream).await;
 
     // SyncBlock
     let mut peer_stream = TcpStream::connect(node.local_address().unwrap()).await.unwrap();
     let sync_block = vec![0u8, 10];
-    write_message_to_stream(Payload::SyncBlock(sync_block), &mut peer_stream).await;
+    let height = Some(1);
+    write_message_to_stream(Payload::SyncBlock(sync_block, height), &mut peer_stream).await;
     assert_node_rejected_message(&node, &mut peer_stream).await;
 
     // Sync

--- a/testing/src/network/encryption.rs
+++ b/testing/src/network/encryption.rs
@@ -29,7 +29,8 @@ async fn encrypt_and_decrypt_a_big_payload() {
 
     // create a big block containing random data
     let fake_block_bytes: Vec<u8> = (&mut thread_rng()).sample_iter(Standard).take(block_size).collect();
-    let big_block = Payload::Block(fake_block_bytes.clone());
+    let fake_block_height = Some(1);
+    let big_block = Payload::Block(fake_block_bytes.clone(), fake_block_height);
 
     let reading_task = tokio::spawn(async move { node1.read_payload().await.unwrap() });
 
@@ -38,8 +39,8 @@ async fn encrypt_and_decrypt_a_big_payload() {
     let payload = reading_task.await.unwrap();
 
     // check if node1 received the expected data
-    if let Payload::Block(bytes) = payload {
-        assert!(bytes == fake_block_bytes);
+    if let Payload::Block(bytes, height) = payload {
+        assert!((bytes, height) == (fake_block_bytes, fake_block_height));
     } else {
         panic!("wrong payload received");
     }
@@ -55,15 +56,16 @@ async fn encrypt_and_decrypt_small_payloads() {
         // create a small block containing random data
         let block_size: u8 = rng.gen();
         let fake_block_bytes: Vec<u8> = (&mut rng).sample_iter(Standard).take(block_size as usize).collect();
-        let big_block = Payload::Block(fake_block_bytes.clone());
+        let fake_block_height = Some(1);
+        let big_block = Payload::Block(fake_block_bytes.clone(), fake_block_height);
 
         // send it from node0 to node1
         node0.write_message(&big_block).await;
         let payload = node1.read_payload().await.unwrap();
 
         // check if node1 received the expected data
-        if let Payload::Block(bytes) = payload {
-            assert!(bytes == fake_block_bytes);
+        if let Payload::Block(bytes, height) = payload {
+            assert!((bytes, height) == (fake_block_bytes, fake_block_height));
         } else {
             panic!("wrong payload received");
         }

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -94,10 +94,10 @@ async fn block_initiator_side() {
     assert!(block_hashes.contains(&block_1_header_hash) && block_hashes.contains(&block_2_header_hash));
 
     // respond with the full blocks
-    let block_1 = Payload::SyncBlock(to_bytes_le![&*BLOCK_1].unwrap());
+    let block_1 = Payload::SyncBlock(to_bytes_le![&*BLOCK_1].unwrap(), Some(1));
     peer.write_message(&block_1).await;
 
-    let block_2 = Payload::SyncBlock(to_bytes_le![&*BLOCK_2].unwrap());
+    let block_2 = Payload::SyncBlock(to_bytes_le![&*BLOCK_2].unwrap(), Some(2));
     peer.write_message(&block_2).await;
 
     // check the blocks have been added to the node's chain
@@ -161,7 +161,7 @@ async fn block_responder_side() {
 
     // receive a SyncBlock message with the requested block
     let payload = peer.read_payload().await.unwrap();
-    let block = if let Payload::SyncBlock(block) = payload {
+    let block = if let Payload::SyncBlock(block, Some(1)) = payload {
         block
     } else {
         unreachable!();


### PR DESCRIPTION
This PR adds a block height field to the `Block` and `SyncBlock` network messages, so that the recipient node can know what the height of the sender's block is if they knew it themself (which might not be the case with re-propagated blocks).

This change alters the network message format, but due to us using schema-based serialization, it is compatible with existing nodes (they just won't provide this information or be able to interpret it themselves).