### PR TITLE
Re-enable incremental compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,3 @@
 [target.'cfg(all(not(target_arch = "wasm32"), not(feature = "noconfig")))']
 rustflags = ["-C", "target-cpu=native"]
 
-[build]
-incremental = false # https://github.com/rust-lang/rust/issues/84970


### PR DESCRIPTION
Rust `1.55` has been released, re-enables incremental compilation as detailed in #1010.