### PR TITLE
Improve the RPC tests

### DIFF
--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -130,14 +130,8 @@ mod rpc_tests {
         assert_eq!(Value::Array(encrypted_records), transaction_info["encrypted_records"]);
     }
 
-    async fn make_request_no_params(rpc: &Rpc, method: String) -> Value {
-        let request = format!("{{ \"jsonrpc\":\"2.0\", \"id\": 1, \"method\": \"{}\" }}", method,);
-
-        let response = rpc.io.handle_request(&request).await.unwrap();
-
-        let extracted: Value = serde_json::from_str(&response).unwrap();
-
-        extracted["result"].clone()
+    async fn make_request_no_params(rpc: &Rpc, method: &str) -> Value {
+        make_request_with_params(rpc, method, "[]").await
     }
 
     async fn make_request_with_params(rpc: &Rpc, method: &str, params: &str) -> Value {
@@ -194,9 +188,7 @@ mod rpc_tests {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
 
-        let method = "getblockcount".to_string();
-
-        let result = make_request_no_params(&rpc, method).await;
+        let result = make_request_no_params(&rpc, "getblockcount").await;
 
         assert_eq!(result.as_u64().unwrap(), 1u64);
     }
@@ -206,9 +198,7 @@ mod rpc_tests {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
 
-        let method = "getbestblockhash".to_string();
-
-        let result = make_request_no_params(&rpc, method).await;
+        let result = make_request_no_params(&rpc, "getbestblockhash").await;
 
         assert_eq!(
             result.as_str().unwrap(),
@@ -316,9 +306,7 @@ mod rpc_tests {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
 
-        let method = "getconnectioncount".to_string();
-
-        let result = make_request_no_params(&rpc, method).await;
+        let result = make_request_no_params(&rpc, "getconnectioncount").await;
 
         assert_eq!(result.as_u64().unwrap(), 0u64);
     }
@@ -328,9 +316,7 @@ mod rpc_tests {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
 
-        let method = "getpeerinfo".to_string();
-
-        let result = make_request_no_params(&rpc, method).await;
+        let result = make_request_no_params(&rpc, "getpeerinfo").await;
 
         let peer_info: PeerInfo = serde_json::from_value(result).unwrap();
 
@@ -344,9 +330,7 @@ mod rpc_tests {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
 
-        let method = "getnodeinfo".to_string();
-
-        let result = make_request_no_params(&rpc, method).await;
+        let result = make_request_no_params(&rpc, "getnodeinfo").await;
 
         let peer_info: NodeInfo = serde_json::from_value(result).unwrap();
 
@@ -363,9 +347,7 @@ mod rpc_tests {
 
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
 
-        let method = "getblocktemplate".to_string();
-
-        let result = make_request_no_params(&rpc, method).await;
+        let result = make_request_no_params(&rpc, "getblocktemplate").await;
 
         let template: BlockTemplate = serde_json::from_value(result).unwrap();
 

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -193,7 +193,7 @@ mod rpc_tests {
         assert_eq!(result.as_u64().unwrap(), 1u64);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_rpc_get_best_block_hash() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -206,7 +206,7 @@ mod rpc_tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_rpc_get_block_hash() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -271,7 +271,7 @@ mod rpc_tests {
     }
 
     // multithreaded necessary due to use of non-async jsonrpc & internal use of async
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_rpc_send_raw_transaction() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -286,7 +286,7 @@ mod rpc_tests {
         assert_eq!(result, hex::encode(&TRANSACTION_2.id[..]),);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_rpc_validate_transaction() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -338,7 +338,7 @@ mod rpc_tests {
         assert!(!peer_info.is_syncing);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_rpc_get_block_template() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let canon = consensus.storage.canon().await.unwrap();

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -147,7 +147,7 @@ mod rpc_tests {
         extracted["result"].clone()
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rpc_get_block() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;
@@ -338,7 +338,7 @@ mod rpc_tests {
         assert!(!peer_info.is_syncing);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rpc_get_block_template() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let canon = consensus.storage.canon().await.unwrap();


### PR DESCRIPTION
These commits were split out from https://github.com/AleoHQ/snarkOS/pull/1116 which might require some more tinkering.

The most important change here is not using any synchronous calls in the RPC tests, which is the right way to run them.