### PR TITLE
Do a better job avoiding mempool syncs and mining when syncing blocks

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2018"
 
 [features]
 prometheus = [ "snarkos-metrics/prometheus" ]
+test = []
 
 [dependencies.snarkvm-algorithms]
 version = "=0.7.9"

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -238,7 +238,6 @@ impl Node {
                     let is_syncing_blocks = node_clone.is_syncing_blocks();
 
                     if !is_syncing_blocks {
-                        node_clone.register_block_sync_attempt();
                         if let Err(e) = node_clone.run_sync().await {
                             error!("failed sync process: {:?}", e);
                         }

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -22,6 +22,8 @@ use chrono::{DateTime, Utc};
 use once_cell::sync::OnceCell;
 use rand::{thread_rng, Rng};
 use snarkos_storage::DynStorage;
+#[cfg(not(feature = "test"))]
+use std::time::Duration;
 use std::{
     net::SocketAddr,
     ops::Deref,
@@ -254,6 +256,15 @@ impl Node {
             let sync_mempool_task = task::spawn(async move {
                 loop {
                     if !node_clone.is_syncing_blocks() {
+                        // Ensure that it's not just a short "break" from syncing blocks
+                        #[cfg(not(feature = "test"))]
+                        if let Some(elapsed) = node_clone.expect_sync().time_since_last_block_sync() {
+                            if elapsed < Duration::from_secs(60) {
+                                sleep(mempool_sync_interval).await;
+                                continue;
+                            }
+                        }
+
                         // TODO (howardwu): Add some random sync nodes beyond this approach
                         //  to ensure some diversity in mempool state that is fetched.
                         //  For now, this is acceptable because we propogate the mempool to

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -65,8 +65,15 @@ impl MinerInstance {
                     break;
                 }
 
-                // Don't mine if the node is currently syncing.
-                if self.node.state() == State::Syncing {
+                // Don't mine if the node is currently syncing; also ensure that it's not just a short "break" from syncing blocks.
+                if self.node.state() == State::Syncing
+                    || self
+                        .node
+                        .expect_sync()
+                        .time_since_last_block_sync()
+                        .map(|elapsed| elapsed < Duration::from_secs(60))
+                        .unwrap_or(false)
+                {
                     thread::sleep(Duration::from_secs(15));
                     continue;
                 } else {

--- a/network/src/sync/sync.rs
+++ b/network/src/sync/sync.rs
@@ -69,6 +69,15 @@ impl Sync {
         self.block_sync_interval
     }
 
+    /// Returns the duration since last block sync.
+    pub fn time_since_last_block_sync(&self) -> Option<Duration> {
+        if self.last_block_sync.is_empty() {
+            None
+        } else {
+            Some(self.last_block_sync.elapsed())
+        }
+    }
+
     /// Returns the interval between each memory pool sync.
     pub fn mempool_sync_interval(&self) -> Duration {
         self.mempool_sync_interval

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -54,6 +54,7 @@ version = "1.3.14"
 path = "../network"
 version = "1.3.14"
 optional = true
+features = [ "test" ]
 
 [dependencies.snarkos-parameters]
 path = "../parameters"


### PR DESCRIPTION
This PR introduces an extra delay before the node starts syncing the mempool or mining; this delay is equal to 1 minute since the last block sync attempt. In addition, this PR adjusts the conditions in which the block sync timestamp is updated, so that it happens only if any prospect sync peers are found - this way the node will no longer register as syncing once it's caught up with the tip of the chain, **and** it will no longer mine blocks if it notices that there are peers with a longer chain and it's unable to sync with them, making potential forks shorter.