### PR TITLE
Block Repropagation Improvement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release --nocapture
+          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- --nocapture
       - clear_environment:
           cache_key: snarkos-testing-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- block_propagation --nocapture
+          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- --nocapture
       - clear_environment:
           cache_key: snarkos-testing-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release
+          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release --nocapture
       - clear_environment:
           cache_key: snarkos-testing-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- --nocapture
+          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- block_propagation --nocapture
       - clear_environment:
           cache_key: snarkos-testing-cache
 

--- a/benchmarks/network/block_cache.rs
+++ b/benchmarks/network/block_cache.rs
@@ -24,7 +24,7 @@ fn block_cache_perf(c: &mut Criterion) {
     const MIN_BLOCK_SIZE: usize = 1024; // 1KiB
     const MAX_BLOCK_SIZE: usize = 1024 * 1024; // 1MiB
 
-    let mut cache = Cache::default();
+    let mut cache = Cache::<8192>::default();
 
     let seed: u64 = thread_rng().gen();
     let mut rng = XorShiftRng::seed_from_u64(seed);
@@ -37,6 +37,7 @@ fn block_cache_perf(c: &mut Criterion) {
             rng.fill(&mut random_bytes[..]);
 
             let _check = cache.contains(&random_bytes);
+            cache.push(&random_bytes);
         })
     });
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -35,6 +35,7 @@ pub mod inbound {
 pub mod outbound {
     pub const ALL_SUCCESSES: &str = "snarkos_outbound_all_successes_total";
     pub const ALL_FAILURES: &str = "snarkos_outbound_all_failures_total";
+    pub const ALL_CACHE_HITS: &str = "snarkos_outbound_all_cache_hits_total";
 }
 
 pub mod connections {

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -156,6 +156,8 @@ pub struct OutboundStats {
     all_successes: Counter,
     /// The number of messages that failed to be sent to peers.
     all_failures: Counter,
+    /// The number of messages that were going to be sent to a peer, but was blocked at the last minute by a cache.
+    all_cache_hits: Counter,
 }
 
 impl OutboundStats {
@@ -163,6 +165,7 @@ impl OutboundStats {
         Self {
             all_successes: Counter::new(),
             all_failures: Counter::new(),
+            all_cache_hits: Counter::new(),
         }
     }
 
@@ -409,6 +412,7 @@ impl Recorder for Stats {
             // outbound
             outbound::ALL_SUCCESSES => &self.outbound.all_successes,
             outbound::ALL_FAILURES => &self.outbound.all_failures,
+            outbound::ALL_CACHE_HITS => &self.outbound.all_cache_hits,
             // connections
             connections::ALL_ACCEPTED => &self.connections.all_accepted,
             connections::ALL_INITIATED => &self.connections.all_initiated,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -78,6 +78,9 @@ pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
 /// The maximum number of peers shared at once in response to a `GetPeers` message.
 pub const SHARED_PEER_COUNT: usize = 25;
 
+pub const BLOCK_CACHE_SIZE: usize = 64;
+pub const PEER_BLOCK_CACHE_SIZE: usize = 8;
+
 /// The version of the network protocol; it can be incremented in order to force users to update.
 /// FIXME: probably doesn't need to be a u64, could also be more informative than just a number
 // TODO (raychu86): Establish a formal node version.

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -61,7 +61,7 @@ pub struct InnerNode {
     /// The pre-configured parameters of this node.
     pub config: Config,
     /// The cache of node's inbound messages.
-    pub inbound_cache: Mutex<Cache>,
+    pub inbound_cache: Mutex<Cache<{ crate::BLOCK_CACHE_SIZE }>>,
     /// The list of connected and disconnected peers of this node.
     pub peer_book: PeerBook,
     /// Tracks the known network crawled by this node.

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -254,7 +254,7 @@ impl Peer {
     ) -> Result<(), NetworkError> {
         let result = match payload {
             Ok(payload) => self.inner_dispatch_payload(node, network, time_received, payload).await,
-            Err(e) => Err(e)
+            Err(e) => Err(e),
         };
         match result {
             Ok(()) => (),

--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -120,7 +120,7 @@ impl Peer {
                     metrics::increment_counter!(metrics::outbound::ALL_CACHE_HITS);
                     return Ok(PeerResponse::None);
                 }
-                
+
                 let message = Payload::Block(block, Some(height));
 
                 network.write_payload(&message).await.map_err(|e| {

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -29,7 +29,7 @@ use std::{
 use tokio::sync::mpsc;
 
 use super::PeerQuality;
-use crate::{Cache, message::Payload, NetworkError, Node};
+use crate::{message::Payload, Cache, NetworkError, Node};
 
 use super::{network::*, outbound_handler::*};
 

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -29,7 +29,7 @@ use std::{
 use tokio::sync::mpsc;
 
 use super::PeerQuality;
-use crate::{message::Payload, NetworkError, Node};
+use crate::{Cache, message::Payload, NetworkError, Node};
 
 use super::{network::*, outbound_handler::*};
 
@@ -62,6 +62,9 @@ pub struct Peer {
     ///
     /// `None` indicates the node has never attempted a connection with this peer.
     pub is_routable: Option<bool>,
+
+    #[serde(skip)]
+    pub block_received_cache: Cache<{ crate::PEER_BLOCK_CACHE_SIZE }>,
 }
 
 const FAILURE_EXPIRY_TIME: Duration = Duration::from_secs(15 * 60);
@@ -80,6 +83,7 @@ impl Peer {
             // Set to `None` since peer creation only ever happens before a connection to the peer,
             // therefore we don't know if its listener is routable or not.
             is_routable: None,
+            block_received_cache: Cache::default(),
         }
     }
 

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -235,7 +235,7 @@ impl FakeNode {
         let message = match self.network.read_payload(raw) {
             Ok(msg) => {
                 let msg = Payload::deserialize(msg)?;
-                debug!("read a {}", msg);
+                debug!("{}: read a {} {:?}", self.addr, msg, msg);
                 msg
             }
             Err(e) => {
@@ -249,7 +249,7 @@ impl FakeNode {
 
     pub async fn write_message(&mut self, payload: &Payload) {
         self.network.write_payload(payload).await.unwrap();
-        debug!("wrote a message containing a {} to the stream", payload);
+        debug!("{}: wrote a message containing a {} to the stream", self.addr, payload);
     }
 
     pub async fn write_bytes(&mut self, bytes: &[u8]) {

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -185,10 +185,10 @@ async fn block_propagation() {
 
     wait_until!(5, node.storage.canon().await.unwrap().block_height == 1);
     wait_until!(
-        5,
+        10,
         matches!(peer2.read_payload().await.unwrap(), Payload::Block(x, Some(1)) if x == block_1)
     );
-    wait_until!(5, match peer.read_payload().await.unwrap() {
+    wait_until!(10, match peer.read_payload().await.unwrap() {
         Payload::Block(_, _) => unreachable!(),
         Payload::Ping(1) => true,
         _ => false,

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -174,11 +174,6 @@ async fn block_responder_side() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_propagation() {
-    let builder = tracing_subscriber::FmtSubscriber::builder();
-
-    let builder = builder.with_env_filter(tracing_subscriber::EnvFilter::new("TRACE"));
-
-    builder.try_init().unwrap();
     let (node, mut peer) = handshaken_node_and_peer(TestSetup::default()).await;
     let mut peer2 = handshaken_peer(node.local_address().unwrap()).await;
 
@@ -186,23 +181,19 @@ async fn block_propagation() {
     let payload = Payload::Block(block_1.clone(), Some(1));
     peer.write_message(&payload).await;
 
-    tracing::info!("wait 1");
     wait_until!(5, node.storage.canon().await.unwrap().block_height == 1);
 
     node.peer_book.broadcast(Payload::Ping(1)).await;
 
-    tracing::info!("wait 2");
     wait_until!(
         10,
         matches!(peer2.read_payload().await.unwrap(), Payload::Block(x, Some(1)) if x == block_1)
     );
-    tracing::info!("wait 3");
     wait_until!(30, match peer.read_payload().await.unwrap() {
         Payload::Block(_, _) => unreachable!(),
         Payload::Ping(1) => true,
         _ => false,
     });
-    tracing::info!("wait 4");
 }
 
 #[tokio::test]

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -186,10 +186,11 @@ async fn block_propagation() {
     let payload = Payload::Block(block_1.clone(), Some(1));
     peer.write_message(&payload).await;
 
-    node.peer_book.broadcast(Payload::Ping(1)).await;
-
     tracing::info!("wait 1");
     wait_until!(5, node.storage.canon().await.unwrap().block_height == 1);
+
+    node.peer_book.broadcast(Payload::Ping(1)).await;
+
     tracing::info!("wait 2");
     wait_until!(
         10,

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -188,7 +188,7 @@ async fn block_propagation() {
         10,
         matches!(peer2.read_payload().await.unwrap(), Payload::Block(x, Some(1)) if x == block_1)
     );
-    wait_until!(10, match peer.read_payload().await.unwrap() {
+    wait_until!(30, match peer.read_payload().await.unwrap() {
         Payload::Block(_, _) => unreachable!(),
         Payload::Ping(1) => true,
         _ => false,


### PR DESCRIPTION
This PR adds a per-peer inbound-populated and outbound-checked cache for block repropagation.

The generally expected flow is:
* Node A receives a block from Peers B, C, D, E, F
* Node A repropagates the block to Peers G, H, I, J, who have not sent Node A the block.

This works in manual testing, needs some unit tests of some form.