### PR TITLE
Sqlite make parent directory

### DIFF
--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -123,6 +123,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     info!("Loading storage at '{}'...", path.to_str().unwrap_or_default());
     let storage: DynStorage = {
+        std::fs::create_dir_all(&path)?;
         let mut sqlite_path = path.clone();
         sqlite_path.push("sqlite.db");
 


### PR DESCRIPTION
Recursively makes parent directories for sqlite to avoid initial boot error in clean slate.