### PR TITLE
Non-blocking transaction verification

### DIFF
--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -201,7 +201,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         let serial_numbers = storage.get_serial_numbers().await?;
         let memos = storage.get_memos().await?;
         info!("Initializing Ledger");
-        let ledger = DynLedger(Box::new(MerkleLedger::new(
+        let ledger = DynLedger(Arc::new(MerkleLedger::new(
             ledger_parameters,
             &ledger_digests[..],
             &commitments[..],

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -70,10 +70,11 @@ impl ConsensusInner {
 
             match message {
                 ConsensusMessage::ReceiveTransaction(transaction) => {
-                    response.send(Box::new(self.receive_transaction(transaction))).ok();
+                    let ret = self.receive_transaction(transaction).await;
+                    response.send(Box::new(ret)).ok();
                 }
                 ConsensusMessage::VerifyTransactions(transactions) => {
-                    let out = match self.verify_transactions(transactions.iter()) {
+                    let out = match self.verify_transactions(transactions).await {
                         Ok(out) => out,
                         Err(e) => {
                             error!(

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -225,7 +225,7 @@ impl ConsensusInner {
         }
 
         // Check that all the transaction proofs verify
-        self.verify_transactions(block.transactions.iter())
+        self.verify_transactions(block.transactions.clone()).await
     }
 
     pub(super) async fn commit_block(&mut self, hash: &Digest, block: &SerialBlock) -> Result<(), ConsensusError> {
@@ -239,7 +239,7 @@ impl ConsensusInner {
         }
 
         let digest = if self.ledger.requires_async_task(commitments.len(), serial_numbers.len()) {
-            let mut ledger = std::mem::replace(&mut self.ledger, DynLedger(Box::new(DummyLedger)));
+            let mut ledger = std::mem::replace(&mut self.ledger, DynLedger(Arc::new(DummyLedger)));
             let (digest, ledger) = tokio::task::spawn_blocking(move || {
                 let digest = ledger.extend(&commitments[..], &serial_numbers[..], &memos[..]);
 

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -82,7 +82,8 @@ pub trait Ledger: Send + Sync {
     fn requires_async_task(&self, new_commitments_len: usize, new_serial_numbers_len: usize) -> bool;
 }
 
-pub struct DynLedger(pub Box<dyn Ledger>);
+#[derive(Clone)]
+pub struct DynLedger(pub Arc<dyn Ledger>);
 
 impl Deref for DynLedger {
     type Target = dyn Ledger;
@@ -94,7 +95,7 @@ impl Deref for DynLedger {
 
 impl DerefMut for DynLedger {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.0
+        Arc::get_mut(&mut self.0).unwrap() // this is safe, because the ledger items are processed sequentially
     }
 }
 

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -178,7 +178,7 @@ mod tests {
             Arc::new(Parameters::from(crh))
         };
 
-        DynLedger(Box::new(
+        DynLedger(Arc::new(
             MerkleLedger::new(ledger_parameters, &[], &[], &[], &[]).unwrap(),
         ))
     }

--- a/testing/src/storage/mod.rs
+++ b/testing/src/storage/mod.rs
@@ -43,7 +43,7 @@ pub fn initialize_test_blockchain() -> (DynStorage, DynLedger) {
         Arc::new(Parameters::from(crh))
     };
 
-    let ledger = DynLedger(Box::new(
+    let ledger = DynLedger(Arc::new(
         MerkleLedger::new(ledger_parameters, &[], &[], &[], &[]).unwrap(),
     ));
     let store = Arc::new(AsyncStorage::new(SqliteStorage::new_ephemeral().unwrap()));

--- a/testing/src/sync/fixture.rs
+++ b/testing/src/sync/fixture.rs
@@ -61,7 +61,7 @@ impl Fixture {
             Arc::new(Parameters::from(crh))
         };
 
-        DynLedger(Box::new(
+        DynLedger(Arc::new(
             MerkleLedger::new(ledger_parameters, &[], &[], &[], &[]).unwrap(),
         ))
     }


### PR DESCRIPTION
Just like Merkle tree rebuilds in https://github.com/AleoHQ/snarkOS/pull/1115, transaction verification was found to be blocking at times, often taking more than 100ms. While spawning a blocking task is not free, it is significantly cheaper than blocking an async worker thread.

An example measurement:
```
10693ms taken by verify_transactions for 263 txs
```

This will be improved by https://github.com/AleoHQ/snarkVM/pull/371, but it's still desirable on its own.