### PR TITLE
Fix merkle tree rebuilding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "snarkvm-algorithms",
  "snarkvm-curves",
@@ -2846,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "derivative",
  "rand 0.8.4",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-dpc"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "anyhow",
  "base58",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2945,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-gadgets"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-marlin"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "blake2",
  "derivative",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "curl",
  "hex",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-polycommit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -3045,12 +3045,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-profiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57ca319#57ca3193bd474073de9d3b2b400ea96aa2292efc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ef32edc#ef32edcc11ad3d60aa5b97f0a154ca0ba6bcc157"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ path = "snarkos/main.rs"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../snarkVM"
 
 [dependencies.snarkos-consensus]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -34,7 +34,7 @@ harness = false
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM"
 features = ["algorithms", "parameters"]
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM"
 features = ["curves", "parameters"]
 

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -38,5 +38,5 @@ features = [ "macros", "rt-multi-thread" ]
 
 [dev-dependencies.snarkvm-derives]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM/derives"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -22,7 +22,7 @@ prometheus = [ "snarkos-metrics/prometheus" ]
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM"
 features = ["algorithms"]
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM"
 
 [dependencies.snarkos-consensus]

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -642,7 +642,9 @@ impl<S: Storage + Send + Sync + 'static> ProtectedRpcFunctions for RpcImpl<S> {
         // Fetch the latest digest.
         let storage = &self.storage;
         let primary_height = self.sync_handler()?.current_block_height();
-        storage.catch_up_secondary(false, primary_height)?;
+        storage.catch_up_secondary(true, primary_height)?;
+        storage.rebuild_merkle_tree()?;
+
         let latest_digest = self.storage.latest_digest()?;
 
         // Generate the Merkle path for each commitment to the latest digest.

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -25,7 +25,7 @@ test = [ ]
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM"
 features = ["parameters"]
 

--- a/storage/src/ledger.rs
+++ b/storage/src/ledger.rs
@@ -183,7 +183,7 @@ impl<C: Parameters, S: Storage> Ledger<C, S> {
                 // the secondary instance requires it.
                 if update_merkle_tree {
                     // Update the Merkle tree of the secondary instance.
-                    self.rebuild_merkle_tree(vec![])?;
+                    self.rebuild_merkle_tree()?;
                 }
             }
         }

--- a/storage/src/objects/insert_commit.rs
+++ b/storage/src/objects/insert_commit.rs
@@ -268,7 +268,7 @@ impl<C: Parameters, S: Storage> Ledger<C, S> {
         }
 
         // Rebuild the new commitment merkle tree
-        self.rebuild_merkle_tree(transaction_cms)?;
+        self.add_new_commitments(transaction_cms)?;
         let tree = self.cm_merkle_tree.load();
         let new_digest = tree.root();
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -30,7 +30,7 @@ network = [
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "57ca319"
+rev = "ef32edc"
 # path = "../../snarkVM"
 features = ["curves", "parameters"]
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Fixes the commitment merkle tree rebuilds in the node. The original implementation did no rebuild the tree correctly when new record commitments were added to the ledger.

Currently, there is still another issue where the ledger digest never changes. 
