### PR TITLE
Remove clone from indexed merkle tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,12 +802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
-
-[[package]]
 name = "ed25519"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,7 +2787,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "criterion",
- "dyn-clone",
  "futures 0.3.16",
  "hex",
  "indexmap",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -82,9 +82,6 @@ version = "1.6"
 [dependencies.lazy_static]
 version = "1.4"
 
-[dependencies.dyn-clone]
-version = "1.0"
-
 [dependencies.futures]
 version = "0.3"
 

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -124,11 +124,7 @@ impl ConsensusInner {
                 }
                 ConsensusMessage::ScanForks() => {
                     response.send(Box::new(self.scan_forks().await)).ok();
-                } /*
-                  ConsensusMessage::RecommitCanon() => {
-                      response.send(Box::new(self.recommit_canon().await)).ok();
-                  }
-                  */
+                }
             }
         }
     }

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -124,10 +124,11 @@ impl ConsensusInner {
                 }
                 ConsensusMessage::ScanForks() => {
                     response.send(Box::new(self.scan_forks().await)).ok();
-                }
-                ConsensusMessage::RecommitCanon() => {
-                    response.send(Box::new(self.recommit_canon().await)).ok();
-                }
+                } /*
+                  ConsensusMessage::RecommitCanon() => {
+                      response.send(Box::new(self.recommit_canon().await)).ok();
+                  }
+                  */
             }
         }
     }

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -59,7 +59,7 @@ pub struct ConsensusInner {
     pub memory_pool: MemoryPool,
     pub storage: DynStorage,
 }
-
+/*
 struct LedgerData {
     ledger: DynLedger,
     commitments: Vec<Digest>,
@@ -67,7 +67,7 @@ struct LedgerData {
     memos: Vec<Digest>,
     ledger_digests: Vec<Digest>,
 }
-
+*/
 impl ConsensusInner {
     /// scans uncommitted blocks with a known path to the canon chain for forks
     async fn scan_forks(&mut self) -> Result<Vec<(Digest, Digest)>> {
@@ -103,7 +103,7 @@ impl ConsensusInner {
 
         Ok(known_forks)
     }
-
+    /*
     fn fresh_ledger(&self, blocks: Vec<SerialBlock>) -> Result<LedgerData> {
         let mut ledger = self.ledger.clone();
         ledger.clear();
@@ -194,4 +194,5 @@ impl ConsensusInner {
             .await?;
         Ok(())
     }
+    */
 }

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -59,15 +59,7 @@ pub struct ConsensusInner {
     pub memory_pool: MemoryPool,
     pub storage: DynStorage,
 }
-/*
-struct LedgerData {
-    ledger: DynLedger,
-    commitments: Vec<Digest>,
-    serial_numbers: Vec<Digest>,
-    memos: Vec<Digest>,
-    ledger_digests: Vec<Digest>,
-}
-*/
+
 impl ConsensusInner {
     /// scans uncommitted blocks with a known path to the canon chain for forks
     async fn scan_forks(&mut self) -> Result<Vec<(Digest, Digest)>> {
@@ -103,96 +95,4 @@ impl ConsensusInner {
 
         Ok(known_forks)
     }
-    /*
-    fn fresh_ledger(&self, blocks: Vec<SerialBlock>) -> Result<LedgerData> {
-        let mut ledger = self.ledger.clone();
-        ledger.clear();
-        let mut new_commitments = vec![];
-        let mut new_serial_numbers = vec![];
-        let mut new_memos = vec![];
-        let mut new_digests = vec![];
-        for (i, block) in blocks.into_iter().enumerate() {
-            trace!("ledger recreation: processing block {}", i);
-            let mut commitments = vec![];
-            let mut serial_numbers = vec![];
-            let mut memos = vec![];
-            for transaction in block.transactions.iter() {
-                commitments.extend_from_slice(&transaction.new_commitments[..]);
-                serial_numbers.extend_from_slice(&transaction.old_serial_numbers[..]);
-                memos.push(transaction.memorandum.clone());
-            }
-            let digest = ledger.extend(&commitments[..], &serial_numbers[..], &memos[..])?;
-            new_commitments.extend(commitments);
-            new_serial_numbers.extend(serial_numbers);
-            new_memos.extend(memos);
-            new_digests.push(digest);
-        }
-        Ok(LedgerData {
-            ledger,
-            commitments: new_commitments,
-            serial_numbers: new_serial_numbers,
-            memos: new_memos,
-            ledger_digests: new_digests,
-        })
-    }
-
-    #[allow(dead_code)]
-    /// diagnostic function for storage/consensus consistency issues
-    async fn diff_canon(&self) -> Result<()> {
-        let blocks = self.storage.get_canon_blocks(Some(128)).await?;
-        info!("diffing canon for {} blocks", blocks.len());
-        let data = self.fresh_ledger(blocks)?;
-        let commitments = self.storage.get_commitments().await?;
-        let serial_numbers = self.storage.get_serial_numbers().await?;
-        let memos = self.storage.get_memos().await?;
-        let ledger_digests = self.storage.get_ledger_digests().await?;
-
-        fn diff(name: &str, calculated: &[Digest], stored: &[Digest]) {
-            info!(
-                "diffing {}: {} calculated vs {} stored",
-                name,
-                calculated.len(),
-                stored.len()
-            );
-            let max_len = calculated.len().max(stored.len());
-            for i in 0..max_len {
-                if calculated.get(i) != stored.get(i) {
-                    error!(
-                        "diff {}: mismatch @ {}: {} calculated != {} stored",
-                        name,
-                        i,
-                        calculated
-                            .get(i)
-                            .map(|x| format!("{}", x))
-                            .unwrap_or_else(|| "missing".to_string()),
-                        stored
-                            .get(i)
-                            .map(|x| format!("{}", x))
-                            .unwrap_or_else(|| "missing".to_string())
-                    );
-                }
-            }
-        }
-        diff("commitments", &data.commitments[..], &commitments[..]);
-        diff("serial_numbers", &data.serial_numbers[..], &serial_numbers[..]);
-        diff("memos", &data.memos[..], &memos[..]);
-        diff("ledger_digests", &data.ledger_digests[..], &ledger_digests[..]);
-        Ok(())
-    }
-
-    /// helper function to rebuild a broken ledger index in storage.
-    /// used in debugging, preserved for future potential use
-    async fn recommit_canon(&mut self) -> Result<()> {
-        let blocks = self.storage.get_canon_blocks(None).await?;
-        let block_count = blocks.len();
-        info!("recommiting {} blocks", block_count);
-        let data = self.fresh_ledger(blocks)?;
-        self.ledger = data.ledger;
-        info!("resetting ledger for {} blocks", block_count);
-        self.storage
-            .reset_ledger(data.commitments, data.serial_numbers, data.memos, data.ledger_digests)
-            .await?;
-        Ok(())
-    }
-    */
 }

--- a/consensus/src/consensus/message.rs
+++ b/consensus/src/consensus/message.rs
@@ -47,7 +47,7 @@ pub(super) enum ConsensusMessage {
     ForceDecommit(Vec<u8>),
     FastForward(),
     ScanForks(),
-    RecommitCanon(),
+    // RecommitCanon(),
 }
 
 pub(super) type ConsensusMessageWrapped = (ConsensusMessage, oneshot::Sender<Box<dyn Any + Send + Sync>>);

--- a/consensus/src/consensus/message.rs
+++ b/consensus/src/consensus/message.rs
@@ -47,7 +47,6 @@ pub(super) enum ConsensusMessage {
     ForceDecommit(Vec<u8>),
     FastForward(),
     ScanForks(),
-    // RecommitCanon(),
 }
 
 pub(super) type ConsensusMessageWrapped = (ConsensusMessage, oneshot::Sender<Box<dyn Any + Send + Sync>>);

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -156,10 +156,4 @@ impl Consensus {
     pub async fn scan_forks(&self) -> Result<Vec<(Digest, Digest)>> {
         self.send(ConsensusMessage::ScanForks()).await
     }
-
-    /*
-    // Diagnostic function to rebuild the stored ledger components
-    pub async fn recommit_canon(&self) -> Result<()> {
-        self.send(ConsensusMessage::RecommitCanon()).await
-    }*/
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -157,8 +157,9 @@ impl Consensus {
         self.send(ConsensusMessage::ScanForks()).await
     }
 
-    /// Diagnostic function to rebuild the stored ledger components
+    /*
+    // Diagnostic function to rebuild the stored ledger components
     pub async fn recommit_canon(&self) -> Result<()> {
         self.send(ConsensusMessage::RecommitCanon()).await
-    }
+    }*/
 }

--- a/consensus/src/ledger/indexed_merkle_tree.rs
+++ b/consensus/src/ledger/indexed_merkle_tree.rs
@@ -27,19 +27,6 @@ pub struct IndexedMerkleTree<P: MerkleParameters> {
     indexed_digests: IndexedDigests,
 }
 
-impl<P: MerkleParameters> Clone for IndexedMerkleTree<P> {
-    fn clone(&self) -> Self {
-        let tree = self
-            .tree
-            .rebuild::<[u8; 32]>(self.indexed_digests.len(), &[])
-            .expect("failed to clone merkle tree");
-        Self {
-            tree,
-            indexed_digests: self.indexed_digests.clone(),
-        }
-    }
-}
-
 fn to_digest<B: ToBytes>(input: &B) -> Result<Digest> {
     let mut data = vec![];
     input.write_le(&mut data)?;

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -22,7 +22,6 @@ use std::{
 };
 
 use anyhow::*;
-use dyn_clone::DynClone;
 use smallvec::SmallVec;
 use snarkos_storage::Digest;
 use snarkvm_algorithms::{
@@ -48,7 +47,7 @@ pub use indexed_digests::IndexedDigests;
 use snarkvm_parameters::{LedgerMerkleTreeParameters, Parameter};
 use snarkvm_utilities::{FromBytes, ToBytes};
 
-pub trait Ledger: Send + Sync + DynClone {
+pub trait Ledger: Send + Sync {
     fn extend(
         &mut self,
         new_commitments: &[Digest],
@@ -81,12 +80,6 @@ pub trait Ledger: Send + Sync + DynClone {
 }
 
 pub struct DynLedger(pub Box<dyn Ledger>);
-
-impl Clone for DynLedger {
-    fn clone(&self) -> Self {
-        DynLedger(dyn_clone::clone_box(&*self.0))
-    }
-}
 
 impl Deref for DynLedger {
     type Target = dyn Ledger;


### PR DESCRIPTION
The clones related to the `IndexedMerkleTree` are costly, and immediately apparent during profiling. The dependent `rocksdb` methods are commented out for now, until the migration process is complete.