### PR TITLE
Introduce the internal RTT metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,8 +2750,11 @@ dependencies = [
 name = "snarkos-metrics"
 version = "1.3.14"
 dependencies = [
+ "circular-queue",
  "metrics",
  "metrics-exporter-prometheus",
+ "once_cell",
+ "parking_lot",
  "serde",
  "snarkvm-derives",
  "tokio",

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -21,12 +21,21 @@ edition = "2018"
 std = [ ]
 prometheus = [ "metrics-exporter-prometheus" ]
 
+[dependencies.circular-queue]
+version = "0.2"
+
 [dependencies.metrics]
 version = "0.17"
 
 [dependencies.metrics-exporter-prometheus]
 version = "0.6"
 optional = true
+
+[dependencies.once_cell]
+version = "1.8.0"
+
+[dependencies.parking_lot]
+version = "0.11.1"
 
 [dependencies.serde]
 version = "1.0"

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -1101,12 +1101,12 @@
     "list": []
   },
   "time": {
-    "from": "now-1m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "snarkOS node",
   "uid": "PAzNcaCGz",
-  "version": 10
+  "version": 11
 }

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -26,6 +26,107 @@
   "panels": [
     {
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "rgba(128, 128, 128, 0)",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgb(140, 140, 140)",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 2,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_misc_block_height_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "block height",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_misc_blocks_mined_total",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "mined blocks",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_misc_duplicate_blocks_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "duplicate Blocks",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_misc_duplicate_sync_blocks_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "duplicate SyncBlocks",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_misc_rpc_requests_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "RPC requests",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_misc_orphan_blocks_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Orphan blocks",
+          "refId": "F"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "miscellaneous",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -55,14 +156,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "spanNulls": true
           },
           "decimals": 0,
           "mappings": [],
@@ -86,8 +180,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 11,
-        "x": 0,
+        "w": 10,
+        "x": 2,
         "y": 0
       },
       "id": 6,
@@ -105,6 +199,9 @@
         },
         "tooltip": {
           "mode": "multi"
+        },
+        "tooltipOptions": {
+          "mode": "single"
         }
       },
       "pluginVersion": "7.5.6",
@@ -141,28 +238,470 @@
     },
     {
       "datasource": null,
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
             "hideFrom": {
+              "graph": false,
               "legend": false,
               "tooltip": false,
               "viz": false
-            }
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
           },
-          "mappings": []
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 7,
-        "x": 11,
+        "h": 14,
+        "w": 12,
+        "x": 12,
         "y": 0
+      },
+      "id": 10,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "mean",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_inbound_total",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "inbound network messages",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_outbound_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "outbound network message",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_storage_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "storage requests",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_peer_events_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "peer events",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_sync_items_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "sync items",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_consensus_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "consensus requests",
+          "refId": "F"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "queued messages",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "id": 14,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_connections_all_accepted_total",
+          "interval": "",
+          "legendFormat": "accepted",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_connections_all_rejected_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "rejected",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_connections_all_initiated_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "initiated",
+          "refId": "C"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "all connections",
+      "type": "piechart"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_handshakes_successes_init_total",
+          "interval": "",
+          "legendFormat": "successes as inititiator",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_handshakes_failures_init_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "failures as initiator",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_handshakes_successes_resp_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "successes as responder",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_handshakes_failures_resp_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "failures as responder",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_handshakes_timeouts_init_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "timeouts as initiator",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_handshakes_timeouts_resp_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "timeouts as responder",
+          "refId": "F"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "handshakes",
+      "type": "piechart"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 18,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_getpeers_sum[$__rate_interval])/rate(snarkos_internal_rtt_getpeers_count[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "GetPeers",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_getsync_sum[$__rate_interval])/rate(snarkos_internal_rtt_getsync_count[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetSync",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_getblocks_sum[$__rate_interval])/rate(snarkos_internal_rtt_getblocks_count[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetBlocks",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_getmemorypool_sum[$__rate_interval])/rate(snarkos_internal_rtt_getmemorypool_count[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetMemoryPool",
+          "refId": "D"
+        }
+      ],
+      "title": "average internal RTT per message type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
       },
       "id": 2,
       "options": {
@@ -192,6 +731,7 @@
         {
           "exemplar": true,
           "expr": "snarkos_inbound_blocks_total",
+          "format": "time_series",
           "hide": false,
           "interval": "",
           "legendFormat": "Block",
@@ -294,85 +834,6 @@
     },
     {
       "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 14,
-      "options": {
-        "displayLabels": [],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "values": [
-            "percent"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "pluginVersion": "7.5.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "snarkos_connections_all_accepted_total",
-          "interval": "",
-          "legendFormat": "accepted",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_connections_all_rejected_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "rejected",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_connections_all_initiated_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "initiated",
-          "refId": "C"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "all connections",
-      "type": "piechart"
-    },
-    {
-      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -388,30 +849,18 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false,
-              "viz": false
+              "tooltip": false
             },
             "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "spanNulls": true
           },
           "mappings": [],
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -420,142 +869,30 @@
                 "value": null
               },
               {
-                "color": "#EAB839",
-                "value": 500
-              },
-              {
                 "color": "red",
-                "value": 1000
+                "value": 80
               }
             ]
           },
-          "unit": "none"
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 15,
-        "w": 11,
-        "x": 0,
-        "y": 10
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 25
       },
-      "id": 10,
+      "id": 20,
       "options": {
         "graph": {},
         "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
+          "calcs": [],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "pluginVersion": "7.5.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "snarkos_queues_inbound_total",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "inbound network messages",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_queues_outbound_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "outbound network message",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_queues_storage_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "storage requests",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_queues_peer_events_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "peer events",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_queues_sync_items_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "sync items",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_queues_consensus_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "consensus requests",
-          "refId": "F"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "queued messages",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 7,
-        "x": 11,
-        "y": 10
-      },
-      "id": 8,
-      "options": {
-        "displayLabels": [],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "values": [
-            "percent"
-          ]
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "tooltip": {
+        "tooltipOptions": {
           "mode": "single"
         }
       },
@@ -563,56 +900,46 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snarkos_handshakes_successes_init_total",
+          "expr": "histogram_quantile(0.999, sum(rate(snarkos_internal_rtt_getpeers_bucket[$__rate_interval])) by (le))",
           "interval": "",
-          "legendFormat": "successes as inititiator",
+          "legendFormat": "P999",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_handshakes_failures_init_total",
+          "expr": "histogram_quantile(0.99, sum(rate(snarkos_internal_rtt_getpeers_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "failures as initiator",
+          "legendFormat": "P99",
           "refId": "B"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_handshakes_successes_resp_total",
+          "expr": "histogram_quantile(0.90, sum(rate(snarkos_internal_rtt_getpeers_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "successes as responder",
+          "legendFormat": "P90",
           "refId": "C"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_handshakes_failures_resp_total",
+          "expr": "histogram_quantile(0.75, sum(rate(snarkos_internal_rtt_getpeers_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "failures as responder",
+          "legendFormat": "P75",
           "refId": "D"
         },
         {
           "exemplar": true,
-          "expr": "snarkos_handshakes_timeouts_init_total",
+          "expr": "histogram_quantile(0.5, sum(rate(snarkos_internal_rtt_getpeers_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "timeouts as initiator",
+          "legendFormat": "P50",
           "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_handshakes_timeouts_resp_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "timeouts as responder",
-          "refId": "F"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "handshakes",
-      "type": "piechart"
+      "title": "internal RTT percentiles (GetPeers)",
+      "type": "timeseries"
     },
     {
       "datasource": null,
@@ -622,22 +949,28 @@
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 6,
-        "x": 18,
-        "y": 10
+        "x": 0,
+        "y": 26
       },
       "id": 16,
       "options": {
@@ -645,9 +978,7 @@
         "legend": {
           "displayMode": "list",
           "placement": "right",
-          "values": [
-            "percent"
-          ]
+          "values": []
         },
         "pieType": "pie",
         "reduceOptions": {
@@ -657,10 +988,7 @@
           "fields": "",
           "values": false
         },
-        "text": {},
-        "tooltip": {
-          "mode": "single"
-        }
+        "text": {}
       },
       "pluginVersion": "7.5.6",
       "targets": [
@@ -680,6 +1008,8 @@
           "refId": "B"
         }
       ],
+      "timeFrom": null,
+      "timeShift": null,
       "title": "all processed inbound messages",
       "type": "piechart"
     },
@@ -691,22 +1021,28 @@
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 6,
-        "x": 18,
-        "y": 20
+        "x": 6,
+        "y": 26
       },
       "id": 4,
       "options": {
@@ -753,111 +1089,10 @@
       "timeShift": null,
       "title": "outbound messages",
       "type": "piechart"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "rgba(128, 128, 128, 0)",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "rgb(140, 140, 140)",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 11,
-        "x": 0,
-        "y": 25
-      },
-      "id": 12,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.1.2",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "snarkos_misc_block_height_total",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "block height",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_misc_blocks_mined_total",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "mined blocks",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_misc_duplicate_blocks_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "duplicate Blocks",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_misc_duplicate_sync_blocks_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "duplicate SyncBlocks",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_misc_rpc_requests_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "RPC requests",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "snarkos_misc_orphan_blocks_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Orphan blocks",
-          "refId": "F"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "miscellaneous",
-      "type": "stat"
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 30,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "prometheus"
@@ -866,12 +1101,12 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "snarkOS node",
   "uid": "PAzNcaCGz",
-  "version": 55
+  "version": 10
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -71,7 +71,10 @@ impl Recorder for CombinedRecorder {
 
 #[cfg(feature = "prometheus")]
 pub fn initialize() -> Option<tokio::task::JoinHandle<()>> {
-    let prometheus_builder = metrics_exporter_prometheus::PrometheusBuilder::new();
+    let prometheus_builder = metrics_exporter_prometheus::PrometheusBuilder::new().set_buckets(&[
+        0.00001, 0.000025, 0.00005, 0.000075, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0,
+        30.0,
+    ]);
 
     let (prometheus_recorder, exporter) = prometheus_builder
         .build_with_exporter()

--- a/metrics/src/metric_types.rs
+++ b/metrics/src/metric_types.rs
@@ -138,6 +138,7 @@ pub struct CircularHistogram(OnceCell<RwLock<CircularQueue<f64>>>);
 #[allow(dead_code)]
 impl CircularHistogram {
     pub(crate) const fn new() -> Self {
+        // The cell allows the creation of the object in a const fn.
         Self(OnceCell::new())
     }
 

--- a/metrics/src/metric_types.rs
+++ b/metrics/src/metric_types.rs
@@ -130,7 +130,7 @@ impl Gauge {
 use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
 
-const QUEUE_CAPACITY: usize = 1024;
+const QUEUE_CAPACITY: usize = 256;
 
 /// A histogram backed by a circular queue.
 pub struct CircularHistogram(OnceCell<RwLock<CircularQueue<f64>>>);

--- a/metrics/src/metric_types.rs
+++ b/metrics/src/metric_types.rs
@@ -16,6 +16,8 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use circular_queue::CircularQueue;
+
 /// Mimics a [`metrics-core`] monotonically increasing [`Counter`] type
 pub struct Counter(AtomicU64);
 
@@ -122,5 +124,42 @@ impl Gauge {
                 return;
             }
         }
+    }
+}
+
+use once_cell::sync::OnceCell;
+use parking_lot::RwLock;
+
+const QUEUE_CAPACITY: usize = 1024;
+
+/// A histogram backed by a circular queue.
+pub struct CircularHistogram(OnceCell<RwLock<CircularQueue<f64>>>);
+
+#[allow(dead_code)]
+impl CircularHistogram {
+    pub(crate) const fn new() -> Self {
+        Self(OnceCell::new())
+    }
+
+    /// Push the value into the queue.
+    #[inline]
+    pub(crate) fn push(&self, val: f64) {
+        self.0
+            .get_or_init(|| RwLock::new(CircularQueue::with_capacity(QUEUE_CAPACITY)))
+            .write()
+            .push(val);
+    }
+
+    /// Computes the average over the stored values in the queue.
+    #[inline]
+    pub(crate) fn average(&self) -> f64 {
+        let queue_r = self
+            .0
+            .get_or_init(|| RwLock::new(CircularQueue::with_capacity(QUEUE_CAPACITY)))
+            .read();
+
+        let sum: f64 = queue_r.iter().copied().sum();
+
+        sum / queue_r.len() as f64
     }
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -71,4 +71,5 @@ pub mod misc {
     pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_misc_duplicate_sync_blocks_total";
     pub const ORPHAN_BLOCKS: &str = "snarkos_misc_orphan_blocks_total";
     pub const RPC_REQUESTS: &str = "snarkos_misc_rpc_requests_total";
+    pub const INTERNAL_RTT: &str = "snarkos_misc_internal_rtt";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -71,5 +71,9 @@ pub mod misc {
     pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_misc_duplicate_sync_blocks_total";
     pub const ORPHAN_BLOCKS: &str = "snarkos_misc_orphan_blocks_total";
     pub const RPC_REQUESTS: &str = "snarkos_misc_rpc_requests_total";
-    pub const INTERNAL_RTT: &str = "snarkos_misc_internal_rtt";
+}
+
+pub mod internal_rtt {
+    pub const GETSYNC: &str = "snarkos_internal_rtt_getsync";
+    pub const GETPEERS: &str = "snarkos_internal_rtt_getpeers";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -74,6 +74,8 @@ pub mod misc {
 }
 
 pub mod internal_rtt {
-    pub const GETSYNC: &str = "snarkos_internal_rtt_getsync";
     pub const GETPEERS: &str = "snarkos_internal_rtt_getpeers";
+    pub const GETSYNC: &str = "snarkos_internal_rtt_getsync";
+    pub const GETBLOCKS: &str = "snarkos_internal_rtt_getblocks";
+    pub const GETMEMORYPOOL: &str = "snarkos_internal_rtt_getmemorypool";
 }

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -143,12 +143,12 @@ pub struct NodeMiscStats {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeInternalRttStats {
-    /// The average internal RTT for `GetPeer` queries.
+    /// The average internal RTT for `GetPeer` queries (in seconds).
     pub getpeers: f64,
-    /// The average internal RTT for `GetSync` queries.
+    /// The average internal RTT for `GetSync` queries (in seconds).
     pub getsync: f64,
-    /// The average internal RTT for `GetBlocks` queries.
+    /// The average internal RTT for `GetBlocks` queries (in seconds).
     pub getblocks: f64,
-    /// The average internal RTT for `GetMemoryPool` queries.
+    /// The average internal RTT for `GetMemoryPool` queries (in seconds).
     pub getmemorypool: f64,
 }

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -17,7 +17,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Returned value for the `getnodestats` rpc call
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeStats {
     /// Stats related to messages received by the node.
     pub inbound: NodeInboundStats,
@@ -31,6 +31,8 @@ pub struct NodeStats {
     pub queues: NodeQueueStats,
     /// Miscellaneous stats related to the node.
     pub misc: NodeMiscStats,
+    /// The node's internal RTT from message received to response sent.
+    pub internal_rtt: NodeInternalRttStats,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -137,4 +139,16 @@ pub struct NodeMiscStats {
     pub orphan_blocks: u64,
     /// The number of RPC requests received.
     pub rpc_requests: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeInternalRttStats {
+    /// The average internal RTT for `GetPeer` queries.
+    pub getpeers: f64,
+    /// The average internal RTT for `GetSync` queries.
+    pub getsync: f64,
+    /// The average internal RTT for `GetBlocks` queries.
+    pub getblocks: f64,
+    /// The average internal RTT for `GetMemoryPool` queries.
+    pub getmemorypool: f64,
 }

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -46,7 +46,7 @@ pub struct Stats {
     queues: QueueStats,
     /// Miscellaneous stats related to the node.
     misc: MiscStats,
-    /// The node's internal RTT from message received to response sent.
+    /// The node's internal RTT from message received to response sent (in seconds).
     internal_rtt: InternalRtt,
 }
 

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -17,12 +17,13 @@
 use metrics::{GaugeValue, Key, Recorder, Unit};
 
 use crate::{
-    metric_types::{Counter, DiscreteGauge},
+    metric_types::{CircularHistogram, Counter, DiscreteGauge},
     names::*,
     snapshots::{
         NodeConnectionStats,
         NodeHandshakeStats,
         NodeInboundStats,
+        NodeInternalRttStats,
         NodeMiscStats,
         NodeOutboundStats,
         NodeQueueStats,
@@ -45,6 +46,8 @@ pub struct Stats {
     queues: QueueStats,
     /// Miscellaneous stats related to the node.
     misc: MiscStats,
+    /// The node's internal RTT from message received to response sent.
+    internal_rtt: InternalRtt,
 }
 
 impl Stats {
@@ -56,6 +59,7 @@ impl Stats {
             handshakes: HandshakeStats::new(),
             queues: QueueStats::new(),
             misc: MiscStats::new(),
+            internal_rtt: InternalRtt::new(),
         }
     }
 
@@ -67,6 +71,7 @@ impl Stats {
             handshakes: self.handshakes.snapshot(),
             queues: self.queues.snapshot(),
             misc: self.misc.snapshot(),
+            internal_rtt: self.internal_rtt.snapshot(),
         }
     }
 }
@@ -324,6 +329,35 @@ impl MiscStats {
     }
 }
 
+/// Each histogram holds the last 1024 measurements for internal RTT for the indicated message
+/// type. The snapshot produced for the RPC stats is the average RTT for each set.
+pub struct InternalRtt {
+    getpeers: CircularHistogram,
+    getsync: CircularHistogram,
+    getblocks: CircularHistogram,
+    getmemorypool: CircularHistogram,
+}
+
+impl InternalRtt {
+    const fn new() -> Self {
+        Self {
+            getpeers: CircularHistogram::new(),
+            getsync: CircularHistogram::new(),
+            getblocks: CircularHistogram::new(),
+            getmemorypool: CircularHistogram::new(),
+        }
+    }
+
+    pub fn snapshot(&self) -> NodeInternalRttStats {
+        NodeInternalRttStats {
+            getpeers: self.getpeers.average(),
+            getsync: self.getsync.average(),
+            getblocks: self.getblocks.average(),
+            getmemorypool: self.getmemorypool.average(),
+        }
+    }
+}
+
 impl Recorder for Stats {
     // The following are unused in Stats
     fn register_counter(&self, _key: &Key, _unit: Option<Unit>, _desc: Option<&'static str>) {}
@@ -332,7 +366,17 @@ impl Recorder for Stats {
 
     fn register_histogram(&self, _key: &Key, _unit: Option<Unit>, _desc: Option<&'static str>) {}
 
-    fn record_histogram(&self, _key: &Key, _value: f64) {}
+    fn record_histogram(&self, key: &Key, value: f64) {
+        let metric = match key.name() {
+            internal_rtt::GETPEERS => &self.internal_rtt.getpeers,
+            internal_rtt::GETSYNC => &self.internal_rtt.getsync,
+            internal_rtt::GETBLOCKS => &self.internal_rtt.getblocks,
+            internal_rtt::GETMEMORYPOOL => &self.internal_rtt.getmemorypool,
+            _ => return,
+        };
+
+        metric.push(value);
+    }
 
     fn increment_counter(&self, key: &Key, value: u64) {
         let metric = match key.name() {

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -329,7 +329,7 @@ impl MiscStats {
     }
 }
 
-/// Each histogram holds the last 1024 measurements for internal RTT for the indicated message
+/// Each histogram holds the last `QUEUE_CAPACITY` (see `metric_types` mod) measurements for internal RTT for the indicated message
 /// type. The snapshot produced for the RPC stats is the average RTT for each set.
 pub struct InternalRtt {
     getpeers: CircularHistogram,

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::{
     net::TcpListener,
@@ -220,7 +220,7 @@ impl Node {
     }
 
     #[inline]
-    pub(crate) fn route(&self, time_received: Option<std::time::Instant>, response: Message) {
+    pub(crate) fn route(&self, time_received: Option<Instant>, response: Message) {
         match self.inbound.sender.try_send((time_received, response)) {
             Err(TrySendError::Full((_, msg))) => {
                 metrics::increment_counter!(inbound::ALL_FAILURES);

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -199,7 +199,7 @@ impl Node {
             Payload::GetPeers => {
                 metrics::increment_counter!(inbound::GETPEERS);
 
-                self.send_peers(source).await;
+                self.send_peers(source, time_received).await;
             }
             Payload::Peers(peers) => {
                 metrics::increment_counter!(inbound::PEERS);

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -88,6 +88,6 @@ pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 // TODO (raychu86): Establish a formal node version.
 pub const PROTOCOL_VERSION: u64 = 2;
 
-pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
+pub(crate) type Sender = tokio::sync::mpsc::Sender<(std::time::Instant, Message)>;
 
-pub(crate) type Receiver = tokio::sync::mpsc::Receiver<Message>;
+pub(crate) type Receiver = tokio::sync::mpsc::Receiver<(std::time::Instant, Message)>;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -88,6 +88,6 @@ pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 // TODO (raychu86): Establish a formal node version.
 pub const PROTOCOL_VERSION: u64 = 2;
 
-pub(crate) type Sender = tokio::sync::mpsc::Sender<(std::time::Instant, Message)>;
+pub(crate) type Sender = tokio::sync::mpsc::Sender<(Option<std::time::Instant>, Message)>;
 
-pub(crate) type Receiver = tokio::sync::mpsc::Receiver<(std::time::Instant, Message)>;
+pub(crate) type Receiver = tokio::sync::mpsc::Receiver<(Option<std::time::Instant>, Message)>;

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -30,7 +30,7 @@ use std::{
         Arc,
     },
     thread,
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::{
     sync::{mpsc, Mutex, RwLock},
@@ -177,6 +177,14 @@ impl Node {
 
     pub fn known_network(&self) -> Option<&KnownNetwork> {
         self.known_network.get()
+    }
+
+    pub async fn clock_now(&self) -> Instant {
+        *self.clock.read().await
+    }
+
+    pub async fn clock_elapsed(&self, start: &Instant) -> Duration {
+        self.clock_now().await - *start
     }
 
     pub async fn start_services(&self) {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -30,7 +30,6 @@ use std::{
         Arc,
     },
     thread,
-    time::{Duration, Instant},
 };
 use tokio::{
     sync::{mpsc, Mutex, RwLock},
@@ -81,9 +80,6 @@ pub struct InnerNode {
     shutting_down: AtomicBool,
     pub(crate) master_dispatch: RwLock<Option<mpsc::Sender<SyncInbound>>>,
     pub terminator: Arc<AtomicBool>,
-
-    // Atomic?
-    pub clock: RwLock<Instant>,
 }
 
 /// A core data structure for operating the networking stack of this node.
@@ -140,7 +136,6 @@ impl Node {
             shutting_down: Default::default(),
             master_dispatch: RwLock::new(None),
             terminator: Arc::new(AtomicBool::new(false)),
-            clock: RwLock::new(Instant::now()),
         }));
 
         if node.config.is_crawler() {
@@ -179,51 +174,7 @@ impl Node {
         self.known_network.get()
     }
 
-    pub async fn clock_now(&self) -> Instant {
-        *self.clock.read().await
-    }
-
-    pub async fn clock_elapsed(&self, start: &Instant) -> Duration {
-        self.clock_now().await - *start
-    }
-
     pub async fn start_services(&self) {
-        let node_clone = self.clone();
-        let clock_task = task::spawn(async move {
-            // Reset the time before the loop starts.
-            {
-                let mut time_g = node_clone.clock.write().await;
-                *time_g = Instant::now();
-            }
-
-            let mut count = 0;
-
-            loop {
-                // Reset the clock with a syscall every 10 cycles.
-                if count == 9 {
-                    {
-                        let mut time_g = node_clone.clock.write().await;
-                        *time_g = Instant::now();
-                    }
-
-                    count = 0;
-                } else {
-                    let interval = std::time::Duration::from_millis(10);
-
-                    sleep(interval).await;
-
-                    // Scope the write lock.
-                    {
-                        let mut time_g = node_clone.clock.write().await;
-                        *time_g = time_g.checked_add(interval).unwrap();
-                    }
-
-                    count += 1;
-                }
-            }
-        });
-        self.register_task(clock_task);
-
         let node_clone = self.clone();
         let mut receiver = self.inbound.take_receiver().await;
         let incoming_task = task::spawn(async move {

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -30,7 +30,7 @@ impl Peer {
         &mut self,
         node: &Node,
         network: &mut PeerIOHandle,
-        time_received: std::time::Instant,
+        time_received: Option<std::time::Instant>,
         payload: Result<Payload, NetworkError>,
     ) -> Result<(), NetworkError> {
         let payload = payload?;
@@ -107,7 +107,7 @@ impl Peer {
         &mut self,
         node: &Node,
         network: &mut PeerIOHandle,
-        time_received: std::time::Instant,
+        time_received: Option<std::time::Instant>,
         payload: Result<Payload, NetworkError>,
     ) -> Result<(), NetworkError> {
         match self.inner_dispatch_payload(node, network, time_received, payload).await {

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -25,12 +25,14 @@ use crate::{Direction, KnownNetworkMessage, Message, NetworkError, Node, Payload
 
 use super::network::PeerIOHandle;
 
+use std::time::Instant;
+
 impl Peer {
     pub(super) async fn inner_dispatch_payload(
         &mut self,
         node: &Node,
         network: &mut PeerIOHandle,
-        time_received: Option<std::time::Instant>,
+        time_received: Option<Instant>,
         payload: Result<Payload, NetworkError>,
     ) -> Result<(), NetworkError> {
         let payload = payload?;
@@ -107,7 +109,7 @@ impl Peer {
         &mut self,
         node: &Node,
         network: &mut PeerIOHandle,
-        time_received: Option<std::time::Instant>,
+        time_received: Option<Instant>,
         payload: Result<Payload, NetworkError>,
     ) -> Result<(), NetworkError> {
         match self.inner_dispatch_payload(node, network, time_received, payload).await {

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -30,6 +30,7 @@ impl Peer {
         &mut self,
         node: &Node,
         network: &mut PeerIOHandle,
+        time_received: std::time::Instant,
         payload: Result<Payload, NetworkError>,
     ) -> Result<(), NetworkError> {
         let payload = payload?;
@@ -92,7 +93,7 @@ impl Peer {
                     }
                 }
 
-                node.route(Message {
+                node.route(time_received, Message {
                     direction: Direction::Inbound(self.address),
                     payload,
                 });
@@ -106,9 +107,10 @@ impl Peer {
         &mut self,
         node: &Node,
         network: &mut PeerIOHandle,
+        time_received: std::time::Instant,
         payload: Result<Payload, NetworkError>,
     ) -> Result<(), NetworkError> {
-        match self.inner_dispatch_payload(node, network, payload).await {
+        match self.inner_dispatch_payload(node, network, time_received, payload).await {
             Ok(()) => (),
             Err(e) => {
                 if e.is_trivial() {

--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -32,7 +32,7 @@ use super::network::PeerIOHandle;
 
 pub(super) enum PeerAction {
     Disconnect,
-    Send(Payload, Option<std::time::Instant>),
+    Send(Payload, Option<Instant>),
     Get(oneshot::Sender<Peer>),
     QualityJudgement,
     CancelSync,
@@ -63,7 +63,7 @@ impl PeerHandle {
         self.sender.send(PeerAction::Disconnect).await.is_ok()
     }
 
-    pub async fn send_payload(&self, payload: Payload, time_received: Option<std::time::Instant>) {
+    pub async fn send_payload(&self, payload: Payload, time_received: Option<Instant>) {
         if self.sender.send(PeerAction::Send(payload, time_received)).await.is_ok() {
             self.queued_outbound_message_count.fetch_add(1, Ordering::SeqCst);
             metrics::increment_gauge!(OUTBOUND, 1.0);

--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -107,8 +107,10 @@ impl Peer {
                 }
 
                 let histogram = match &message {
-                    Payload::SyncBlock(_, _) => Some(metrics::internal_rtt::GETSYNC),
                     Payload::Peers(_) => Some(metrics::internal_rtt::GETPEERS),
+                    Payload::Sync(_) => Some(metrics::internal_rtt::GETSYNC),
+                    Payload::SyncBlock(_, _) => Some(metrics::internal_rtt::GETBLOCKS),
+                    Payload::MemoryPool(_) => Some(metrics::internal_rtt::GETMEMORYPOOL),
                     _ => None,
                 };
 

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -131,6 +131,11 @@ impl Peer {
         let (sender, mut read_receiver) = mpsc::channel::<Result<Vec<u8>, NetworkError>>(8);
         tokio::spawn(async move {
             loop {
+                // Start the clock on the RTT.
+                //
+                // Syscalls are too slow for this purpose, it's likely best to keep track of this
+                // on the node level with a task.
+
                 if sender
                     .send(reader.read_raw_payload().await.map(|x| x.to_vec()))
                     .await

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -157,7 +157,7 @@ impl Peer {
                     if data.is_none() {
                         break;
                     }
-                    let  data = match data.unwrap() {
+                    let data = match data.unwrap() {
                         // decrypt
                         Ok(data) => network.read_payload(&data[..]),
                         Err(e) => Err(e)

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -179,10 +179,12 @@ impl Peer {
 
                     use crate::message::Payload;
 
-                    let time_received = if let Ok(Payload::GetPeers) | Ok(Payload::GetBlocks(_)) = deserialized {
-                        Some(std::time::Instant::now())
-                    } else {
-                        None
+                    let time_received = match deserialized {
+                        Ok(Payload::GetPeers)
+                        | Ok(Payload::GetSync(_))
+                        | Ok(Payload::GetBlocks(_))
+                        | Ok(Payload::GetMemoryPool) => Some(std::time::Instant::now()),
+                        _ => None,
                     };
 
                     self.dispatch_payload(&node, &mut network, time_received, deserialized).await?;

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -213,14 +213,22 @@ impl PeerBook {
         self.for_each_peer(move |peer| {
             let payload = payload.clone();
             async move {
-                peer.send_payload(payload).await;
+                peer.send_payload(payload, None).await;
             }
         })
         .await;
     }
 
-    pub async fn send_to(&self, address: SocketAddr, payload: Payload) -> Option<()> {
-        self.connected_peers.get(&address)?.send_payload(payload).await;
+    pub async fn send_to(
+        &self,
+        address: SocketAddr,
+        payload: Payload,
+        time_received: Option<std::time::Instant>,
+    ) -> Option<()> {
+        self.connected_peers
+            .get(&address)?
+            .send_payload(payload, time_received)
+            .await;
         Some(())
     }
 

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -20,6 +20,7 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc,
     },
+    time::Instant,
 };
 
 use futures::Future;
@@ -219,12 +220,7 @@ impl PeerBook {
         .await;
     }
 
-    pub async fn send_to(
-        &self,
-        address: SocketAddr,
-        payload: Payload,
-        time_received: Option<std::time::Instant>,
-    ) -> Option<()> {
+    pub async fn send_to(&self, address: SocketAddr, payload: Payload, time_received: Option<Instant>) -> Option<()> {
         self.connected_peers
             .get(&address)?
             .send_payload(payload, time_received)

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -301,7 +301,7 @@ impl Node {
         }
     }
 
-    pub(crate) async fn send_peers(&self, remote_address: SocketAddr, time_received: std::time::Instant) {
+    pub(crate) async fn send_peers(&self, remote_address: SocketAddr, time_received: Option<std::time::Instant>) {
         // Broadcast the sanitized list of connected peers back to the requesting peer.
 
         use crate::Peer;
@@ -350,7 +350,7 @@ impl Node {
             .collect();
 
         self.peer_book
-            .send_to(remote_address, Payload::Peers(peers), Some(time_received))
+            .send_to(remote_address, Payload::Peers(peers), time_received)
             .await;
     }
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -301,7 +301,7 @@ impl Node {
         }
     }
 
-    pub(crate) async fn send_peers(&self, remote_address: SocketAddr) {
+    pub(crate) async fn send_peers(&self, remote_address: SocketAddr, time_received: std::time::Instant) {
         // Broadcast the sanitized list of connected peers back to the requesting peer.
 
         use crate::Peer;
@@ -349,7 +349,9 @@ impl Node {
             .copied()
             .collect();
 
-        self.peer_book.send_to(remote_address, Payload::Peers(peers)).await;
+        self.peer_book
+            .send_to(remote_address, Payload::Peers(peers), Some(time_received))
+            .await;
     }
 
     /// A node has sent their list of peer addresses.

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{cmp, net::SocketAddr, time::Duration};
+use std::{
+    cmp,
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
 
 use rand::{prelude::SliceRandom, seq::IteratorRandom};
 use tokio::task;
@@ -301,7 +305,7 @@ impl Node {
         }
     }
 
-    pub(crate) async fn send_peers(&self, remote_address: SocketAddr, time_received: Option<std::time::Instant>) {
+    pub(crate) async fn send_peers(&self, remote_address: SocketAddr, time_received: Option<Instant>) {
         // Broadcast the sanitized list of connected peers back to the requesting peer.
 
         use crate::Peer;

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{net::SocketAddr, sync::atomic::Ordering, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
 
 use snarkos_storage::{BlockStatus, Digest, VMBlock};
 use snarkvm_dpc::{
@@ -155,7 +159,7 @@ impl Node {
         &self,
         remote_address: SocketAddr,
         header_hashes: Vec<Digest>,
-        time_received: Option<std::time::Instant>,
+        time_received: Option<Instant>,
     ) -> Result<(), NetworkError> {
         for (i, hash) in header_hashes
             .into_iter()
@@ -192,7 +196,7 @@ impl Node {
         &self,
         remote_address: SocketAddr,
         block_locator_hashes: Vec<Digest>,
-        time_received: Option<std::time::Instant>,
+        time_received: Option<Instant>,
     ) -> Result<(), NetworkError> {
         let sync_hashes = self
             .storage

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -172,6 +172,7 @@ impl Node {
                 _ => None,
             };
 
+            // Only stop the clock on internal RTT for the last block in the response.
             let time_received = if i == crate::MAX_BLOCK_SYNC_COUNT as usize - 1 {
                 time_received
             } else {

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -155,7 +155,7 @@ impl Node {
         &self,
         remote_address: SocketAddr,
         header_hashes: Vec<Digest>,
-        time_received: std::time::Instant,
+        time_received: Option<std::time::Instant>,
     ) -> Result<(), NetworkError> {
         for (i, hash) in header_hashes
             .into_iter()
@@ -169,7 +169,7 @@ impl Node {
             };
 
             let time_received = if i == crate::MAX_BLOCK_SYNC_COUNT as usize - 1 {
-                Some(time_received)
+                time_received
             } else {
                 None
             };
@@ -192,6 +192,7 @@ impl Node {
         &self,
         remote_address: SocketAddr,
         block_locator_hashes: Vec<Digest>,
+        time_received: Option<std::time::Instant>,
     ) -> Result<(), NetworkError> {
         let sync_hashes = self
             .storage
@@ -204,7 +205,7 @@ impl Node {
 
         // send a `Sync` message to the connected peer.
         self.peer_book
-            .send_to(remote_address, Payload::Sync(sync_hashes), None)
+            .send_to(remote_address, Payload::Sync(sync_hashes), time_received)
             .await;
 
         Ok(())

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -40,7 +40,7 @@ impl Node {
             let mut futures = Vec::with_capacity(connected_peers.len());
             for remote_address in connected_peers.iter() {
                 if remote_address != &block_miner {
-                    futures.push(peer_book.send_to(*remote_address, Payload::Block(block_bytes.clone(), height)));
+                    futures.push(peer_book.send_to(*remote_address, Payload::Block(block_bytes.clone(), height), None));
                 }
             }
             tokio::time::timeout(Duration::from_secs(1), futures::future::join_all(futures))
@@ -165,7 +165,7 @@ impl Node {
 
             // Send a `SyncBlock` message to the connected peer.
             self.peer_book
-                .send_to(remote_address, Payload::SyncBlock(block.serialize(), height))
+                .send_to(remote_address, Payload::SyncBlock(block.serialize(), height), None)
                 .await;
         }
 
@@ -188,7 +188,9 @@ impl Node {
             .ok_or_else(|| anyhow!("invalid block header size in locator hash"))?;
 
         // send a `Sync` message to the connected peer.
-        self.peer_book.send_to(remote_address, Payload::Sync(sync_hashes)).await;
+        self.peer_book
+            .send_to(remote_address, Payload::Sync(sync_hashes), None)
+            .await;
 
         Ok(())
     }

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -121,7 +121,7 @@ impl SyncMaster {
                     .map(|x| BlockHeaderHash(x.bytes::<32>().unwrap()))
                     .collect();
                 future_set.push(async move {
-                    handle.send_payload(Payload::GetSync(block_locator_hashes)).await;
+                    handle.send_payload(Payload::GetSync(block_locator_hashes), None).await;
                 });
             }
         }
@@ -293,7 +293,7 @@ impl SyncMaster {
                     .collect();
                 future_set.push(async move {
                     peer.expecting_sync_blocks(request.len() as u32).await;
-                    peer.send_payload(Payload::GetBlocks(request)).await;
+                    peer.send_payload(Payload::GetBlocks(request), None).await;
                 });
             }
         }

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -20,7 +20,7 @@ use snarkvm_dpc::testnet1::instantiated::Testnet1Transaction;
 use snarkvm_utilities::bytes::{FromBytes, ToBytes};
 
 use anyhow::*;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Instant};
 
 impl Node {
     ///
@@ -83,7 +83,7 @@ impl Node {
     pub(crate) async fn received_get_memory_pool(
         &self,
         remote_address: SocketAddr,
-        time_received: Option<std::time::Instant>,
+        time_received: Option<Instant>,
     ) -> Result<()> {
         let transactions = self
             .expect_sync()

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -30,7 +30,7 @@ impl Node {
         if let Some(sync_node) = sync_node {
             info!("Updating memory pool from {}", sync_node);
 
-            self.peer_book.send_to(sync_node, Payload::GetMemoryPool).await;
+            self.peer_book.send_to(sync_node, Payload::GetMemoryPool, None).await;
         } else {
             debug!("No sync node is registered, memory pool could not be synced");
         }
@@ -52,7 +52,7 @@ impl Node {
             if remote_address != transaction_sender && remote_address != local_address {
                 // Send a `Transaction` message to the connected peer.
                 self.peer_book
-                    .send_to(remote_address, Payload::Transaction(transaction_bytes.clone()))
+                    .send_to(remote_address, Payload::Transaction(transaction_bytes.clone()), None)
                     .await;
             }
         }
@@ -97,7 +97,7 @@ impl Node {
         if !transactions.is_empty() {
             // Send a `MemoryPool` message to the connected peer.
             self.peer_book
-                .send_to(remote_address, Payload::MemoryPool(transactions))
+                .send_to(remote_address, Payload::MemoryPool(transactions), None)
                 .await;
         }
         Ok(())

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -80,7 +80,11 @@ impl Node {
     }
 
     /// A peer has requested our memory pool transactions.
-    pub(crate) async fn received_get_memory_pool(&self, remote_address: SocketAddr) -> Result<()> {
+    pub(crate) async fn received_get_memory_pool(
+        &self,
+        remote_address: SocketAddr,
+        time_received: Option<std::time::Instant>,
+    ) -> Result<()> {
         let transactions = self
             .expect_sync()
             .consensus
@@ -97,7 +101,7 @@ impl Node {
         if !transactions.is_empty() {
             // Send a `MemoryPool` message to the connected peer.
             self.peer_book
-                .send_to(remote_address, Payload::MemoryPool(transactions), None)
+                .send_to(remote_address, Payload::MemoryPool(transactions), time_received)
                 .await;
         }
         Ok(())

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -45,8 +45,12 @@ None
 | `misc.duplicate_sync_blocks`     | u64  | The number of duplicate sync blocks received                                 |
 | `outbound.all_successes`         | u64  | The number of successfully sent messages                                     |
 | `outbound.all_failures`          | u64  | The number of failures to send messages                                      |
-| `queues.inbound`                 | u32  | The number of messages queued in the common inbound channel                  |
-| `queues.outbound`                | u32  | The number of messages queued in the individual outbound channels            |
+| `queues.consensus`               | u64  | The number of queued consensus requests                                      |
+| `queues.inbound`                 | u64  | The number of messages queued in the common inbound channel                  |
+| `queues.outbound`                | u64  | The number of messages queued in the individual outbound channels            |
+| `queues.peer_events`             | u64  | The number of queued peer events                                             |
+| `queues.storage`                 | u64  | The number of queued storage requests                                        |
+| `queues.sync_items`              | u64  | The number of queued sync items                                              |
 
 ### Example
 ```ignore

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -6,43 +6,47 @@ None
 
 ### Response
 
-|             Parameter            | Type |                             Description                           |
-|:--------------------------------:|:----:|:-----------------------------------------------------------------:|
-| `connections.all_accepted`       | u64  | The number of connection requests the node has received           |
-| `connections.all_initiated`      | u64  | The number of connection requests the node has made               |
-| `connections.all_rejected`       | u64  | The number of connection requests the node has rejected           |
-| `connections.connected_peers`    | u16  | The number of currently connected peers                           |
-| `connections.connecting_peers`   | u16  | The number of currently connecting peers                          |
-| `connections.disconnected_peers` | u16  | The number of known disconnected peers                            |
-| `handshakes.failures_init`       | u64  | The number of failed handshakes as the initiator                  |
-| `handshakes.failures_resp`       | u64  | The number of failed handshakes as the responder                  |
-| `handshakes.successes_init`      | u64  | The number of successful handshakes as the initiator              |
-| `handshakes.successes_resp`      | u64  | The number of successful handshakes as the responder              |
-| `handshakes.timeouts_init`       | u64  | The number of handshake timeouts as the initiator                 |
-| `handshakes.timeouts_resp`       | u64  | The number of handshake timeouts as the responder                 |
-| `inbound.all_successes`          | u64  | The number of successfully processed inbound messages             |
-| `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed         |
-| `inbound.blocks`                 | u64  | The number of all received Block messages                         |
-| `inbound.getblocks`              | u64  | The number of all received GetBlocks messages                     |
-| `inbound.getmemorypool`          | u64  | The number of all received GetMemoryPool messages                 |
-| `inbound.getpeers`               | u64  | The number of all received GetPeers messages                      |
-| `inbound.getsync`                | u64  | The number of all received GetSync messages                       |
-| `inbound.memorypool`             | u64  | The number of all received MemoryPool messages                    |
-| `inbound.peers`                  | u64  | The number of all received Peers messages                         |
-| `inbound.pings`                  | u64  | The number of all received Ping messages                          |
-| `inbound.pongs`                  | u64  | The number of all received Pong messages                          |
-| `inbound.syncs`                  | u64  | The number of all received Sync messages                          |
-| `inbound.syncblocks`             | u64  | The number of all received SyncBlock messages                     |
-| `inbound.transactions`           | u64  | The number of all received Transaction messages                   |
-| `inbound.unknown`                | u64  | The number of all received Unknown messages                       |
-| `misc.block_height`              | u32  | The current block height of the node                              |
-| `misc.blocks_mined`              | u32  | The number of blocks the node has mined                           |
-| `misc.duplicate_blocks`          | u64  | The number of duplicate blocks received                           |
-| `misc.duplicate_sync_blocks`     | u64  | The number of duplicate sync blocks received                      |
-| `outbound.all_successes`         | u64  | The number of successfully sent messages                          |
-| `outbound.all_failures`          | u64  | The number of failures to send messages                           |
-| `queues.inbound`                 | u32  | The number of messages queued in the common inbound channel       |
-| `queues.outbound`                | u32  | The number of messages queued in the individual outbound channels |
+| Parameter                        | Type | Description                                                                  |
+| :------------------------------: | :--: | :--------------------------------------------------------------------------: |
+| `connections.all_accepted`       | u64  | The number of connection requests the node has received                      |
+| `connections.all_initiated`      | u64  | The number of connection requests the node has made                          |
+| `connections.all_rejected`       | u64  | The number of connection requests the node has rejected                      |
+| `connections.connected_peers`    | u16  | The number of currently connected peers                                      |
+| `connections.connecting_peers`   | u16  | The number of currently connecting peers                                     |
+| `connections.disconnected_peers` | u16  | The number of known disconnected peers                                       |
+| `handshakes.failures_init`       | u64  | The number of failed handshakes as the initiator                             |
+| `handshakes.failures_resp`       | u64  | The number of failed handshakes as the responder                             |
+| `handshakes.successes_init`      | u64  | The number of successful handshakes as the initiator                         |
+| `handshakes.successes_resp`      | u64  | The number of successful handshakes as the responder                         |
+| `handshakes.timeouts_init`       | u64  | The number of handshake timeouts as the initiator                            |
+| `handshakes.timeouts_resp`       | u64  | The number of handshake timeouts as the responder                            |
+| `inbound.all_successes`          | u64  | The number of successfully processed inbound messages                        |
+| `inbound.all_failures`           | u64  | The number of inbound messages that couldn't be processed                    |
+| `inbound.blocks`                 | u64  | The number of all received Block messages                                    |
+| `inbound.getblocks`              | u64  | The number of all received GetBlocks messages                                |
+| `inbound.getmemorypool`          | u64  | The number of all received GetMemoryPool messages                            |
+| `inbound.getpeers`               | u64  | The number of all received GetPeers messages                                 |
+| `inbound.getsync`                | u64  | The number of all received GetSync messages                                  |
+| `inbound.memorypool`             | u64  | The number of all received MemoryPool messages                               |
+| `inbound.peers`                  | u64  | The number of all received Peers messages                                    |
+| `inbound.pings`                  | u64  | The number of all received Ping messages                                     |
+| `inbound.pongs`                  | u64  | The number of all received Pong messages                                     |
+| `inbound.syncs`                  | u64  | The number of all received Sync messages                                     |
+| `inbound.syncblocks`             | u64  | The number of all received SyncBlock messages                                |
+| `inbound.transactions`           | u64  | The number of all received Transaction messages                              |
+| `inbound.unknown`                | u64  | The number of all received Unknown messages                                  |
+| `internal_rtt.getpeer`           | f64  | The average internal RTT (query to response) for GetPeer messages in seconds |
+| `internal_rtt.getsync`           | f64  | The average internal RTT for GetSync messages in seconds                     |
+| `internal_rtt.getblocks`         | f64  | The average internal RTT for GetBlocks messages in seconds                   |
+| `internal_rtt.getmemorypool`     | f64  | The average internal RTT for GetMemoryPool messages in seconds               |
+| `misc.block_height`              | u32  | The current block height of the node                                         |
+| `misc.blocks_mined`              | u32  | The number of blocks the node has mined                                      |
+| `misc.duplicate_blocks`          | u64  | The number of duplicate blocks received                                      |
+| `misc.duplicate_sync_blocks`     | u64  | The number of duplicate sync blocks received                                 |
+| `outbound.all_successes`         | u64  | The number of successfully sent messages                                     |
+| `outbound.all_failures`          | u64  | The number of failures to send messages                                      |
+| `queues.inbound`                 | u32  | The number of messages queued in the common inbound channel                  |
+| `queues.outbound`                | u32  | The number of messages queued in the individual outbound channels            |
 
 ### Example
 ```ignore


### PR DESCRIPTION
This PR introduces the internal RTT metric (both exposed as an average via rpc and present in grafana/prometheus with percentiles) for the query/response messages: `GetPeers`, `GetSync`, `GetBlocks` and `GetMemoryPool`. 

Block processing time will be measured in a subsquent PR (tracking issue: #1076). 

Closes #1050.