### PR TITLE
Report potential canon tip via the `getnetworkgraph` rpc

### DIFF
--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -218,6 +218,7 @@ impl KnownNetwork {
         self.nodes.read().clone()
     }
 
+    #[allow(clippy::type_complexity)]
     /// Returns a map of the potential forks (including the tip) and the key to the tip.
     pub fn potential_forks(&self) -> (Option<(u32, Vec<SocketAddr>)>, HashMap<u32, Vec<SocketAddr>>) {
         use itertools::Itertools;

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -649,7 +649,7 @@ mod test {
                 vec![
                     (addr_b, 24),
                     (addr_a, 1),
-                    (addr_g, 77),
+                    (addr_g, 75),
                     (addr_d, 26),
                     (addr_f, 77),
                     (addr_c, 25),

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -639,6 +639,7 @@ mod test {
         let addr_d = "44.44.44.44:4000".parse().unwrap();
         let addr_e = "55.55.55.55:5000".parse().unwrap();
         let addr_f = "66.66.66.66:6000".parse().unwrap();
+        let addr_g = "77.77.77.77:7000".parse().unwrap();
 
         let (tx, rx) = mpsc::channel(100);
         let known_network = KnownNetwork {
@@ -648,10 +649,11 @@ mod test {
                 vec![
                     (addr_b, 24),
                     (addr_a, 1),
+                    (addr_g, 77),
                     (addr_d, 26),
-                    (addr_f, 50),
+                    (addr_f, 77),
                     (addr_c, 25),
-                    (addr_e, 50),
+                    (addr_e, 79),
                 ]
                 .into_iter()
                 .collect(),
@@ -659,10 +661,13 @@ mod test {
             connections: Default::default(),
         };
 
-        let potential_forks = known_network.potential_forks();
+        let (potential_tip, potential_forks) = known_network.potential_forks();
+
+        let expected_potential_tip = Some((79, vec![addr_g, addr_f, addr_e]));
         let expected_potential_forks: HashMap<u32, Vec<SocketAddr>> =
             vec![(26, vec![addr_b, addr_c, addr_d])].into_iter().collect();
 
         assert_eq!(potential_forks, expected_potential_forks);
+        assert_eq!(potential_tip, expected_potential_tip);
     }
 }

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -677,9 +677,14 @@ mod test {
 
         let (potential_tip, potential_forks) = known_network.potential_forks();
 
-        let expected_potential_tip = Some((79, vec![addr_g, addr_f, addr_e]));
-        let expected_potential_forks: HashMap<u32, Vec<SocketAddr>> =
-            vec![(26, vec![addr_b, addr_c, addr_d])].into_iter().collect();
+        let expected_potential_tip = Some(NodeCluster {
+            height: 79,
+            members: vec![addr_g, addr_f, addr_e],
+        });
+        let expected_potential_forks = vec![NodeCluster {
+            height: 26,
+            members: vec![addr_b, addr_c, addr_d],
+        }];
 
         assert_eq!(potential_forks, expected_potential_forks);
         assert_eq!(potential_tip, expected_potential_tip);

--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -219,7 +219,7 @@ impl KnownNetwork {
     }
 
     #[allow(clippy::type_complexity)]
-    /// Returns a map of the potential forks (including the tip) and the key to the tip.
+    /// Returns the canon tip height and members, and a map of the potential forks.
     pub fn potential_forks(&self) -> (Option<(u32, Vec<SocketAddr>)>, HashMap<u32, Vec<SocketAddr>>) {
         use itertools::Itertools;
 

--- a/rpc/documentation/public_endpoints/getnetworkgraph.md
+++ b/rpc/documentation/public_endpoints/getnetworkgraph.md
@@ -13,6 +13,8 @@ None
 | `density`                            | f64        | The density of the known network                                                          |
 | `algebraic_connectivity`             | f64        | The algebraic connectivity, aka the fiedler eigenvalue of the known network               |
 | `degree_centrality_delta`            | f64        | The difference between the largest and the smallest peer count in the network             |
+| `potential_tip`                      | Option     | The crawler's best guess at the canon tip                                                 |
+| `potential_forks`                    | array      | The crawler's best guess at the forks in the network                                      |
 | `edges`                              | array      | The list of connections known by the node                                                 |
 | `vertices`                           | array      | The list of nodes known by the node                                                       |
 | `edges[i].source`                    | SocketAddr | One side of the crawled connection                                                        |

--- a/rpc/documentation/public_endpoints/getnetworkgraph.md
+++ b/rpc/documentation/public_endpoints/getnetworkgraph.md
@@ -13,7 +13,7 @@ None
 | `density`                            | f64        | The density of the known network                                                          |
 | `algebraic_connectivity`             | f64        | The algebraic connectivity, aka the fiedler eigenvalue of the known network               |
 | `degree_centrality_delta`            | f64        | The difference between the largest and the smallest peer count in the network             |
-| `potential_tip`                      | Option     | The crawler's best guess at the canon tip                                                 |
+| `potential_tip`                      | Option     | The crawler's best guess at the canon block height and member addresses                   |
 | `potential_forks`                    | array      | The crawler's best guess at the forks in the network                                      |
 | `edges`                              | array      | The list of connections known by the node                                                 |
 | `vertices`                           | array      | The list of nodes known by the node                                                       |

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -494,12 +494,6 @@ impl RpcFunctions for RpcImpl {
             .collect();
 
         let (potential_tip, potential_forks) = known_network.potential_forks();
-        let potential_tip = potential_tip.map(|(height, members)| PotentialFork { height, members });
-
-        let potential_forks = potential_forks
-            .into_iter()
-            .map(|(height, members)| PotentialFork { height, members })
-            .collect();
 
         let node_count = if network_metrics.node_count == 0 {
             known_network.nodes().len()

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -493,8 +493,10 @@ impl RpcFunctions for RpcImpl {
             })
             .collect();
 
-        let potential_forks = known_network
-            .potential_forks()
+        let (potential_tip, potential_forks) = known_network.potential_forks();
+        let potential_tip = potential_tip.map(|(height, members)| PotentialFork { height, members });
+
+        let potential_forks = potential_forks
             .into_iter()
             .map(|(height, members)| PotentialFork { height, members })
             .collect();
@@ -511,6 +513,7 @@ impl RpcFunctions for RpcImpl {
             density: network_metrics.density,
             algebraic_connectivity: network_metrics.algebraic_connectivity,
             degree_centrality_delta: network_metrics.degree_centrality_delta,
+            potential_tip,
             potential_forks,
             vertices,
             edges,

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -305,6 +305,8 @@ pub struct NetworkGraph {
     /// lowest.
     pub degree_centrality_delta: f64,
 
+    /// The potential height and members of the canon chain tip.
+    pub potential_tip: Option<PotentialFork>,
     /// The potential forks in the network and their member nodes.
     pub potential_forks: Vec<PotentialFork>,
 

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -21,6 +21,8 @@ use jsonrpc_core::Metadata;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
+use snarkos_network::NodeCluster;
+
 /// Defines the authentication format for accessing private endpoints on the RPC server
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RpcCredentials {
@@ -306,21 +308,14 @@ pub struct NetworkGraph {
     pub degree_centrality_delta: f64,
 
     /// The potential height and members of the canon chain tip.
-    pub potential_tip: Option<PotentialFork>,
+    pub potential_tip: Option<NodeCluster>,
     /// The potential forks in the network and their member nodes.
-    pub potential_forks: Vec<PotentialFork>,
+    pub potential_forks: Vec<NodeCluster>,
 
     /// Known nodes.
     pub vertices: Vec<Vertice>,
     /// Known connections.
     pub edges: Vec<Edge>,
-}
-
-/// A potential fork in the network, maps height to members.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct PotentialFork {
-    pub height: u32,
-    pub members: Vec<SocketAddr>,
 }
 
 /// Metadata and measurements pertaining to a node in the graph of the known network.


### PR DESCRIPTION
The crawler currently only reports potential fork clusters which don't include the canon chain candidates. This PR adds the crawler's best guess at the canon tip (3+ members and heighest height in the graph) to the values exposed via rpc.