### PR TITLE
select! tweaks

### DIFF
--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -16,7 +16,7 @@
 
 use anyhow::*;
 use chrono::Utc;
-use futures::{select, FutureExt};
+use futures::{select_biased, FutureExt};
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
@@ -154,7 +154,7 @@ impl Peer {
         });
 
         loop {
-            select! {
+            select_biased! {
                 message = receiver.recv().fuse() => {
                     if message.is_none() {
                         break;


### PR DESCRIPTION
If multiple futures passed to `futures::select` are ready, one is picked at random; this could cause issues (possibly even the stalls we've been seeing), so use `select_biased` or avoid `select` altogether instead, which will ensure that disconnects and timeouts are always triggered when necessary.

Cc https://github.com/AleoHQ/snarkOS/issues/1037, https://github.com/AleoHQ/snarkOS/issues/1066