### PR TITLE
Fix stackoverflow in fast-forward

### DIFF
--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -281,7 +281,9 @@ impl ConsensusInner {
             canon.block_height
         );
         loop {
-            let mut sub_children = children.children().to_vec();
+            let mut sub_children = children.take_children();
+            // rust doesn't believe we will always set children before the next loop
+            children = DigestTree::Leaf(Digest::from([0u8; 32]));
             if sub_children.is_empty() {
                 break;
             }

--- a/storage/src/storage/digest_tree.rs
+++ b/storage/src/storage/digest_tree.rs
@@ -16,7 +16,8 @@
 
 use crate::Digest;
 
-#[derive(Clone, Debug)]
+// do not implement clone: this structure can be too deep, resulting in stack overflow
+#[derive(Debug)]
 pub enum DigestTree {
     // digest of leaf node
     Leaf(Digest),
@@ -64,6 +65,13 @@ impl DigestTree {
         match self {
             DigestTree::Leaf(_) => &[],
             DigestTree::Node(_, children, _) => &children[..],
+        }
+    }
+
+    pub fn take_children(self) -> Vec<DigestTree> {
+        match self {
+            DigestTree::Leaf(_) => vec![],
+            DigestTree::Node(_, children, _) => children,
         }
     }
 }


### PR DESCRIPTION
`to_vec` was cloning each layer of digest tree, recursively cloning all nodes in the tree. This caused a stack overflow with sufficiently large numbers of blocks.