### PR TITLE
Sqlite tree query, fix migration

### DIFF
--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -224,7 +224,9 @@ async fn start_server(config: Config) -> anyhow::Result<()> {
         info!("Loaded Ledger");
 
         if config.storage.scan_for_forks {
-            consensus.scan_forks().await?;
+            storage
+                .scan_forks(snarkos_consensus::OLDEST_FORK_THRESHOLD as u32)
+                .await?;
         }
 
         if let Some(import_path) = config.storage.import {

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -32,24 +32,6 @@ impl ConsensusInner {
             self.commit_block(&hash, &block).await?;
         }
 
-        // scan for forks
-        // let forks = self.scan_forks().await?;
-        // for (canon, fork_child) in forks {
-        //     let canon_height = match self.storage.get_block_state(&canon).await? {
-        //         BlockStatus::Committed(n) => n,
-        //         _ => continue,
-        //     };
-        //     let fork_blocks = self.storage.longest_child_path(&fork_child).await?;
-        //     debug!(
-        //         "fork detected @ {}/{} -- starts at {}, goes for {} blocks, ending at {}",
-        //         canon_height,
-        //         canon,
-        //         fork_child,
-        //         fork_blocks.len(),
-        //         fork_blocks.last().unwrap()
-        //     );
-        // }
-
         if let Err(e) = self.try_to_fast_forward().await {
             match e {
                 ConsensusError::InvalidBlock(e) => debug!("invalid block in initial fast-forward: {}", e),
@@ -125,9 +107,6 @@ impl ConsensusInner {
                 ConsensusMessage::FastForward() => {
                     let out = self.try_to_fast_forward().await;
                     response.send(Box::new(out)).ok();
-                }
-                ConsensusMessage::ScanForks() => {
-                    response.send(Box::new(self.scan_forks().await)).ok();
                 }
                 #[cfg(feature = "test")]
                 ConsensusMessage::Reset() => {

--- a/consensus/src/consensus/message.rs
+++ b/consensus/src/consensus/message.rs
@@ -46,7 +46,6 @@ pub(super) enum ConsensusMessage {
     CreatePartialTransaction(CreatePartialTransactionRequest),
     ForceDecommit(Vec<u8>),
     FastForward(),
-    ScanForks(),
     #[cfg(feature = "test")]
     Reset(),
 }

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -152,11 +152,6 @@ impl Consensus {
         self.send(ConsensusMessage::FastForward()).await
     }
 
-    /// Diagnostic function to scan for valid forks
-    pub async fn scan_forks(&self) -> Result<Vec<(Digest, Digest)>> {
-        self.send(ConsensusMessage::ScanForks()).await
-    }
-
     /// Fully reset the ledger and the storage
     #[cfg(feature = "test")]
     pub async fn reset(&self) -> Result<()> {

--- a/network/src/sync/blocks/aggro.rs
+++ b/network/src/sync/blocks/aggro.rs
@@ -18,7 +18,6 @@ use std::{sync::Arc, time::Duration};
 
 use crate::{Cache, Node, Payload, Peer, SyncBase, SyncInbound};
 use anyhow::*;
-use indexmap::IndexSet;
 use snarkos_storage::Digest;
 use snarkvm_dpc::BlockHeaderHash;
 use tokio::{

--- a/network/src/sync/blocks/base.rs
+++ b/network/src/sync/blocks/base.rs
@@ -67,7 +67,10 @@ impl SyncBase {
     }
 
     pub async fn block_locator_hashes(node: &Node) -> Result<Vec<BlockHeaderHash>> {
-        let forks_of_interest = node.expect_sync().consensus.scan_forks().await?;
+        let forks_of_interest = node
+            .storage
+            .scan_forks(snarkos_consensus::OLDEST_FORK_THRESHOLD as u32)
+            .await?;
         trace!("sync found {} forks", forks_of_interest.len());
         let blocks_of_interest: Vec<Digest> = forks_of_interest.into_iter().map(|(_canon, fork)| fork).collect();
         let mut tips_of_blocks_of_interest: Vec<Digest> = Vec::with_capacity(blocks_of_interest.len());

--- a/storage/src/migrate.rs
+++ b/storage/src/migrate.rs
@@ -19,17 +19,10 @@ use anyhow::*;
 
 pub async fn migrate(from: &DynStorage, to: &DynStorage) -> Result<()> {
     let blocks = from.get_canon_blocks(None).await?;
-    let ledger_digests = from.get_ledger_digests().await?;
-    if blocks.len() != ledger_digests.len() {
-        return Err(anyhow!(
-            "canon, ledger digest lengths differed for migration -- corrupt DB?"
-        ));
-    }
 
     // transfer blocks
-    for (block, digest) in blocks.into_iter().zip(ledger_digests.into_iter()) {
+    for block in blocks {
         to.insert_block(&block).await?;
-        to.commit_block(&block.header.hash(), digest).await?;
     }
 
     // transfer miner records

--- a/storage/src/storage/storage.rs
+++ b/storage/src/storage/storage.rs
@@ -139,6 +139,9 @@ pub trait Storage: Send + Sync {
         oldest_fork_threshold: usize,
     ) -> Result<Vec<Digest>>;
 
+    /// scans uncommitted blocks with a known path to the canon chain for forks
+    async fn scan_forks(&self, scan_depth: u32) -> Result<Vec<(Digest, Digest)>>;
+
     /// Find hashes to provide for a syncing node given `block_locator_hashes`.
     async fn find_sync_blocks(&self, block_locator_hashes: &[Digest], block_count: usize) -> Result<Vec<Digest>>;
 


### PR DESCRIPTION
This PR:
* Makes the block tree fetch a single query for sqlite
* Makes scanning for forks a storage owned operation (only ever called storage anyways), single query
* Fixes migration by not attempting to carry over previous commit state.