### PR TITLE
Fix the connected count metric

### DIFF
--- a/network/src/peers/peer/receiver.rs
+++ b/network/src/peers/peer/receiver.rs
@@ -52,6 +52,7 @@ impl Peer {
             };
 
             peer.set_connected();
+            metrics::increment_gauge!(CONNECTED, 1.0);
             event_target
                 .send(PeerEvent {
                     address: peer.address,


### PR DESCRIPTION
The `connected` count was not being incremented when receiving connections resulting in integer underflow. 