### PR TITLE
Non-blocking Merkle tree rebuilds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd consensus && RUST_MIN_STACK=8388608 cargo test
+          command: cd consensus && RUST_MIN_STACK=8388608 cargo test --release
       - clear_environment:
           cache_key: snarkos-consensus-cache
 
@@ -162,7 +162,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd rpc && RUST_MIN_STACK=8388608 cargo test
+          command: cd rpc && RUST_MIN_STACK=8388608 cargo test --release
       - clear_environment:
           cache_key: snarkos-rpc-cache
 

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+use crate::ledger::dummy::DummyLedger;
 use snarkos_metrics as metrics;
 use snarkos_storage::DigestTree;
 use snarkvm_dpc::AleoAmount;
@@ -238,7 +239,7 @@ impl ConsensusInner {
         }
 
         let digest = if self.ledger.requires_async_task(commitments.len(), serial_numbers.len()) {
-            let mut ledger = std::mem::take(&mut self.ledger);
+            let mut ledger = std::mem::replace(&mut self.ledger, DynLedger(Box::new(DummyLedger)));
             let (digest, ledger) = tokio::task::spawn_blocking(move || {
                 let digest = ledger.extend(&commitments[..], &serial_numbers[..], &memos[..]);
 

--- a/consensus/src/ledger/dummy.rs
+++ b/consensus/src/ledger/dummy.rs
@@ -19,7 +19,8 @@ use crate::Ledger;
 use anyhow::*;
 use snarkos_storage::Digest;
 
-pub(super) struct DummyLedger;
+/// This object only serves as a temporary replacement for the regular Ledger so that it can be sent to a blocking task.
+pub(crate) struct DummyLedger;
 
 impl Ledger for DummyLedger {
     fn extend(&mut self, _new_cms: &[Digest], _new_sns: &[Digest], _new_memos: &[Digest]) -> Result<Digest> {

--- a/consensus/src/ledger/dummy.rs
+++ b/consensus/src/ledger/dummy.rs
@@ -1,0 +1,76 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::Ledger;
+
+use anyhow::*;
+use snarkos_storage::Digest;
+
+pub(super) struct DummyLedger;
+
+impl Ledger for DummyLedger {
+    fn extend(&mut self, _new_cms: &[Digest], _new_sns: &[Digest], _new_memos: &[Digest]) -> Result<Digest> {
+        unimplemented!()
+    }
+
+    fn rollback(&mut self, _commitments: &[Digest], _serial_numbers: &[Digest], _memos: &[Digest]) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn clear(&mut self) {
+        unimplemented!()
+    }
+
+    fn commitment_len(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn contains_commitment(&self, _commitment: &Digest) -> bool {
+        unimplemented!()
+    }
+
+    fn commitment_index(&self, _commitment: &Digest) -> Option<usize> {
+        unimplemented!()
+    }
+
+    fn contains_serial(&self, _serial: &Digest) -> bool {
+        unimplemented!()
+    }
+
+    fn contains_memo(&self, _memo: &Digest) -> bool {
+        unimplemented!()
+    }
+
+    fn validate_digest(&self, _digest: &Digest) -> bool {
+        unimplemented!()
+    }
+
+    fn digest(&self) -> Digest {
+        unimplemented!()
+    }
+
+    fn generate_proof(&self, _commitment: &Digest, _index: usize) -> Result<Vec<(Digest, Digest)>> {
+        unimplemented!()
+    }
+
+    fn validate_ledger(&self) -> bool {
+        unimplemented!()
+    }
+
+    fn requires_async_task(&self, _new_commitments_len: usize, _new_serial_numbers_len: usize) -> bool {
+        unimplemented!()
+    }
+}

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -132,4 +132,9 @@ impl<P: MerkleParameters> Ledger for MerkleLedger<P> {
         let calculated_digest = self.commitments.digest();
         self.digest() == calculated_digest
     }
+
+    fn requires_async_task(&self, new_commitments_len: usize, new_serial_numbers_len: usize) -> bool {
+        (self.commitments.len() + new_commitments_len).is_power_of_two()
+            || (self.serial_numbers.len() + new_serial_numbers_len).is_power_of_two()
+    }
 }

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -37,6 +37,7 @@ use snarkvm_dpc::{
     TransactionScheme,
 };
 
+mod dummy;
 mod merkle;
 pub use merkle::MerkleLedger;
 mod indexed_merkle_tree;
@@ -77,9 +78,17 @@ pub trait Ledger: Send + Sync {
 
     /// checks if a ledgers state is consistent
     fn validate_ledger(&self) -> bool;
+
+    fn requires_async_task(&self, new_commitments_len: usize, new_serial_numbers_len: usize) -> bool;
 }
 
 pub struct DynLedger(pub Box<dyn Ledger>);
+
+impl Default for DynLedger {
+    fn default() -> Self {
+        DynLedger(Box::new(dummy::DummyLedger))
+    }
+}
 
 impl Deref for DynLedger {
     type Target = dyn Ledger;

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -37,7 +37,7 @@ use snarkvm_dpc::{
     TransactionScheme,
 };
 
-mod dummy;
+pub(crate) mod dummy;
 mod merkle;
 pub use merkle::MerkleLedger;
 mod indexed_merkle_tree;
@@ -83,12 +83,6 @@ pub trait Ledger: Send + Sync {
 }
 
 pub struct DynLedger(pub Box<dyn Ledger>);
-
-impl Default for DynLedger {
-    fn default() -> Self {
-        DynLedger(Box::new(dummy::DummyLedger))
-    }
-}
 
 impl Deref for DynLedger {
     type Target = dyn Ledger;

--- a/consensus/tests/consensus_dpc.rs
+++ b/consensus/tests/consensus_dpc.rs
@@ -29,7 +29,7 @@ mod consensus_dpc {
     };
     use snarkvm_utilities::{to_bytes_le, ToBytes};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn base_dpc_multiple_transactions() {
         let program = FIXTURE.program.clone();
         let [_genesis_address, miner_acc, recipient] = FIXTURE.test_accounts.clone();

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -187,7 +187,7 @@ mod rpc_tests {
         assert_eq!(result.as_u64().unwrap(), 1u64);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rpc_get_best_block_hash() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -202,7 +202,7 @@ mod rpc_tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rpc_get_block_hash() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -330,7 +330,7 @@ mod rpc_tests {
         assert!(!peer_info.is_syncing);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rpc_get_block_template() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;


### PR DESCRIPTION
The Merkle trees the node is using are most of the time rebuilt in an optimized fashion, reusing as many hashes as possible. However, whenever the number of leaves is a power of 2, the entire tree needs to be rebuilt. This PR spawns a dedicated blocking task whenever such conditions are detected, making it a non-blocking operation.