### PR TITLE
Groth16 Allow IPv4 Connections Specified With DNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,70 @@
-FROM rust:1.51.0
+FROM ubuntu:18.04 AS builder
 
-RUN apt-get update \
- && apt-get install -y \
-   build-essential \
-   clang \
-   gcc \
-   libssl-dev \
-   make \
-   pkg-config \
-   xz-utils
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux ; \
+    apt-get update -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        build-essential \
+        clang \
+        gcc \
+        libssl-dev \
+        make \
+        pkg-config \
+        xz-utils && \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    \
+    url="https://static.rust-lang.org/rustup/dist/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain stable; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    apt-get remove -y --auto-remove wget && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*;
 
 WORKDIR /usr/src/snarkOS
+
 COPY . .
 
 RUN cargo build --release
 
-CMD ["./target/release/snarkos"]
+FROM ubuntu:18.04
+
+SHELL ["/bin/bash", "-c"]
+
+RUN set -ex && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o DPkg::Options::=--force-confold && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /aleo/{bin,data} && \
+    mkdir -p /aleo/data/params/{git,registry} && \
+    mkdir -p /usr/local/cargo/git/checkouts/snarkvm-f1160780ffe17de8/ef32edc/parameters/src/ && \
+    mkdir -p /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/snarkvm-parameters-0.7.9/src/ && \
+    ln -s /aleo/data/params/git /usr/local/cargo/git/checkouts/snarkvm-f1160780ffe17de8/ef32edc/parameters/src/testnet1 && \
+    ln -s /aleo/data/params/registry /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/snarkvm-parameters-0.7.9/src/testnet1
+
+COPY --from=builder /usr/src/snarkOS/target/release/snarkos /aleo/bin/
+
+CMD ["/aleo/bin/snarkos -d /aleo/data"]

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ OPTIONS:
         --network <network-id>                   Specify the network id (default = 1) of the node
     -d, --path <path>                            Specify the node's storage path
     -p, --port <port>                            Specify the port the node is run on
+        --host <host>                            Specify the host with the port the node is run on
         --rpc-password <rpc-password>            Specify a password for rpc authentication
         --rpc-port <rpc-port>                    Specify the port the json rpc server is run on
         --rpc-username <rpc-username>            Specify a username for rpc authentication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,77 @@
 version: "3"
+
 services:
-    app:
-        container_name: snarkOS
-        image: snarkos:latest
-        build: .
+    bootnode:
+        container_name: snarkos-bootnode
+        image: aleohq/snarkos:groth16-devnet
+        volumes:
+            - snarkos-bootn-vol:/aleo/data
+        build:
+            context: .
+            dockerfile: ./Dockerfile
+        command: ["bash", "-c", "/aleo/bin/snarkos -d /aleo/data --is-bootnode  --verbose 3 --host bootnode:14131 --rpc-port 13031 --connect bootnode:14131"]
         ports:
-            - "4130:4130"
-        networks:
-            - default
+            - 13031:13031
+            - 14131:14131
+        deploy:
+            resources:
+                limits:
+                    cpus: "0.50"
+                    memory: 512M
+                reservations:
+                    memory: 256M
+            restart_policy:
+                condition: on-failure
+                max_attempts: 3
+
+    client:
+        container_name: snarkos-client
+        image: aleohq/snarkos:groth16-devnet
+        volumes:
+            - snarkos-client-vol:/aleo/data
+        build:
+            context: .
+            dockerfile: ./Dockerfile
+        command: ["bash", "-c", "/aleo/bin/snarkos -d /aleo/data --verbose 3 --host client:14132 --rpc-port 13032 --connect bootnode:14131"]
+        ports:
+            - 13032:13032
+            - 14132:14132
+        deploy:
+            resources:
+                limits:
+                    cpus: "0.50"
+                    memory: 512M
+                reservations:
+                    memory: 256M
+            restart_policy:
+                condition: on-failure
+                max_attempts: 3
+
+    miner:
+        container_name: snarkos-miner
+        image: aleohq/snarkos:groth16-devnet
+        volumes:
+            - snarkos-miner-vol:/aleo/data
+        build:
+            context: .
+            dockerfile: ./Dockerfile
+        command: ["bash", "-c", "/aleo/bin/snarkos -d /aleo/data --verbose 3 --rpc-port 13033 --is-miner --miner-address ${ALEO_ADDRESS} --host client:14133 --connect bootnode:14131"]
+        ports:
+            - 13033:13033
+            - 14133:14133
+        deploy:
+            resources:
+                limits:
+                    cpus: "3.00"
+                    memory: 7168M
+                reservations:
+                    memory: 4096M
+            restart_policy:
+                condition: on-failure
+                max_attempts: 3
+
+
+volumes:
+    snarkos-bootn-vol:
+    snarkos-miner-vol:
+    snarkos-client-vol:

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -87,7 +87,7 @@ pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 /// The version of the network protocol; it can be incremented in order to force users to update.
 /// FIXME: probably doesn't need to be a u64, could also be more informative than just a number
 // TODO (raychu86): Establish a formal node version.
-pub const PROTOCOL_VERSION: u64 = 66;
+pub const PROTOCOL_VERSION: u64 = 2;
 
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -87,7 +87,7 @@ pub const OUTBOUND_CHANNEL_DEPTH: usize = 1024;
 /// The version of the network protocol; it can be incremented in order to force users to update.
 /// FIXME: probably doesn't need to be a u64, could also be more informative than just a number
 // TODO (raychu86): Establish a formal node version.
-pub const PROTOCOL_VERSION: u64 = 2;
+pub const PROTOCOL_VERSION: u64 = 66;
 
 pub(crate) type Sender = tokio::sync::mpsc::Sender<Message>;
 

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -24,8 +24,11 @@ use crate::{
 use clap::ArgMatches;
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf};
-use std::net::{ToSocketAddrs, SocketAddr::V4};
+use std::{
+    fs,
+    net::{SocketAddr::V4, ToSocketAddrs},
+    path::PathBuf,
+};
 
 /// Bootnodes maintained by Aleo.
 /// A node should try and connect to these first after coming online.
@@ -300,9 +303,9 @@ impl Config {
     fn host(&mut self, argument: Option<&str>) {
         if let Some(host) = argument {
             let mut address_iter = host.to_socket_addrs().unwrap();
-            if let V4(socket_address)  = address_iter.next().unwrap() {
-                let mut ip_and_port: Vec<String> = socket_address.to_string().split(':')
-                    .map(|s| s.to_string()).collect();
+            if let V4(socket_address) = address_iter.next().unwrap() {
+                let mut ip_and_port: Vec<String> =
+                    socket_address.to_string().split(':').map(|s| s.to_string()).collect();
                 self.node.port = ip_and_port.pop().unwrap().parse::<u16>().unwrap();
                 self.node.ip = ip_and_port.pop().unwrap();
             }
@@ -318,12 +321,15 @@ impl Config {
     fn connect(&mut self, argument: Option<&str>) {
         if let Some(bootnodes) = argument {
             let sanitize_bootnodes = bootnodes.replace(&['[', ']', ' '][..], "");
-            let bootnodes: Vec<String> = sanitize_bootnodes.split(',')
-                .map(|sa| sa.to_socket_addrs()
-                    .unwrap()
-                    .filter(|f| f.is_ipv4())
-                    .map(|s| s.to_string())
-                    .collect::<Vec<String>>())
+            let bootnodes: Vec<String> = sanitize_bootnodes
+                .split(',')
+                .map(|sa| {
+                    sa.to_socket_addrs()
+                        .unwrap()
+                        .filter(|f| f.is_ipv4())
+                        .map(|s| s.to_string())
+                        .collect::<Vec<String>>()
+                })
                 .flatten()
                 .collect::<Vec<String>>();
             self.p2p.bootnodes = bootnodes;

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -25,6 +25,7 @@ use clap::ArgMatches;
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use std::{fs, path::PathBuf};
+use std::net::{ToSocketAddrs, SocketAddr::V4};
 
 /// Bootnodes maintained by Aleo.
 /// A node should try and connect to these first after coming online.
@@ -219,6 +220,7 @@ impl Config {
             "export-canon-blocks" => self.export_canon_blocks(clap::value_t!(arguments.value_of(*option), u32).ok()),
             "import-canon-blocks" => self.import_canon_blocks(arguments.value_of(option)),
             "ip" => self.ip(arguments.value_of(option)),
+            "host" => self.host(arguments.value_of(option)),
             "miner-address" => self.miner_address(arguments.value_of(option)),
             "mempool-interval" => self.mempool_interval(clap::value_t!(arguments.value_of(*option), u8).ok()),
             "max-peers" => self.max_peers(clap::value_t!(arguments.value_of(*option), u16).ok()),
@@ -295,6 +297,18 @@ impl Config {
         }
     }
 
+    fn host(&mut self, argument: Option<&str>) {
+        if let Some(host) = argument {
+            let mut address_iter = host.to_socket_addrs().unwrap();
+            if let V4(socket_address)  = address_iter.next().unwrap() {
+                let mut ip_and_port: Vec<String> = socket_address.to_string().split(':')
+                    .map(|s| s.to_string()).collect();
+                self.node.port = ip_and_port.pop().unwrap().parse::<u16>().unwrap();
+                self.node.ip = ip_and_port.pop().unwrap();
+            }
+        }
+    }
+
     fn path(&mut self, argument: Option<&str>) {
         if let Some(path) = argument {
             self.node.db = path.into();
@@ -304,7 +318,14 @@ impl Config {
     fn connect(&mut self, argument: Option<&str>) {
         if let Some(bootnodes) = argument {
             let sanitize_bootnodes = bootnodes.replace(&['[', ']', ' '][..], "");
-            let bootnodes: Vec<String> = sanitize_bootnodes.split(',').map(|s| s.to_string()).collect();
+            let bootnodes: Vec<String> = sanitize_bootnodes.split(',')
+                .map(|sa| sa.to_socket_addrs()
+                    .unwrap()
+                    .filter(|f| f.is_ipv4())
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>())
+                .flatten()
+                .collect::<Vec<String>>();
             self.p2p.bootnodes = bootnodes;
         }
     }
@@ -420,6 +441,7 @@ impl CLI for ConfigCli {
         option::IP,
         option::PORT,
         option::PATH,
+        option::HOST,
         option::CONNECT,
         option::EXPORT_CANON_BLOCKS,
         option::IMPORT_CANON_BLOCKS,
@@ -449,6 +471,7 @@ impl CLI for ConfigCli {
             "is-crawler",
             "ip",
             "port",
+            "host",
             "path",
             "connect",
             "miner-address",

--- a/snarkos/parameters/option.rs
+++ b/snarkos/parameters/option.rs
@@ -37,6 +37,13 @@ pub const PORT: OptionType = (
     &[],
 );
 
+pub const HOST: OptionType = (
+    "[host] --host=[host] 'Specify the host with the port the node is run on'",
+    &[],
+    &[],
+    &[],
+);
+
 pub const CONNECT: OptionType = (
     "[connect] --connect=[ip] 'Specify one or more node ip addresses to connect to on startup'",
     &[],


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

In debugging running a local version of snarkOS on my machine I was trying to connect the bootnode, the client, and the miner over DNS for purposes of assigning dynamic IPs to the containers to run the network locally via dockers recommendation [here](https://docs.docker.com/desktop/mac/networking/) and the compose recommendation [here](https://docs.docker.com/compose/compose-file/compose-file-v3/). I was able to add IPv4 DNS resolution using the rust standard library, this makes the docker-compose network easier to use on Windows and Mac, allowing snarkOS nodes to be configured using docker's special DNS names. 

## Test Plan

I built the new ubuntu docker image created by @zosorock and updated @zosorock's docker-compose file to support a new `--host` flag. I was able to get a local network running and communicating with this setup. 

## Related PRs

https://github.com/AleoHQ/snarkOS/pull/1082
