### PR TITLE
Aggro Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,6 +2760,7 @@ dependencies = [
  "futures 0.3.17",
  "hash_hasher",
  "hex",
+ "indexmap",
  "itertools",
  "log",
  "metrics",

--- a/benchmarks/network/block_cache.rs
+++ b/benchmarks/network/block_cache.rs
@@ -18,7 +18,7 @@ use criterion::*;
 use rand::{thread_rng, Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 
-use snarkos_network::Cache;
+use snarkos_network::BlockCache;
 
 fn block_cache_perf(c: &mut Criterion) {
     const MIN_BLOCK_SIZE: usize = 1024; // 1KiB

--- a/benchmarks/network/block_cache.rs
+++ b/benchmarks/network/block_cache.rs
@@ -24,7 +24,7 @@ fn block_cache_perf(c: &mut Criterion) {
     const MIN_BLOCK_SIZE: usize = 1024; // 1KiB
     const MAX_BLOCK_SIZE: usize = 1024 * 1024; // 1MiB
 
-    let mut cache = Cache::<8192>::default();
+    let mut cache = BlockCache::<8192>::default();
 
     let seed: u64 = thread_rng().gen();
     let mut rng = XorShiftRng::seed_from_u64(seed);

--- a/benchmarks/network/syncing.rs
+++ b/benchmarks/network/syncing.rs
@@ -42,7 +42,7 @@ fn providing_sync_blocks(c: &mut Criterion) {
         assert!(rt.block_on(provider.expect_sync().consensus.receive_block(block.clone())));
     }
 
-    let canon = rt.block_on(provider.expect_storage().canon()).unwrap();
+    let canon = rt.block_on(provider.storage.canon()).unwrap();
 
     assert_eq!(canon.block_height, NUM_BLOCKS);
 

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -138,7 +138,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (miner, RPC) needs to use it.
-    let mut node = Node::new(node_config, Some(storage.clone())).await?;
+    let mut node = Node::new(node_config, storage.clone()).await?;
 
     if let Some(limit) = config.storage.export {
         let mut export_path = path.clone();
@@ -275,7 +275,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
         let rpc_handle = start_rpc_server(
             rpc_address,
-            Some(storage),
+            storage,
             node.clone(),
             config.rpc.username,
             config.rpc.password,

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -91,6 +91,9 @@ impl ConsensusInner {
                     }
                     Err(e) => {
                         match e {
+                            ConsensusError::PreExistingBlock => {
+                                trace!("failed receiving block: {:?}", e);
+                            }
                             ConsensusError::InvalidBlock(e) => {
                                 debug!("failed receiving block: {:?}", e);
                             }

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -27,7 +27,6 @@ impl ConsensusInner {
         match self.storage.get_block_state(&hash).await? {
             BlockStatus::Unknown => (),
             BlockStatus::Committed(_) | BlockStatus::Uncommitted => {
-                debug!("Received a pre-existing block");
                 metrics::increment_counter!(DUPLICATE_BLOCKS);
                 return Err(ConsensusError::PreExistingBlock);
             }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -41,6 +41,9 @@ version = "1.3.14"
 path = "../storage"
 version = "1.3.14"
 
+[dependencies.indexmap]
+version = "1.6"
+
 [dependencies.futures]
 version = "0.3"
 

--- a/network/src/inbound/cache.rs
+++ b/network/src/inbound/cache.rs
@@ -14,17 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_dpc::block::BlockHeader;
-
 use circular_queue::CircularQueue;
+use snarkvm_dpc::BlockHeader;
 use twox_hash::xxh3::hash64;
 
 #[derive(Debug, Clone)]
-pub struct Cache<const N: usize> {
+pub struct Cache<const N: usize, const S: usize> {
     queue: CircularQueue<u64>,
 }
 
-impl<const N: usize> Default for Cache<N> {
+const BLOCK_HEADER_SIZE: usize = BlockHeader::size();
+
+pub type BlockCache<const N: usize> = Cache<N, BLOCK_HEADER_SIZE>;
+
+impl<const N: usize, const S: usize> Default for Cache<N, S> {
     fn default() -> Self {
         Self {
             queue: CircularQueue::with_capacity(N),
@@ -32,9 +35,9 @@ impl<const N: usize> Default for Cache<N> {
     }
 }
 
-impl<const N: usize> Cache<N> {
+impl<const N: usize, const S: usize> Cache<N, S> {
     fn hash_block(payload: &[u8]) -> u64 {
-        hash64(&payload[..BlockHeader::size()])
+        hash64(&payload[..S.min(payload.len())])
     }
 
     pub fn contains(&self, payload: &[u8]) -> bool {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -342,10 +342,7 @@ impl Node {
 
         // The node can already be at some non-zero height.
         if self.sync().is_some() {
-            metrics::gauge!(
-                misc::BLOCK_HEIGHT,
-                self.storage.canon().await?.block_height as f64
-            );
+            metrics::gauge!(misc::BLOCK_HEIGHT, self.storage.canon().await?.block_height as f64);
         }
 
         Ok(())

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -61,7 +61,7 @@ pub struct InnerNode {
     /// The pre-configured parameters of this node.
     pub config: Config,
     /// The cache of node's inbound messages.
-    pub inbound_cache: Mutex<Cache<{ crate::BLOCK_CACHE_SIZE }>>,
+    pub inbound_cache: Mutex<BlockCache<{ crate::BLOCK_CACHE_SIZE }>>,
     /// The list of connected and disconnected peers of this node.
     pub peer_book: PeerBook,
     /// Tracks the known network crawled by this node.

--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -213,8 +213,8 @@ impl Peer {
                 Ok(PeerResponse::None)
             }
             PeerAction::ExpectingSyncBlocks(amount) => {
-                self.quality.remaining_sync_blocks = amount;
-                self.quality.total_sync_blocks = amount;
+                self.quality.remaining_sync_blocks += amount;
+                self.quality.total_sync_blocks += amount;
                 Ok(PeerResponse::None)
             }
             PeerAction::SoftFail => {

--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -208,7 +208,7 @@ impl Peer {
                 if self.quality.remaining_sync_blocks > 0 {
                     self.quality.remaining_sync_blocks -= 1;
                 } else {
-                    warn!("received unexpected or late sync block from {}", self.address);
+                    trace!("received unexpected or late sync block from {}", self.address);
                 }
                 Ok(PeerResponse::None)
             }

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -29,7 +29,7 @@ use std::{
 use tokio::sync::mpsc;
 
 use super::PeerQuality;
-use crate::{message::Payload, Cache, NetworkError, Node};
+use crate::{BlockCache, NetworkError, Node, message::Payload};
 
 use super::{network::*, outbound_handler::*};
 
@@ -64,7 +64,7 @@ pub struct Peer {
     pub is_routable: Option<bool>,
 
     #[serde(skip)]
-    pub block_received_cache: Cache<{ crate::PEER_BLOCK_CACHE_SIZE }>,
+    pub block_received_cache: BlockCache<{ crate::PEER_BLOCK_CACHE_SIZE }>,
 }
 
 const FAILURE_EXPIRY_TIME: Duration = Duration::from_secs(15 * 60);
@@ -83,7 +83,7 @@ impl Peer {
             // Set to `None` since peer creation only ever happens before a connection to the peer,
             // therefore we don't know if its listener is routable or not.
             is_routable: None,
-            block_received_cache: Cache::default(),
+            block_received_cache: BlockCache::default(),
         }
     }
 

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -29,7 +29,7 @@ use std::{
 use tokio::sync::mpsc;
 
 use super::PeerQuality;
-use crate::{BlockCache, NetworkError, Node, message::Payload};
+use crate::{message::Payload, BlockCache, NetworkError, Node};
 
 use super::{network::*, outbound_handler::*};
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -287,7 +287,7 @@ impl Node {
 
         // Consider peering tests that don't use the sync layer.
         let current_block_height = if self.sync().is_some() {
-            self.expect_storage().canon().await?.block_height as u32
+            self.storage.canon().await?.block_height as u32
         } else {
             0
         };

--- a/network/src/sync/blocks/aggro.rs
+++ b/network/src/sync/blocks/aggro.rs
@@ -1,0 +1,204 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Duration};
+
+use crate::{Cache, Node, Payload, Peer, SyncBase, SyncInbound};
+use anyhow::*;
+use indexmap::IndexSet;
+use snarkos_storage::Digest;
+use snarkvm_dpc::BlockHeaderHash;
+use tokio::{sync::{RwLock, mpsc}, time::Instant};
+
+#[derive(Default)]
+struct PeerSyncInfo {
+    known_canon_depth: u32,
+    known_latest_hash: Option<BlockHeaderHash>,
+    pending_block_hashes: Vec<BlockHeaderHash>,
+}
+
+pub struct SyncAggro {
+    base: SyncBase,
+    peer_info: BTreeMap<SocketAddr, PeerSyncInfo>,
+}
+
+struct BlockLocatorHashes {
+    hashes: IndexSet<BlockHeaderHash>,
+    last_update: Instant,
+}
+
+impl SyncAggro {
+    pub fn new(node: Node) -> (Self, mpsc::Sender<SyncInbound>) {
+        let (base, sender) = SyncBase::new(node);
+        let new = Self {
+            base,
+            peer_info: BTreeMap::new(),
+        };
+        (new, sender)
+    }
+
+    async fn send_sync_messages(&mut self, nodes: Vec<(Peer, Vec<BlockHeaderHash>)>) -> Result<usize> {
+        info!("requested block information from {} peers", nodes.len());
+        let mut future_set = vec![];
+
+        for (peer, hashes) in nodes {
+            if let Some(handle) = self.base.node.peer_book.get_peer_handle(peer.address) {
+                future_set.push(async move {
+                    handle.send_payload(Payload::GetSync(hashes), None).await;
+                });
+            }
+        }
+        let sent = future_set.len();
+        futures::future::join_all(future_set).await;
+        Ok(sent)
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        let sync_nodes = self.base.find_sync_nodes().await?;
+
+        if sync_nodes.is_empty() {
+            return Ok(());
+        }
+
+        self.base.node.register_block_sync_attempt();
+
+        let block_locator_hashes = Arc::new(RwLock::new(BlockLocatorHashes {
+            hashes: SyncBase::block_locator_hashes(&self.base.node).await?.into_iter().collect(),
+            last_update: Instant::now(),
+        }));
+
+        let peer_syncs = {
+            let block_locator_hashes = block_locator_hashes.read().await;
+            let mut peer_syncs = Vec::with_capacity(sync_nodes.len());
+            for peer in &sync_nodes {
+                let mut initial_hashes = self.peer_info.entry(peer.address).or_default().pending_block_hashes.clone();
+                if initial_hashes.is_empty() {
+                    initial_hashes = block_locator_hashes.hashes.iter().cloned().collect();
+                }
+                peer_syncs.push((peer.clone(), initial_hashes));
+            }
+            peer_syncs
+        };
+
+        let hash_requests_sent = self.send_sync_messages(peer_syncs).await?;
+
+        if hash_requests_sent == 0 {
+            return Ok(());
+        }
+
+        let received_hashes = Arc::new(RwLock::new(Cache::default()));
+
+        let node = self.base.node.clone();
+        self.base.receive_messages(15, 3, |msg| {
+            metrics::decrement_gauge!(snarkos_metrics::queues::SYNC_ITEMS, 1.0);
+            match msg {
+                SyncInbound::BlockHashes(peer, hashes) => {
+                    let hashes: Vec<Digest> = hashes.into_iter().map(|x| x.0.into()).collect::<Vec<_>>();
+                    if hashes.is_empty() {
+                        return false;
+                    }
+                    let last_hash = hashes.last().unwrap().clone();
+                    
+                    let node = node.clone();
+                    let block_locator_hashes = block_locator_hashes.clone();
+                    let received_hashes = received_hashes.clone();
+                    tokio::spawn(async move {
+                        if block_locator_hashes.read().await.last_update.elapsed() > Duration::from_secs(10) {
+                            match SyncBase::block_locator_hashes(&node).await {
+                                Ok(hashes) => {
+                                    let mut target = block_locator_hashes.write().await;
+                                    target.hashes = hashes.into_iter().collect();
+                                    target.last_update = Instant::now();
+                                },
+                                Err(e) => warn!("sync failed to fetch block locator hashes: {:?}", e),
+                            }
+                        }
+
+                        let mut hashes_trimmed = Vec::with_capacity(hashes.len());
+                        {
+                            let received_hashes = received_hashes.read().await;
+                            for hash in hashes {
+                                if !received_hashes.contains(&hash[..]) {
+                                    hashes_trimmed.push(hash);
+                                }
+                            }
+                        }
+
+                        let early_block_states = match node.storage.get_block_states(&hashes_trimmed[..]).await {
+                            Ok(x) => x,
+                            Err(e) => {
+                                warn!("failed to get block states: {:?}", e);
+                                return;
+                            }
+                        };
+
+                        let block_locator_hashes: Vec<_> = block_locator_hashes.read().await.hashes.iter().cloned().collect();
+
+                        let blocks: IndexSet<_> = {
+                            let received_hashes = received_hashes.read().await;
+                            block_locator_hashes
+                                .into_iter()
+                                .filter(|x| !received_hashes.contains(&x.0[..]))
+                                .chain(
+                                    hashes_trimmed
+                                        .into_iter()
+                                        .zip(early_block_states.iter())
+                                        .filter(|(_, status)| matches!(status, snarkos_storage::BlockStatus::Unknown))
+                                        .map(|(hash, _)| BlockHeaderHash(hash.bytes().unwrap()))
+                                ).collect()
+                        };
+                        if blocks.is_empty() {
+                            return;
+                        }
+    
+                        if let Some(peer) = node.peer_book.get_peer_handle(peer) {
+                            let request: Vec<BlockHeaderHash> = blocks
+                                .into_iter()
+                                .collect();
+                            peer.expecting_sync_blocks(request.len() as u32).await;
+                            peer.send_payload(Payload::GetBlocks(request), None).await;
+                            peer.send_payload(Payload::GetSync(vec![BlockHeaderHash(last_hash.bytes().unwrap())]), None).await;
+                        }
+                    });
+                },
+                SyncInbound::Block(peer, block, peer_height) => {
+                    let node = node.clone();
+                    tokio::spawn(async move {
+                        match node
+                            .process_received_block(peer, block, peer_height, false)
+                            .await {
+                                Err(e) => warn!("failed to process received block from {}: {:?}", peer, e),
+                                Ok(()) => (),
+                            }
+                    });
+                },
+            }
+            false
+        }).await;
+
+        let sync_addresses = sync_nodes.iter().map(|x| x.address).collect::<Vec<_>>();
+
+        self.base.cancel_outstanding_syncs(&sync_addresses[..]).await;
+
+        Ok(())
+    }
+}
+
+impl Drop for SyncAggro {
+    fn drop(&mut self) {
+        metrics::gauge!(snarkos_metrics::queues::SYNC_ITEMS, 0.0);
+    }
+}

--- a/network/src/sync/blocks/aggro.rs
+++ b/network/src/sync/blocks/aggro.rs
@@ -26,6 +26,7 @@ use tokio::{
     time::Instant,
 };
 
+/// Aggressive, continuous sync process that pulls peers entire canon trees.
 pub struct SyncAggro {
     base: SyncBase,
 }

--- a/network/src/sync/blocks/base.rs
+++ b/network/src/sync/blocks/base.rs
@@ -24,6 +24,7 @@ use tokio::{sync::mpsc, time::Instant};
 use crate::{Node, Peer, SyncInbound};
 use anyhow::*;
 
+/// Base sync helpers
 pub struct SyncBase {
     pub node: Node,
     pub incoming: mpsc::Receiver<SyncInbound>,

--- a/network/src/sync/blocks/base.rs
+++ b/network/src/sync/blocks/base.rs
@@ -1,0 +1,112 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{net::SocketAddr, time::Duration};
+
+use futures::{FutureExt, pin_mut, select};
+use snarkos_storage::Digest;
+use snarkvm_dpc::BlockHeaderHash;
+use tokio::{sync::mpsc, time::Instant};
+
+use crate::{Node, Peer, SyncInbound};
+use anyhow::*;
+
+pub struct SyncBase {
+    pub node: Node,
+    pub incoming: mpsc::Receiver<SyncInbound>,
+}
+
+impl SyncBase {
+    pub fn new(node: Node) -> (Self, mpsc::Sender<SyncInbound>) {
+        let (sender, receiver) = mpsc::channel(256);
+        let new = Self {
+            node,
+            incoming: receiver,
+        };
+        (new, sender)
+    }
+
+    pub async fn find_sync_nodes(&self) -> Result<Vec<Peer>> {
+        let our_block_height = self.node.storage.canon().await?.block_height;
+        let mut interesting_peers = vec![];
+        for mut node in self.node.peer_book.connected_peers_snapshot().await {
+            let judge_bad = node.judge_bad();
+            if !judge_bad && node.quality.block_height as usize > our_block_height + 1 {
+                interesting_peers.push(node);
+            }
+        }
+        interesting_peers.sort_by(|x, y| y.quality.block_height.cmp(&x.quality.block_height));
+
+        // trim nodes close to us if any are > 10 blocks ahead
+        if let Some(i) = interesting_peers
+            .iter()
+            .position(|x| x.quality.block_height as usize <= our_block_height + 10)
+        {
+            interesting_peers.truncate(i + 1);
+        }
+
+        if !interesting_peers.is_empty() {
+            info!("found {} interesting peers for sync", interesting_peers.len());
+            trace!("sync interesting peers = {:?}", interesting_peers);
+        }
+
+        Ok(interesting_peers)
+    }
+
+    /// receives an arbitrary amount of inbound sync messages with a given timeout.
+    /// if the passed `handler` callback returns `true`, then the loop is terminated early.
+    /// if the sync stream closes, the loop is also terminated early.
+    pub async fn receive_messages<F: FnMut(SyncInbound) -> bool> (
+        &mut self,
+        timeout_sec: u64,
+        moving_timeout_sec: u64,
+        mut handler: F,
+    ) {
+        let end = Instant::now() + Duration::from_secs(timeout_sec);
+        let mut moving_end = Instant::now() + Duration::from_secs(moving_timeout_sec);
+        loop {
+            let timeout = tokio::time::sleep_until(end.min(moving_end)).fuse();
+            pin_mut!(timeout);
+            select! {
+                msg = self.incoming.recv().fuse() => {
+                    if msg.is_none() {
+                        break;
+                    }
+                    metrics::decrement_gauge!(snarkos_metrics::queues::SYNC_ITEMS, 1.0);
+                    if handler(msg.unwrap()) {
+                        break;
+                    }
+                    moving_end += Duration::from_secs(moving_timeout_sec);
+                },
+                _ = timeout => {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub async fn cancel_outstanding_syncs(&self, addresses: &[SocketAddr]) {
+        let mut future_set = vec![];
+        for addr in addresses {
+            if let Some(peer) = self.node.peer_book.get_peer_handle(*addr) {
+                future_set.push(async move {
+                    peer.cancel_sync().await;
+                });
+            }
+        }
+        futures::future::join_all(future_set).await;
+    }
+}

--- a/network/src/sync/blocks/batched.rs
+++ b/network/src/sync/blocks/batched.rs
@@ -25,6 +25,7 @@ use snarkvm_algorithms::crh::double_sha256;
 use snarkvm_dpc::{BlockHeader, BlockHeaderHash};
 use tokio::sync::mpsc;
 
+/// Efficient but slow and fork-prone sync method that operates in distributed batches.
 pub struct SyncBatched {
     base: SyncBase,
 }

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -30,7 +30,7 @@ use snarkvm_dpc::{
 use snarkos_consensus::error::ConsensusError;
 use snarkos_metrics as metrics;
 
-use crate::{SyncInbound, message::*, NetworkError, Node, State};
+use crate::{message::*, NetworkError, Node, State, SyncInbound};
 use anyhow::*;
 use tokio::task;
 

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -30,7 +30,7 @@ use snarkvm_dpc::{
 use snarkos_consensus::error::ConsensusError;
 use snarkos_metrics as metrics;
 
-use crate::{master::SyncInbound, message::*, NetworkError, Node, State};
+use crate::{SyncInbound, message::*, NetworkError, Node, State};
 use anyhow::*;
 use tokio::task;
 

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -131,7 +131,7 @@ impl Node {
         .map_err(|e| NetworkError::Other(e.into()))??;
         let previous_block_hash = block_struct.header.previous_block_hash.clone();
 
-        let canon = self.expect_storage().canon().await?;
+        let canon = self.storage.canon().await?;
 
         info!(
             "Got a block from {} ({}) with hash {}... (current head {})",
@@ -175,8 +175,8 @@ impl Node {
             .map(|x| -> Digest { x.0.into() })
             .enumerate()
         {
-            let block = self.expect_storage().get_block(&hash).await?;
-            let height = match self.expect_storage().get_block_state(&block.header.hash()).await? {
+            let block = self.storage.get_block(&hash).await?;
+            let height = match self.storage.get_block_state(&block.header.hash()).await? {
                 BlockStatus::Committed(h) => Some(h as u32),
                 _ => None,
             };
@@ -211,7 +211,7 @@ impl Node {
         let block_locator_hashes = block_locator_hashes.into_iter().map(|x| x.0.into()).collect::<Vec<_>>();
 
         let sync_hashes = self
-            .expect_storage()
+            .storage
             .find_sync_blocks(&block_locator_hashes[..], crate::MAX_BLOCK_SYNC_COUNT as usize)
             .await?
             .into_iter()

--- a/network/src/sync/blocks/mod.rs
+++ b/network/src/sync/blocks/mod.rs
@@ -14,15 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod blocks;
-pub use blocks::*;
+mod batched;
+pub use batched::*;
+mod interface;
+pub use interface::*;
+mod base;
+pub use base::*;
+mod aggro;
+pub use aggro::*;
 
-pub mod memory_pool;
-pub use memory_pool::*;
+use std::net::SocketAddr;
+use snarkvm_dpc::BlockHeaderHash;
 
-// TODO (howardwu): Move this out of network/sync. It should be on a much higher level.
-pub mod miner;
-pub use miner::*;
-
-pub mod sync;
-pub use sync::*;
+pub enum SyncInbound {
+    BlockHashes(SocketAddr, Vec<BlockHeaderHash>),
+    Block(SocketAddr, Vec<u8>, Option<u32>),
+}

--- a/network/src/sync/blocks/mod.rs
+++ b/network/src/sync/blocks/mod.rs
@@ -23,8 +23,8 @@ pub use base::*;
 mod aggro;
 pub use aggro::*;
 
-use std::net::SocketAddr;
 use snarkvm_dpc::BlockHeaderHash;
+use std::net::SocketAddr;
 
 pub enum SyncInbound {
     BlockHashes(SocketAddr, Vec<BlockHeaderHash>),

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -124,12 +124,7 @@ impl MinerInstance {
 
                 let serialized_block = block.serialize();
                 let node_clone = self.node.clone();
-                let new_height = node_clone
-                    .storage
-                    .canon()
-                    .await
-                    .map(|c| c.block_height as u32)
-                    .ok();
+                let new_height = node_clone.storage.canon().await.map(|c| c.block_height as u32).ok();
 
                 self.node.propagate_block(serialized_block, new_height, local_addr);
             }

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -125,7 +125,7 @@ impl MinerInstance {
                 let serialized_block = block.serialize();
                 let node_clone = self.node.clone();
                 let new_height = node_clone
-                    .expect_storage()
+                    .storage
                     .canon()
                     .await
                     .map(|c| c.block_height as u32)

--- a/rpc/src/custom_rpc_server.rs
+++ b/rpc/src/custom_rpc_server.rs
@@ -60,7 +60,7 @@ const METHODS_EXPECTING_PARAMS: [&str; 15] = [
 #[allow(clippy::too_many_arguments)]
 pub fn start_rpc_server(
     rpc_addr: SocketAddr,
-    storage: Option<DynStorage>,
+    storage: DynStorage,
     node_server: Node,
     username: Option<String>,
     password: Option<String>,

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -621,7 +621,7 @@ impl ProtectedRpcFunctions for RpcImpl {
 
     /// Returns the number of record commitments that are stored on the full node.
     async fn get_record_commitment_count(&self) -> Result<usize, RpcError> {
-        let storage = &self.storage()?;
+        let storage = &self.storage;
         let record_commitments = storage.get_record_commitments(None).await?;
 
         Ok(record_commitments.len())
@@ -629,7 +629,7 @@ impl ProtectedRpcFunctions for RpcImpl {
 
     /// Returns a list of record commitments that are stored on the full node.
     async fn get_record_commitments(&self) -> Result<Vec<String>, RpcError> {
-        let record_commitments = self.storage()?.get_record_commitments(Some(100)).await?;
+        let record_commitments = self.storage.get_record_commitments(Some(100)).await?;
         let record_commitment_strings: Vec<String> = record_commitments.iter().map(hex::encode).collect();
 
         Ok(record_commitment_strings)
@@ -638,7 +638,7 @@ impl ProtectedRpcFunctions for RpcImpl {
     /// Returns the hex encoded bytes of a record from its record commitment
     async fn get_raw_record(&self, record_commitment: String) -> Result<String, RpcError> {
         let decoded = hex::decode(record_commitment)?;
-        match self.storage()?.get_record(decoded[..].into()).await? {
+        match self.storage.get_record(decoded[..].into()).await? {
             Some(record) => Ok(hex::encode(to_bytes_le![record]?)),
             None => Ok("Record not found".to_string()),
         }

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -80,7 +80,7 @@ mod protected_rpc_tests {
         };
 
         let environment = test_config(node_setup.unwrap_or_default());
-        let mut node = Node::new(environment, Some(consensus.storage.clone())).await.unwrap();
+        let mut node = Node::new(environment, consensus.storage.clone()).await.unwrap();
         let consensus_setup = ConsensusSetup::default();
 
         let node_consensus = snarkos_network::Sync::new(

--- a/rpc/tests/protected_rpc_tests.rs
+++ b/rpc/tests/protected_rpc_tests.rs
@@ -92,7 +92,7 @@ mod protected_rpc_tests {
 
         node.set_sync(node_consensus);
 
-        let rpc_impl = RpcImpl::new(Some(consensus.storage.clone()), Some(credentials), node.clone());
+        let rpc_impl = RpcImpl::new(consensus.storage.clone(), Some(credentials), node.clone());
         let mut io = jsonrpc_core::MetaIoHandler::default();
 
         rpc_impl.add_protected(&mut io);

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -39,7 +39,7 @@ mod rpc_tests {
     async fn initialize_test_rpc(consensus: &Arc<Consensus>, node_setup: Option<TestSetup>) -> (Rpc, Node) {
         let environment = test_config(node_setup.unwrap_or_default());
 
-        let mut node = Node::new(environment, Some(consensus.storage.clone())).await.unwrap();
+        let mut node = Node::new(environment, consensus.storage.clone()).await.unwrap();
         let consensus_setup = ConsensusSetup::default();
 
         let node_consensus = snarkos_network::Sync::new(

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -185,15 +185,13 @@ pub async fn test_node(setup: TestSetup) -> Node {
     let node = match setup.consensus_setup {
         None => Node::new(
             config,
-            Some(Arc::new(AsyncStorage::new(SqliteStorage::new_ephemeral().unwrap()))),
+            Arc::new(AsyncStorage::new(SqliteStorage::new_ephemeral().unwrap())),
         )
         .await
         .unwrap(),
         Some(consensus_setup) => {
             let consensus = test_consensus(consensus_setup).await;
-            let mut node = Node::new(config, Some(consensus.consensus.storage.clone()))
-                .await
-                .unwrap();
+            let mut node = Node::new(config, consensus.consensus.storage.clone()).await.unwrap();
 
             node.set_sync(consensus);
             node

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -227,10 +227,7 @@ async fn block_two_node() {
     let node_bob = test_node(setup).await;
 
     // check blocks present in alice's chain were synced to bob's
-    wait_until!(
-        30,
-        node_bob.storage.canon().await.unwrap().block_height == NUM_BLOCKS
-    );
+    wait_until!(30, node_bob.storage.canon().await.unwrap().block_height == NUM_BLOCKS);
 }
 
 #[tokio::test]

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -104,7 +104,7 @@ async fn block_initiator_side() {
     wait_until!(
         5,
         matches!(
-            node.expect_storage()
+            node.storage
                 .get_block_state(&block_1_header_hash.0.into())
                 .await
                 .unwrap(),
@@ -114,7 +114,7 @@ async fn block_initiator_side() {
     wait_until!(
         1,
         matches!(
-            node.expect_storage()
+            node.storage
                 .get_block_state(&block_2_header_hash.0.into())
                 .await
                 .unwrap(),
@@ -181,7 +181,7 @@ async fn block_propagation() {
     let payload = Payload::Block(block_1.clone(), Some(1));
     peer.write_message(&payload).await;
 
-    wait_until!(5, node.expect_storage().canon().await.unwrap().block_height == 1);
+    wait_until!(5, node.storage.canon().await.unwrap().block_height == 1);
 
     node.peer_book.broadcast(Payload::Ping(1)).await;
 
@@ -229,7 +229,7 @@ async fn block_two_node() {
     // check blocks present in alice's chain were synced to bob's
     wait_until!(
         30,
-        node_bob.expect_storage().canon().await.unwrap().block_height == NUM_BLOCKS
+        node_bob.storage.canon().await.unwrap().block_height == NUM_BLOCKS
     );
 }
 


### PR DESCRIPTION
This PR massively increases network-bound sync performance and significantly reduces any chances of forks not being considered.

The old sync process:
1. Request sync hashes from peers based on block locator hashes
2. Randomly request each novel sync block from a random peer who has it
3. Repeat

The new sync process:
1. Request sync hashes from peers based on block locator hashes
2. For each peer that responds, broadcast back their highest sync hash, request all blocks we don't have at that instant
3. Repeat step # 2 until no one responds for a while

This has the following effects:
* Continuous sync process eliminates cyclical performance observed/expected in old sync process.
* Increase in the number of received duplicate blocks (from effectively zero to scaling linearly by number of peers)
* An effective, naive negotiation for any peers on really distant forks to still be able to send blocks.
* Pulling forks that are ultimately suboptimal, in their entirety.

My current node synced to canon tip from origin in ~18 hours of runtime -- unclean test. Has ~40K forked blocks from the process (not forks, blocks not in canon).