### PR TITLE
Node performance tweaks

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -80,8 +80,6 @@ pub const SHARED_PEER_COUNT: usize = 25;
 
 /// The depth of the common inbound channel.
 pub const INBOUND_CHANNEL_DEPTH: usize = 16 * 1024;
-/// The depth of the per-connection outbound channels.
-pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 
 /// The version of the network protocol; it can be incremented in order to force users to update.
 /// FIXME: probably doesn't need to be a u64, could also be more informative than just a number

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -32,7 +32,7 @@ use std::{
     thread,
 };
 use tokio::{
-    sync::{mpsc, Mutex, RwLock},
+    sync::{mpsc, RwLock},
     task,
     time::sleep,
 };
@@ -61,7 +61,7 @@ pub struct InnerNode {
     /// The inbound handler of this node.
     pub inbound: Inbound,
     /// The cache of node's inbound messages.
-    pub inbound_cache: Mutex<Cache>,
+    pub inbound_cache: Cache,
     /// The list of connected and disconnected peers of this node.
     pub peer_book: PeerBook,
     /// Tracks the known network crawled by this node.

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -83,12 +83,12 @@ impl Peer {
                 if matches!(payload, Payload::Block(..)) {
                     metrics::increment_counter!(inbound::BLOCKS);
 
-                    if node.inbound_cache.contains(&payload).await {
-                        metrics::increment_counter!(misc::DUPLICATE_BLOCKS);
+                    if node.state() == State::Syncing {
                         return Ok(());
                     }
 
-                    if node.state() == State::Syncing {
+                    if node.inbound_cache.contains(&payload).await {
+                        metrics::increment_counter!(misc::DUPLICATE_BLOCKS);
                         return Ok(());
                     }
                 }

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -83,7 +83,7 @@ impl Peer {
                 if matches!(payload, Payload::Block(..)) {
                     metrics::increment_counter!(inbound::BLOCKS);
 
-                    if node.inbound_cache.lock().await.contains(&payload) {
+                    if node.inbound_cache.contains(&payload).await {
                         metrics::increment_counter!(misc::DUPLICATE_BLOCKS);
                         return Ok(());
                     }

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -61,6 +61,7 @@ impl Peer {
             }
             Payload::Ping(block_height) => {
                 network.write_payload(&Payload::Pong).await?;
+                debug!("Sent a '{}' message to {}", Payload::Pong, self.address);
                 self.quality.block_height = block_height;
                 metrics::increment_counter!(PINGS);
                 metrics::increment_counter!(inbound::ALL_SUCCESSES);

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -154,7 +154,7 @@ impl SyncMaster {
                     if handler(msg.unwrap()) {
                         break;
                     }
-                    moving_end = Instant::now() + Duration::from_secs(moving_timeout_sec);
+                    moving_end += Duration::from_secs(moving_timeout_sec);
                 },
                 _ = timeout => {
                     break;

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -72,7 +72,7 @@ impl SyncMaster {
         }
 
         info!("found {} interesting peers for sync", interesting_peers.len());
-        debug!("sync interesting peers = {:?}", interesting_peers);
+        trace!("sync interesting peers = {:?}", interesting_peers);
 
         Ok(interesting_peers)
     }

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -391,7 +391,6 @@ impl SyncMaster {
             }
         }
 
-        self.node.finished_syncing_blocks();
         Ok(())
     }
 }


### PR DESCRIPTION
This PR is the result of monitoring and tweaking the performance of a node that has a lot of connections.

performance improvements:
- convert a vector of hashes just once in `SyncMaster::send_sync_messages`
- reduce the number of syscalls when calculating sync timeouts
- reduce the scope of the Block cache lock (it no longer involves hashing)
- check if the node is syncing before checking the `Block` cache (skips the cache lookup)

drive-by tweaks:
- downgrade the log with the list of prospect sync peers to `TRACE` (very verbose)
- add a missing `DEBUG` log when a `Pong` is sent
- remove an unused `const`
- remove one redundant call to `Node::finished_syncing_blocks`