### PR TITLE
Remove fork detection log

### DIFF
--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -33,22 +33,22 @@ impl ConsensusInner {
         }
 
         // scan for forks
-        let forks = self.scan_forks().await?;
-        for (canon, fork_child) in forks {
-            let canon_height = match self.storage.get_block_state(&canon).await? {
-                BlockStatus::Committed(n) => n,
-                _ => continue,
-            };
-            let fork_blocks = self.storage.longest_child_path(&fork_child).await?;
-            debug!(
-                "fork detected @ {}/{} -- starts at {}, goes for {} blocks, ending at {}",
-                canon_height,
-                canon,
-                fork_child,
-                fork_blocks.len(),
-                fork_blocks.last().unwrap()
-            );
-        }
+        // let forks = self.scan_forks().await?;
+        // for (canon, fork_child) in forks {
+        //     let canon_height = match self.storage.get_block_state(&canon).await? {
+        //         BlockStatus::Committed(n) => n,
+        //         _ => continue,
+        //     };
+        //     let fork_blocks = self.storage.longest_child_path(&fork_child).await?;
+        //     debug!(
+        //         "fork detected @ {}/{} -- starts at {}, goes for {} blocks, ending at {}",
+        //         canon_height,
+        //         canon,
+        //         fork_child,
+        //         fork_blocks.len(),
+        //         fork_blocks.last().unwrap()
+        //     );
+        // }
 
         if let Err(e) = self.try_to_fast_forward().await {
             match e {


### PR DESCRIPTION
Adds too much startup overhead when we remove fork limit.