### PR TITLE
Misc clippy lints

### DIFF
--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -251,7 +251,7 @@ impl ConsensusInner {
             if sub_children.is_empty() {
                 break;
             }
-            sub_children.sort_by(|a, b| b.longest_length().cmp(&a.longest_length()));
+            sub_children.sort_by_key(|child| std::cmp::Reverse(child.longest_length()));
             debug!("Processing the next known descendant.");
             let mut last_error = None;
             for child in sub_children {

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -390,7 +390,7 @@ mod rpc_tests {
 
         wait_until!(5, !rpc_node.known_network().unwrap().connections().is_empty());
 
-        let request = format!("{{ \"jsonrpc\":\"2.0\", \"id\": 1, \"method\": \"getnetworkgraph\" }}");
+        let request = "{ \"jsonrpc\":\"2.0\", \"id\": 1, \"method\": \"getnetworkgraph\" }".to_string();
         let response = rpc.io.handle_request(&request).await.unwrap();
         let value: Value = serde_json::from_str(&response).unwrap();
         let result: NetworkGraph = serde_json::from_value(value["result"].clone()).unwrap();

--- a/storage/src/storage/digest_tree.rs
+++ b/storage/src/storage/digest_tree.rs
@@ -34,11 +34,7 @@ impl DigestTree {
         if children.is_empty() {
             DigestTree::Leaf(digest)
         } else {
-            DigestTree::Node(
-                digest,
-                children.into_iter().map(|child| DigestTree::Leaf(child)).collect(),
-                2,
-            )
+            DigestTree::Node(digest, children.into_iter().map(DigestTree::Leaf).collect(), 2)
         }
     }
 

--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -407,7 +407,7 @@ impl SyncStorage for SqliteStorage {
         let canon = self.canon()?;
         match self.get_block_state(hash)? {
             BlockStatus::Committed(_) => {
-                return Err(anyhow!("attempted to recommit block {}", hex::encode(hash)).into());
+                return Err(anyhow!("attempted to recommit block {}", hex::encode(hash)));
             }
             BlockStatus::Unknown => return Err(anyhow!("attempted to commit unknown block")),
             _ => (),


### PR DESCRIPTION
Fixes a few lints. I left out the nested `storage` module name, since this will be fixed when rocksdb is removed.