### PR TITLE
Miner Termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,7 @@ dependencies = [
  "chrono",
  "criterion",
  "dyn-clone",
+ "futures 0.3.16",
  "hex",
  "indexmap",
  "lazy_static",
@@ -2791,6 +2792,7 @@ dependencies = [
  "snarkos-testing",
  "snarkvm-algorithms",
  "snarkvm-dpc",
+ "snarkvm-posw",
  "snarkvm-utilities",
  "snow",
  "thiserror",
@@ -2923,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40caa98abd0a874a003d844d6a73562020fb5fa976daa14055f030d9803430b7"
+checksum = "3534da2cfa71894e4d28c5dcaf9f9c5c94315904c4ace6c86419a8f2ff8b1641"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2951,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010ae5c95693279db519e4a8525a8a3145edc8e36198efdfaf250622f4540cc1"
+checksum = "83b4de7cd1533c67dd386058b631d7e5ea8b2063ebca212159b13fc1a94ff4a7"
 dependencies = [
  "derivative",
  "rand 0.8.4",
@@ -2967,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e963ae4209f0166a619ab9266ce71c6f9228861ec55615a1b6154d673ffc158"
+checksum = "3e854888634305d8c5c79fe59adaae593971a8b29d3148834f698141b16c2c7b"
 dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro-error",
@@ -2980,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1588a3d2f38307bd64838cf1761d8cef485461e5224831c9b9df11a1fa9864e7"
+checksum = "c922bb690fbe9c5919f67f2d887452376339a36bf5ffb50dc6b00d58a5650284"
 dependencies = [
  "anyhow",
  "base58",
@@ -3012,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761cb4c19d6685ac9d1d3a6eb1619600334bcf80dc6ac742cc38f4fe349ba871"
+checksum = "bca141a8eae489ea39600b04f0a642059ce076bd3a7d21704b38b90fc87c37f0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3028,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b0cd11387a572f9a1c318c1d446dd46e0522c9be7681b8d6af6882d20880fd"
+checksum = "3138cfcaaa27e53cabc7a4fc596b3b0abb47c3cb46fee496e3ac7ce2cd07df9d"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -3048,9 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-marlin"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206d633d6299dfb4f52640a3188567462dbf1f207de70cbb829707c07858c7e6"
+checksum = "12e6987cde7b734415afc7afe58a038d224393842ad5dfaba728a601c5c5473d"
 dependencies = [
  "blake2",
  "derivative",
@@ -3072,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5c4d4233a623c46c483296aa24bf4d95a5f3344c669ce4f2956467fe6ea904"
+checksum = "506cbbbfe27acb4d4e8dd15e49b430dbfb920fd680cfe1c69ab87542083d0422"
 dependencies = [
  "curl",
  "hex",
@@ -3085,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-polycommit"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5ca8d560cb6f49d9de9b4a955778cc14563b0a381c56db48ea6171788f30d4"
+checksum = "c23a7fa2aab25aa6fc3b7fb27b3d639936725a5c29b29936d1530b64bd011e67"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -3104,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-posw"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a9c030d0d620d13dba77b4a2dcee9e651ad50082540b23f4f351e6dd6c024b"
+checksum = "fdc5cea871518430ed422b45b4432a7569c9d509d84f2cd1e496ca74b9ca27cd"
 dependencies = [
  "blake2",
  "rand 0.8.4",
@@ -3126,15 +3128,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cb28d79c59db77774484dbc0f4e876dc8604085d8d7f43eee1b813ec0614b4"
+checksum = "f7d80cc343b9e19e0f38582fa7e17e6263c4c7449122cf9a606279567ff33d71"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e3b7acea34af74dbe5dea056714a9f3c9b1029a9ac888595c96a6e3c676e6"
+checksum = "537f2123c7da8a9d3482523156318479790c41e390d33f6936b89a3ed9eee0a8"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -3147,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0842ff685e625cb7a2f9ddc7ca1b1560d2a3e3a7220099781a28ea54564133b"
+checksum = "a6d1565a7c2a320b711308188adf84980013872e579ae2e6abffe8796eb8e6fe"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,20 +44,20 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkos-consensus]
 path = "./consensus"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -48,22 +48,22 @@ path = "network/hasher_hash.rs"
 harness = false
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-curves]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkos-profiler]
 path = "../profiler"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,25 +18,25 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-curves]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.metrics]
 version = "0.17"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.tokio]
 version = "1"
@@ -84,6 +84,9 @@ version = "1.4"
 
 [dependencies.dyn-clone]
 version = "1.0"
+
+[dependencies.futures]
+version = "0.3"
 
 [dependencies.tracing]
 default-features = false

--- a/consensus/src/miner.rs
+++ b/consensus/src/miner.rs
@@ -18,12 +18,15 @@ use crate::{error::ConsensusError, Consensus};
 use snarkos_storage::{SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction};
 use snarkvm_algorithms::SNARKError;
 use snarkvm_dpc::{testnet1::instantiated::*, Address, BlockHeader, BlockHeaderHash, DPCComponents, ProgramScheme};
-use snarkvm_posw::{PoswMarlin, error::PoswError, txids_to_roots};
+use snarkvm_posw::{error::PoswError, txids_to_roots, PoswMarlin};
 use snarkvm_utilities::{to_bytes_le, ToBytes};
 
 use chrono::Utc;
 use rand::thread_rng;
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 lazy_static::lazy_static! {
     /// The mining instance that is initialized with a proving key.
@@ -141,14 +144,16 @@ impl MineContext {
                 // technically a race condition, but non-critical
                 trace!("terminated miner due to canon block received");
                 terminator.store(false, Ordering::SeqCst);
-                return Err(ConsensusError::PoswError(PoswError::SnarkError(SNARKError::Terminated)))
-            },
-            Err(PoswError::SnarkError(SNARKError::Crate("marlin", message))) if message == "Failed to generate proof - Terminated" => {
+                return Err(ConsensusError::PoswError(PoswError::SnarkError(SNARKError::Terminated)));
+            }
+            Err(PoswError::SnarkError(SNARKError::Crate("marlin", message)))
+                if message == "Failed to generate proof - Terminated" =>
+            {
                 // todo: remove in snarkvm 0.7.10+
                 trace!("terminated miner due to canon block received");
                 terminator.store(false, Ordering::SeqCst);
-                return Err(ConsensusError::PoswError(PoswError::SnarkError(SNARKError::Terminated)))
-            },
+                return Err(ConsensusError::PoswError(PoswError::SnarkError(SNARKError::Terminated)));
+            }
             Err(e) => return Err(e.into()),
             Ok(x) => x,
         };
@@ -167,7 +172,10 @@ impl MineContext {
 
     /// Returns a mined block.
     /// Calls methods to fetch transactions, run proof of work, and add the block into the chain for storage.
-    pub async fn mine_block(&self, terminator: &AtomicBool) -> Result<(SerialBlock, Vec<SerialRecord>), ConsensusError> {
+    pub async fn mine_block(
+        &self,
+        terminator: &AtomicBool,
+    ) -> Result<(SerialBlock, Vec<SerialRecord>), ConsensusError> {
         let candidate_transactions = self.consensus.fetch_memory_pool().await;
         debug!("Miner@{}: creating a block", self.block_height);
 

--- a/consensus/tests/consensus_dpc.rs
+++ b/consensus/tests/consensus_dpc.rs
@@ -43,7 +43,9 @@ mod consensus_dpc {
         println!("Creating block with coinbase transaction");
         let (transactions, coinbase_records) = miner.establish_block(vec![]).await.unwrap();
         let previous_block_header = genesis().header.into();
-        let header = miner.find_block(&transactions, &previous_block_header, &AtomicBool::new(false)).unwrap();
+        let header = miner
+            .find_block(&transactions, &previous_block_header, &AtomicBool::new(false))
+            .unwrap();
         let previous_block_header = header.clone();
         let block = SerialBlock { header, transactions };
 
@@ -156,7 +158,9 @@ mod consensus_dpc {
 
         assert!(consensus.verify_transactions(transactions.clone()).await);
 
-        let header = miner.find_block(&transactions, &previous_block_header, &AtomicBool::new(false)).unwrap();
+        let header = miner
+            .find_block(&transactions, &previous_block_header, &AtomicBool::new(false))
+            .unwrap();
         let new_block = SerialBlock { header, transactions };
         let new_block_reward = get_block_reward(consensus.storage.canon().await.unwrap().block_height as u32);
 

--- a/consensus/tests/consensus_dpc.rs
+++ b/consensus/tests/consensus_dpc.rs
@@ -15,6 +15,8 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod consensus_dpc {
+    use std::sync::atomic::AtomicBool;
+
     use rand::thread_rng;
     use snarkos_consensus::{get_block_reward, CreateTransactionRequest, MineContext};
     use snarkos_storage::{SerialBlock, VMRecord};
@@ -41,7 +43,7 @@ mod consensus_dpc {
         println!("Creating block with coinbase transaction");
         let (transactions, coinbase_records) = miner.establish_block(vec![]).await.unwrap();
         let previous_block_header = genesis().header.into();
-        let header = miner.find_block(&transactions, &previous_block_header).unwrap();
+        let header = miner.find_block(&transactions, &previous_block_header, &AtomicBool::new(false)).unwrap();
         let previous_block_header = header.clone();
         let block = SerialBlock { header, transactions };
 
@@ -154,7 +156,7 @@ mod consensus_dpc {
 
         assert!(consensus.verify_transactions(transactions.clone()).await);
 
-        let header = miner.find_block(&transactions, &previous_block_header).unwrap();
+        let header = miner.find_block(&transactions, &previous_block_header, &AtomicBool::new(false)).unwrap();
         let new_block = SerialBlock { header, transactions };
         let new_block_reward = get_block_reward(consensus.storage.canon().await.unwrap().block_height as u32);
 

--- a/consensus/tests/consensus_integration.rs
+++ b/consensus/tests/consensus_integration.rs
@@ -29,7 +29,9 @@ mod consensus_integration {
         let miner_address = FIXTURE_VK.test_accounts[0].address.clone();
         let miner = MineContext::prepare(miner_address, consensus.clone()).await.unwrap();
 
-        let header = miner.find_block(transactions, parent_header, &AtomicBool::new(false)).unwrap();
+        let header = miner
+            .find_block(transactions, parent_header, &AtomicBool::new(false))
+            .unwrap();
 
         let expected_prev_block_hash = parent_header.hash();
         assert_eq!(header.previous_block_hash, expected_prev_block_hash);

--- a/consensus/tests/consensus_integration.rs
+++ b/consensus/tests/consensus_integration.rs
@@ -15,6 +15,8 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod consensus_integration {
+    use std::sync::atomic::AtomicBool;
+
     use snarkos_consensus::miner::MineContext;
     use snarkos_storage::{SerialBlockHeader, SerialTransaction};
     use snarkos_testing::sync::*;
@@ -27,7 +29,7 @@ mod consensus_integration {
         let miner_address = FIXTURE_VK.test_accounts[0].address.clone();
         let miner = MineContext::prepare(miner_address, consensus.clone()).await.unwrap();
 
-        let header = miner.find_block(transactions, parent_header).unwrap();
+        let header = miner.find_block(transactions, parent_header, &AtomicBool::new(false)).unwrap();
 
         let expected_prev_block_hash = parent_header.hash();
         assert_eq!(header.previous_block_hash, expected_prev_block_hash);

--- a/consensus/tests/miner.rs
+++ b/consensus/tests/miner.rs
@@ -127,8 +127,7 @@ mod miner {
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
         terminator.store(true, Ordering::SeqCst);
-
-        wait_until!(100, !terminator.load(Ordering::SeqCst));
+        wait_until!(60, !terminator.load(Ordering::SeqCst));
         assert_eq!(receiver.recv().await.unwrap(), "terminated");
     }
 }

--- a/consensus/tests/miner.rs
+++ b/consensus/tests/miner.rs
@@ -85,7 +85,6 @@ mod miner {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn terminate_on_block() {
-        tracing_subscriber::fmt::init();
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         consensus.fetch_memory_pool().await; // just make sure we're fully initialized by blocking on consensus call
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -37,4 +37,4 @@ version = "1"
 features = [ "macros", "rt-multi-thread" ]
 
 [dev-dependencies.snarkvm-derives]
-version = "=0.7.8"
+version = "=0.7.9"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,13 +21,16 @@ edition = "2018"
 prometheus = [ "snarkos-metrics/prometheus" ]
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
+
+[dependencies.snarkvm-posw]
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -79,6 +79,7 @@ pub struct InnerNode {
     /// An indicator of whether the node is shutting down.
     shutting_down: AtomicBool,
     pub(crate) master_dispatch: RwLock<Option<mpsc::Sender<SyncInbound>>>,
+    pub terminator: Arc<AtomicBool>,
 }
 
 /// A core data structure for operating the networking stack of this node.
@@ -134,6 +135,7 @@ impl Node {
             threads: Default::default(),
             shutting_down: Default::default(),
             master_dispatch: RwLock::new(None),
+            terminator: Arc::new(AtomicBool::new(false)),
         }));
 
         if node.config.is_crawler() {

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -25,7 +25,7 @@ use snarkvm_dpc::{
 
 use snarkos_consensus::error::ConsensusError;
 
-use crate::{NetworkError, Node, State, master::SyncInbound, message::*};
+use crate::{master::SyncInbound, message::*, NetworkError, Node, State};
 use anyhow::*;
 use tokio::task;
 
@@ -118,7 +118,7 @@ impl Node {
         .map_err(|e| NetworkError::Other(e.into()))??;
         let block_struct = <Block<Transaction<Components>> as VMBlock>::serialize(&block_struct)?;
         let previous_block_hash = block_struct.header.previous_block_hash.clone();
-        
+
         let canon = self.storage.canon().await?;
 
         info!(
@@ -141,7 +141,7 @@ impl Node {
             if previous_block_hash == canon.hash && self.state() == State::Mining {
                 self.terminator.store(true, Ordering::SeqCst);
             }
-    
+
             // This is a non-sync Block, send it to our peers.
             self.propagate_block(block, height, remote_address);
         }

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -21,14 +21,12 @@ use std::{
 };
 
 use futures::executor::block_on;
-use snarkvm_algorithms::SNARKError;
 use snarkvm_dpc::{testnet1::instantiated::*, Address};
 use tokio::task;
 use tracing::*;
 
 use snarkos_consensus::{error::ConsensusError, MineContext};
 use snarkos_metrics::{self as metrics, misc::*};
-use snarkvm_posw::error::PoswError;
 
 use crate::{Node, State};
 

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{sync::{Arc, atomic::Ordering}, thread, time::Duration};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    thread,
+    time::Duration,
+};
 
 use futures::executor::block_on;
 use snarkvm_algorithms::SNARKError;

--- a/parameters/Cargo.toml
+++ b/parameters/Cargo.toml
@@ -18,17 +18,17 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 default-features = false
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.arc-swap]
 version = "1.2"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 default-features = false
 
 [dependencies.curl]
@@ -36,16 +36,16 @@ version = "0.4.36"
 optional = true
 
 [dev-dependencies.snarkvm-curves]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dev-dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dev-dependencies.snarkvm-marlin]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dev-dependencies.snarkvm-posw]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dev-dependencies.snarkos-consensus]
 path = "../consensus"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,14 +18,14 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -24,16 +24,16 @@ mem_storage = [ ]
 test = [ ]
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkos-parameters]
 path = "../parameters"
@@ -105,7 +105,7 @@ version = "0.1"
 path = "../consensus"
 
 [dev-dependencies.snarkvm-curves]
-version = "=0.7.8"
+version = "=0.7.9"
 
 #[dev-dependencies.snarkos-testing]
 #path = "../testing"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -29,22 +29,22 @@ network = [
 ]
 
 [dependencies.snarkvm-algorithms]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-curves]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-dpc]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-parameters]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-posw]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkvm-utilities]
-version = "=0.7.8"
+version = "=0.7.9"
 
 [dependencies.snarkos-consensus]
 path = "../consensus"

--- a/testing/examples/test_blocks.rs
+++ b/testing/examples/test_blocks.rs
@@ -24,7 +24,7 @@ use snarkos_testing::{
 };
 use tracing_subscriber::EnvFilter;
 
-use std::{fs::File, path::PathBuf};
+use std::{fs::File, path::PathBuf, sync::atomic::AtomicBool};
 
 async fn mine_blocks(n: u32) -> Result<TestBlocks, ConsensusError> {
     info!("Creating test account");

--- a/testing/examples/test_blocks.rs
+++ b/testing/examples/test_blocks.rs
@@ -24,7 +24,7 @@ use snarkos_testing::{
 };
 use tracing_subscriber::EnvFilter;
 
-use std::{fs::File, path::PathBuf, sync::atomic::AtomicBool};
+use std::{fs::File, path::PathBuf};
 
 async fn mine_blocks(n: u32) -> Result<TestBlocks, ConsensusError> {
     info!("Creating test account");

--- a/testing/examples/test_data.rs
+++ b/testing/examples/test_data.rs
@@ -67,10 +67,15 @@ async fn setup_test_data() -> TestData {
                 .get_block_header(&block_1.header.previous_block_hash)
                 .await
                 .unwrap(),
+            &AtomicBool::new(false),
         )
         .unwrap();
     let alternative_block_2_header = miner
-        .find_block(&block_2.transactions, &alternative_block_1_header)
+        .find_block(
+            &block_2.transactions,
+            &alternative_block_1_header,
+            &AtomicBool::new(false),
+        )
         .unwrap();
 
     TestData {

--- a/testing/examples/test_data.rs
+++ b/testing/examples/test_data.rs
@@ -21,7 +21,7 @@ use snarkos_testing::{
 };
 
 use snarkvm_utilities::ToBytes;
-use std::{fs::File, path::PathBuf};
+use std::{fs::File, path::PathBuf, sync::atomic::AtomicBool};
 
 async fn setup_test_data() -> TestData {
     let [miner_acc, acc_1, _] = FIXTURE.test_accounts.clone();

--- a/testing/src/mining/mod.rs
+++ b/testing/src/mining/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::sync::atomic::AtomicBool;
+
 use snarkos_consensus::{error::ConsensusError, Consensus, CreateTransactionRequest, MineContext, TransactionResponse};
 use snarkos_storage::{PrivateKey, SerialBlock, SerialBlockHeader, SerialRecord, SerialTransaction};
 use snarkvm_dpc::{
@@ -31,7 +33,7 @@ pub async fn mine_block(
 ) -> Result<(SerialBlock, Vec<SerialRecord>), ConsensusError> {
     let (transactions, coinbase_records) = miner.establish_block(transactions).await?;
 
-    let header = miner.find_block(&transactions, parent_block_header)?;
+    let header = miner.find_block(&transactions, parent_block_header, &AtomicBool::new(false))?;
 
     let block = SerialBlock { header, transactions };
 


### PR DESCRIPTION
This PR adds miner termination and updates snarkVM to 0.7.9.

This PR does not include aborting a coinbase transaction formation.