### PR TITLE
Iterative block tree implementation

### DIFF
--- a/storage/src/storage/digest_tree.rs
+++ b/storage/src/storage/digest_tree.rs
@@ -25,19 +25,6 @@ pub enum DigestTree {
 }
 
 impl DigestTree {
-    pub fn with_children(self, children: Vec<Digest>) -> Self {
-        let digest = match self {
-            DigestTree::Leaf(digest) => digest,
-            _ => panic!("cannot add children to non-leaf node"),
-        };
-
-        if children.is_empty() {
-            DigestTree::Leaf(digest)
-        } else {
-            DigestTree::Node(digest, children.into_iter().map(DigestTree::Leaf).collect(), 2)
-        }
-    }
-
     pub fn root(&self) -> &Digest {
         match self {
             DigestTree::Leaf(root) => root,

--- a/storage/src/storage/sync.rs
+++ b/storage/src/storage/sync.rs
@@ -160,8 +160,8 @@ pub trait SyncStorage {
         let mut stack = vec![block_hash.clone()];
         while let Some(hash) = stack.pop() {
             let children = self.get_block_children(&hash)?;
-            stack.extend_from_slice(&children[..]);
             if !children.is_empty() {
+                stack.extend_from_slice(&children[..]);
                 nodes.insert(hash, children);
             }
         }
@@ -171,10 +171,7 @@ pub trait SyncStorage {
         let mut node_entries: HashSet<Digest> = nodes.keys().cloned().collect();
 
         let mut trees: HashMap<Digest, DigestTree> = HashMap::new();
-        loop {
-            if nodes.is_empty() {
-                break;
-            }
+        while !nodes.is_empty() {
             nodes.retain(|hash, children| {
                 let mut new_children = vec![];
                 let mut longest_tree_len = 0usize;
@@ -200,24 +197,9 @@ pub trait SyncStorage {
                 false
             });
         }
-        assert_eq!(nodes.len(), 0);
         assert_eq!(trees.len(), 1);
 
         Ok(trees.remove(block_hash).expect("missing block hash tree"))
-
-        // let mut out = DigestTree::Node(block_hash.clone(), vec![], 0);
-
-        // let mut out_children = Vec::with_capacity(children.len());
-        // let mut longest_tree_len = 0usize;
-        // for child in children {
-        //     let subtree = self.get_block_digest_tree(&child)?;
-        //     let len = subtree.longest_length() + 1;
-        //     if len > longest_tree_len {
-        //         longest_tree_len = len;
-        //     }
-        //     out_children.push(subtree);
-        // }
-        // Ok(DigestTree::Node(block_hash.clone(), out_children, longest_tree_len))
     }
 
     /// Stores the immediate children of `block_hash` in a cache.

--- a/testing/src/sync/mod.rs
+++ b/testing/src/sync/mod.rs
@@ -159,6 +159,6 @@ pub async fn create_test_consensus() -> Arc<snarkos_consensus::Consensus> {
         FIXTURE_VK.storage(),
         MemoryPool::new(),
     );
-    tokio::time::sleep(tokio::time::Duration::from_millis(25)).await; // plenty of time to let consensus setup genesis block
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // plenty of time to let consensus setup genesis block
     consensus
 }


### PR DESCRIPTION
This PR removes the recursive implementation of block tree fetching from sqlite in favor of an iterative approach -- not implemented as a SQL query for now.