### PR TITLE
deal with aggro sync on receiving side

### DIFF
--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -175,10 +175,8 @@ impl Peer {
                     if sync.is_empty() {
                         // An empty `Sync` is unexpected, as `GetSync` requests are only
                         // sent to peers that declare a greater block height.
-                        warn!("{} doesn't have sync blocks to share", source);
-                        if let Some(peer) = node.peer_book.get_peer_handle(source) {
-                            peer.fail().await;
-                        }
+                        // They can happen due to aggro sync ignoring canon during sync for better fork resolution
+                        trace!("{} doesn't have sync blocks to share", source);
                     } else {
                         trace!("Received {} sync block hashes from {}", sync.len(), source);
                         let node = node.clone();

--- a/network/src/sync/blocks/aggro.rs
+++ b/network/src/sync/blocks/aggro.rs
@@ -135,25 +135,12 @@ impl SyncAggro {
                                 }
                             };
 
-                            let blocks: IndexSet<_> = {
-                                let received_hashes = received_hashes.read().await;
-                                let hashes = block_locator_hashes.read().await;
-                                hashes
-                                    .hashes
-                                    .iter()
-                                    .filter(|x| !received_hashes.contains(&x.0[..]))
-                                    .cloned()
-                                    .chain(
-                                        hashes_trimmed
-                                            .into_iter()
-                                            .zip(early_block_states.iter())
-                                            .filter(|(_, status)| {
-                                                matches!(status, snarkos_storage::BlockStatus::Unknown)
-                                            })
-                                            .map(|(hash, _)| BlockHeaderHash(hash.bytes().unwrap())),
-                                    )
-                                    .collect()
-                            };
+                            let blocks: Vec<_> = hashes_trimmed
+                                .into_iter()
+                                .zip(early_block_states.iter())
+                                .filter(|(_, status)| matches!(status, snarkos_storage::BlockStatus::Unknown))
+                                .map(|(hash, _)| BlockHeaderHash(hash.bytes().unwrap()))
+                                .collect();
                             if blocks.is_empty() {
                                 return;
                             }

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -219,6 +219,11 @@ impl Node {
             .collect::<Option<Vec<_>>>()
             .ok_or_else(|| anyhow!("invalid block header size in locator hash"))?;
 
+        if sync_hashes.is_empty() {
+            trace!("warning: no sync hashes found");
+            return Ok(());
+        }
+
         // send a `Sync` message to the connected peer.
         self.peer_book
             .send_to(remote_address, Payload::Sync(sync_hashes), time_received)

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -175,11 +175,11 @@ impl Node {
             .map(|x| -> Digest { x.0.into() })
             .enumerate()
         {
-            let block = self.storage.get_block(&hash).await?;
-            let height = match self.storage.get_block_state(&block.header.hash()).await? {
+            let height = match self.storage.get_block_state(&hash).await? {
                 BlockStatus::Committed(h) => Some(h as u32),
                 _ => None,
             };
+            let block = self.storage.get_block(&hash).await?;
 
             // Only stop the clock on internal RTT for the last block in the response.
             let time_received = if i == crate::MAX_BLOCK_SYNC_COUNT as usize - 1 {

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -219,11 +219,6 @@ impl Node {
             .collect::<Option<Vec<_>>>()
             .ok_or_else(|| anyhow!("invalid block header size in locator hash"))?;
 
-        if sync_hashes.is_empty() {
-            trace!("warning: no sync hashes found");
-            return Ok(());
-        }
-
         // send a `Sync` message to the connected peer.
         self.peer_book
             .send_to(remote_address, Payload::Sync(sync_hashes), time_received)


### PR DESCRIPTION
This PR:
* Removes peer failure from returning empty sync

Note, avoiding sending the empty sync on the other end can induce a failure (looks like a timeout) -- so we still send empty syncs.