### PR TITLE
Non-blocking header verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "colored",
  "dirs",
  "hex",
+ "num_cpus",
  "parking_lot",
  "rand 0.8.4",
  "self_update",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ version = "3.0.2"
 [dependencies.hex]
 version = "0.4.1"
 
+[dependencies.num_cpus]
+version = "1"
+
 [dependencies.parking_lot]
 version = "0.11.1"
 

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -316,6 +316,7 @@ fn main() -> Result<(), NodeError> {
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(8 * 1024 * 1024)
+        .max_blocking_threads(std::cmp::max(num_cpus::get().saturating_sub(2), 1)) // don't use 100% of the cores
         .build()?;
 
     runtime.block_on(start_server(config))?;


### PR DESCRIPTION
Block header verification usually takes more than 10ms, while spawning a blocking task takes microseconds.