### PR TITLE
Make cloning used in block propagation cheaper

### DIFF
--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -35,7 +35,7 @@ use crate::{NetworkError, Node, Payload, Peer, PeerEvent, PeerEventData, PeerHan
 ///
 /// A data structure for storing the history of all peers with this node server.
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PeerBook {
     disconnected_peers: MpmcMap<SocketAddr, Peer>,
     connected_peers: MpmcMap<SocketAddr, PeerHandle>,

--- a/network/src/sync/blocks.rs
+++ b/network/src/sync/blocks.rs
@@ -40,12 +40,15 @@ impl Node {
         debug!("Propagating a block to peers");
 
         let connected_peers = self.connected_peers();
-        let peer_book = self.peer_book.clone();
+        let node = self.clone();
         tokio::spawn(async move {
             let mut futures = Vec::with_capacity(connected_peers.len());
-            for remote_address in connected_peers.iter() {
-                if remote_address != &block_miner {
-                    futures.push(peer_book.send_to(*remote_address, Payload::Block(block_bytes.clone(), height), None));
+            for addr in connected_peers.iter() {
+                if addr != &block_miner {
+                    futures.push(
+                        node.peer_book
+                            .send_to(*addr, Payload::Block(block_bytes.clone(), height), None),
+                    );
                 }
             }
             tokio::time::timeout(Duration::from_secs(1), futures::future::join_all(futures))


### PR DESCRIPTION
Cloning a `Node` is cheaper than cloning a `PeerBook`.