### PR TITLE
Introduce peer discovery and sync provider nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ path = "bin/crawler.rs"
 name = "beacon"
 path = "bin/beacon.rs"
 
+[[bin]]
+name = "sync_provider"
+path = "bin/sync_provider.rs"
+
 [dependencies.snarkvm-algorithms]
 version = "=0.7.9"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ path = "bin/snarkos.rs"
 name = "crawler"
 path = "bin/crawler.rs"
 
+[[bin]]
+name = "beacon"
+path = "bin/beacon.rs"
+
 [dependencies.snarkvm-algorithms]
 version = "=0.7.9"
 default-features = false

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ USAGE:
 
 FLAGS:
     -h, --help           Prints help information
-        --is-bootnode    Run the node as a bootnode (IP is hard coded in the protocol)
         --is-miner       Start mining blocks from this node
         --no-jsonrpc     Run the node without running the json rpc server
 

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -35,6 +35,7 @@ use tokio::runtime;
 ///
 /// 1. Creates network server.
 /// 2. Starts rpc server thread.
+/// 3. Starts the network listener.
 ///
 async fn start_server(config: Config) -> anyhow::Result<()> {
     initialize_logger(&config);
@@ -61,6 +62,9 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Initialize metrics framework.
     node.initialize_metrics().await?;
+
+    // Start listening for incoming connections.
+    node.listen().await?;
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -50,7 +50,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,
-        config.p2p.bootnodes.clone(),
+        config.p2p.beacons.clone(),
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -1,0 +1,103 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate tracing;
+
+use snarkos::{
+    cli::CLI,
+    config::{Config, ConfigCli},
+    display::{initialize_logger, print_welcome},
+    errors::NodeError,
+};
+use snarkos_network::{config::Config as NodeConfig, Node, NodeType};
+use snarkos_rpc::start_rpc_server;
+
+use std::{net::SocketAddr, time::Duration};
+
+use tokio::runtime;
+
+///
+/// Builds a node from configuration parameters.
+///
+/// 1. Creates network server.
+/// 2. Starts rpc server thread.
+///
+async fn start_server(config: Config) -> anyhow::Result<()> {
+    initialize_logger(&config);
+
+    print_welcome(&config);
+
+    let address = format!("{}:{}", config.node.ip, config.node.port);
+    let desired_address = address.parse::<SocketAddr>()?;
+
+    let node_config = NodeConfig::new(
+        NodeType::Beacon,
+        desired_address,
+        config.p2p.min_peers,
+        config.p2p.max_peers,
+        config.p2p.bootnodes.clone(),
+        // Set sync intervals for peers.
+        Duration::from_secs(config.p2p.peer_sync_interval.into()),
+    )?;
+
+    // Construct the node instance. Note this does not start the network services.
+    // This is done early on, so that the local address can be discovered
+    // before any other object (RPC) needs to use it.
+    let node = Node::new(node_config, None).await?;
+
+    // Initialize metrics framework.
+    node.initialize_metrics().await?;
+
+    // Start RPC thread, if the RPC configuration is enabled.
+    if config.rpc.json_rpc {
+        let rpc_address = format!("{}:{}", config.rpc.ip, config.rpc.port)
+            .parse()
+            .expect("Invalid RPC server address!");
+
+        let rpc_handle = start_rpc_server(
+            rpc_address,
+            None,
+            node.clone(),
+            config.rpc.username,
+            config.rpc.password,
+        );
+        node.register_task(rpc_handle);
+
+        info!("Listening for RPC requests on port {}", config.rpc.port);
+    }
+
+    // Start the network services.
+    node.start_services().await;
+
+    std::future::pending::<()>().await;
+
+    Ok(())
+}
+
+fn main() -> Result<(), NodeError> {
+    let arguments = ConfigCli::args();
+
+    let mut config: Config = ConfigCli::parse(&arguments)?;
+    config.is_crawler(true);
+    config.check().map_err(|e| NodeError::Message(e.to_string()))?;
+
+    let runtime = runtime::Builder::new_multi_thread().enable_all().build()?;
+
+    runtime.block_on(start_server(config))?;
+
+    Ok(())
+}

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -56,7 +56,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        let rpc_handle = init_rpc(&config, node.clone(), None);
+        init_rpc(&config, node.clone(), None)?;
     }
 
     // Start the network services.

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -46,7 +46,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     let desired_address = address.parse::<SocketAddr>()?;
 
     let node_config = NodeConfig::new(
-        NodeType::Beacon,
+        config.node.kind,
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), NodeError> {
     let arguments = ConfigCli::args();
 
     let mut config: Config = ConfigCli::parse(&arguments)?;
-    config.is_crawler(true);
+    config.node.kind = NodeType::Beacon;
     config.check().map_err(|e| NodeError::Message(e.to_string()))?;
 
     let runtime = runtime::Builder::new_multi_thread().enable_all().build()?;

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -22,6 +22,7 @@ use snarkos::{
     config::{Config, ConfigCli},
     display::{initialize_logger, print_welcome},
     errors::NodeError,
+    init::{init_node, init_rpc},
 };
 use snarkos_network::{config::Config as NodeConfig, Node, NodeType};
 use snarkos_rpc::start_rpc_server;
@@ -42,23 +43,10 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     print_welcome(&config);
 
-    let address = format!("{}:{}", config.node.ip, config.node.port);
-    let desired_address = address.parse::<SocketAddr>()?;
-
-    let node_config = NodeConfig::new(
-        config.node.kind,
-        desired_address,
-        config.p2p.min_peers,
-        config.p2p.max_peers,
-        config.p2p.beacons.clone(),
-        // Set sync intervals for peers.
-        Duration::from_secs(config.p2p.peer_sync_interval.into()),
-    )?;
-
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (RPC) needs to use it.
-    let node = Node::new(node_config, None).await?;
+    let node = init_node(&config, None).await?;
 
     // Initialize metrics framework.
     node.initialize_metrics().await?;
@@ -68,20 +56,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        let rpc_address = format!("{}:{}", config.rpc.ip, config.rpc.port)
-            .parse()
-            .expect("Invalid RPC server address!");
-
-        let rpc_handle = start_rpc_server(
-            rpc_address,
-            None,
-            node.clone(),
-            config.rpc.username,
-            config.rpc.password,
-        );
-        node.register_task(rpc_handle);
-
-        info!("Listening for RPC requests on port {}", config.rpc.port);
+        let rpc_handle = init_rpc(&config, node.clone(), None);
     }
 
     // Start the network services.

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-extern crate tracing;
-
 use snarkos::{
     cli::CLI,
     config::{Config, ConfigCli},
@@ -24,10 +21,7 @@ use snarkos::{
     errors::NodeError,
     init::{init_node, init_rpc},
 };
-use snarkos_network::{config::Config as NodeConfig, Node, NodeType};
-use snarkos_rpc::start_rpc_server;
-
-use std::{net::SocketAddr, time::Duration};
+use snarkos_network::NodeType;
 
 use tokio::runtime;
 

--- a/bin/beacon.rs
+++ b/bin/beacon.rs
@@ -19,7 +19,7 @@ use snarkos::{
     config::{Config, ConfigCli},
     display::{initialize_logger, print_welcome},
     errors::NodeError,
-    init::{init_node, init_rpc},
+    init::{init_ephemeral_storage, init_node, init_rpc},
 };
 use snarkos_network::NodeType;
 
@@ -37,10 +37,12 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     print_welcome(&config);
 
+    let storage = init_ephemeral_storage()?;
+
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (RPC) needs to use it.
-    let node = init_node(&config, None).await?;
+    let node = init_node(&config, storage.clone()).await?;
 
     // Initialize metrics framework.
     node.initialize_metrics().await?;
@@ -50,7 +52,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        init_rpc(&config, node.clone(), None)?;
+        init_rpc(&config, node.clone(), storage)?;
     }
 
     // Start the network services.

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -54,7 +54,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        let rpc_handle = init_rpc(&config, node.clone(), storage);
+        init_rpc(&config, node.clone(), storage)?;
     }
 
     // Start the network services.

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), NodeError> {
     let arguments = ConfigCli::args();
 
     let mut config: Config = ConfigCli::parse(&arguments)?;
-    config.is_crawler(true);
+    config.node.kind = NodeType::Crawler;
     config.check().map_err(|e| NodeError::Message(e.to_string()))?;
 
     let runtime = runtime::Builder::new_multi_thread().enable_all().build()?;

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -23,7 +23,7 @@ use snarkos::{
     display::{initialize_logger, print_welcome},
     errors::NodeError,
 };
-use snarkos_network::{config::Config as NodeConfig, Node};
+use snarkos_network::{config::Config as NodeConfig, Node, NodeType};
 use snarkos_rpc::start_rpc_server;
 use snarkos_storage::{AsyncStorage, SqliteStorage};
 
@@ -47,12 +47,11 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     let node_config = NodeConfig::new(
         None,
+        NodeType::Crawler,
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,
         config.p2p.bootnodes.clone(),
-        false, // is_bootnode
-        true,  // is crawler
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -51,7 +51,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,
-        config.p2p.bootnodes.clone(),
+        config.p2p.beacons.clone(),
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -47,7 +47,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     let node_config = NodeConfig::new(
         None,
-        NodeType::Crawler,
+        config.node.kind,
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-extern crate tracing;
-
 use snarkos::{
     cli::CLI,
     config::{Config, ConfigCli},
@@ -24,11 +21,8 @@ use snarkos::{
     errors::NodeError,
     init::{init_node, init_rpc},
 };
-use snarkos_network::{config::Config as NodeConfig, Node, NodeType};
-use snarkos_rpc::start_rpc_server;
 use snarkos_storage::{AsyncStorage, SqliteStorage};
-
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use snarkos_network::NodeType;
 
 use tokio::runtime;
 

--- a/bin/crawler.rs
+++ b/bin/crawler.rs
@@ -19,9 +19,8 @@ use snarkos::{
     config::{Config, ConfigCli},
     display::{initialize_logger, print_welcome},
     errors::NodeError,
-    init::{init_node, init_rpc},
+    init::{init_ephemeral_storage, init_node, init_rpc},
 };
-use snarkos_storage::{AsyncStorage, SqliteStorage};
 use snarkos_network::NodeType;
 
 use tokio::runtime;
@@ -37,10 +36,11 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     print_welcome(&config);
 
+    let storage = init_ephemeral_storage()?;
+
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (RPC) needs to use it.
-    let storage = Arc::new(AsyncStorage::new(SqliteStorage::new_ephemeral().unwrap()));
     let node = init_node(&config, storage.clone()).await?;
 
     // Initialize metrics framework.

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -94,7 +94,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,
-        config.p2p.bootnodes.clone(),
+        config.p2p.beacons.clone(),
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -24,7 +24,7 @@ use snarkos::{
     errors::NodeError,
 };
 use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
-use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, Sync};
+use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, NodeType, Sync};
 use snarkos_rpc::start_rpc_server;
 use snarkos_storage::{
     export_canon_blocks,
@@ -82,14 +82,19 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         fs::create_dir(&path)?;
     }
 
+    let node_type = if config.node.is_bootnode {
+        NodeType::Bootnode
+    } else {
+        NodeType::Client
+    };
+
     let node_config = NodeConfig::new(
         None,
+        node_type,
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,
         config.p2p.bootnodes.clone(),
-        config.node.is_bootnode,
-        false, // is_crawler
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -95,7 +95,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        let rpc_handle = init_rpc(&config, node.clone(), storage);
+        init_rpc(&config, node.clone(), storage)?;
     }
 
     // Start the network services

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-extern crate tracing;
-
 use snarkos::{
     cli::CLI,
     config::{Config, ConfigCli},
@@ -24,36 +21,7 @@ use snarkos::{
     errors::NodeError,
     init::{init_miner, init_node, init_rpc, init_storage, init_sync},
 };
-use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
-use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, NodeType, Sync};
-use snarkos_rpc::start_rpc_server;
-use snarkos_storage::{
-    export_canon_blocks,
-    key_value::KeyValueStore,
-    AsyncStorage,
-    DynStorage,
-    RocksDb,
-    SerialBlock,
-    SqliteStorage,
-    VMBlock,
-};
-
-use snarkvm_algorithms::{MerkleParameters, CRH, SNARK};
-use snarkvm_dpc::{
-    testnet1::{
-        instantiated::{Components, Testnet1DPC, Testnet1Transaction},
-        Testnet1Components,
-    },
-    Address,
-    Block,
-    DPCScheme,
-    Network,
-};
-use snarkvm_parameters::{testnet1::GenesisBlock, Genesis, LedgerMerkleTreeParameters, Parameter};
-use snarkvm_posw::PoswMarlin;
-use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
-
-use std::{fs, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+use snarkos_network::NodeType;
 
 use tokio::runtime;
 

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -50,7 +50,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (miner, RPC) needs to use it.
-    let mut node = init_node(&config, Some(storage.clone())).await?;
+    let mut node = init_node(&config, storage.clone()).await?;
 
     // Enable the sync layer.
     node.set_sync(sync);
@@ -63,7 +63,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        init_rpc(&config, node.clone(), Some(storage))?;
+        init_rpc(&config, node.clone(), storage)?;
     }
 
     // Start the network services

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -83,7 +83,7 @@ fn main() -> Result<(), NodeError> {
 
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_stack_size(8 * 1024 * 1024)
+        .thread_stack_size(4 * 1024 * 1024)
         .build()?;
 
     runtime.block_on(start_server(config))?;

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -95,7 +95,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        init_rpc(&config, node.clone(), Some(storage));
+        init_rpc(&config, node.clone(), Some(storage))?;
     }
 
     // Start the network services

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -22,6 +22,7 @@ use snarkos::{
     config::{Config, ConfigCli},
     display::{initialize_logger, print_welcome},
     errors::NodeError,
+    init::{init_miner, init_node, init_rpc, init_storage, init_sync},
 };
 use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
 use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, NodeType, Sync};
@@ -62,203 +63,29 @@ use tokio::runtime;
 /// 1. Creates new storage database or uses existing.
 /// 2. Creates new memory pool or uses existing from storage.
 /// 3. Creates sync parameters.
-/// 4. Creates network server.
+/// 4. Creates network server and starts the listener.
 /// 5. Starts rpc server thread.
 /// 6. Starts miner thread.
-/// 7. Starts network server listener.
 ///
 async fn start_server(config: Config) -> anyhow::Result<()> {
     initialize_logger(&config);
 
     print_welcome(&config);
 
-    let address = format!("{}:{}", config.node.ip, config.node.port);
-    let desired_address = address.parse::<SocketAddr>()?;
-
-    let mut path = config.node.dir.clone();
-    path.push(&config.node.db);
-
-    if !path.exists() {
-        fs::create_dir(&path)?;
-    }
-
-    let node_config = NodeConfig::new(
-        config.node.kind,
-        desired_address,
-        config.p2p.min_peers,
-        config.p2p.max_peers,
-        config.p2p.beacons.clone(),
-        // Set sync intervals for peers.
-        Duration::from_secs(config.p2p.peer_sync_interval.into()),
-    )?;
-
-    info!("Loading storage at '{}'...", path.to_str().unwrap_or_default());
-    let storage: DynStorage = {
-        let mut sqlite_path = path.clone();
-        sqlite_path.push("sqlite.db");
-
-        if config.storage.validate {
-            error!("validator not implemented for sqlite");
-            return Ok(());
-        }
-
-        Arc::new(AsyncStorage::new(SqliteStorage::new(&sqlite_path)?))
+    let storage = match init_storage(&config).await? {
+        Some(storage) => storage,
+        None => return Ok(()), // Return if no storage was returned (usually in case of validation).
     };
 
-    if storage.canon().await?.block_height == 0 {
-        let mut rocks_identity_path = path.clone();
-        rocks_identity_path.push("IDENTITY");
-        if rocks_identity_path.exists() {
-            info!("Empty sqlite DB with existing rocksdb found, migrating...");
-            let rocks_storage = RocksDb::open(&path)?;
-            let rocks_storage: DynStorage = Arc::new(AsyncStorage::new(KeyValueStore::new(rocks_storage)));
-
-            snarkos_storage::migrate(&rocks_storage, &storage).await?;
-        }
-    }
-
-    if let Some(max_head) = config.storage.max_head {
-        let canon_next = storage.get_block_hash(max_head + 1).await?;
-        if let Some(canon_next) = canon_next {
-            storage.decommit_blocks(&canon_next).await?;
-        }
-    }
-
-    if config.storage.trim {
-        let now = std::time::Instant::now();
-        // There shouldn't be issues after validation, but if there are, ignore them.
-        let _ = snarkos_storage::trim(storage.clone()).await;
-        info!("Storage trimmed in {}ms", now.elapsed().as_millis());
-        return Ok(());
-    }
-
-    info!("Storage is ready");
+    let sync = init_sync(&config, storage.clone()).await?;
 
     // Construct the node instance. Note this does not start the network services.
     // This is done early on, so that the local address can be discovered
     // before any other object (miner, RPC) needs to use it.
-    let mut node = Node::new(node_config, Some(storage.clone())).await?;
-
-    if let Some(limit) = config.storage.export {
-        let mut export_path = path.clone();
-        export_path.push("canon_blocks");
-
-        let limit = if limit == 0 { None } else { Some(limit) };
-
-        let now = std::time::Instant::now();
-        match export_canon_blocks(storage.clone(), limit, &export_path).await {
-            Ok(num_exported) => {
-                info!(
-                    "{} canon blocks exported to {} in {}ms",
-                    num_exported,
-                    export_path.display(),
-                    now.elapsed().as_millis()
-                );
-            }
-            Err(e) => error!("Couldn't export canon blocks to {}: {}", export_path.display(), e),
-        }
-    }
+    let mut node = init_node(&config, Some(storage.clone())).await?;
 
     // Enable the sync layer.
-    {
-        let memory_pool = MemoryPool::new(); // from_storage(&storage).await?;
-
-        debug!("Loading Aleo parameters...");
-        let dpc = <Testnet1DPC as DPCScheme<DeserializedLedger<'_, Components>>>::load(!config.miner.is_miner)?;
-        info!("Loaded Aleo parameters");
-
-        // Fetch the set of valid inner circuit IDs.
-        let inner_snark_vk: <<Components as Testnet1Components>::InnerSNARK as SNARK>::VerifyingKey =
-            dpc.inner_snark_parameters.1.clone().into();
-        let inner_snark_id = dpc
-            .system_parameters
-            .inner_circuit_id_crh
-            .hash(&to_bytes_le![inner_snark_vk]?)?;
-
-        let authorized_inner_snark_ids = vec![to_bytes_le![inner_snark_id]?];
-
-        // Set the initial sync parameters.
-        let consensus_params = ConsensusParameters {
-            max_block_size: 1_000_000_000usize,
-            max_nonce: u32::max_value(),
-            target_block_time: 10i64,
-            network_id: Network::from_id(config.aleo.network_id),
-            verifier: PoswMarlin::verify_only().expect("could not instantiate PoSW verifier"),
-            authorized_inner_snark_ids,
-        };
-
-        let ledger_parameters = {
-            type Parameters = <Components as Testnet1Components>::MerkleParameters;
-            let parameters: <<Parameters as MerkleParameters>::H as CRH>::Parameters =
-                FromBytes::read_le(&LedgerMerkleTreeParameters::load_bytes()?[..])?;
-            let crh = <Parameters as MerkleParameters>::H::from(parameters);
-            Arc::new(Parameters::from(crh))
-        };
-        info!("Loading Ledger");
-        let ledger_digests = storage.get_ledger_digests().await?;
-        let commitments = storage.get_commitments().await?;
-        let serial_numbers = storage.get_serial_numbers().await?;
-        let memos = storage.get_memos().await?;
-        info!("Initializing Ledger");
-        let ledger = DynLedger(Box::new(MerkleLedger::new(
-            ledger_parameters,
-            &ledger_digests[..],
-            &commitments[..],
-            &serial_numbers[..],
-            &memos[..],
-        )?));
-
-        let genesis_block: Block<Testnet1Transaction> = FromBytes::read_le(GenesisBlock::load_bytes().as_slice())?;
-        let genesis_block: SerialBlock = <Block<Testnet1Transaction> as VMBlock>::serialize(&genesis_block)?;
-
-        let consensus = Consensus::new(
-            consensus_params,
-            Arc::new(dpc),
-            genesis_block,
-            ledger,
-            storage.clone(),
-            memory_pool,
-        );
-        info!("Loaded Ledger");
-
-        if config.storage.scan_for_forks {
-            consensus.scan_forks().await?;
-        }
-
-        if let Some(import_path) = config.storage.import {
-            info!("Importing canon blocks from {}", import_path.display());
-
-            let now = std::time::Instant::now();
-            let mut blocks = std::io::Cursor::new(std::fs::read(import_path)?);
-
-            let mut processed = 0usize;
-            let mut imported = 0usize;
-            while let Ok(block) = Block::<Testnet1Transaction>::read_le(&mut blocks) {
-                let block = <Block<Testnet1Transaction> as VMBlock>::serialize(&block)?;
-                // Skip possible duplicate blocks etc.
-                if consensus.receive_block(block).await {
-                    imported += 1;
-                }
-                processed += 1;
-            }
-
-            info!(
-                "Processed {} canon blocks ({} imported) in {}ms",
-                processed,
-                imported,
-                now.elapsed().as_millis()
-            );
-        }
-
-        let sync = Sync::new(
-            consensus,
-            config.miner.is_miner,
-            Duration::from_secs(config.p2p.block_sync_interval.into()),
-            Duration::from_secs(config.p2p.mempool_sync_interval.into()),
-        );
-
-        node.set_sync(sync);
-    }
+    node.set_sync(sync);
 
     // Initialize metrics framework.
     node.initialize_metrics().await?;
@@ -268,37 +95,16 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start RPC thread, if the RPC configuration is enabled.
     if config.rpc.json_rpc {
-        let rpc_address = format!("{}:{}", config.rpc.ip, config.rpc.port)
-            .parse()
-            .expect("Invalid RPC server address!");
-
-        let rpc_handle = start_rpc_server(
-            rpc_address,
-            Some(storage),
-            node.clone(),
-            config.rpc.username,
-            config.rpc.password,
-        );
-        node.register_task(rpc_handle);
-
-        info!("Listening for RPC requests on port {}", config.rpc.port);
+        init_rpc(&config, node.clone(), Some(storage));
     }
 
     // Start the network services
     node.start_services().await;
 
     // Start the miner task if mining configuration is enabled.
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     if config.miner.is_miner {
-        match Address::<Components>::from_str(&config.miner.miner_address) {
-            Ok(miner_address) => {
-                let handle = MinerInstance::new(miner_address, node.clone()).spawn();
-                node.register_task(handle);
-            }
-            Err(_) => info!(
-                "Miner not started. Please specify a valid miner address in your ~/.snarkOS/config.toml file or by using the --miner-address option in the CLI."
-            ),
-        }
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        init_miner(&config, node);
     }
 
     std::future::pending::<()>().await;

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -19,7 +19,7 @@ use snarkos::{
     config::{Config, ConfigCli},
     display::{initialize_logger, print_welcome},
     errors::NodeError,
-    init::{init_miner, init_node, init_rpc, init_storage, init_sync},
+    init::{init_node, init_rpc, init_storage, init_sync},
 };
 use snarkos_network::NodeType;
 
@@ -68,12 +68,6 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
 
     // Start the network services
     node.start_services().await;
-
-    // Start the miner task if mining configuration is enabled.
-    if config.miner.is_miner {
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-        init_miner(&config, node);
-    }
 
     std::future::pending::<()>().await;
 

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-extern crate tracing;
-
 use snarkos::{
     cli::CLI,
     config::{Config, ConfigCli},
@@ -24,36 +21,7 @@ use snarkos::{
     errors::NodeError,
     init::{init_miner, init_node, init_rpc, init_storage, init_sync},
 };
-use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
-use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, NodeType, Sync};
-use snarkos_rpc::start_rpc_server;
-use snarkos_storage::{
-    export_canon_blocks,
-    key_value::KeyValueStore,
-    AsyncStorage,
-    DynStorage,
-    RocksDb,
-    SerialBlock,
-    SqliteStorage,
-    VMBlock,
-};
-
-use snarkvm_algorithms::{MerkleParameters, CRH, SNARK};
-use snarkvm_dpc::{
-    testnet1::{
-        instantiated::{Components, Testnet1DPC, Testnet1Transaction},
-        Testnet1Components,
-    },
-    Address,
-    Block,
-    DPCScheme,
-    Network,
-};
-use snarkvm_parameters::{testnet1::GenesisBlock, Genesis, LedgerMerkleTreeParameters, Parameter};
-use snarkvm_posw::PoswMarlin;
-use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
-
-use std::{fs, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+use snarkos_network::NodeType;
 
 use tokio::runtime;
 

--- a/bin/sync_provider.rs
+++ b/bin/sync_provider.rs
@@ -83,7 +83,7 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
     }
 
     let node_config = NodeConfig::new(
-        NodeType::SyncProvider,
+        config.node.kind,
         desired_address,
         config.p2p.min_peers,
         config.p2p.max_peers,

--- a/network/documentation/concepts/network_server.md
+++ b/network/documentation/concepts/network_server.md
@@ -11,7 +11,7 @@ snarkOS downloads, verifies, and stores the history of valid blocks and transact
 ## Peer Discovery
 
 When a node joins the network for the first time, it needs to populate a list of active peers in the network.
-In order to bootstrap peer discovery, snarkOS includes a set of optional bootnodes which provides an initial set of peers.
+In order to bootstrap peer discovery, snarkOS includes a set of optional specialised beacon nodes. Once connected, these provide an initial set of peers which includes the address of a sync provider. The sync provider will supply the node with an initial sync of the chainstate.
 To allow users flexibility, snarkOS provides allows users to configure the initial set of nodes in the configuration file,
 or as a input via a command-line flag.
 
@@ -20,13 +20,7 @@ This processes starts by asking peers for more connected nodes in the network wi
 followed by attempts to establish a connection with each newly discovered peer.
 
 Upon success, snarkOS will store the new peer address to allow it to connect directly with this peer in the future,
-without needing to use bootnodes to startup in the future.
-
-#### Bootnodes
-
-Bootnodes operate like other full nodes and serve as a public access point for all peers in the network.
-Bootnodes are run by community members and bolster the network
-by enabling new nodes to connect and participate in the network effortlessly.
+without needing to use peer discovery nodes to startup in the future.
 
 ## Connecting to Peers
 

--- a/network/documentation/concepts/network_server.md
+++ b/network/documentation/concepts/network_server.md
@@ -11,7 +11,7 @@ snarkOS downloads, verifies, and stores the history of valid blocks and transact
 ## Peer Discovery
 
 When a node joins the network for the first time, it needs to populate a list of active peers in the network.
-In order to bootstrap peer discovery, snarkOS includes a set of optional specialised beacon nodes. Once connected, these provide an initial set of peers which includes the address of a sync provider. The sync provider will supply the node with an initial sync of the chainstate.
+In order to bootstrap peer discovery, snarkOS includes a set of optional specialised "beacon" nodes. Once connected, these provide an initial set of peers which includes the address of a sync provider. The sync provider will supply the node with an initial sync of the chainstate.
 To allow users flexibility, snarkOS provides allows users to configure the initial set of nodes in the configuration file,
 or as a input via a command-line flag.
 
@@ -20,7 +20,7 @@ This processes starts by asking peers for more connected nodes in the network wi
 followed by attempts to establish a connection with each newly discovered peer.
 
 Upon success, snarkOS will store the new peer address to allow it to connect directly with this peer in the future,
-without needing to use peer discovery nodes to startup in the future.
+without needing to use beacons to startup in the future.
 
 ## Connecting to Peers
 

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -106,10 +106,6 @@ impl Config {
         self.sync_providers.load_full()
     }
 
-    pub fn is_of_type(&self, t: NodeType) -> bool {
-        self.node_type == t
-    }
-
     /// Returns the minimum number of peers this node maintains a connection with.
     #[inline]
     pub fn minimum_number_of_connected_peers(&self) -> u16 {

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -27,6 +27,7 @@ use std::{
 pub enum NodeType {
     Client, // Sometimes referred to as a "regular" node.
     Crawler,
+    Beacon,   // Used for peer discovery.
     Bootnode, // Soon to be "SyncProvider".
 }
 
@@ -100,6 +101,12 @@ impl Config {
     #[inline]
     pub fn is_regular_node(&self) -> bool {
         matches!(self.node_type, NodeType::Bootnode | NodeType::Crawler)
+    }
+
+    /// Returns `true` if this node is a peer discovery node. Otherwise, returns `false`.
+    #[inline]
+    pub fn is_beacon(&self) -> bool {
+        matches!(self.node_type, NodeType::Beacon)
     }
 
     /// Returns the minimum number of peers this node maintains a connection with.

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -17,6 +17,7 @@
 use crate::NetworkError;
 
 use arc_swap::ArcSwap;
+use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
     sync::Arc,
@@ -24,11 +25,12 @@ use std::{
     {self},
 };
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum NodeType {
     Client, // Sometimes referred to as a "regular" node.
     Crawler,
-    Beacon,   // Used for peer discovery.
-    Bootnode, // Soon to be "SyncProvider".
+    Beacon, // Used for peer discovery.
+    SyncProvider,
 }
 
 /// A core data structure containing the pre-configured parameters for the node.
@@ -96,8 +98,8 @@ impl Config {
 
     /// Returns `true` if this node is a bootnode. Otherwise, returns `false`.
     #[inline]
-    pub fn is_bootnode(&self) -> bool {
-        matches!(self.node_type, NodeType::Bootnode)
+    pub fn is_sync_provider(&self) -> bool {
+        matches!(self.node_type, NodeType::SyncProvider)
     }
 
     /// Returns `true` if this node is a crawler. Otherwise, returns `false`.
@@ -108,8 +110,8 @@ impl Config {
 
     /// Returns `true` if this node is a plain node. Otherwise, returns `false`.
     #[inline]
-    pub fn is_regular_node(&self) -> bool {
-        matches!(self.node_type, NodeType::Bootnode | NodeType::Crawler)
+    pub fn is_client(&self) -> bool {
+        matches!(self.node_type, NodeType::Client)
     }
 
     /// Returns `true` if this node is a peer discovery node. Otherwise, returns `false`.

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -42,8 +42,10 @@ pub struct Config {
     minimum_number_of_connected_peers: u16,
     /// The maximum number of peers permitted to maintain connections with.
     maximum_number_of_connected_peers: u16,
-    /// The default bootnodes of the network.
-    pub bootnodes: ArcSwap<Vec<SocketAddr>>,
+    /// The default peer discovery nodes of the network.
+    pub beacons: ArcSwap<Vec<SocketAddr>>,
+    /// The default sync provider nodes of the network.
+    sync_providers: ArcSwap<Vec<SocketAddr>>,
     /// The interval between each peer sync.
     peer_sync_interval: Duration,
 }
@@ -57,14 +59,14 @@ impl Config {
         desired_address: SocketAddr,
         minimum_number_of_connected_peers: u16,
         maximum_number_of_connected_peers: u16,
-        bootnodes_addresses: Vec<String>,
+        beacon_addresses: Vec<String>,
         peer_sync_interval: Duration,
     ) -> Result<Self, NetworkError> {
         // Convert the given bootnodes into socket addresses.
-        let mut bootnodes = Vec::with_capacity(bootnodes_addresses.len());
-        for bootnode_address in bootnodes_addresses.iter() {
-            if let Ok(bootnode) = bootnode_address.parse::<SocketAddr>() {
-                bootnodes.push(bootnode);
+        let mut beacons = Vec::with_capacity(beacon_addresses.len());
+        for beacon_address in beacon_addresses.iter() {
+            if let Ok(beacon) = beacon_address.parse::<SocketAddr>() {
+                beacons.push(beacon);
             }
         }
 
@@ -74,15 +76,22 @@ impl Config {
             desired_address,
             minimum_number_of_connected_peers,
             maximum_number_of_connected_peers,
-            bootnodes: ArcSwap::new(Arc::new(bootnodes)),
+            beacons: ArcSwap::new(Arc::new(beacons)),
+            sync_providers: ArcSwap::new(Arc::new(Vec::new())),
             peer_sync_interval,
         })
     }
 
-    /// Returns the default bootnodes of the network.
+    /// Returns the default peer discovery nodes of the network.
     #[inline]
-    pub fn bootnodes(&self) -> Arc<Vec<SocketAddr>> {
-        self.bootnodes.load_full()
+    pub fn beacons(&self) -> Arc<Vec<SocketAddr>> {
+        self.beacons.load_full()
+    }
+
+    /// Returns the default sync provider nodes of the network.
+    #[inline]
+    pub fn sync_providers(&self) -> Arc<Vec<SocketAddr>> {
+        self.sync_providers.load_full()
     }
 
     /// Returns `true` if this node is a bootnode. Otherwise, returns `false`.

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -62,15 +62,20 @@ impl Config {
         minimum_number_of_connected_peers: u16,
         maximum_number_of_connected_peers: u16,
         beacon_addresses: Vec<String>,
+        sync_provider_addresses: Vec<String>,
         peer_sync_interval: Duration,
     ) -> Result<Self, NetworkError> {
         // Convert the given bootnodes into socket addresses.
-        let mut beacons = Vec::with_capacity(beacon_addresses.len());
-        for beacon_address in beacon_addresses.iter() {
-            if let Ok(beacon) = beacon_address.parse::<SocketAddr>() {
-                beacons.push(beacon);
-            }
-        }
+
+        let beacons: Vec<SocketAddr> = beacon_addresses
+            .into_iter()
+            .flat_map(|addr| addr.parse().ok())
+            .collect();
+
+        let sync_providers: Vec<SocketAddr> = sync_provider_addresses
+            .into_iter()
+            .filter_map(|addr| addr.parse().ok())
+            .collect();
 
         Ok(Self {
             node_id,
@@ -79,7 +84,7 @@ impl Config {
             minimum_number_of_connected_peers,
             maximum_number_of_connected_peers,
             beacons: ArcSwap::new(Arc::new(beacons)),
-            sync_providers: ArcSwap::new(Arc::new(Vec::new())),
+            sync_providers: ArcSwap::new(Arc::new(sync_providers)),
             peer_sync_interval,
         })
     }

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -65,8 +65,7 @@ impl Config {
         sync_provider_addresses: Vec<String>,
         peer_sync_interval: Duration,
     ) -> Result<Self, NetworkError> {
-        // Convert the given bootnodes into socket addresses.
-
+        // Convert the given seeded nodes into socket addresses.
         let beacons: Vec<SocketAddr> = beacon_addresses
             .into_iter()
             .flat_map(|addr| addr.parse().ok())
@@ -101,7 +100,7 @@ impl Config {
         self.sync_providers.load_full()
     }
 
-    /// Returns `true` if this node is a bootnode. Otherwise, returns `false`.
+    /// Returns `true` if this node is a sync provider node. Otherwise, returns `false`.
     #[inline]
     pub fn is_sync_provider(&self) -> bool {
         matches!(self.node_type, NodeType::SyncProvider)
@@ -113,7 +112,7 @@ impl Config {
         matches!(self.node_type, NodeType::Crawler)
     }
 
-    /// Returns `true` if this node is a plain node. Otherwise, returns `false`.
+    /// Returns `true` if this node is a plain client node. Otherwise, returns `false`.
     #[inline]
     pub fn is_client(&self) -> bool {
         matches!(self.node_type, NodeType::Client)

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -27,9 +27,15 @@ use std::{
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum NodeType {
-    Client, // Sometimes referred to as a "regular" node.
+    /// The default "regular" node.
+    Client,
+    /// Crawls the network to track the known network.
     Crawler,
-    Beacon, // Used for peer discovery.
+    /// Used for peer discovery, they are the entry point into the network.
+    Beacon,
+    /// Used for initial sync after joining the network.
+    ///
+    /// Sync provider addresses are shared by the beacons.
     SyncProvider,
 }
 
@@ -68,7 +74,7 @@ impl Config {
         // Convert the given seeded nodes into socket addresses.
         let beacons: Vec<SocketAddr> = beacon_addresses
             .into_iter()
-            .flat_map(|addr| addr.parse().ok())
+            .filter_map(|addr| addr.parse().ok())
             .collect();
 
         let sync_providers: Vec<SocketAddr> = sync_provider_addresses
@@ -100,28 +106,8 @@ impl Config {
         self.sync_providers.load_full()
     }
 
-    /// Returns `true` if this node is a sync provider node. Otherwise, returns `false`.
-    #[inline]
-    pub fn is_sync_provider(&self) -> bool {
-        matches!(self.node_type, NodeType::SyncProvider)
-    }
-
-    /// Returns `true` if this node is a crawler. Otherwise, returns `false`.
-    #[inline]
-    pub fn is_crawler(&self) -> bool {
-        matches!(self.node_type, NodeType::Crawler)
-    }
-
-    /// Returns `true` if this node is a plain client node. Otherwise, returns `false`.
-    #[inline]
-    pub fn is_client(&self) -> bool {
-        matches!(self.node_type, NodeType::Client)
-    }
-
-    /// Returns `true` if this node is a peer discovery node. Otherwise, returns `false`.
-    #[inline]
-    pub fn is_beacon(&self) -> bool {
-        matches!(self.node_type, NodeType::Beacon)
+    pub fn is_of_type(&self, t: NodeType) -> bool {
+        self.node_type == t
     }
 
     /// Returns the minimum number of peers this node maintains a connection with.

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -65,7 +65,7 @@ pub const NOISE_TAG_LEN: usize = 16;
 
 /// The maximum amount of time in which a handshake with a regular node can conclude before dropping the
 /// connection; it should be no greater than the `peer_sync_interval`.
-pub const HANDSHAKE_PEER_TIMEOUT_SECS: u8 = 5;
+pub const HANDSHAKE_TIMEOUT_SECS: u8 = 5;
 /// The amount of time after which a peer will be considered inactive an disconnected from if they have
 /// not sent any messages in the meantime.
 pub const MAX_PEER_INACTIVITY_SECS: u8 = 30;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -63,9 +63,6 @@ pub const NOISE_BUF_LEN: usize = 65535;
 /// The spec-compliant size of the noise tag field.
 pub const NOISE_TAG_LEN: usize = 16;
 
-/// The maximum amount of time in which a handshake with a bootnode can conclude before dropping the
-/// connection; it should be no greater than the `peer_sync_interval`.
-pub const HANDSHAKE_BOOTNODE_TIMEOUT_SECS: u8 = 10;
 /// The maximum amount of time in which a handshake with a regular node can conclude before dropping the
 /// connection; it should be no greater than the `peer_sync_interval`.
 pub const HANDSHAKE_PEER_TIMEOUT_SECS: u8 = 5;

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -248,7 +248,9 @@ impl Node {
             #[cfg(not(feature = "test"))]
             sleep(Duration::from_secs(5)).await;
 
-            let sync_providers = self.config.sync_providers();
+            // FIXME: sync providers are set as beacons in the configuration during the rollout.
+            // let sync_providers = self.config.sync_providers();
+            let sync_providers = self.config.beacons();
             let node_clone = self.clone();
             let mempool_sync_interval = node_clone.expect_sync().mempool_sync_interval();
             let sync_mempool_task = task::spawn(async move {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -265,7 +265,7 @@ impl Node {
                         //  all of our connected peers anyways.
 
                         // The order of preference for the sync node is as follows:
-                        //   1. Iterate (in declared order) through the sync_providers:
+                        //   1. Iterate (in declared order) through the sync providers:
                         //      a. Check if this node is connected to the specified sync provider in the peer book.
                         //      b. Select the specified sync provider as the sync node if this node is connected to it.
                         //   2. If this node is not connected to any sync provider,

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -137,7 +137,7 @@ impl Node {
             terminator: Arc::new(AtomicBool::new(false)),
         }));
 
-        if node.config.is_crawler() {
+        if node.config.is_of_type(NodeType::Crawler) {
             // Safe since crawlers don't start the listener service.
             node.set_local_addr(node.config.desired_address);
 
@@ -205,7 +205,7 @@ impl Node {
             self.register_task(known_network_task);
         }
 
-        if !self.config.is_crawler() {
+        if !self.config.is_of_type(NodeType::Crawler) {
             let node_clone = self.clone();
             let state_tracking_task = task::spawn(async move {
                 loop {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -137,7 +137,7 @@ impl Node {
             terminator: Arc::new(AtomicBool::new(false)),
         }));
 
-        if node.config.is_of_type(NodeType::Crawler) {
+        if node.is_of_type(NodeType::Crawler) {
             // Safe since crawlers don't start the listener service.
             node.set_local_addr(node.config.desired_address);
 
@@ -146,6 +146,10 @@ impl Node {
         }
 
         Ok(node)
+    }
+
+    pub fn is_of_type(&self, t: NodeType) -> bool {
+        self.config.node_type == t
     }
 
     pub fn set_sync(&mut self, sync: Sync) {
@@ -205,7 +209,7 @@ impl Node {
             self.register_task(known_network_task);
         }
 
-        if !self.config.is_of_type(NodeType::Crawler) {
+        if !self.is_of_type(NodeType::Crawler) {
             let node_clone = self.clone();
             let state_tracking_task = task::spawn(async move {
                 loop {

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -244,7 +244,7 @@ impl Node {
             #[cfg(not(feature = "test"))]
             sleep(Duration::from_secs(5)).await;
 
-            let bootnodes = self.config.bootnodes();
+            let sync_providers = self.config.sync_providers();
             let node_clone = self.clone();
             let mempool_sync_interval = node_clone.expect_sync().mempool_sync_interval();
             let sync_mempool_task = task::spawn(async move {
@@ -265,17 +265,17 @@ impl Node {
                         //  all of our connected peers anyways.
 
                         // The order of preference for the sync node is as follows:
-                        //   1. Iterate (in declared order) through the bootnodes:
-                        //      a. Check if this node is connected to the specified bootnode in the peer book.
-                        //      b. Select the specified bootnode as the sync node if this node is connected to it.
-                        //   2. If this node is not connected to any bootnode,
+                        //   1. Iterate (in declared order) through the sync_providers:
+                        //      a. Check if this node is connected to the specified sync provider in the peer book.
+                        //      b. Select the specified sync provider as the sync node if this node is connected to it.
+                        //   2. If this node is not connected to any sync provider,
                         //      then select the last seen peer as the sync node.
 
                         // Step 1.
                         let mut sync_node = None;
-                        for bootnode in bootnodes.iter() {
-                            if node_clone.peer_book.is_connected(*bootnode) {
-                                sync_node = Some(*bootnode);
+                        for sync_provider in sync_providers.iter() {
+                            if node_clone.peer_book.is_connected(*sync_provider) {
+                                sync_node = Some(*sync_provider);
                                 break;
                             }
                         }

--- a/network/src/peers/peer/handshake.rs
+++ b/network/src/peers/peer/handshake.rs
@@ -168,7 +168,7 @@ impl Peer {
         let (mut reader, mut writer) = stream.into_split();
 
         let result = tokio::time::timeout(
-            Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
+            Duration::from_secs(crate::HANDSHAKE_TIMEOUT_SECS as u64),
             initiator_handshake(self.address, &our_version, &mut writer, &mut reader),
         )
         .await;
@@ -202,7 +202,7 @@ impl Peer {
         let (mut reader, mut writer) = stream.into_split();
 
         let result = tokio::time::timeout(
-            Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
+            Duration::from_secs(crate::HANDSHAKE_TIMEOUT_SECS as u64),
             responder_handshake(address, &our_version, &mut writer, &mut reader),
         )
         .await;

--- a/network/src/peers/peer/handshake.rs
+++ b/network/src/peers/peer/handshake.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use snow::TransportState;
 use tokio::{
@@ -168,7 +168,7 @@ impl Peer {
         let (mut reader, mut writer) = stream.into_split();
 
         let result = tokio::time::timeout(
-            self.handshake_timeout(),
+            Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
             initiator_handshake(self.address, &our_version, &mut writer, &mut reader),
         )
         .await;
@@ -185,10 +185,7 @@ impl Peer {
             }
         };
 
-        match self.is_beacon {
-            true => info!("Connected to peer discovery node {}", self.address),
-            false => info!("Connected to peer {}", self.address),
-        };
+        info!("Connected to peer {}", self.address);
 
         Ok(PeerIOHandle {
             reader: Some(reader),
@@ -205,7 +202,7 @@ impl Peer {
         let (mut reader, mut writer) = stream.into_split();
 
         let result = tokio::time::timeout(
-            Peer::peer_handshake_timeout(),
+            Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64),
             responder_handshake(address, &our_version, &mut writer, &mut reader),
         )
         .await;
@@ -224,7 +221,7 @@ impl Peer {
 
         let mut peer_address = address;
         peer_address.set_port(data.version.listening_port);
-        let peer = Peer::new(peer_address, false);
+        let peer = Peer::new(peer_address);
 
         info!("Connected to peer {}", peer_address);
 

--- a/network/src/peers/peer/handshake.rs
+++ b/network/src/peers/peer/handshake.rs
@@ -185,8 +185,8 @@ impl Peer {
             }
         };
 
-        match self.is_bootnode {
-            true => info!("Connected to bootnode {}", self.address),
+        match self.is_beacon {
+            true => info!("Connected to peer discovery node {}", self.address),
             false => info!("Connected to peer {}", self.address),
         };
 

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -32,10 +32,6 @@ use super::{network::*, outbound_handler::*};
 pub struct Peer {
     pub address: SocketAddr,
     pub quality: PeerQuality,
-    #[serde(skip)]
-    pub queued_inbound_message_count: Arc<AtomicUsize>,
-    #[serde(skip)]
-    pub queued_outbound_message_count: Arc<AtomicUsize>,
     /// Whether this peer is routable or not.
     ///
     /// `None` indicates the node has never attempted a connection with this peer.
@@ -53,8 +49,6 @@ impl Peer {
         Self {
             address,
             quality: Default::default(),
-            queued_inbound_message_count: Default::default(),
-            queued_outbound_message_count: Default::default(),
 
             // Set to `None` since peer creation only ever happens before a connection to the peer,
             // therefore we don't know if its listener is routable or not.

--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -32,7 +32,6 @@ use super::{network::*, outbound_handler::*};
 pub struct Peer {
     pub address: SocketAddr,
     pub quality: PeerQuality,
-    pub is_beacon: bool,
     #[serde(skip)]
     pub queued_inbound_message_count: Arc<AtomicUsize>,
     #[serde(skip)]
@@ -50,11 +49,10 @@ const FAILURE_EXPIRY_TIME: Duration = Duration::from_secs(15 * 60);
 const FAILURE_THRESHOLD: usize = 5;
 
 impl Peer {
-    pub fn new(address: SocketAddr, is_beacon: bool) -> Self {
+    pub fn new(address: SocketAddr) -> Self {
         Self {
             address,
             quality: Default::default(),
-            is_beacon,
             queued_inbound_message_count: Default::default(),
             queued_outbound_message_count: Default::default(),
 
@@ -91,18 +89,6 @@ impl Peer {
                 .collect();
         }
         self.quality.failures.len()
-    }
-
-    pub fn handshake_timeout(&self) -> Duration {
-        if self.is_beacon {
-            Duration::from_secs(crate::HANDSHAKE_BOOTNODE_TIMEOUT_SECS as u64)
-        } else {
-            Self::peer_handshake_timeout()
-        }
-    }
-
-    pub fn peer_handshake_timeout() -> Duration {
-        Duration::from_secs(crate::HANDSHAKE_PEER_TIMEOUT_SECS as u64)
     }
 
     pub(super) async fn run(

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -166,7 +166,7 @@ impl PeerBook {
                 metrics::decrement_gauge!(DISCONNECTED, 1.0);
                 peer
             } else {
-                Peer::new(address, node.config.beacons().contains(&address))
+                Peer::new(address)
             };
             self.pending_connections.fetch_add(1, Ordering::SeqCst);
             peer.connect(node, self.peer_events.clone());
@@ -235,7 +235,7 @@ impl PeerBook {
     ///
     /// Adds the given address to the disconnected peers in this `PeerBook`.
     ///
-    pub async fn add_peer(&self, address: SocketAddr, is_beacon: bool) {
+    pub async fn add_peer(&self, address: SocketAddr) {
         if self.connected_peers.contains_key(&address) || self.disconnected_peers.contains_key(&address) {
             return;
         }
@@ -243,7 +243,7 @@ impl PeerBook {
         // Add the given address to the map of disconnected peers.
         if self
             .disconnected_peers
-            .insert(address, Peer::new(address, is_beacon))
+            .insert(address, Peer::new(address))
             .await
             .is_none()
         {

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -166,7 +166,7 @@ impl PeerBook {
                 metrics::decrement_gauge!(DISCONNECTED, 1.0);
                 peer
             } else {
-                Peer::new(address, node.config.bootnodes().contains(&address))
+                Peer::new(address, node.config.beacons().contains(&address))
             };
             self.pending_connections.fetch_add(1, Ordering::SeqCst);
             peer.connect(node, self.peer_events.clone());
@@ -235,7 +235,7 @@ impl PeerBook {
     ///
     /// Adds the given address to the disconnected peers in this `PeerBook`.
     ///
-    pub async fn add_peer(&self, address: SocketAddr, is_bootnode: bool) {
+    pub async fn add_peer(&self, address: SocketAddr, is_beacon: bool) {
         if self.connected_peers.contains_key(&address) || self.disconnected_peers.contains_key(&address) {
             return;
         }
@@ -243,7 +243,7 @@ impl PeerBook {
         // Add the given address to the map of disconnected peers.
         if self
             .disconnected_peers
-            .insert(address, Peer::new(address, is_bootnode))
+            .insert(address, Peer::new(address, is_beacon))
             .await
             .is_none()
         {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -358,12 +358,12 @@ impl Node {
             .copied()
             .collect();
 
-        // Make sure to include a sync provider in the addresses if this node is a peer discovery
-        // node. In future, sync provider addresses wouldn't be provided if their capacity is
-        // maxed out.
+        // Make sure to include a sync provider in the addresses if this node is a beacon. In
+        // future, sync provider addresses wouldn't be provided if their capacity is maxed out.
         if self.config.is_of_type(NodeType::Beacon) {
             if let Some(random_sync_provider) = self.config.sync_providers().choose(&mut SmallRng::from_entropy()) {
-                peers.push(*random_sync_provider);
+                // Replace to maintain the size of the list.
+                peers[0] = *random_sync_provider;
             }
         }
 

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -115,8 +115,9 @@ impl Node {
 
         // Attempt to connect to a few random beacons if the node has no active
         // connections or if it's a beacon itself.
-        if (!self.is_of_type(NodeType::SyncProvider) && self.peer_book.get_active_peer_count() == 0)
+        if self.peer_book.get_active_peer_count() == 0
             || self.is_of_type(NodeType::Beacon)
+            || self.is_of_type(NodeType::SyncProvider)
         {
             let random_beacons = self
                 .config
@@ -330,7 +331,9 @@ impl Node {
 
         // Beacons apply less strict filtering rules if the set is empty by falling back on
         // connected peers that may or may not be routable...
-        let peers = if self.is_of_type(NodeType::Beacon) && strictly_filtered_peers.is_empty() {
+        let peers = if (self.is_of_type(NodeType::SyncProvider) || self.is_of_type(NodeType::Beacon))
+            && strictly_filtered_peers.is_empty()
+        {
             let filtered_peers: Vec<SocketAddr> = connected_peers
                 .iter()
                 .filter(|peer| basic_filter(peer))

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -372,9 +372,7 @@ impl Node {
             // Inform the peer book that we found a peer.
             // The peer book will determine if we have seen the peer before,
             // and include the peer if it is new.
-            self.peer_book
-                .add_peer(*peer_address, self.config.beacons().contains(peer_address))
-                .await;
+            self.peer_book.add_peer(*peer_address).await;
         }
 
         if let Some(known_network) = self.known_network() {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -25,7 +25,7 @@ use tokio::task;
 
 use snarkos_metrics::{self as metrics, connections::*};
 
-use crate::{message::*, KnownNetworkMessage, NetworkError, Node};
+use crate::{message::*, KnownNetworkMessage, NetworkError, Node, NodeType};
 use anyhow::*;
 
 impl Node {
@@ -60,7 +60,7 @@ impl Node {
 
         // Calculate the peer counts to disconnect and connect based on the node type and current
         // peer counts.
-        let (number_to_disconnect, number_to_connect) = if self.config.is_crawler() {
+        let (number_to_disconnect, number_to_connect) = if self.config.is_of_type(NodeType::Crawler) {
             // Crawlers disconnect down to the min peer count, this to free up room for
             // the next crawled peers...
             let number_to_disconnect = active_peer_count.saturating_sub(min_peers);
@@ -71,7 +71,7 @@ impl Node {
             let number_to_connect = crawling_capacity.saturating_sub(active_peer_count - number_to_disconnect);
 
             (number_to_disconnect, number_to_connect)
-        } else if self.config.is_sync_provider() || self.config.is_beacon() {
+        } else if self.config.is_of_type(NodeType::SyncProvider) || self.config.is_of_type(NodeType::Beacon) {
             // Bootnodes disconnect down to 80% of their max to leave capacity open for new
             // connections.
             const BOOTNODE_CAPACITY_PERCENTAGE: f64 = 0.8;
@@ -96,7 +96,7 @@ impl Node {
         if number_to_disconnect != 0 {
             let mut current_peers = self.peer_book.connected_peers_snapshot().await;
 
-            if !self.config.is_client() {
+            if !self.config.is_of_type(NodeType::Client) {
                 // Bootnodes and crawlers will disconnect from their oldest peers...
                 current_peers.sort_unstable_by_key(|peer| cmp::Reverse(peer.quality.last_connected));
             } else {
@@ -115,7 +115,9 @@ impl Node {
 
         // Attempt to connect to a few random peer provider nodes if the node has no active
         // connections or if it's a beacon itself.
-        if (!self.config.is_sync_provider() && self.peer_book.get_active_peer_count() == 0) || self.config.is_beacon() {
+        if (!self.config.is_of_type(NodeType::SyncProvider) && self.peer_book.get_active_peer_count() == 0)
+            || self.config.is_of_type(NodeType::Beacon)
+        {
             let random_beacons = self
                 .config
                 .beacons()
@@ -225,14 +227,14 @@ impl Node {
             let beacons = self.config.beacons();
             candidates.retain(|peer| peer.address != own_address && !beacons.contains(&peer.address));
 
-            if !self.config.is_client() {
+            if !self.config.is_of_type(NodeType::Client) {
                 // Bootnodes and crawlers prefer peers they haven't dialed in a while.
                 candidates.sort_unstable_by_key(|peer| peer.quality.last_connected);
             }
 
             let addr_iter = candidates.iter().map(|peer| peer.address);
 
-            if !self.config.is_client() {
+            if !self.config.is_of_type(NodeType::Client) {
                 addr_iter.take(count).collect()
             } else {
                 addr_iter.choose_multiple(&mut SmallRng::from_entropy(), count)
@@ -264,7 +266,7 @@ impl Node {
     async fn broadcast_getpeers_requests(&self) {
         // If the node is a client node, check if the request for peers is needed
         // based on the number of active connections.
-        if self.config.is_client() {
+        if self.config.is_of_type(NodeType::Client) {
             // Fetch the number of connected and connecting peers.
             let number_of_peers = self.peer_book.get_active_peer_count() as usize;
 
@@ -328,7 +330,7 @@ impl Node {
 
         // Beacons apply less strict filtering rules if the set is empty by falling back on
         // connected peers that may or may not be routable...
-        let peers = if self.config.is_beacon() && strictly_filtered_peers.is_empty() {
+        let peers = if self.config.is_of_type(NodeType::Beacon) && strictly_filtered_peers.is_empty() {
             let filtered_peers: Vec<SocketAddr> = connected_peers
                 .iter()
                 .filter(|peer| basic_filter(peer))
@@ -359,7 +361,7 @@ impl Node {
         // Make sure to include a sync provider in the addresses if this node is a peer discovery
         // node. In future, sync provider addresses wouldn't be provided if their capacity is
         // maxed out.
-        if self.config.is_beacon() {
+        if self.config.is_of_type(NodeType::Beacon) {
             if let Some(random_sync_provider) = self.config.sync_providers().choose(&mut SmallRng::from_entropy()) {
                 peers.push(*random_sync_provider);
             }

--- a/network/tests/fuzzing.rs
+++ b/network/tests/fuzzing.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_network::{MessageHeader, Payload, Version};
+use snarkos_network::{MessageHeader, NodeType, Payload, Version};
+use snarkvm_dpc::BlockHeaderHash;
 
 use rand::{distributions::Standard, thread_rng, Rng};
 use snarkos_storage::Digest;
@@ -53,8 +54,8 @@ fn corrupt_bytes(serialized: &[u8]) -> Vec<u8> {
 #[tokio::test]
 async fn fuzzing_zeroes_pre_handshake() {
     let node_setup = TestSetup {
+        node_type: NodeType::Beacon, // same rules for establishing connections and reading messages as a regular node, but lighter
         consensus_setup: None,
-        is_bootnode: true, // same rules for establishing connections and reading messages as a regular node, but lighter
         ..Default::default()
     };
     let node = test_node(node_setup).await;
@@ -70,8 +71,8 @@ async fn fuzzing_zeroes_pre_handshake() {
 #[tokio::test]
 async fn fuzzing_zeroes_post_handshake() {
     let node_setup = TestSetup {
+        node_type: NodeType::Beacon, // same rules for establishing connections and reading messages as a regular node, but lighter
         consensus_setup: None,
-        is_bootnode: true,
         ..Default::default()
     };
     let (node, mut fake_node) = handshaken_node_and_peer(node_setup).await;
@@ -86,8 +87,8 @@ async fn fuzzing_valid_header_pre_handshake() {
     // tracing_subscriber::fmt::init();
 
     let node_setup = TestSetup {
+        node_type: NodeType::Beacon, // same rules for establishing connections and reading messages as a regular node, but lighter
         consensus_setup: None,
-        is_bootnode: true,
         ..Default::default()
     };
     let node = test_node(node_setup).await;
@@ -139,8 +140,8 @@ async fn fuzzing_pre_handshake() {
     // tracing_subscriber::fmt::init();
 
     let node_setup = TestSetup {
+        node_type: NodeType::Beacon, // same rules for establishing connections and reading messages as a regular node, but lighter
         consensus_setup: None,
-        is_bootnode: true,
         ..Default::default()
     };
     let node = test_node(node_setup).await;
@@ -543,7 +544,7 @@ async fn connection_request_spam() {
     wait_until!(3, node.peer_book.get_active_peer_count() >= max_peers as u32);
 
     wait_until!(
-        snarkos_network::HANDSHAKE_PEER_TIMEOUT_SECS as u64 * 2,
+        snarkos_network::HANDSHAKE_TIMEOUT_SECS as u64 * 2,
         node.peer_book.get_active_peer_count() == 0
     );
 }

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -90,15 +90,14 @@ async fn handshake_initiator_side() {
     let peer_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let peer_address = peer_listener.local_addr().unwrap();
 
-    // start node with the peer as a bootnode; that way it will get connected to
     // note: using the smallest allowed interval for peer sync
     let setup = TestSetup {
         consensus_setup: None,
-        bootnodes: vec![peer_address.to_string()],
         peer_sync_interval: 1,
         ..Default::default()
     };
     let node = test_node(setup).await;
+    node.connect_to_addresses(&[peer_address]).await;
 
     // accept the node's connection on peer side
     let (mut peer_stream, _node_address) = peer_listener.accept().await.unwrap();
@@ -235,18 +234,18 @@ async fn reject_non_version_messages_before_handshake() {
 
 #[tokio::test]
 async fn handshake_timeout_initiator_side() {
-    const NUM_BOOTSTRAPPERS: usize = 5;
+    const NUM_BEACONS: usize = 5;
 
-    // set up bootnodes that won't perform a valid handshake
-    let mut failing_bootnodes = Vec::with_capacity(NUM_BOOTSTRAPPERS);
-    for _ in 0..NUM_BOOTSTRAPPERS {
-        failing_bootnodes.push(TcpListener::bind("127.0.0.1:0").await.unwrap());
+    // set up beacons that won't perform a valid handshake
+    let mut failing_beacons = Vec::with_capacity(NUM_BEACONS);
+    for _ in 0..NUM_BEACONS {
+        failing_beacons.push(TcpListener::bind("127.0.0.1:0").await.unwrap());
     }
 
     // start the node
     let setup = TestSetup {
         consensus_setup: None,
-        bootnodes: failing_bootnodes
+        beacons: failing_beacons
             .iter()
             .map(|l| {
                 let addr = l.local_addr().unwrap();
@@ -262,7 +261,7 @@ async fn handshake_timeout_initiator_side() {
 
     // but since they won't reply, it should drop them after the handshake deadline
     wait_until!(
-        snarkos_network::HANDSHAKE_BOOTNODE_TIMEOUT_SECS as u64 + 1,
+        snarkos_network::HANDSHAKE_TIMEOUT_SECS as u64 + 1,
         node.peer_book.get_active_peer_count() == 0
     );
 }
@@ -285,7 +284,7 @@ async fn handshake_timeout_responder_side() {
 
     // but since it won't conclude the handshake, it should be dropped after the handshake deadline
     wait_until!(
-        snarkos_network::HANDSHAKE_PEER_TIMEOUT_SECS as u64 + 1,
+        snarkos_network::HANDSHAKE_TIMEOUT_SECS as u64 + 1,
         node.peer_book.get_active_peer_count() == 0
     );
 }

--- a/network/tests/handshake.rs
+++ b/network/tests/handshake.rs
@@ -256,7 +256,7 @@ async fn handshake_timeout_initiator_side() {
     };
     let node = test_node(setup).await;
 
-    // the node should start connecting to all the configured bootnodes
+    // the node should start connecting to all the configured beacons.
     wait_until!(3, node.peer_book.get_active_peer_count() != 0);
 
     // but since they won't reply, it should drop them after the handshake deadline

--- a/network/tests/peers.rs
+++ b/network/tests/peers.rs
@@ -100,7 +100,7 @@ async fn beacon_peer_propagation() {
             && node_charlie.peer_book.get_active_peer_count() == 2
     };
 
-    // Make sure B and C connect => becon propagates peers (without `is_routable` check in this
+    // Make sure B and C connect => beacon propagates peers (without `is_routable` check in this
     // case).
     wait_until!(5, triangle_is_formed());
 }

--- a/network/tests/peers.rs
+++ b/network/tests/peers.rs
@@ -100,7 +100,7 @@ async fn beacon_peer_propagation() {
             && node_charlie.peer_book.get_active_peer_count() == 2
     };
 
-    // Make sure B and C connect => bootnode propagates peers (without `is_routable` check in this
+    // Make sure B and C connect => becon propagates peers (without `is_routable` check in this
     // case).
     wait_until!(5, triangle_is_formed());
 }

--- a/network/tests/peers.rs
+++ b/network/tests/peers.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-use snarkos_network::message::*;
+use snarkos_network::{message::*, NodeType};
 use snarkos_testing::{
     network::{handshaken_node_and_peer, random_bound_address, test_node, TestSetup},
     wait_until,
@@ -70,28 +70,28 @@ async fn peer_responder_side() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn bootnode_peer_propagation() {
-    let setup = |is_bootnode, bootnodes| TestSetup {
+async fn beacon_peer_propagation() {
+    let setup = |node_type, beacons| TestSetup {
+        node_type,
         consensus_setup: None,
         min_peers: 2,
         peer_sync_interval: 1,
-        is_bootnode,
-        bootnodes,
+        beacons,
         ..Default::default()
     };
 
-    // Spin up and connect nodes A and B.
-    let node_alice = test_node(setup(true, vec![])).await;
+    // Spin up nodes A and B.
+    let node_alice = test_node(setup(NodeType::Beacon, vec![])).await;
     let addr_alice = node_alice.expect_local_addr();
 
     // Connect B to A.
-    let node_bob = test_node(setup(false, vec![addr_alice.to_string()])).await;
+    let node_bob = test_node(setup(NodeType::Client, vec![addr_alice.to_string()])).await;
 
     // Sleep to avoid C and B trying to simultaneously connect to each other.
     sleep(Duration::from_millis(100)).await;
 
     // Connect C to A.
-    let node_charlie = test_node(setup(false, vec![addr_alice.to_string()])).await;
+    let node_charlie = test_node(setup(NodeType::Client, vec![addr_alice.to_string()])).await;
 
     let triangle_is_formed = || {
         node_charlie.peer_book.is_connected(addr_alice)

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -206,7 +206,7 @@ async fn star_converges_to_mesh() {
         ..Default::default()
     };
 
-    // A bootnode will be necessary at the center of the star for peers to get propagated.
+    // A beacon node will be necessary at the center of the star for peers to get propagated.
     let hub_setup = TestSetup {
         node_type: NodeType::Beacon,
         ..setup()
@@ -215,7 +215,7 @@ async fn star_converges_to_mesh() {
     // Create the regular nodes.
     let mut nodes = test_nodes(N - 1, setup).await;
 
-    // Insert the bootnode at the head of the list.
+    // Insert the beacon at the head of the list.
     nodes.insert(0, test_node(hub_setup).await);
 
     connect_nodes(&mut nodes, Topology::Star).await;
@@ -231,9 +231,9 @@ async fn star_converges_to_mesh() {
 #[tokio::test(flavor = "multi_thread")]
 async fn binary_star_contact() {
     // Two initally separate star topologies subsequently connected by a single node connecting to
-    // their bootnodes.
+    // the peer discovery nodes at their center.
 
-    // Setup the bootnodes for each star topology.
+    // Setup the beacons for each star topology.
     let beacon_setup = || TestSetup {
         node_type: NodeType::Beacon,
         consensus_setup: None,

--- a/network/tests/topology.rs
+++ b/network/tests/topology.rs
@@ -231,7 +231,7 @@ async fn star_converges_to_mesh() {
 #[tokio::test(flavor = "multi_thread")]
 async fn binary_star_contact() {
     // Two initally separate star topologies subsequently connected by a single node connecting to
-    // the peer discovery nodes at their center.
+    // the beacons at their center.
 
     // Setup the beacons for each star topology.
     let beacon_setup = || TestSetup {

--- a/rpc/documentation/public_endpoints/getnetworkgraph.md
+++ b/rpc/documentation/public_endpoints/getnetworkgraph.md
@@ -1,4 +1,4 @@
-Returns the network graph crawled by this node (if it is a bootnode).
+Returns the network graph crawled by this node (if it is a crawler).
 
 ### Arguments
 
@@ -20,7 +20,8 @@ None
 | `edges[i].source`                    | SocketAddr | One side of the crawled connection                                                        |
 | `edges[i].target`                    | SocketAddr | The other side of the crawled connection                                                  |
 | `vertices[i].addr`                   | SocketAddr | The recorded address of the crawled node                                                  |
-| `vertices[i].is_bootnode`            | bool       | Indicates whether the node is a bootnode                                                  |
+| `vertices[i].is_beacon`              | bool       | Indicates whether the node is a beacon                                                    |
+| `vertices[i].is_sync_provider`       | bool       | Indicates whether the node is a sync provider                                             |
 | `vertices[i].degree_centrality`      | u16        | The node's degree centrality, aka its connection count                                    |
 | `vertices[i].eigenvector_centrality` | f64        | The node's eigenvector centrality, indicates its relative importance in the network       |
 | `vertices[i].fiedler_value`          | f64        | The node's fiedler value, can be used to partition the network graph                      |

--- a/rpc/documentation/public_endpoints/getnodeinfo.md
+++ b/rpc/documentation/public_endpoints/getnodeinfo.md
@@ -8,7 +8,7 @@ None
 
 |     Parameter    |     Type      |                  Description                  |
 |:----------------:|:-------------:|:---------------------------------------------:|
-| `is_bootnode`    | bool          | Flag indicating if the node is a bootnode     |
+| `node_type`      | NodeType      | Flag indicating if the node type              |
 | `is_miner`       | bool          | Flag indicating if the node is a miner        |
 | `is_syncing`     | bool          | Flag indicating if the node currently syncing |
 | `launched`       | timestamp     | The timestamp of when the node was launched   |

--- a/rpc/documentation/public_endpoints/getnodeinfo.md
+++ b/rpc/documentation/public_endpoints/getnodeinfo.md
@@ -8,7 +8,7 @@ None
 
 |     Parameter    |     Type      |                  Description                  |
 |:----------------:|:-------------:|:---------------------------------------------:|
-| `node_type`      | NodeType      | Flag indicating if the node type              |
+| `node_type`      | NodeType      | Flag indicating the node type                 |
 | `is_miner`       | bool          | Flag indicating if the node is a miner        |
 | `is_syncing`     | bool          | Flag indicating if the node currently syncing |
 | `launched`       | timestamp     | The timestamp of when the node was launched   |

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -482,7 +482,8 @@ impl RpcFunctions for RpcImpl {
             .iter()
             .map(|(addr, node_centrality)| Vertice {
                 addr: *addr,
-                is_bootnode: self.node.config.bootnodes().contains(addr),
+                is_beacon: self.node.config.beacons().contains(addr),
+                is_sync_provider: self.node.config.sync_providers().contains(addr),
                 degree_centrality: node_centrality.degree_centrality,
                 eigenvector_centrality: node_centrality.eigenvector_centrality,
                 fiedler_value: node_centrality.fiedler_value,

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -408,7 +408,7 @@ impl RpcFunctions for RpcImpl {
     async fn get_node_info(&self) -> Result<NodeInfo, RpcError> {
         Ok(NodeInfo {
             listening_addr: self.node.config.desired_address,
-            is_bootnode: self.node.config.is_bootnode(),
+            node_type: self.node.config.node_type,
             is_miner: self.sync_handler()?.is_miner,
             is_syncing: self.node.is_syncing_blocks(),
             launched: self.node.launched,

--- a/rpc/src/rpc_impl_protected.rs
+++ b/rpc/src/rpc_impl_protected.rs
@@ -276,7 +276,7 @@ impl RpcImpl {
             .map_err(|e| JsonRPCError::invalid_params(format!("Invalid params: {}.", e)))?;
 
         for addr in &addresses {
-            self.node.peer_book.add_peer(*addr, false).await;
+            self.node.peer_book.add_peer(*addr).await;
         }
         self.node.connect_to_addresses(&addresses).await;
 
@@ -697,7 +697,7 @@ impl ProtectedRpcFunctions for RpcImpl {
         let node = self.node.clone();
         tokio::spawn(async move {
             for addr in &addresses {
-                node.peer_book.add_peer(*addr, false).await;
+                node.peer_book.add_peer(*addr).await;
             }
             node.connect_to_addresses(&addresses).await
         });

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -322,7 +322,8 @@ pub struct NetworkGraph {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Vertice {
     pub addr: SocketAddr,
-    pub is_bootnode: bool,
+    pub is_beacon: bool,
+    pub is_sync_provider: bool,
 
     // Centrality measurements for the node.
     pub degree_centrality: u16,

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -21,7 +21,7 @@ use jsonrpc_core::Metadata;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
-use snarkos_network::NodeCluster;
+use snarkos_network::{NodeCluster, NodeType};
 
 /// Defines the authentication format for accessing private endpoints on the RPC server
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -129,7 +129,7 @@ pub struct NodeInfo {
     pub listening_addr: SocketAddr,
 
     /// Flag indicating if the node is a bootnode
-    pub is_bootnode: bool,
+    pub node_type: NodeType,
 
     /// Flag indicating if the node is operating as a miner
     pub is_miner: bool,

--- a/rpc/src/rpc_types.rs
+++ b/rpc/src/rpc_types.rs
@@ -128,7 +128,7 @@ pub struct NodeInfo {
     /// The configured listening address of the node.
     pub listening_addr: SocketAddr,
 
-    /// Flag indicating if the node is a bootnode
+    /// Flag indicating if the node's type.
     pub node_type: NodeType,
 
     /// Flag indicating if the node is operating as a miner

--- a/rpc/tests/rpc_tests.rs
+++ b/rpc/tests/rpc_tests.rs
@@ -18,7 +18,7 @@
 mod rpc_tests {
     use jsonrpc_core::{MetaIoHandler, Params, RemoteProcedure, RpcMethod};
     use snarkos_consensus::{get_block_reward, Consensus};
-    use snarkos_network::Node;
+    use snarkos_network::{Node, NodeType};
     use snarkos_rpc::*;
     use snarkos_testing::{
         network::{test_config, test_node, ConsensusSetup, TestSetup},
@@ -366,7 +366,7 @@ mod rpc_tests {
     async fn test_rpc_getnetworkgraph() {
         let consensus = snarkos_testing::sync::create_test_consensus().await;
         let setup = TestSetup {
-            is_crawler: true,
+            node_type: NodeType::Crawler,
             peer_sync_interval: 1,
             min_peers: 2,
             consensus_setup: None,

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -422,9 +422,7 @@ impl Config {
         if self.miner.is_miner {
             match self.node.kind {
                 NodeType::Client => {}
-                NodeType::Crawler => return Err(CliError::MinerCrawler),
-                NodeType::Beacon => return Err(CliError::MinerBeacon),
-                NodeType::SyncProvider => return Err(CliError::MinerSyncProvider),
+                NodeType::Crawler | NodeType::Beacon | NodeType::SyncProvider => return Err(CliError::CantMine),
             }
         }
 

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -32,11 +32,8 @@ use std::{fs, path::PathBuf};
 /// A node should try and connect to these first after coming online.
 pub const MAINNET_BEACONS: &[&str] = &[]; // "192.168.0.1:4130"
 // FIXME: setup peer discovery node addresses.
-pub const TESTNET_BEACONS: &[&str] = &[];
-
-pub const MAINNET_SYNC_PROVIDERS: &[&str] = &[];
-// TODO: these are the current "bootnodes".
-pub const TESTNET_SYNC_PROVIDERS: &[&str] = &[
+// Setting the old bootnodes as beacons ensures backwards compaibility during the transition.
+pub const TESTNET_BEACONS: &[&str] = &[
     "50.18.83.123:4131",
     "50.18.246.201:4131",
     "159.89.152.247:4131",
@@ -49,6 +46,9 @@ pub const TESTNET_SYNC_PROVIDERS: &[&str] = &[
     "206.189.80.245:4131",
     "178.128.18.3:4131",
 ];
+
+pub const MAINNET_SYNC_PROVIDERS: &[&str] = &[];
+pub const TESTNET_SYNC_PROVIDERS: &[&str] = &[];
 
 /// Represents all configuration options for a node.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -443,8 +443,6 @@ impl CLI for ConfigCli {
     const ABOUT: AboutType = "Run an Aleo node (include -h for more options)";
     const FLAGS: &'static [FlagType] = &[
         flag::NO_JSONRPC,
-        flag::IS_BOOTNODE,
-        flag::IS_MINER,
         flag::TRIM_STORAGE,
         flag::VALIDATE_STORAGE,
         flag::SQLITE,

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -443,6 +443,7 @@ impl CLI for ConfigCli {
     const ABOUT: AboutType = "Run an Aleo node (include -h for more options)";
     const FLAGS: &'static [FlagType] = &[
         flag::NO_JSONRPC,
+        flag::IS_MINER,
         flag::TRIM_STORAGE,
         flag::VALIDATE_STORAGE,
         flag::SQLITE,
@@ -477,7 +478,6 @@ impl CLI for ConfigCli {
             "no-jsonrpc",
             "export-canon-blocks",
             "import-canon-blocks",
-            "is-bootnode",
             "is-miner",
             "ip",
             "port",

--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::config::Config;
+use snarkos_network::NodeType;
 use snarkvm_dpc::{testnet1::instantiated::Components, Address};
 
 use colored::*;
@@ -93,12 +94,31 @@ fn render_welcome(config: &Config) -> String {
         0 => "mainnet".to_string(),
         i => format!("testnet{}", i),
     };
-    if is_miner {
-        output += &format!("Starting a mining node on {}.\n", network).bold().to_string();
-    } else if config.node.is_crawler {
-        output += &format!("Starting a crawler node on {}.\n", network).bold().to_string();
-    } else {
-        output += &format!("Starting a client node on {}.\n", network).bold().to_string();
+
+    //     if is_miner {
+    //         output += &format!("Starting a mining node on {}.\n", network).bold().to_string();
+    //     } else {
+    //         output += &format!("Starting a client node on {}.\n", network).bold().to_string();
+    //     }
+
+    match config.node.kind {
+        NodeType::Client if is_miner => {
+            output += &format!("Starting a mining node on {}.\n", network).bold().to_string();
+        }
+        NodeType::Client => {
+            output += &format!("Starting a client node on {}.\n", network).bold().to_string();
+        }
+        NodeType::Crawler => output += &format!("Starting a crawler node on {}.\n", network).bold().to_string(),
+        NodeType::Beacon => {
+            output += &format!("Starting a peer discovery node on {}.\n", network)
+                .bold()
+                .to_string()
+        }
+        NodeType::SyncProvider => {
+            output += &format!("Starting a sync provider node on {}.\n", network)
+                .bold()
+                .to_string()
+        }
     }
 
     output

--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -103,11 +103,7 @@ fn render_welcome(config: &Config) -> String {
             output += &format!("Starting a client node on {}.\n", network).bold().to_string();
         }
         NodeType::Crawler => output += &format!("Starting a crawler node on {}.\n", network).bold().to_string(),
-        NodeType::Beacon => {
-            output += &format!("Starting a beacon node on {}.\n", network)
-                .bold()
-                .to_string()
-        }
+        NodeType::Beacon => output += &format!("Starting a beacon node on {}.\n", network).bold().to_string(),
         NodeType::SyncProvider => {
             output += &format!("Starting a sync provider node on {}.\n", network)
                 .bold()

--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -95,12 +95,6 @@ fn render_welcome(config: &Config) -> String {
         i => format!("testnet{}", i),
     };
 
-    //     if is_miner {
-    //         output += &format!("Starting a mining node on {}.\n", network).bold().to_string();
-    //     } else {
-    //         output += &format!("Starting a client node on {}.\n", network).bold().to_string();
-    //     }
-
     match config.node.kind {
         NodeType::Client if is_miner => {
             output += &format!("Starting a mining node on {}.\n", network).bold().to_string();

--- a/snarkos/display.rs
+++ b/snarkos/display.rs
@@ -104,7 +104,7 @@ fn render_welcome(config: &Config) -> String {
         }
         NodeType::Crawler => output += &format!("Starting a crawler node on {}.\n", network).bold().to_string(),
         NodeType::Beacon => {
-            output += &format!("Starting a peer discovery node on {}.\n", network)
+            output += &format!("Starting a beacon node on {}.\n", network)
                 .bold()
                 .to_string()
         }

--- a/snarkos/errors/cli.rs
+++ b/snarkos/errors/cli.rs
@@ -28,11 +28,14 @@ pub enum CliError {
     #[error("TomlDeError: {0}")]
     TomlDeError(#[from] toml::de::Error),
 
-    #[error("The node can't be a bootstrapper and a miner at the same time")]
-    MinerBootstrapper,
+    #[error("A crawler node can't also be a miner")]
+    MinerCrawler,
 
-    #[error("The node can't be a bootstrapper and a crawler at the same time")]
-    CrawlerBootstrapper,
+    #[error("The peer discovery node can't also be a miner")]
+    MinerBeacon,
+
+    #[error("The sync provider node can't also be a miner")]
+    MinerSyncProvider,
 
     #[error("The minimum or maximum value for peer count is invalid")]
     PeerCountInvalid,

--- a/snarkos/errors/cli.rs
+++ b/snarkos/errors/cli.rs
@@ -31,7 +31,7 @@ pub enum CliError {
     #[error("A crawler node can't also be a miner")]
     MinerCrawler,
 
-    #[error("The peer discovery node can't also be a miner")]
+    #[error("The beacon node can't also be a miner")]
     MinerBeacon,
 
     #[error("The sync provider node can't also be a miner")]

--- a/snarkos/errors/cli.rs
+++ b/snarkos/errors/cli.rs
@@ -28,14 +28,8 @@ pub enum CliError {
     #[error("TomlDeError: {0}")]
     TomlDeError(#[from] toml::de::Error),
 
-    #[error("A crawler node can't also be a miner")]
-    MinerCrawler,
-
-    #[error("The beacon node can't also be a miner")]
-    MinerBeacon,
-
-    #[error("The sync provider node can't also be a miner")]
-    MinerSyncProvider,
+    #[error("Only client nodes can run with mining enabled")]
+    CantMine,
 
     #[error("The minimum or maximum value for peer count is invalid")]
     PeerCountInvalid,

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -14,14 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    cli::CLI,
-    config::{Config, ConfigCli},
-    display::{initialize_logger, print_welcome},
-    errors::NodeError,
-};
+use crate::config::Config;
 use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
-use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, NodeType, Sync};
+use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, Sync};
 use snarkos_rpc::start_rpc_server;
 use snarkos_storage::{
     export_canon_blocks,
@@ -49,9 +44,7 @@ use snarkvm_parameters::{testnet1::GenesisBlock, Genesis, LedgerMerkleTreeParame
 use snarkvm_posw::PoswMarlin;
 use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
-use std::{fs, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
-
-use tokio::runtime;
+use std::{fs, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 pub async fn init_storage(config: &Config) -> anyhow::Result<Option<DynStorage>> {
     let mut path = config.node.dir.clone();

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -46,6 +46,10 @@ use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
 
 use std::{fs, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
+pub fn init_ephemeral_storage() -> anyhow::Result<DynStorage> {
+    Ok(Arc::new(AsyncStorage::new(SqliteStorage::new_ephemeral()?)))
+}
+
 pub async fn init_storage(config: &Config) -> anyhow::Result<Option<DynStorage>> {
     let mut path = config.node.dir.clone();
     path.push(&config.node.db);
@@ -222,7 +226,7 @@ pub async fn init_sync(config: &Config, storage: DynStorage) -> anyhow::Result<S
     Ok(sync)
 }
 
-pub async fn init_node(config: &Config, storage: Option<DynStorage>) -> anyhow::Result<Node> {
+pub async fn init_node(config: &Config, storage: DynStorage) -> anyhow::Result<Node> {
     let address = format!("{}:{}", config.node.ip, config.node.port);
     let desired_address = address.parse::<SocketAddr>()?;
 
@@ -243,7 +247,7 @@ pub async fn init_node(config: &Config, storage: Option<DynStorage>) -> anyhow::
     Ok(node)
 }
 
-pub fn init_rpc(config: &Config, node: Node, storage: Option<DynStorage>) -> anyhow::Result<()> {
+pub fn init_rpc(config: &Config, node: Node, storage: DynStorage) -> anyhow::Result<()> {
     let rpc_address = format!("{}:{}", config.rpc.ip, config.rpc.port)
         .parse()
         .expect("Invalid RPC server address!");

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -1,0 +1,108 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    cli::CLI,
+    config::{Config, ConfigCli},
+    display::{initialize_logger, print_welcome},
+    errors::NodeError,
+};
+use snarkos_consensus::{Consensus, ConsensusParameters, DeserializedLedger, DynLedger, MemoryPool, MerkleLedger};
+use snarkos_network::{config::Config as NodeConfig, MinerInstance, Node, NodeType, Sync};
+use snarkos_rpc::start_rpc_server;
+use snarkos_storage::{
+    export_canon_blocks,
+    key_value::KeyValueStore,
+    AsyncStorage,
+    DynStorage,
+    RocksDb,
+    SerialBlock,
+    SqliteStorage,
+    VMBlock,
+};
+
+use snarkvm_algorithms::{MerkleParameters, CRH, SNARK};
+use snarkvm_dpc::{
+    testnet1::{
+        instantiated::{Components, Testnet1DPC, Testnet1Transaction},
+        Testnet1Components,
+    },
+    Address,
+    Block,
+    DPCScheme,
+    Network,
+};
+use snarkvm_parameters::{testnet1::GenesisBlock, Genesis, LedgerMerkleTreeParameters, Parameter};
+use snarkvm_posw::PoswMarlin;
+use snarkvm_utilities::{to_bytes_le, FromBytes, ToBytes};
+
+use std::{fs, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+
+use tokio::runtime;
+
+pub async fn init_storage(config: &Config) -> anyhow::Result<Option<(PathBuf, DynStorage)>> {
+    let mut path = config.node.dir.clone();
+    path.push(&config.node.db);
+
+    if !path.exists() {
+        fs::create_dir(&path)?;
+    }
+
+    info!("Loading storage at '{}'...", path.to_str().unwrap_or_default());
+    let storage: DynStorage = {
+        let mut sqlite_path = path.clone();
+        sqlite_path.push("sqlite.db");
+
+        if config.storage.validate {
+            error!("validator not implemented for sqlite");
+            // FIXME: this should probably be an error, perhaps handled at the CLI level.
+            return Ok(None);
+        }
+
+        Arc::new(AsyncStorage::new(SqliteStorage::new(&sqlite_path)?))
+    };
+
+    if storage.canon().await?.block_height == 0 {
+        let mut rocks_identity_path = path.clone();
+        rocks_identity_path.push("IDENTITY");
+        if rocks_identity_path.exists() {
+            info!("Empty sqlite DB with existing rocksdb found, migrating...");
+            let rocks_storage = RocksDb::open(&path)?;
+            let rocks_storage: DynStorage = Arc::new(AsyncStorage::new(KeyValueStore::new(rocks_storage)));
+
+            snarkos_storage::migrate(&rocks_storage, &storage).await?;
+        }
+    }
+
+    if let Some(max_head) = config.storage.max_head {
+        let canon_next = storage.get_block_hash(max_head + 1).await?;
+        if let Some(canon_next) = canon_next {
+            storage.decommit_blocks(&canon_next).await?;
+        }
+    }
+
+    if config.storage.trim {
+        let now = std::time::Instant::now();
+        // There shouldn't be issues after validation, but if there are, ignore them.
+        let _ = snarkos_storage::trim(storage.clone()).await;
+        info!("Storage trimmed in {}ms", now.elapsed().as_millis());
+        return Ok(None);
+    }
+
+    info!("Storage is ready");
+
+    Ok(Some((path, storage)))
+}

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -233,6 +233,7 @@ pub async fn init_node(config: &Config, storage: Option<DynStorage>) -> anyhow::
         config.p2p.min_peers,
         config.p2p.max_peers,
         config.p2p.beacons.clone(),
+        config.p2p.sync_providers.clone(),
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
     )?;

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -249,7 +249,7 @@ pub async fn init_node(config: &Config, storage: Option<DynStorage>) -> anyhow::
     Ok(node)
 }
 
-pub async fn init_rpc(config: &Config, node: Node, storage: Option<DynStorage>) -> anyhow::Result<()> {
+pub fn init_rpc(config: &Config, node: Node, storage: Option<DynStorage>) -> anyhow::Result<()> {
     let rpc_address = format!("{}:{}", config.rpc.ip, config.rpc.port)
         .parse()
         .expect("Invalid RPC server address!");

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -187,8 +187,8 @@ pub async fn init_sync(config: &Config, storage: DynStorage) -> anyhow::Result<S
 
     if config.storage.scan_for_forks {
         storage
-        .scan_forks(snarkos_consensus::OLDEST_FORK_THRESHOLD as u32)
-        .await?;
+            .scan_forks(snarkos_consensus::OLDEST_FORK_THRESHOLD as u32)
+            .await?;
     }
 
     if let Some(import_path) = &config.storage.import {

--- a/snarkos/lib.rs
+++ b/snarkos/lib.rs
@@ -17,9 +17,13 @@
 #[macro_use]
 extern crate thiserror;
 
+#[macro_use]
+extern crate tracing;
+
 pub mod cli;
 pub mod config;
 pub mod display;
 pub mod errors;
+pub mod init;
 pub mod parameters;
 pub mod update;

--- a/snarkos/parameters/flag.rs
+++ b/snarkos/parameters/flag.rs
@@ -18,12 +18,7 @@
 
 pub const NO_JSONRPC: &str = "[no-jsonrpc] --no-jsonrpc 'Run the node without running the json rpc server'";
 
-pub const IS_BOOTNODE: &str =
-    "[is-bootnode] --is-bootnode 'Run the node as a bootnode (IP is hard coded in the protocol)'";
-
 pub const IS_MINER: &str = "[is-miner] --is-miner 'Start mining blocks from this node'";
-
-pub const IS_CRAWLER: &str = "[is-crawler] --is-crawler 'Run this node as a network crawler'";
 
 pub const LIST: &str = "[list] -l --list 'List all available releases of snarkOS'";
 

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -96,42 +96,42 @@ impl Default for ConsensusSetup {
 
 #[derive(Clone)]
 pub struct TestSetup {
+    pub node_type: NodeType,
     pub node_id: u64,
     pub socket_address: SocketAddr,
     pub consensus_setup: Option<ConsensusSetup>,
     pub peer_sync_interval: u64,
     pub min_peers: u16,
     pub max_peers: u16,
-    pub is_bootnode: bool,
-    pub is_crawler: bool,
-    pub bootnodes: Vec<String>,
+    pub beacons: Vec<String>,
+    pub sync_providers: Vec<String>,
     pub network_enabled: bool,
 }
 
 impl TestSetup {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        node_type: NodeType,
         node_id: u64,
         socket_address: SocketAddr,
         consensus_setup: Option<ConsensusSetup>,
         peer_sync_interval: u64,
         min_peers: u16,
         max_peers: u16,
-        is_bootnode: bool,
-        is_crawler: bool,
-        bootnodes: Vec<String>,
+        beacons: Vec<String>,
+        sync_providers: Vec<String>,
         network_enabled: bool,
     ) -> Self {
         Self {
+            node_type,
             node_id,
             socket_address,
             consensus_setup,
             peer_sync_interval,
             min_peers,
             max_peers,
-            is_bootnode,
-            is_crawler,
-            bootnodes,
+            beacons,
+            sync_providers,
             network_enabled,
         }
     }
@@ -141,14 +141,15 @@ impl Default for TestSetup {
     fn default() -> Self {
         Self {
             node_id: SmallRng::from_entropy().gen(),
+            node_type: NodeType::Client,
+            node_id: u64::MAX,
             socket_address: "127.0.0.1:0".parse().unwrap(),
             consensus_setup: Some(Default::default()),
             peer_sync_interval: 600,
             min_peers: 1,
             max_peers: 100,
-            is_bootnode: false,
-            is_crawler: false,
-            bootnodes: vec![],
+            beacons: vec![],
+            sync_providers: vec![],
             network_enabled: true,
         }
     }
@@ -169,12 +170,12 @@ pub async fn test_consensus(setup: ConsensusSetup) -> snarkos_network::Sync {
 pub fn test_config(setup: TestSetup) -> Config {
     Config::new(
         Some(setup.node_id),
+        setup.node_type,
         setup.socket_address,
         setup.min_peers,
         setup.max_peers,
-        setup.bootnodes,
-        setup.is_bootnode,
-        setup.is_crawler,
+        setup.beacons,
+        setup.sync_providers,
         Duration::from_secs(setup.peer_sync_interval),
     )
     .unwrap()

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -142,7 +142,6 @@ impl Default for TestSetup {
         Self {
             node_id: SmallRng::from_entropy().gen(),
             node_type: NodeType::Client,
-            node_id: u64::MAX,
             socket_address: "127.0.0.1:0".parse().unwrap(),
             consensus_setup: Some(Default::default()),
             peer_sync_interval: 600,

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -214,10 +214,10 @@ async fn block_two_node() {
             ..Default::default()
         }),
         peer_sync_interval: 5,
-        bootnodes: vec![alice_address.to_string()],
         ..Default::default()
     };
     let node_bob = test_node(setup).await;
+    node_bob.connect_to_addresses(&[alice_address]).await;
 
     // check blocks present in alice's chain were synced to bob's
     wait_until!(30, node_bob.storage.canon().await.unwrap().block_height == NUM_BLOCKS);
@@ -330,10 +330,10 @@ async fn transaction_two_node() {
             ..Default::default()
         }),
         peer_sync_interval: 1,
-        bootnodes: vec![alice_address.to_string()],
         ..Default::default()
     };
     let node_bob = test_node(setup).await;
+    node_bob.connect_to_addresses(&[alice_address]).await;
 
     // check transaction is present in bob's memory pool
     wait_until!(

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -44,7 +44,7 @@ pub async fn connect_nodes(nodes: &mut Vec<Node>, topology: Topology) {
         Topology::Line => line(nodes).await,
         Topology::Ring => ring(nodes).await,
         Topology::Mesh => mesh(nodes).await,
-        Topology::Star => star(nodes),
+        Topology::Star => star(nodes).await,
     }
 }
 
@@ -92,13 +92,12 @@ async fn mesh(nodes: &mut Vec<Node>) {
 }
 
 /// Connects the network nodes in a star topology.
-fn star(nodes: &mut Vec<Node>) {
+async fn star(nodes: &mut Vec<Node>) {
     // Setup the hub.
     let hub_address = nodes.first().unwrap().expect_local_addr();
 
-    // Start the rest of the nodes with the core node as the bootnode.
-    let bootnodes = vec![hub_address];
+    // Start the rest of the nodes with the core node at the center.
     for node in nodes.iter_mut().skip(1) {
-        node.config.bootnodes.store(Arc::new(bootnodes.clone()));
+        node.connect_to_addresses(&[hub_address]).await;
     }
 }

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -31,8 +31,7 @@ pub enum Topology {
 
 /// Connects the nodes in a given `Topology`.
 ///
-/// This function assumes the nodes have an established address but don't have their services
-/// started yet, as it uses the bootnodes to establish the connections between nodes.
+/// This function assumes the nodes have an established address.
 ///
 /// When connecting in a `Star`, the first node in the `nodes` will be used as the hub.
 pub async fn connect_nodes(nodes: &mut Vec<Node>, topology: Topology) {
@@ -52,7 +51,7 @@ pub async fn connect_nodes(nodes: &mut Vec<Node>, topology: Topology) {
 async fn line(nodes: &mut Vec<Node>) {
     let mut prev_node: Option<SocketAddr> = None;
 
-    // Start each node with the previous as a bootnode.
+    // Connect each node with the previous.
     for node in nodes {
         if let Some(addr) = prev_node {
             node.connect_to_addresses(&[addr]).await;

--- a/testing/src/network/topology.rs
+++ b/testing/src/network/topology.rs
@@ -16,7 +16,7 @@
 
 use snarkos_network::Node;
 
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
 
 pub enum Topology {
     /// Each node - except the last one - connects to the next one in a linear fashion.


### PR DESCRIPTION
This PR implements the first steps towards splitting the bootnodes into peer discovery nodes (beacons) and sync provider nodes as described in #1101. It introduces separate binaries for each node type and refactors node configuration.

Although not included here, these changes also pave the way for load balancing the sync providers and leveraging the crawler(s) to improve network cohesion. 

Opening as a draft as this PR introduces architectural changes and seed addresses will need to be updated. 

~~Todo: documentation modifications.~~
