### PR TITLE
Spawn a blocking task for transaction verification

### DIFF
--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -70,10 +70,11 @@ impl ConsensusInner {
 
             match message {
                 ConsensusMessage::ReceiveTransaction(transaction) => {
-                    response.send(Box::new(self.receive_transaction(transaction))).ok();
+                    let ret = self.receive_transaction(transaction).await;
+                    response.send(Box::new(ret)).ok();
                 }
                 ConsensusMessage::VerifyTransactions(transactions) => {
-                    let out = match self.verify_transactions(transactions.iter()) {
+                    let out = match self.verify_transactions(transactions).await {
                         Ok(out) => out,
                         Err(e) => {
                             error!(

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -172,7 +172,7 @@ impl ConsensusInner {
 
     /// Check if the block is valid.
     /// Verify transactions and transaction fees.
-    pub(super) async fn verify_block(&self, block: &SerialBlock) -> Result<bool, ConsensusError> {
+    pub(super) async fn verify_block(&mut self, block: &SerialBlock) -> Result<bool, ConsensusError> {
         let canon = self.storage.canon().await?;
         // Verify the block header
         if block.header.previous_block_hash != canon.hash {
@@ -225,7 +225,7 @@ impl ConsensusInner {
         }
 
         // Check that all the transaction proofs verify
-        self.verify_transactions(block.transactions.iter())
+        self.verify_transactions(block.transactions.clone()).await
     }
 
     pub(super) async fn commit_block(&mut self, hash: &Digest, block: &SerialBlock) -> Result<(), ConsensusError> {

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -84,6 +84,12 @@ pub trait Ledger: Send + Sync {
 
 pub struct DynLedger(pub Box<dyn Ledger>);
 
+impl DynLedger {
+    pub fn dummy() -> Self {
+        Self(Box::new(dummy::DummyLedger))
+    }
+}
+
 impl Deref for DynLedger {
     type Target = dyn Ledger;
 

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -193,7 +193,7 @@ mod rpc_tests {
         assert_eq!(result.as_u64().unwrap(), 1u64);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rpc_get_best_block_hash() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let (rpc, _rpc_node) = initialize_test_rpc(&consensus, None).await;


### PR DESCRIPTION
Supersedes https://github.com/AleoHQ/snarkOS/pull/1116; copying its description over:

Just like Merkle tree rebuilds in #1115, transaction verification was found to be blocking at times, often taking more than 100ms. While spawning a blocking task is not free, it is significantly cheaper than blocking an async worker thread.

An example measurement:

```
10693ms taken by verify_transactions for 263 txs
```

This will be improved by AleoHQ/snarkVM#371, but it's still desirable on its own.