### PR TITLE
Upgrade the miner termination log from TRACE to DEBUG

### DIFF
--- a/consensus/src/miner.rs
+++ b/consensus/src/miner.rs
@@ -144,7 +144,7 @@ impl MineContext {
         let (nonce, proof) = match mined {
             Err(PoswError::SnarkError(SNARKError::Terminated)) => {
                 // technically a race condition, but non-critical
-                trace!("terminated miner due to canon block received");
+                debug!("terminated miner due to canon block received");
                 terminator.store(false, Ordering::SeqCst);
                 return Err(ConsensusError::PoswError(PoswError::SnarkError(SNARKError::Terminated)));
             }
@@ -152,7 +152,7 @@ impl MineContext {
                 if message == "Failed to generate proof - Terminated" =>
             {
                 // todo: remove in snarkvm 0.7.10+
-                trace!("terminated miner due to canon block received");
+                debug!("terminated miner due to canon block received");
                 terminator.store(false, Ordering::SeqCst);
                 return Err(ConsensusError::PoswError(PoswError::SnarkError(SNARKError::Terminated)));
             }


### PR DESCRIPTION
This doesn't happen too often, so the log can be upgraded for greater visibility.