### PR TITLE
Make the getnetworkgraph RPC not return nodes with height 0 as potential forks

### DIFF
--- a/network/src/topology.rs
+++ b/network/src/topology.rs
@@ -233,7 +233,7 @@ impl KnownNetwork {
         const HEIGHT_DELTA_TOLERANCE: u32 = 5;
         const MIN_CLUSTER_SIZE: usize = 3;
 
-        let mut nodes: Vec<(SocketAddr, u32)> = self.nodes().into_iter().collect();
+        let mut nodes: Vec<(SocketAddr, u32)> = self.nodes().into_iter().filter(|(_, height)| *height != 0).collect();
         nodes.sort_unstable_by_key(|&(_, height)| height);
 
         // Find the indices at which to split the heights.


### PR DESCRIPTION
Fixes https://github.com/AleoHQ/snarkOS/issues/1173.