### PR TITLE
Use a cheaper rng for network operations

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -108,6 +108,7 @@ version = "0.11.1"
 
 [dependencies.rand]
 version = "0.8"
+features = [ "small_rng" ]
 
 [dependencies.serde]
 version = "1.0"

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -25,7 +25,7 @@ use std::{
 
 use futures::Future;
 use mpmc_map::MpmcMap;
-use rand::prelude::IteratorRandom;
+use rand::{prelude::IteratorRandom, rngs::SmallRng, SeedableRng};
 use tokio::{net::TcpStream, sync::mpsc};
 
 use snarkos_metrics::{self as metrics, connections::*};
@@ -289,7 +289,10 @@ impl PeerBook {
             .collect::<Vec<Peer>>();
         let count_total_higher = peers.len();
 
-        Some((peers.into_iter().choose(&mut rand::thread_rng())?, count_total_higher))
+        Some((
+            peers.into_iter().choose(&mut SmallRng::from_entropy())?,
+            count_total_higher,
+        ))
     }
 
     /// Cancels any expected sync block counts from all peers.

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -20,7 +20,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use rand::{prelude::SliceRandom, seq::IteratorRandom};
+use rand::{prelude::SliceRandom, rngs::SmallRng, seq::IteratorRandom, SeedableRng};
 use tokio::task;
 
 use snarkos_metrics::{self as metrics, connections::*};
@@ -119,7 +119,7 @@ impl Node {
             let random_bootnodes = self
                 .config
                 .bootnodes()
-                .choose_multiple(&mut rand::thread_rng(), 2)
+                .choose_multiple(&mut SmallRng::from_entropy(), 2)
                 .copied()
                 .collect::<Vec<_>>();
 
@@ -236,7 +236,7 @@ impl Node {
             if !self.config.is_regular_node() {
                 addr_iter.take(count).collect()
             } else {
-                addr_iter.choose_multiple(&mut rand::thread_rng(), count)
+                addr_iter.choose_multiple(&mut SmallRng::from_entropy(), count)
             }
         };
 
@@ -349,7 +349,7 @@ impl Node {
 
         // Limit set size.
         let peers = peers
-            .choose_multiple(&mut rand::thread_rng(), crate::SHARED_PEER_COUNT)
+            .choose_multiple(&mut SmallRng::from_entropy(), crate::SHARED_PEER_COUNT)
             .copied()
             .collect();
 

--- a/network/src/sync/master.rs
+++ b/network/src/sync/master.rs
@@ -20,7 +20,7 @@ use crate::{Node, Payload, Peer};
 use anyhow::*;
 use futures::{pin_mut, select, FutureExt};
 use hash_hasher::{HashBuildHasher, HashedMap, HashedSet};
-use rand::prelude::SliceRandom;
+use rand::{prelude::SliceRandom, rngs::SmallRng, SeedableRng};
 use snarkos_storage::Digest;
 use snarkvm_algorithms::crh::double_sha256;
 use snarkvm_dpc::{BlockHeader, BlockHeaderHash};
@@ -269,7 +269,7 @@ impl SyncMaster {
             if peers.is_none() {
                 continue;
             }
-            let random_peer = peers.unwrap().choose(&mut rand::thread_rng());
+            let random_peer = peers.unwrap().choose(&mut SmallRng::from_entropy());
             if random_peer.is_none() {
                 continue;
             }


### PR DESCRIPTION
This PR changes the costly `ThreadRng` uses in networking to the cheaper `SmallRng`, as cryptographic qualities are not required there.