### PR TITLE
Make the getnodeinfo RPC work for non-client nodes

### DIFF
--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -409,7 +409,7 @@ impl RpcFunctions for RpcImpl {
         Ok(NodeInfo {
             listening_addr: self.node.config.desired_address,
             node_type: self.node.config.node_type,
-            is_miner: self.sync_handler()?.is_miner,
+            is_miner: self.sync_handler().map(|sync| sync.is_miner).unwrap_or(false),
             is_syncing: self.node.is_syncing_blocks(),
             launched: self.node.launched,
             version: env!("CARGO_PKG_VERSION").into(),


### PR DESCRIPTION
Fixes https://github.com/AleoHQ/snarkOS/issues/1171.