### PR TITLE
Include min- and max-peers in the getnodeinfo RPC

### DIFF
--- a/rpc/documentation/public_endpoints/getnodeinfo.md
+++ b/rpc/documentation/public_endpoints/getnodeinfo.md
@@ -14,6 +14,8 @@ None
 | `launched`       | timestamp     | The timestamp of when the node was launched   |
 | `listening_addr` | SocketAddr    | The configured listening address of the node  |
 | `version`        | string        | The version of the client binary              |
+| `min_peers`      | number        | The minimum desired number of connected peers |
+| `max_peers`      | number        | The maximum allowed number of connected peers |
 
 ### Example
 ```ignore

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -413,6 +413,8 @@ impl RpcFunctions for RpcImpl {
             is_syncing: self.node.is_syncing_blocks(),
             launched: self.node.launched,
             version: env!("CARGO_PKG_VERSION").into(),
+            min_peers: self.node.config.minimum_number_of_connected_peers(),
+            max_peers: self.node.config.maximum_number_of_connected_peers(),
         })
     }
 

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -140,6 +140,12 @@ pub struct NodeInfo {
 
     /// The version of the client binary.
     pub version: String,
+
+    // The minimum desired number of connected peers.
+    pub min_peers: u16,
+
+    // The maximum allowed number of connected peers.
+    pub max_peers: u16,
 }
 
 /// Returned value for the `getpeerinfo` rpc call


### PR DESCRIPTION
This PR introduces 2 new fields, `min_peers` and `max_peers` to the reply to the `getnodeinfo` RPC.