### PR TITLE
Dedicated inbound thread

### DIFF
--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -44,6 +44,7 @@ mod message;
 pub use message::*;
 mod utility;
 
+#[derive(Clone)]
 pub struct Consensus {
     pub parameters: ConsensusParameters,
     pub dpc: Arc<Testnet1DPC>,

--- a/consensus/src/consensus/utility.rs
+++ b/consensus/src/consensus/utility.rs
@@ -16,6 +16,8 @@
 
 use snarkos_storage::PrivateKey;
 
+use tokio::task;
+
 use super::*;
 
 impl Consensus {
@@ -24,97 +26,105 @@ impl Consensus {
     pub async fn create_coinbase_transaction(
         &self,
         block_num: u32,
-        transactions: &[SerialTransaction],
+        transactions: Vec<SerialTransaction>,
         program_vk_hash: Vec<u8>,
         new_birth_program_ids: Vec<Vec<u8>>,
         new_death_program_ids: Vec<Vec<u8>>,
         recipients: Vec<Address>,
     ) -> Result<TransactionResponse, ConsensusError> {
-        let mut rng = thread_rng();
-        let mut total_value_balance = crate::get_block_reward(block_num);
+        let consensus = self.clone();
+        let (old_records, old_account_private_keys, new_records, memo) = task::spawn_blocking(move || {
+            let mut rng = thread_rng();
+            let mut total_value_balance = crate::get_block_reward(block_num);
 
-        for transaction in transactions.iter() {
-            let tx_value_balance = transaction.value_balance;
+            for transaction in transactions.iter() {
+                let tx_value_balance = transaction.value_balance;
 
-            if tx_value_balance.is_negative() {
-                return Err(ConsensusError::CoinbaseTransactionAlreadyExists());
+                if tx_value_balance.is_negative() {
+                    return Err(ConsensusError::CoinbaseTransactionAlreadyExists());
+                }
+
+                total_value_balance = total_value_balance.add(transaction.value_balance);
             }
 
-            total_value_balance = total_value_balance.add(transaction.value_balance);
-        }
-
-        // Generate a new account that owns the dummy input records
-        let new_account = Account::<Components>::new(
-            &self.dpc.system_parameters.account_signature,
-            &self.dpc.system_parameters.account_commitment,
-            &self.dpc.system_parameters.account_encryption,
-            &mut rng,
-        )
-        .unwrap();
-
-        // Generate dummy input records having as address the genesis address.
-        let old_account_private_keys = vec![new_account.private_key.clone(); Components::NUM_INPUT_RECORDS];
-        let mut old_records = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
-        let mut joint_serial_numbers = vec![];
-
-        for old_account_private_key in old_account_private_keys.iter().take(Components::NUM_INPUT_RECORDS) {
-            let sn_nonce_input: [u8; 4] = rng.gen();
-
-            let old_sn_nonce = <Components as DPCComponents>::SerialNumberNonceCRH::hash(
-                &self.dpc.system_parameters.serial_number_nonce,
-                &sn_nonce_input,
-            )?;
-
-            let old_record = DPCRecord::new(
-                &self.dpc.system_parameters.record_commitment,
-                new_account.address.clone(),
-                true, // The input record is dummy
-                0,
-                Payload::default(),
-                // Filler program input
-                program_vk_hash.clone(),
-                program_vk_hash.clone(),
-                old_sn_nonce,
+            // Generate a new account that owns the dummy input records
+            let new_account = Account::<Components>::new(
+                &consensus.dpc.system_parameters.account_signature,
+                &consensus.dpc.system_parameters.account_commitment,
+                &consensus.dpc.system_parameters.account_encryption,
                 &mut rng,
-            )?;
+            )
+            .unwrap();
 
-            let (sn, _) =
-                old_record.to_serial_number(&self.dpc.system_parameters.account_signature, old_account_private_key)?;
-            joint_serial_numbers.extend_from_slice(&to_bytes_le![sn]?);
+            // Generate dummy input records having as address the genesis address.
+            let old_account_private_keys = vec![new_account.private_key.clone(); Components::NUM_INPUT_RECORDS];
+            let mut old_records = Vec::with_capacity(Components::NUM_INPUT_RECORDS);
+            let mut joint_serial_numbers = vec![];
 
-            old_records.push(old_record.serialize()?);
-        }
+            for old_account_private_key in old_account_private_keys.iter().take(Components::NUM_INPUT_RECORDS) {
+                let sn_nonce_input: [u8; 4] = rng.gen();
 
-        let new_is_dummy_flags = [vec![false], vec![true; Components::NUM_OUTPUT_RECORDS - 1]].concat();
-        let new_values = [vec![total_value_balance.0 as u64], vec![
-            0;
-            Components::NUM_OUTPUT_RECORDS
-                - 1
-        ]]
-        .concat();
-        let new_payloads = vec![Payload::default(); Components::NUM_OUTPUT_RECORDS];
+                let old_sn_nonce = <Components as DPCComponents>::SerialNumberNonceCRH::hash(
+                    &consensus.dpc.system_parameters.serial_number_nonce,
+                    &sn_nonce_input,
+                )?;
 
-        let mut new_records = vec![];
-        for j in 0..Components::NUM_OUTPUT_RECORDS {
-            new_records.push(
-                DPCRecord::new_full(
-                    &self.dpc.system_parameters.serial_number_nonce,
-                    &self.dpc.system_parameters.record_commitment,
-                    recipients[j].clone().into(),
-                    new_is_dummy_flags[j],
-                    new_values[j],
-                    new_payloads[j].clone(),
-                    new_birth_program_ids[j].clone(),
-                    new_death_program_ids[j].clone(),
-                    j as u8,
-                    joint_serial_numbers.clone(),
+                let old_record = DPCRecord::new(
+                    &consensus.dpc.system_parameters.record_commitment,
+                    new_account.address.clone(),
+                    true, // The input record is dummy
+                    0,
+                    Payload::default(),
+                    // Filler program input
+                    program_vk_hash.clone(),
+                    program_vk_hash.clone(),
+                    old_sn_nonce,
                     &mut rng,
-                )?
-                .serialize()?,
-            );
-        }
+                )?;
 
-        let memo: [u8; 32] = rng.gen();
+                let (sn, _) = old_record.to_serial_number(
+                    &consensus.dpc.system_parameters.account_signature,
+                    old_account_private_key,
+                )?;
+                joint_serial_numbers.extend_from_slice(&to_bytes_le![sn]?);
+
+                old_records.push(old_record.serialize()?);
+            }
+
+            let new_is_dummy_flags = [vec![false], vec![true; Components::NUM_OUTPUT_RECORDS - 1]].concat();
+            let new_values = [vec![total_value_balance.0 as u64], vec![
+                0;
+                Components::NUM_OUTPUT_RECORDS
+                    - 1
+            ]]
+            .concat();
+            let new_payloads = vec![Payload::default(); Components::NUM_OUTPUT_RECORDS];
+
+            let mut new_records = vec![];
+            for j in 0..Components::NUM_OUTPUT_RECORDS {
+                new_records.push(
+                    DPCRecord::new_full(
+                        &consensus.dpc.system_parameters.serial_number_nonce,
+                        &consensus.dpc.system_parameters.record_commitment,
+                        recipients[j].clone().into(),
+                        new_is_dummy_flags[j],
+                        new_values[j],
+                        new_payloads[j].clone(),
+                        new_birth_program_ids[j].clone(),
+                        new_death_program_ids[j].clone(),
+                        j as u8,
+                        joint_serial_numbers.clone(),
+                        &mut rng,
+                    )?
+                    .serialize()?,
+                );
+            }
+
+            let memo: [u8; 32] = rng.gen();
+
+            Ok((old_records, old_account_private_keys, new_records, memo))
+        })
+        .await??;
 
         self.create_transaction(CreateTransactionRequest {
             old_records,

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -123,3 +123,9 @@ impl From<std::io::Error> for ConsensusError {
         ConsensusError::Crate("std::io", format!("{:?}", error))
     }
 }
+
+impl From<tokio::task::JoinError> for ConsensusError {
+    fn from(error: tokio::task::JoinError) -> Self {
+        ConsensusError::Crate("tokio", error.to_string())
+    }
+}

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::{Duration, Instant};
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
 
 #[cfg(not(feature = "test"))]
 use tokio::runtime;
@@ -119,7 +122,7 @@ impl Node {
             };
 
             let node = self.clone();
-            rt_handle.spawn(async move { node.process_incoming_message(payload, source).await });
+            rt_handle.spawn(async move { node.process_incoming_message(payload, source, time_received).await });
         }
     }
 
@@ -135,11 +138,11 @@ impl Node {
                 unreachable!("All messages processed sent to the inbound receiver are Inbound");
             };
 
-            self.process_incoming_message(payload, source).await;
+            self.process_incoming_message(payload, source, time_received).await;
         }
     }
 
-    pub async fn process_incoming_message(&self, payload: Payload, source: SocketAddr) {
+    pub async fn process_incoming_message(&self, payload: Payload, source: SocketAddr, time_received: Option<Instant>) {
         match payload {
             Payload::Transaction(transaction) => {
                 metrics::increment_counter!(inbound::TRANSACTIONS);

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -79,7 +79,7 @@ pub const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; // 8MiB
 pub const SHARED_PEER_COUNT: usize = 25;
 
 /// The depth of the common inbound channel.
-pub const INBOUND_CHANNEL_DEPTH: usize = 16 * 1024;
+pub const INBOUND_CHANNEL_DEPTH: usize = 4096;
 /// The depth of the per-connection outbound channels.
 pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{master::SyncInbound, sync::master::SyncMaster, *};
-use snarkos_metrics::{self as metrics, inbound, misc};
+use snarkos_metrics::{self as metrics, misc};
 
 use anyhow::*;
 use chrono::{DateTime, Utc};
@@ -177,20 +177,24 @@ impl Node {
         self.known_network.get()
     }
 
-    pub async fn start_services(&self, rt_handle: runtime::Handle) {
+    pub async fn start_services(&self, _rt_handle: Option<runtime::Handle>) {
         let node_clone = self.clone();
         let mut receiver = self.inbound.take_receiver().await;
-        let incoming_thread = thread::spawn(move || {
-            loop {
-                if let Err(e) = node_clone.process_incoming_messages(&mut receiver, &rt_handle) {
-                    metrics::increment_counter!(inbound::ALL_FAILURES);
-                    error!("Node error: {}", e);
-                } else {
-                    metrics::increment_counter!(inbound::ALL_SUCCESSES);
-                }
-            }
-        });
-        self.register_thread(incoming_thread);
+
+        #[cfg(not(feature = "test"))]
+        {
+            // The runtime handle is available outside of tests.
+            let rt_handle = _rt_handle.unwrap();
+            let incoming_thread =
+                thread::spawn(move || node_clone.process_incoming_messages(&mut receiver, &rt_handle));
+            self.register_thread(incoming_thread);
+        }
+
+        #[cfg(feature = "test")]
+        {
+            let incoming_task = task::spawn(async move { node_clone.process_incoming_messages(&mut receiver).await });
+            self.register_task(incoming_task);
+        }
 
         let node_clone: Node = self.clone();
         let peer_sync_interval = self.config.peer_sync_interval();

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -77,14 +77,12 @@ impl Node {
 
         if is_block_new {
             let node_clone = self.clone();
-            tokio::spawn(async move {
-                if let Err(e) = node_clone
-                    .process_received_block(remote_address, block, height, is_block_new)
-                    .await
-                {
-                    warn!("error accepting received block: {:?}", e);
-                }
-            });
+            if let Err(e) = node_clone
+                .process_received_block(remote_address, block, height, is_block_new)
+                .await
+            {
+                warn!("error accepting received block: {:?}", e);
+            }
         } else {
             let sender = self.master_dispatch.read().await;
             if let Some(sender) = &*sender {

--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -67,13 +67,13 @@ impl Node {
         source: SocketAddr,
         transaction: Vec<u8>,
     ) -> Result<()> {
-        if let Ok(tx) = Testnet1Transaction::read_le(&*transaction) {
-            let inserted = self.expect_sync().consensus.receive_transaction(tx.serialize()?).await;
+        let tx = Testnet1Transaction::read_le(&*transaction)?;
 
-            if inserted {
-                info!("Transaction added to memory pool.");
-                self.propagate_memory_pool_transaction(transaction, source).await;
-            }
+        let inserted = self.expect_sync().consensus.receive_transaction(tx.serialize()?).await;
+
+        if inserted {
+            info!("Transaction added to memory pool.");
+            self.propagate_memory_pool_transaction(transaction, source).await;
         }
 
         Ok(())

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -76,7 +76,7 @@ impl MinerInstance {
                         .map(|elapsed| elapsed < Duration::from_secs(60))
                         .unwrap_or(false)
                 {
-                    sleep(Duration::from_secs(15));
+                    sleep(Duration::from_secs(15)).await;
                     continue;
                 } else {
                     self.node.set_state(State::Mining);

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -16,16 +16,14 @@
 
 use std::{
     sync::{atomic::Ordering, Arc},
-    thread,
     time::Duration,
 };
 
-use futures::executor::block_on;
 use snarkvm_dpc::{testnet1::instantiated::*, Address};
-use tokio::task;
+use tokio::{task, time::sleep};
 use tracing::*;
 
-use snarkos_consensus::{error::ConsensusError, MineContext};
+use snarkos_consensus::MineContext;
 use snarkos_metrics::{self as metrics, misc::*};
 
 use crate::{Node, State};
@@ -45,20 +43,24 @@ impl MinerInstance {
     /// Spawns a new miner on a new thread using MinerInstance parameters.
     /// Once a block is found, A block message is sent to all peers.
     /// Calling this function multiple times will spawn additional listeners on separate threads.
-    pub async fn spawn(self) -> Result<task::JoinHandle<()>, ConsensusError> {
-        let local_address = self.node.local_address().unwrap();
-        info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
-        let miner = MineContext::prepare(
-            self.miner_address.clone(),
-            Arc::clone(&self.node.expect_sync().consensus),
-        )
-        .await?;
-        info!("Miner instantiated; starting to mine blocks");
+    pub fn spawn(self) -> task::JoinHandle<()> {
+        task::spawn(async move {
+            let local_address = self.node.local_address().unwrap();
 
-        let mut mining_failure_count = 0;
-        let mining_failure_threshold = 10;
+            info!("Initializing Aleo miner - Your miner address is {}", self.miner_address);
 
-        Ok(task::spawn_blocking(move || {
+            let miner = MineContext::prepare(
+                self.miner_address.clone(),
+                Arc::clone(&self.node.expect_sync().consensus),
+            )
+            .await
+            .expect("Couldn't initialize the miner!");
+
+            info!("Miner instantiated; starting to mine blocks");
+
+            let mut mining_failure_count = 0;
+            let mining_failure_threshold = 10;
+
             loop {
                 if self.node.is_shutting_down() {
                     debug!("The node is shutting down, stopping mining");
@@ -74,7 +76,7 @@ impl MinerInstance {
                         .map(|elapsed| elapsed < Duration::from_secs(60))
                         .unwrap_or(false)
                 {
-                    thread::sleep(Duration::from_secs(15));
+                    sleep(Duration::from_secs(15));
                     continue;
                 } else {
                     self.node.set_state(State::Mining);
@@ -84,7 +86,7 @@ impl MinerInstance {
                 // any values in terminator here are stale, we havent pulled the canon block in the miner yet
                 self.node.terminator.store(false, Ordering::SeqCst);
 
-                let (block, _coinbase_records) = match block_on(miner.mine_block(&self.node.terminator)) {
+                let (block, _coinbase_records) = match miner.mine_block(self.node.terminator.clone()).await {
                     Ok(mined_block) => mined_block,
                     Err(error) => {
                         // It's possible that the node realized that it needs to sync with another one in the
@@ -122,13 +124,10 @@ impl MinerInstance {
 
                 let serialized_block = block.serialize();
                 let node_clone = self.node.clone();
-                let new_height = futures::executor::block_on(async move {
-                    node_clone.storage.canon().await.map(|c| c.block_height as u32)
-                })
-                .ok();
+                let new_height = node_clone.storage.canon().await.map(|c| c.block_height as u32).ok();
 
                 self.node.propagate_block(serialized_block, new_height, local_address);
             }
-        }))
+        })
     }
 }

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -368,7 +368,7 @@ mod rpc_tests {
         };
         let (rpc, rpc_node) = initialize_test_rpc(&consensus, Some(setup.clone())).await;
         rpc_node.listen().await.unwrap();
-        rpc_node.start_services().await;
+        rpc_node.start_services(None).await;
 
         let setup = TestSetup {
             consensus_setup: None,

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -303,7 +303,7 @@ async fn start_server(config: Config, rt_handle: runtime::Handle) -> anyhow::Res
     if config.miner.is_miner {
         match Address::<Components>::from_str(&config.miner.miner_address) {
             Ok(miner_address) => {
-                let handle = MinerInstance::new(miner_address, node.clone()).spawn().await?;
+                let handle = MinerInstance::new(miner_address, node.clone()).spawn();
                 node.register_task(handle);
             }
             Err(_) => info!(

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -93,7 +93,7 @@ fn print_welcome(config: &Config) {
 /// 6. Starts miner thread.
 /// 7. Starts network server listener.
 ///
-async fn start_server(config: Config) -> anyhow::Result<()> {
+async fn start_server(config: Config, rt_handle: runtime::Handle) -> anyhow::Result<()> {
     initialize_logger(&config);
 
     print_welcome(&config);
@@ -296,7 +296,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     }
 
     // Start the network services
-    node.start_services().await;
+    node.start_services(rt_handle).await;
 
     // Start the miner task if mining configuration is enabled.
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -327,8 +327,9 @@ fn main() -> Result<(), NodeError> {
         .enable_all()
         .thread_stack_size(8 * 1024 * 1024)
         .build()?;
+    let rt_handle = runtime.handle().clone();
 
-    runtime.block_on(start_server(config))?;
+    runtime.block_on(start_server(config, rt_handle))?;
 
     Ok(())
 }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -296,7 +296,7 @@ async fn start_server(config: Config, rt_handle: runtime::Handle) -> anyhow::Res
     }
 
     // Start the network services
-    node.start_services(rt_handle).await;
+    node.start_services(Some(rt_handle)).await;
 
     // Start the miner task if mining configuration is enabled.
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -196,11 +196,11 @@ pub async fn test_node(setup: TestSetup) -> Node {
     };
 
     node.listen().await.unwrap();
-    node.start_services().await;
+    node.start_services(None).await;
 
     if is_miner {
         let miner_address = FIXTURE.test_accounts[0].address.clone();
-        tokio::spawn(MinerInstance::new(miner_address, node.clone()).spawn());
+        MinerInstance::new(miner_address, node.clone()).spawn();
     }
 
     node


### PR DESCRIPTION
This PR adjusts the node's resource handling in order to prioritize the processing of already-read network messages over reading new ones. In scenarios where the node has a lot of connections and they are sending **many** messages (especially big ones, like blocks), the async runtime can just run out of resources it can dedicate to anything else than reading from network sockets.

This PR introduces a thread dedicated to just processing of inbound messages in a blocking fashion; this means that the node's sockets are a lot more likely to become full (instead of the inbound message queue), making the connections that send too many messages likely to drop themselves, reducing the strain on the node and the network (as it limits re-broadcasting from nodes that are potentially "too eager" to send messages).

This PR also re-works the resource management for the miner, using short-lived blocking tasks only for operations that are actually blocking. Some new `clone()`s are introduced, but all the related objects were small or contained `Arc`s, so this should be fine.

The `#[cfg(feature = "test")]` attribute can be used in order to limit the number of changes necessary for tests - otherwise all of them would need to create a `tokio` runtime manually and pass it on to the `Node`, so that the dedicated thread can use `async` code.

Filing this PR as draft, as the earlier https://github.com/AleoHQ/snarkOS/pull/1074 already introduces a `test` feature for `snarkos-network`, and I only realized it's needed late in the implementation. I'll drop the last commit once that PR is in.