### PR TITLE
Extra performance metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "serde",
  "smallvec",
  "snarkos-consensus",
+ "snarkos-metrics",
  "snarkos-parameters",
  "snarkvm-algorithms",
  "snarkvm-curves",

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -69,6 +69,8 @@ impl ConsensusInner {
             .expect("failed to initialize ledger & storage with genesis block");
 
         while let Some((message, response)) = receiver.recv().await {
+            metrics::decrement_gauge!(snarkos_metrics::queues::CONSENSUS, 1.0);
+
             match message {
                 ConsensusMessage::ReceiveTransaction(transaction) => {
                     response.send(Box::new(self.receive_transaction(transaction))).ok();

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -90,6 +90,7 @@ impl Consensus {
     async fn send<T: Send + Sync + 'static>(&self, message: ConsensusMessage) -> T {
         let (sender, receiver) = oneshot::channel();
         self.sender.send((message, sender)).await.ok();
+        metrics::increment_gauge!(snarkos_metrics::queues::CONSENSUS, 1.0);
         *receiver
             .await
             .ok()

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -8,6 +8,12 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
@@ -311,7 +317,7 @@
         "x": 18,
         "y": 0
       },
-      "id": 16,
+      "id": 14,
       "options": {
         "displayLabels": [],
         "legend": {
@@ -338,21 +344,31 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snarkos_inbound_all_successes_total",
+          "expr": "snarkos_connections_all_accepted_total",
           "interval": "",
-          "legendFormat": "valid",
+          "legendFormat": "accepted",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_inbound_all_failures_total",
+          "expr": "snarkos_connections_all_rejected_total",
           "hide": false,
           "interval": "",
-          "legendFormat": "invalid",
+          "legendFormat": "rejected",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_connections_all_initiated_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "initiated",
+          "refId": "C"
         }
       ],
-      "title": "all processed inbound messages",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "all connections",
       "type": "piechart"
     },
     {
@@ -395,6 +411,7 @@
             }
           },
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -417,8 +434,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 5,
+        "h": 15,
+        "w": 11,
         "x": 0,
         "y": 10
       },
@@ -446,7 +463,7 @@
           "expr": "snarkos_queues_inbound_total",
           "instant": false,
           "interval": "",
-          "legendFormat": "inbound",
+          "legendFormat": "inbound network messages",
           "refId": "A"
         },
         {
@@ -454,85 +471,46 @@
           "expr": "snarkos_queues_outbound_total",
           "hide": false,
           "interval": "",
-          "legendFormat": "outbound",
+          "legendFormat": "outbound network message",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_storage_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "storage requests",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_peer_events_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "peer events",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_sync_items_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "sync items",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_consensus_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "consensus requests",
+          "refId": "F"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
       "title": "queued messages",
       "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 5,
-        "y": 10
-      },
-      "id": 4,
-      "options": {
-        "displayLabels": [],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "values": [
-            "percent"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "pluginVersion": "7.5.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "snarkos_outbound_all_successes_total",
-          "interval": "",
-          "legendFormat": "delivered",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_outbound_all_failures_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "lost",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "outbound messages",
-      "type": "piechart"
     },
     {
       "datasource": null,
@@ -661,7 +639,7 @@
         "x": 18,
         "y": 10
       },
-      "id": 14,
+      "id": 16,
       "options": {
         "displayLabels": [],
         "legend": {
@@ -688,31 +666,92 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snarkos_connections_all_accepted_total",
+          "expr": "snarkos_inbound_all_successes_total",
           "interval": "",
-          "legendFormat": "accepted",
+          "legendFormat": "valid",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_connections_all_rejected_total",
+          "expr": "snarkos_inbound_all_failures_total",
           "hide": false,
           "interval": "",
-          "legendFormat": "rejected",
+          "legendFormat": "invalid",
           "refId": "B"
+        }
+      ],
+      "title": "all processed inbound messages",
+      "type": "piechart"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 20
+      },
+      "id": 4,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_outbound_all_successes_total",
+          "interval": "",
+          "legendFormat": "delivered",
+          "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_connections_all_initiated_total",
+          "expr": "snarkos_outbound_all_failures_total",
           "hide": false,
           "interval": "",
-          "legendFormat": "initiated",
-          "refId": "C"
+          "legendFormat": "lost",
+          "refId": "B"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "all connections",
+      "title": "outbound messages",
       "type": "piechart"
     },
     {
@@ -737,10 +776,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 5,
         "w": 11,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 12,
       "options": {
@@ -758,7 +797,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.0.6",
+      "pluginVersion": "8.1.2",
       "targets": [
         {
           "exemplar": true,
@@ -834,5 +873,5 @@
   "timezone": "",
   "title": "snarkOS node",
   "uid": "PAzNcaCGz",
-  "version": 53
+  "version": 55
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -58,6 +58,7 @@ pub mod handshakes {
 pub mod queues {
     pub const INBOUND: &str = "snarkos_queues_inbound_total";
     pub const OUTBOUND: &str = "snarkos_queues_outbound_total";
+    pub const STORAGE: &str = "snarkos_queues_storage_total";
 }
 
 pub mod misc {

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -60,6 +60,7 @@ pub mod queues {
     pub const OUTBOUND: &str = "snarkos_queues_outbound_total";
     pub const PEER_EVENTS: &str = "snarkos_queues_peer_events_total";
     pub const STORAGE: &str = "snarkos_queues_storage_total";
+    pub const SYNC_ITEMS: &str = "snarkos_queues_sync_items_total";
 }
 
 pub mod misc {

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -56,6 +56,7 @@ pub mod handshakes {
 }
 
 pub mod queues {
+    pub const CONSENSUS: &str = "snarkos_queues_consensus_total";
     pub const INBOUND: &str = "snarkos_queues_inbound_total";
     pub const OUTBOUND: &str = "snarkos_queues_outbound_total";
     pub const PEER_EVENTS: &str = "snarkos_queues_peer_events_total";

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -58,6 +58,7 @@ pub mod handshakes {
 pub mod queues {
     pub const INBOUND: &str = "snarkos_queues_inbound_total";
     pub const OUTBOUND: &str = "snarkos_queues_outbound_total";
+    pub const PEER_EVENTS: &str = "snarkos_queues_peer_events_total";
     pub const STORAGE: &str = "snarkos_queues_storage_total";
 }
 

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -109,6 +109,8 @@ pub struct NodeHandshakeStats {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NodeQueueStats {
+    /// The number of queued consensus requests.
+    pub consensus: u64,
     /// The number of messages queued in the common inbound channel.
     pub inbound: u64,
     /// The number of messages queued in the individual outbound channels.

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -117,6 +117,8 @@ pub struct NodeQueueStats {
     pub peer_events: u64,
     /// The number of queued storage requests.
     pub storage: u64,
+    /// The number of queued sync items.
+    pub sync_items: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -113,6 +113,8 @@ pub struct NodeQueueStats {
     pub inbound: u64,
     /// The number of messages queued in the individual outbound channels.
     pub outbound: u64,
+    /// The number of queued storage requests.
+    pub storage: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -113,6 +113,8 @@ pub struct NodeQueueStats {
     pub inbound: u64,
     /// The number of messages queued in the individual outbound channels.
     pub outbound: u64,
+    /// The number of queued peer events.
+    pub peer_events: u64,
     /// The number of queued storage requests.
     pub storage: u64,
 }

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -252,6 +252,8 @@ pub struct QueueStats {
     inbound: DiscreteGauge,
     /// The number of messages queued in the individual outbound channels.
     outbound: DiscreteGauge,
+    /// The number of queued storage requests.
+    storage: DiscreteGauge,
 }
 
 impl QueueStats {
@@ -259,6 +261,7 @@ impl QueueStats {
         Self {
             inbound: DiscreteGauge::new(),
             outbound: DiscreteGauge::new(),
+            storage: DiscreteGauge::new(),
         }
     }
 
@@ -266,6 +269,7 @@ impl QueueStats {
         NodeQueueStats {
             inbound: self.inbound.read(),
             outbound: self.outbound.read(),
+            storage: self.storage.read(),
         }
     }
 }
@@ -368,6 +372,7 @@ impl Recorder for Stats {
             // queues
             queues::INBOUND => &self.queues.inbound,
             queues::OUTBOUND => &self.queues.outbound,
+            queues::STORAGE => &self.queues.storage,
             // misc
             misc::BLOCK_HEIGHT => &self.misc.block_height,
             // connections

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -248,6 +248,8 @@ impl HandshakeStats {
 }
 
 pub struct QueueStats {
+    /// The number of queued consensus items.
+    consensus: DiscreteGauge,
     /// The number of messages queued in the common inbound channel.
     inbound: DiscreteGauge,
     /// The number of messages queued in the individual outbound channels.
@@ -263,6 +265,7 @@ pub struct QueueStats {
 impl QueueStats {
     const fn new() -> Self {
         Self {
+            consensus: DiscreteGauge::new(),
             inbound: DiscreteGauge::new(),
             outbound: DiscreteGauge::new(),
             peer_events: DiscreteGauge::new(),
@@ -273,6 +276,7 @@ impl QueueStats {
 
     pub fn snapshot(&self) -> NodeQueueStats {
         NodeQueueStats {
+            consensus: self.consensus.read(),
             inbound: self.inbound.read(),
             outbound: self.outbound.read(),
             peer_events: self.peer_events.read(),

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -252,6 +252,8 @@ pub struct QueueStats {
     inbound: DiscreteGauge,
     /// The number of messages queued in the individual outbound channels.
     outbound: DiscreteGauge,
+    /// The number of queued peer events.
+    peer_events: DiscreteGauge,
     /// The number of queued storage requests.
     storage: DiscreteGauge,
 }
@@ -261,6 +263,7 @@ impl QueueStats {
         Self {
             inbound: DiscreteGauge::new(),
             outbound: DiscreteGauge::new(),
+            peer_events: DiscreteGauge::new(),
             storage: DiscreteGauge::new(),
         }
     }
@@ -269,6 +272,7 @@ impl QueueStats {
         NodeQueueStats {
             inbound: self.inbound.read(),
             outbound: self.outbound.read(),
+            peer_events: self.peer_events.read(),
             storage: self.storage.read(),
         }
     }
@@ -372,6 +376,7 @@ impl Recorder for Stats {
             // queues
             queues::INBOUND => &self.queues.inbound,
             queues::OUTBOUND => &self.queues.outbound,
+            queues::PEER_EVENTS => &self.queues.peer_events,
             queues::STORAGE => &self.queues.storage,
             // misc
             misc::BLOCK_HEIGHT => &self.misc.block_height,

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -256,6 +256,8 @@ pub struct QueueStats {
     peer_events: DiscreteGauge,
     /// The number of queued storage requests.
     storage: DiscreteGauge,
+    /// The number of queued sync items.
+    sync_items: DiscreteGauge,
 }
 
 impl QueueStats {
@@ -265,6 +267,7 @@ impl QueueStats {
             outbound: DiscreteGauge::new(),
             peer_events: DiscreteGauge::new(),
             storage: DiscreteGauge::new(),
+            sync_items: DiscreteGauge::new(),
         }
     }
 
@@ -274,6 +277,7 @@ impl QueueStats {
             outbound: self.outbound.read(),
             peer_events: self.peer_events.read(),
             storage: self.storage.read(),
+            sync_items: self.sync_items.read(),
         }
     }
 }

--- a/network/src/peers/peer/connector.rs
+++ b/network/src/peers/peer/connector.rs
@@ -77,6 +77,8 @@ impl Peer {
                         })
                         .await
                         .ok();
+                    metrics::increment_gauge!(snarkos_metrics::queues::PEER_EVENTS, 1.0);
+
                     if let Err(e) = self.run(node, network, receiver).await {
                         if !e.is_trivial() {
                             self.fail();
@@ -103,6 +105,7 @@ impl Peer {
                 })
                 .await
                 .ok();
+            metrics::increment_gauge!(snarkos_metrics::queues::PEER_EVENTS, 1.0);
         });
     }
 

--- a/network/src/peers/peer/receiver.rs
+++ b/network/src/peers/peer/receiver.rs
@@ -41,6 +41,7 @@ impl Peer {
                         })
                         .await
                         .ok();
+                    metrics::increment_gauge!(snarkos_metrics::queues::PEER_EVENTS, 1.0);
                     return;
                 }
                 Ok(x) => x,
@@ -58,6 +59,8 @@ impl Peer {
                 })
                 .await
                 .ok();
+            metrics::increment_gauge!(snarkos_metrics::queues::PEER_EVENTS, 1.0);
+
             if let Err(e) = peer.run(node, network, receiver).await {
                 if !e.is_trivial() {
                     peer.fail();
@@ -81,6 +84,7 @@ impl Peer {
                 })
                 .await
                 .ok();
+            metrics::increment_gauge!(snarkos_metrics::queues::PEER_EVENTS, 1.0);
         });
     }
 

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -53,6 +53,8 @@ impl PeerBookRef {
     // gets terminated when sender is dropped from PeerBook
     async fn handle_peer_events(self, mut receiver: mpsc::Receiver<PeerEvent>) {
         while let Some(event) = receiver.recv().await {
+            metrics::decrement_gauge!(snarkos_metrics::queues::PEER_EVENTS, 1.0);
+
             match event.data {
                 PeerEventData::Connected(handle) => {
                     self.pending_connections.fetch_sub(1, Ordering::SeqCst);

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -88,6 +88,7 @@ impl Node {
                     .send(SyncInbound::Block(remote_address, block, height))
                     .await
                     .ok();
+                metrics::increment_gauge!(snarkos_metrics::queues::SYNC_ITEMS, 1.0);
             }
         }
         Ok(())
@@ -200,6 +201,7 @@ impl Node {
                 .send(SyncInbound::BlockHashes(remote_address, block_hashes))
                 .await
                 .ok();
+            metrics::increment_gauge!(snarkos_metrics::queues::SYNC_ITEMS, 1.0);
         }
     }
 }

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -149,6 +149,7 @@ impl SyncMaster {
                     if msg.is_none() {
                         break;
                     }
+                    metrics::decrement_gauge!(snarkos_metrics::queues::SYNC_ITEMS, 1.0);
                     if handler(msg.unwrap()) {
                         break;
                     }
@@ -391,5 +392,11 @@ impl SyncMaster {
 
         self.node.finished_syncing_blocks();
         Ok(())
+    }
+}
+
+impl Drop for SyncMaster {
+    fn drop(&mut self) {
+        metrics::gauge!(snarkos_metrics::queues::SYNC_ITEMS, 0.0);
     }
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -35,6 +35,9 @@ version = "=0.7.9"
 [dependencies.snarkvm-utilities]
 version = "=0.7.9"
 
+[dependencies.snarkos-metrics]
+path = "../metrics"
+
 [dependencies.snarkos-parameters]
 path = "../parameters"
 version = "1.3.13"

--- a/storage/src/key_value/agent/mod.rs
+++ b/storage/src/key_value/agent/mod.rs
@@ -237,6 +237,7 @@ impl<S: KeyValueStorage + Validator + 'static> Agent<S> {
 
     pub(super) fn agent(mut self, mut receiver: mpsc::Receiver<MessageWrapper>) {
         while let Some((message, response)) = receiver.blocking_recv() {
+            metrics::decrement_gauge!(queues::STORAGE, 1.0);
             let out = self.handle_message(message);
             response.send(out).ok();
         }

--- a/storage/src/key_value/mod.rs
+++ b/storage/src/key_value/mod.rs
@@ -20,6 +20,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::{BlockFilter, Digest, FixMode, SerialBlock, SerialRecord};
 use anyhow::*;
+use snarkos_metrics::{self as metrics, queues};
 
 mod storage;
 pub use storage::*;
@@ -179,6 +180,7 @@ impl KeyValueStore {
     async fn send<T: Send + Sync + 'static>(&self, message: Message) -> T {
         let (sender, receiver) = oneshot::channel();
         self.sender.send((message, sender)).await.ok();
+        metrics::increment_gauge!(queues::STORAGE, 1.0);
         *receiver
             .await
             .ok()


### PR DESCRIPTION
This PR introduces 4 new queue-related metrics and includes them in the example `grafana` dashboard; the queues that receive these new metrics are:
- the sync master queue
- the consensus agent queue
- the storage agent queue
- the peer event queue