### PR TITLE
Add a pending inbound messages metric

### DIFF
--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -86,7 +86,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -137,86 +137,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "states of current connections",
-      "type": "timeseries"
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "always",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 24,
-      "interval": null,
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "bottom"
-        },
-        "tooltipOptions": {
-          "mode": "single"
-        }
-      },
-      "pluginVersion": "7.5.6",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "rate(snarkos_connections_average_duration_sum[$__rate_interval])/rate(snarkos_connections_average_duration_count[$__rate_interval])",
-          "interval": "",
-          "legendFormat": "values (rolling average on short interval)",
-          "refId": "A"
-        }
-      ],
-      "title": "connection duration",
       "type": "timeseries"
     },
     {
@@ -396,7 +316,7 @@
             "min",
             "max",
             "mean",
-            "last"
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -407,6 +327,14 @@
       },
       "pluginVersion": "7.5.6",
       "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_queues_inbound_total",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "inbound network messages",
+          "refId": "A"
+        },
         {
           "exemplar": true,
           "expr": "snarkos_queues_outbound_total",
@@ -446,6 +374,10 @@
           "interval": "",
           "legendFormat": "consensus requests",
           "refId": "F"
+        },
+        {
+          "hide": false,
+          "refId": "G"
         }
       ],
       "timeFrom": null,
@@ -856,6 +788,7 @@
           "calcs": [
             "min",
             "max",
+            "mean",
             "lastNotNull"
           ],
           "displayMode": "table",
@@ -970,7 +903,8 @@
           "calcs": [
             "min",
             "max",
-            "last"
+            "mean",
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1016,7 +950,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "type": "linear"
+              "log": 10,
+              "type": "log"
             },
             "showPoints": "never",
             "spanNulls": true,
@@ -1059,7 +994,8 @@
           "calcs": [
             "min",
             "max",
-            "last"
+            "mean",
+            "lastNotNull"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1264,12 +1200,12 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "snarkOS node",
-  "uid": "PAzNcaCGz",
-  "version": 18
+  "uid": "nuiNXZV7k",
+  "version": 7
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -58,6 +58,7 @@ pub mod handshakes {
 
 pub mod queues {
     pub const CONSENSUS: &str = "snarkos_queues_consensus_total";
+    pub const INBOUND: &str = "snarkos_queues_inbound_total";
     pub const OUTBOUND: &str = "snarkos_queues_outbound_total";
     pub const PEER_EVENTS: &str = "snarkos_queues_peer_events_total";
     pub const STORAGE: &str = "snarkos_queues_storage_total";

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -259,7 +259,7 @@ impl HandshakeStats {
 pub struct QueueStats {
     /// The number of queued consensus items.
     consensus: DiscreteGauge,
-    /// The number of messages queued in the common inbound channel.
+    /// The number of messages queued in the individual inbound channels.
     inbound: DiscreteGauge,
     /// The number of messages queued in the individual outbound channels.
     outbound: DiscreteGauge,
@@ -436,6 +436,7 @@ impl Recorder for Stats {
     fn update_gauge(&self, key: &Key, value: GaugeValue) {
         let metric = match key.name() {
             // queues
+            queues::INBOUND => &self.queues.inbound,
             queues::OUTBOUND => &self.queues.outbound,
             queues::PEER_EVENTS => &self.queues.peer_events,
             queues::STORAGE => &self.queues.storage,

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -67,6 +67,8 @@ impl PeerBookRef {
                 PeerEventData::Disconnect(peer, status) => {
                     self.connected_peers.remove(peer.address).await;
 
+                    let queued_inbound_message_count = peer.queued_inbound_message_count.swap(0, Ordering::SeqCst);
+                    metrics::decrement_gauge!(snarkos_metrics::queues::INBOUND, queued_inbound_message_count as f64);
                     let queued_outbound_message_count = peer.queued_outbound_message_count.swap(0, Ordering::SeqCst);
                     metrics::decrement_gauge!(snarkos_metrics::queues::OUTBOUND, queued_outbound_message_count as f64);
 


### PR DESCRIPTION
I missed this last time, but we can also follow the number of per-peer inbound network messages; this metric can indicate whether the node is experiencing a large influx of messages or has difficulty processing them.