### PR TITLE
Reduce the max peers breach log level 

### DIFF
--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -380,7 +380,7 @@ impl Node {
         let max_peers = self.config.maximum_number_of_connected_peers() as usize;
 
         if num_connected > max_peers {
-            warn!(
+            info!(
                 "Max number of connections ({} connected; max: {}) reached",
                 num_connected, max_peers
             );

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -380,7 +380,7 @@ impl Node {
         let max_peers = self.config.maximum_number_of_connected_peers() as usize;
 
         if num_connected > max_peers {
-            info!(
+            debug!(
                 "Max number of connections ({} connected; max: {}) reached",
                 num_connected, max_peers
             );


### PR DESCRIPTION
Reduces the log level for breached max peers limit. Softly breaching the limit isn't a `WARN`-worthy message, downgraded to `DEBUG`. 
