### PR TITLE
replace base image with Ubuntu 18.04 and Rust stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,45 @@
-FROM rust:1.51.0
+FROM ubuntu:18.04
 
-RUN apt-get update \
- && apt-get install -y \
-   build-essential \
-   clang \
-   gcc \
-   libssl-dev \
-   make \
-   pkg-config \
-   xz-utils
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux ; \
+    apt-get update -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        build-essential \
+        clang \
+        gcc \
+        libssl-dev \
+        make \
+        pkg-config \
+        xz-utils && \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    \
+    url="https://static.rust-lang.org/rustup/dist/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain stable; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    apt-get remove -y --auto-remove wget && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*;
 
 WORKDIR /usr/src/snarkOS
 COPY . .

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     * [Option 1 - Download snarkOS](#option-1---download-snarkos)
     * [Option 2 - Install from Crates.io](#option-2---install-from-cratesio)
     * [Option 3 - Build from Source Code](#option-3---build-from-source-code)
+    * [Option 4 - Build from Source Code and run on a Docker container](#option-4---build-from-source-code-and-run-ib-a-Docker-container)
 * [3. Usage Guide](#3-usage-guide)
     * [3.1 Connecting to the Aleo Network](#31-connecting-to-the-aleo-network)
     * [3.2 Command Line Interface](#32-command-line-interface)
@@ -40,11 +41,11 @@ enables applications to verify and store state in a publicly verifiable manner.
 
 [mac_logo]: https://raw.githubusercontent.com/wiki/ryanoasis/nerd-fonts/screenshots/v1.0.x/mac-pass-sm.png
 [mac_badge]: https://img.shields.io/badge/download-testnet1_for_mac-blue?url=https%3A%2F%2Fapi.github.com%2Frepos%2Faleohq%2Fsnarkos%2Freleases%2Flatest&query=%24.assets[0].name&style=for-the-badge
-[mac_dl]: https://github.com/AleoHQ/snarkOS/releases/download/v1.3.12/aleo-testnet1-v1.3.12-x86_64-apple-darwin.zip
+[mac_dl]: https://github.com/AleoHQ/snarkOS/releases/download/v1.3.14/aleo-testnet1-v1.3.14-x86_64-apple-darwin.zip
 
 [linux_logo]: https://raw.githubusercontent.com/wiki/ryanoasis/nerd-fonts/screenshots/v1.0.x/linux-pass-sm.png
 [linux_badge]: https://img.shields.io/badge/download-testnet1_for_linux-blue?url=https%3A%2F%2Fapi.github.com%2Frepos%2Faleohq%2Fsnarkos%2Freleases%2Flatest&query=%24.assets[1].name&style=for-the-badge
-[linux_dl]: https://github.com/AleoHQ/snarkOS/releases/download/v1.3.12/aleo-testnet1-v1.3.12-x86_64-unknown-linux-gnu.zip
+[linux_dl]: https://github.com/AleoHQ/snarkOS/releases/download/v1.3.14/aleo-testnet1-v1.3.14-x86_64-unknown-linux-gnu.zip
 
 [windows_logo]: https://raw.githubusercontent.com/wiki/ryanoasis/nerd-fonts/screenshots/v1.0.x/windows-pass-sm.png
 [windows_badge]: https://img.shields.io/badge/download-coming_soon-orange?style=for-the-badge
@@ -144,27 +145,31 @@ To start a snarkOS client node, run:
 snarkos
 ```
 
-<!--
-### 2.2c Build with Docker
+### Option 4 - Build from Source Code and run on a Docker container
+
+
+Start by cloning this repository:
+```bash
+git clone https://github.com/AleoHQ/snarkOS --depth 1
+```
+
+Then install Docker and build the container:
 
 #### Docker build
 ```bash
-docker build -t snarkos:latest .
-```
-or
-```bash
-docker-compose build
+docker build --rm -t aleohq/snarkos:latest .
 ```
 
 #### Docker run
 ``` bash
-docker run -d -p 4131:4131 --name snarkos snarkos
+docker run -d -p 4131:4131 --name snarkos aleohq/snarkos:latest
 ```
-or
+
+#### Devnet (local) 
+
 ```bash
-docker-compose up
+docker-compose -p snarkos up -d
 ```
--->
 
 ## 3. Usage Guide
 
@@ -180,8 +185,7 @@ To start a mining node, run:
 snarkos --is-miner --miner-address {ALEO_ADDRESS}
 ```
 
-To run a node with custom settings, refer to the full list of options and flags available
-in the CLI.
+To run a node with custom settings, refer to the full list of options and flags available in the CLI.
 
 ### 3.2 Command Line Interface
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,92 @@
-version: "3"
+version: "3.5"
+
 services:
-    app:
-        container_name: snarkOS
-        image: snarkos:latest
-        build: .
-        ports:
-            - "4130:4130"
-        networks:
-            - default
+  bootnode:
+    container_name: snarkos-bootnode
+    image: aleohq/snarkos:staging-latest
+    volumes:
+      - snarkos-bootn-vol:/aleo/data
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: ["bash", "-c", "/aleo/bin/snarkos -d /aleo/data --verbose 3 --port 14131 --rpc-port 13031 --is-bootnode --ip 172.22.0.11 --connect 172.22.0.11:14131"]
+    ports:
+      - 13031:13031
+      - 14131:14131
+    deploy:
+      resources:
+        limits:
+          cpus: 0.50
+          memory: 512M
+        reservations:
+          memory: 96M
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+    networks:
+      aleo_devnet:
+        ipv4_address: 172.22.0.11
+
+  client:
+    container_name: snarkos-client
+    image: aleohq/snarkos:staging-latest
+    volumes:
+      - snarkos-client-vol:/aleo/data
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: ["bash", "-c", "/aleo/bin/snarkos -d /aleo/data --verbose 3 --port 14132 --rpc-port 13032 --ip 172.22.0.12 --connect 172.22.0.11:14131"]
+    ports:
+      - 13032:13032
+      - 14132:14132
+    deploy:
+      resources:
+        limits:
+          cpus: 0.50
+          memory: 512M
+        reservations:
+          memory: 96M
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+    networks:
+      aleo_devnet:
+        ipv4_address: 172.22.0.12
+
+  miner:
+    container_name: snarkos-miner
+    image: aleohq/snarkos:staging-latest
+    volumes:
+      - snarkos-miner-vol:/aleo/data
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: ["bash", "-c", "/aleo/bin/snarkos -d /aleo/data --verbose 3 --port 14133 --rpc-port 13033 --is-miner --miner-address ${ALEO_ADDRESS} --ip 172.22.0.13 --connect 172.22.0.11:14131"]
+    ports:
+      - 13033:13033
+      - 14133:14133
+    deploy:
+      resources:
+        limits:
+          cpus: 3.00
+          memory: 7168M
+        reservations:
+          memory: 4096M
+      restart_policy:
+        condition: on-failure
+        max_attempts: 3
+    networks:
+      aleo_devnet:
+        ipv4_address: 172.22.0.13
+
+networks:
+  aleo_devnet:
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.22.0.0/24"
+
+volumes:
+  snarkos-bootn-vol:
+  snarkos-miner-vol:
+  snarkos-client-vol:


### PR DESCRIPTION
## Motivation
Started with the intent to fix #1069 same as the below PR but then evolved into moving into a Ubuntu-based build as this seems to be the most popular platform. I also added the 'stable' pointer so Rust will always be up-to-date, requiring less maintenance in this Dockerfile. 

## Related PRs
https://github.com/AleoHQ/snarkOS/pull/1070
