### PR TITLE
Replace futures::select with tokio::select

### DIFF
--- a/network/src/peers/peer/peer.rs
+++ b/network/src/peers/peer/peer.rs
@@ -16,7 +16,6 @@
 
 use anyhow::*;
 use chrono::Utc;
-use futures::{select_biased, FutureExt};
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
@@ -154,8 +153,10 @@ impl Peer {
         });
 
         loop {
-            select_biased! {
-                message = receiver.recv().fuse() => {
+            tokio::select! {
+                biased;
+
+                message = receiver.recv() => {
                     if message.is_none() {
                         break;
                     }
@@ -165,7 +166,7 @@ impl Peer {
                         PeerResponse::None => (),
                     }
                 },
-                data = read_receiver.recv().fuse() => {
+                data = read_receiver.recv() => {
                     if data.is_none() {
                         break;
                     }

--- a/network/src/peers/peer_book.rs
+++ b/network/src/peers/peer_book.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use std::{
+    future::Future,
     net::SocketAddr,
     sync::{
         atomic::{AtomicU32, Ordering},
@@ -23,7 +24,6 @@ use std::{
     time::Instant,
 };
 
-use futures::Future;
 use mpmc_map::MpmcMap;
 use rand::{prelude::IteratorRandom, rngs::SmallRng, SeedableRng};
 use tokio::{net::TcpStream, sync::mpsc};


### PR DESCRIPTION
I've been able to reproduce node stalls with peer attrition reliably using my slightly less powerful other PC; the node was barely doing anything (just some internal `tokio` functions were detected by `perf record`) during that time, and surprisingly, it was able to just snap back to life after a long delay, suggesting that it was a glitch related to peer/connection handling and that the removal of a "problem peer" would unblock things.

At that time I started suspecting that this is some `tokio`/`futures` bug, or an issue related to their interop; with `tokio-console` still in its infancy, and with seemingly no related existing GitHub issues for either `tokio` or `futures`, I decided to just try to reduce the possible scope of issues by removing the use of `futures` where `tokio` equivalents existed.

With this PR (on its own), which just replaces the use of `futures::select` with `tokio::select` (and `futures::Future` with `std::future::Future` as a drive-by, though that's just an import cleanup), my node no longer hangs; it still occasionally loses a few peers at once, but it is able to immediately connect to others via regular connection maintenance.

Cc #1037, #1066