### PR TITLE
Re-structure block metrics

### DIFF
--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -28,7 +28,7 @@ impl ConsensusInner {
         match self.storage.get_block_state(&hash).await? {
             BlockStatus::Unknown => (),
             BlockStatus::Committed(_) | BlockStatus::Uncommitted => {
-                metrics::increment_counter!(DUPLICATE_BLOCKS);
+                metrics::increment_counter!(metrics::blocks::DUPLICATE_BLOCKS);
                 return Err(ConsensusError::PreExistingBlock);
             }
         }
@@ -54,7 +54,7 @@ impl ConsensusInner {
         match self.storage.get_block_state(&block.header.previous_block_hash).await? {
             BlockStatus::Committed(n) if n == canon.block_height => {
                 debug!("Processing a block that is on canon chain. Height {} -> {}", n, n + 1);
-                metrics::gauge!(BLOCK_HEIGHT, n as f64 + 1.0);
+                metrics::gauge!(metrics::blocks::HEIGHT, n as f64 + 1.0);
                 // Process the block now.
             }
             BlockStatus::Unknown => {
@@ -102,7 +102,7 @@ impl ConsensusInner {
 
                             {
                                 let canon = self.storage.canon().await?;
-                                metrics::gauge!(BLOCK_HEIGHT, canon.block_height as f64);
+                                metrics::gauge!(metrics::blocks::HEIGHT, canon.block_height as f64);
                             }
 
                             for block_hash in fork_path.path {
@@ -169,7 +169,7 @@ impl ConsensusInner {
             self.memory_pool.remove(&transaction.id.into())?;
         }
 
-        metrics::histogram!(BLOCK_COMMIT_TIME, now.elapsed());
+        metrics::histogram!(metrics::blocks::COMMIT_TIME, now.elapsed());
 
         Ok(())
     }

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -28,7 +28,7 @@ impl ConsensusInner {
         match self.storage.get_block_state(&hash).await? {
             BlockStatus::Unknown => (),
             BlockStatus::Committed(_) | BlockStatus::Uncommitted => {
-                metrics::increment_counter!(metrics::blocks::DUPLICATE_BLOCKS);
+                metrics::increment_counter!(metrics::blocks::DUPLICATES);
                 return Err(ConsensusError::PreExistingBlock);
             }
         }

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -42,8 +42,6 @@ use snarkvm_dpc::{
 use snarkvm_posw::txids_to_roots;
 use snarkvm_utilities::has_duplicates;
 
-use snarkos_metrics::misc::*;
-
 use rand::thread_rng;
 
 use super::message::{ConsensusMessage, CreateTransactionRequest, TransactionResponse};

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -204,7 +204,7 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_duplicate_blocks_total",
+          "expr": "snarkos_duplicates_total",
           "hide": false,
           "interval": "",
           "legendFormat": "duplicate Blocks",
@@ -212,7 +212,7 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_duplicate_sync_blocks_total",
+          "expr": "snarkos_duplicates_sync_total",
           "hide": false,
           "interval": "",
           "legendFormat": "duplicate SyncBlocks",
@@ -1215,5 +1215,5 @@
   "timezone": "",
   "title": "snarkOS node",
   "uid": "nuiNXZV7k",
-  "version": 7
+  "version": 8
 }

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -186,7 +186,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "snarkos_misc_block_height_total",
+          "expr": "snarkos_blocks_height_total",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -196,7 +196,7 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_misc_blocks_mined_total",
+          "expr": "snarkos_blocks_mined_total",
           "instant": false,
           "interval": "",
           "legendFormat": "mined blocks",
@@ -204,7 +204,7 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_misc_duplicate_blocks_total",
+          "expr": "snarkos_duplicate_blocks_total",
           "hide": false,
           "interval": "",
           "legendFormat": "duplicate Blocks",
@@ -212,7 +212,7 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_misc_duplicate_sync_blocks_total",
+          "expr": "snarkos_duplicate_sync_blocks_total",
           "hide": false,
           "interval": "",
           "legendFormat": "duplicate SyncBlocks",
@@ -228,7 +228,7 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_misc_orphan_blocks_total",
+          "expr": "snarkos_blocks_orphan_total",
           "hide": false,
           "interval": "",
           "legendFormat": "Orphan blocks",
@@ -917,14 +917,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(snarkos_misc_block_processing_time_sum[$__rate_interval])/rate(snarkos_misc_block_processing_time_count[$__rate_interval])",
+          "expr": "rate(snarkos_blocks_inbound_processing_time_sum[$__rate_interval])/rate(snarkos_blocks_inbound_processing_time_count[$__rate_interval])",
           "interval": "",
           "legendFormat": "total for inbound block",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "rate(snarkos_misc_block_commit_time_sum[$__rate_interval])/rate(snarkos_misc_block_commit_time_count[$__rate_interval])",
+          "expr": "rate(snarkos_blocks_commit_time_sum[$__rate_interval])/rate(snarkos_blocks_commit_time_count[$__rate_interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "verification and commit",
@@ -1215,5 +1215,5 @@
   "timezone": "",
   "title": "snarkOS node",
   "uid": "nuiNXZV7k",
-  "version": 6
+  "version": 7
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -67,14 +67,17 @@ pub mod queues {
 }
 
 pub mod misc {
-    pub const BLOCK_HEIGHT: &str = "snarkos_misc_block_height_total";
-    pub const BLOCKS_MINED: &str = "snarkos_misc_blocks_mined_total";
-    pub const DUPLICATE_BLOCKS: &str = "snarkos_misc_duplicate_blocks_total";
-    pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_misc_duplicate_sync_blocks_total";
-    pub const ORPHAN_BLOCKS: &str = "snarkos_misc_orphan_blocks_total";
     pub const RPC_REQUESTS: &str = "snarkos_misc_rpc_requests_total";
-    pub const BLOCK_PROCESSING_TIME: &str = "snarkos_misc_block_processing_time";
-    pub const BLOCK_COMMIT_TIME: &str = "snarkos_misc_block_commit_time";
+}
+
+pub mod blocks {
+    pub const HEIGHT: &str = "snarkos_blocks_height_total";
+    pub const MINED: &str = "snarkos_blocks_mined_total";
+    pub const DUPLICATE_BLOCKS: &str = "snarkos_blocks_duplicate_blocks_total";
+    pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_blocks_duplicate_sync_blocks_total";
+    pub const ORPHANS: &str = "snarkos_blocks_orphan_total";
+    pub const INBOUND_PROCESSING_TIME: &str = "snarkos_blocks_inbound_processing_time";
+    pub const COMMIT_TIME: &str = "snarkos_blocks_commit_time";
 }
 
 pub mod internal_rtt {

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -73,8 +73,8 @@ pub mod misc {
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
     pub const MINED: &str = "snarkos_blocks_mined_total";
-    pub const DUPLICATE_BLOCKS: &str = "snarkos_duplicate_blocks_total";
-    pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_duplicate_sync_blocks_total";
+    pub const DUPLICATES: &str = "snarkos_blocks_duplicates_total";
+    pub const DUPLICATES_SYNC: &str = "snarkos_blocks_duplicates_sync_total";
     pub const ORPHANS: &str = "snarkos_blocks_orphan_total";
     pub const INBOUND_PROCESSING_TIME: &str = "snarkos_blocks_inbound_processing_time";
     pub const COMMIT_TIME: &str = "snarkos_blocks_commit_time";

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -73,8 +73,8 @@ pub mod misc {
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
     pub const MINED: &str = "snarkos_blocks_mined_total";
-    pub const DUPLICATE_BLOCKS: &str = "snarkos_blocks_duplicate_blocks_total";
-    pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_blocks_duplicate_sync_blocks_total";
+    pub const DUPLICATE_BLOCKS: &str = "snarkos_duplicate_blocks_total";
+    pub const DUPLICATE_SYNC_BLOCKS: &str = "snarkos_duplicate_sync_blocks_total";
     pub const ORPHANS: &str = "snarkos_blocks_orphan_total";
     pub const INBOUND_PROCESSING_TIME: &str = "snarkos_blocks_inbound_processing_time";
     pub const COMMIT_TIME: &str = "snarkos_blocks_commit_time";

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -31,6 +31,8 @@ pub struct NodeStats {
     pub queues: NodeQueueStats,
     /// Miscellaneous stats related to the node.
     pub misc: NodeMiscStats,
+    /// The node's block-related stats.
+    pub blocks: NodeBlockStats,
     /// The node's internal RTT from message received to response sent.
     pub internal_rtt: NodeInternalRttStats,
 }
@@ -129,22 +131,26 @@ pub struct NodeQueueStats {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeMiscStats {
+    /// The number of RPC requests received.
+    pub rpc_requests: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeBlockStats {
     /// The current block height of the node.
-    pub block_height: u64,
+    pub height: u64,
     /// The number of blocks the node has mined.
-    pub blocks_mined: u64,
+    pub mined: u64,
     /// The average inbound block processing time (in seconds).
-    pub block_processing_time: f64,
+    pub inbound_processing_time: f64,
     /// The average block verification and commit time (in seconds).
-    pub block_commit_time: f64,
+    pub commit_time: f64,
     /// The number of duplicate blocks received.
     pub duplicate_blocks: u64,
     /// The number of duplicate sync blocks received.
     pub duplicate_sync_blocks: u64,
     /// The number of orphan blocks received.
-    pub orphan_blocks: u64,
-    /// The number of RPC requests received.
-    pub rpc_requests: u64,
+    pub orphans: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -146,9 +146,9 @@ pub struct NodeBlockStats {
     /// The average block verification and commit time (in seconds).
     pub commit_time: f64,
     /// The number of duplicate blocks received.
-    pub duplicate_blocks: u64,
+    pub duplicates: u64,
     /// The number of duplicate sync blocks received.
-    pub duplicate_sync_blocks: u64,
+    pub duplicates_sync: u64,
     /// The number of orphan blocks received.
     pub orphans: u64,
 }

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -332,9 +332,9 @@ pub struct BlockStats {
     /// The verification and commit time for a block.
     commit_time: CircularHistogram,
     /// The number of duplicate blocks received.
-    duplicate_blocks: Counter,
+    duplicates: Counter,
     /// The number of duplicate sync blocks received.
-    duplicate_sync_blocks: Counter,
+    duplicates_sync: Counter,
     /// The number of orphan blocks received.
     orphans: Counter,
 }
@@ -346,8 +346,8 @@ impl BlockStats {
             mined: Counter::new(),
             inbound_processing_time: CircularHistogram::new(),
             commit_time: CircularHistogram::new(),
-            duplicate_blocks: Counter::new(),
-            duplicate_sync_blocks: Counter::new(),
+            duplicates: Counter::new(),
+            duplicates_sync: Counter::new(),
             orphans: Counter::new(),
         }
     }
@@ -358,8 +358,8 @@ impl BlockStats {
             mined: self.mined.read(),
             inbound_processing_time: self.inbound_processing_time.average(),
             commit_time: self.commit_time.average(),
-            duplicate_blocks: self.duplicate_blocks.read(),
-            duplicate_sync_blocks: self.duplicate_sync_blocks.read(),
+            duplicates: self.duplicates.read(),
+            duplicates_sync: self.duplicates_sync.read(),
             orphans: self.orphans.read(),
         }
     }
@@ -454,8 +454,8 @@ impl Recorder for Stats {
             misc::RPC_REQUESTS => &self.misc.rpc_requests,
             // blocks
             blocks::MINED => &self.blocks.mined,
-            blocks::DUPLICATE_BLOCKS => &self.blocks.duplicate_blocks,
-            blocks::DUPLICATE_SYNC_BLOCKS => &self.blocks.duplicate_sync_blocks,
+            blocks::DUPLICATES => &self.blocks.duplicates,
+            blocks::DUPLICATES_SYNC => &self.blocks.duplicates_sync,
             blocks::ORPHANS => &self.blocks.orphans,
             _ => {
                 return;

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -20,6 +20,7 @@ use crate::{
     metric_types::{CircularHistogram, Counter, DiscreteGauge},
     names::*,
     snapshots::{
+        NodeBlockStats,
         NodeConnectionStats,
         NodeHandshakeStats,
         NodeInboundStats,
@@ -46,6 +47,8 @@ pub struct Stats {
     queues: QueueStats,
     /// Miscellaneous stats related to the node.
     misc: MiscStats,
+    /// The node's block-related stats.
+    blocks: BlockStats,
     /// The node's internal RTT from message received to response sent (in seconds).
     internal_rtt: InternalRtt,
 }
@@ -59,6 +62,7 @@ impl Stats {
             handshakes: HandshakeStats::new(),
             queues: QueueStats::new(),
             misc: MiscStats::new(),
+            blocks: BlockStats::new(),
             internal_rtt: InternalRtt::new(),
         }
     }
@@ -71,6 +75,7 @@ impl Stats {
             handshakes: self.handshakes.snapshot(),
             queues: self.queues.snapshot(),
             misc: self.misc.snapshot(),
+            blocks: self.blocks.snapshot(),
             internal_rtt: self.internal_rtt.snapshot(),
         }
     }
@@ -299,19 +304,6 @@ impl QueueStats {
 }
 
 pub struct MiscStats {
-    block_height: DiscreteGauge,
-    /// The number of mined blocks.
-    blocks_mined: Counter,
-    /// The processing time for an inbound block.
-    block_processing_time: CircularHistogram,
-    /// The verification and commit time for a block.
-    block_commit_time: CircularHistogram,
-    /// The number of duplicate blocks received.
-    duplicate_blocks: Counter,
-    /// The number of duplicate sync blocks received.
-    duplicate_sync_blocks: Counter,
-    /// The number of orphan blocks received.
-    orphan_blocks: Counter,
     /// The number of RPC requests received.
     rpc_requests: Counter,
 }
@@ -319,27 +311,56 @@ pub struct MiscStats {
 impl MiscStats {
     const fn new() -> Self {
         Self {
-            block_height: DiscreteGauge::new(),
-            blocks_mined: Counter::new(),
-            block_processing_time: CircularHistogram::new(),
-            block_commit_time: CircularHistogram::new(),
-            duplicate_blocks: Counter::new(),
-            duplicate_sync_blocks: Counter::new(),
-            orphan_blocks: Counter::new(),
             rpc_requests: Counter::new(),
         }
     }
 
     pub fn snapshot(&self) -> NodeMiscStats {
         NodeMiscStats {
-            block_height: self.block_height.read(),
-            blocks_mined: self.blocks_mined.read(),
-            block_processing_time: self.block_processing_time.average(),
-            block_commit_time: self.block_commit_time.average(),
+            rpc_requests: self.rpc_requests.read(),
+        }
+    }
+}
+
+pub struct BlockStats {
+    /// The block height of the node's canon chain.
+    height: DiscreteGauge,
+    /// The number of mined blocks.
+    mined: Counter,
+    /// The processing time for an inbound block.
+    inbound_processing_time: CircularHistogram,
+    /// The verification and commit time for a block.
+    commit_time: CircularHistogram,
+    /// The number of duplicate blocks received.
+    duplicate_blocks: Counter,
+    /// The number of duplicate sync blocks received.
+    duplicate_sync_blocks: Counter,
+    /// The number of orphan blocks received.
+    orphans: Counter,
+}
+
+impl BlockStats {
+    const fn new() -> Self {
+        BlockStats {
+            height: DiscreteGauge::new(),
+            mined: Counter::new(),
+            inbound_processing_time: CircularHistogram::new(),
+            commit_time: CircularHistogram::new(),
+            duplicate_blocks: Counter::new(),
+            duplicate_sync_blocks: Counter::new(),
+            orphans: Counter::new(),
+        }
+    }
+
+    pub fn snapshot(&self) -> NodeBlockStats {
+        NodeBlockStats {
+            height: self.height.read(),
+            mined: self.mined.read(),
+            inbound_processing_time: self.inbound_processing_time.average(),
+            commit_time: self.commit_time.average(),
             duplicate_blocks: self.duplicate_blocks.read(),
             duplicate_sync_blocks: self.duplicate_sync_blocks.read(),
-            orphan_blocks: self.orphan_blocks.read(),
-            rpc_requests: self.rpc_requests.read(),
+            orphans: self.orphans.read(),
         }
     }
 }
@@ -384,8 +405,8 @@ impl Recorder for Stats {
     fn record_histogram(&self, key: &Key, value: f64) {
         let metric = match key.name() {
             connections::DURATION => &self.connections.duration,
-            misc::BLOCK_PROCESSING_TIME => &self.misc.block_processing_time,
-            misc::BLOCK_COMMIT_TIME => &self.misc.block_commit_time,
+            blocks::INBOUND_PROCESSING_TIME => &self.blocks.inbound_processing_time,
+            blocks::COMMIT_TIME => &self.blocks.commit_time,
             internal_rtt::GETPEERS => &self.internal_rtt.getpeers,
             internal_rtt::GETSYNC => &self.internal_rtt.getsync,
             internal_rtt::GETBLOCKS => &self.internal_rtt.getblocks,
@@ -430,11 +451,12 @@ impl Recorder for Stats {
             handshakes::TIMEOUTS_INIT => &self.handshakes.timeouts_init,
             handshakes::TIMEOUTS_RESP => &self.handshakes.timeouts_resp,
             // misc
-            misc::BLOCKS_MINED => &self.misc.blocks_mined,
-            misc::DUPLICATE_BLOCKS => &self.misc.duplicate_blocks,
-            misc::DUPLICATE_SYNC_BLOCKS => &self.misc.duplicate_sync_blocks,
-            misc::ORPHAN_BLOCKS => &self.misc.orphan_blocks,
             misc::RPC_REQUESTS => &self.misc.rpc_requests,
+            // blocks
+            blocks::MINED => &self.blocks.mined,
+            blocks::DUPLICATE_BLOCKS => &self.blocks.duplicate_blocks,
+            blocks::DUPLICATE_SYNC_BLOCKS => &self.blocks.duplicate_sync_blocks,
+            blocks::ORPHANS => &self.blocks.orphans,
             _ => {
                 return;
             }
@@ -449,8 +471,8 @@ impl Recorder for Stats {
             queues::OUTBOUND => &self.queues.outbound,
             queues::PEER_EVENTS => &self.queues.peer_events,
             queues::STORAGE => &self.queues.storage,
-            // misc
-            misc::BLOCK_HEIGHT => &self.misc.block_height,
+            // blocks
+            blocks::HEIGHT => &self.blocks.height,
             // connections
             connections::CONNECTING => &self.connections.connecting_peers,
             connections::CONNECTED => &self.connections.connected_peers,

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::*;
-use snarkos_metrics::{self as metrics, misc, wrapped_mpsc};
+use snarkos_metrics::{self as metrics, wrapped_mpsc};
 
 use anyhow::*;
 use chrono::{DateTime, Utc};

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -348,7 +348,7 @@ impl Node {
 
         // The node can already be at some non-zero height.
         if self.sync().is_some() {
-            metrics::gauge!(misc::BLOCK_HEIGHT, self.storage.canon().await?.block_height as f64);
+            metrics::gauge!(metrics::blocks::HEIGHT, self.storage.canon().await?.block_height as f64);
         }
 
         Ok(())

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -17,7 +17,6 @@
 use snarkos_metrics::{
     self as metrics,
     inbound::{self, *},
-    misc,
     outbound,
 };
 use tokio::task;

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -76,7 +76,7 @@ impl Peer {
                         {
                             let mut inbound_cache = node.inbound_cache.lock().await;
                             if inbound_cache.contains(&block[..]) {
-                                metrics::increment_counter!(misc::DUPLICATE_BLOCKS);
+                                metrics::increment_counter!(metrics::blocks::DUPLICATE_BLOCKS);
                                 return;
                             } else {
                                 inbound_cache.push(&block[..]);

--- a/network/src/peers/peer/inbound_handler.rs
+++ b/network/src/peers/peer/inbound_handler.rs
@@ -75,7 +75,7 @@ impl Peer {
                         {
                             let mut inbound_cache = node.inbound_cache.lock().await;
                             if inbound_cache.contains(&block[..]) {
-                                metrics::increment_counter!(metrics::blocks::DUPLICATE_BLOCKS);
+                                metrics::increment_counter!(metrics::blocks::DUPLICATES);
                                 return;
                             } else {
                                 inbound_cache.push(&block[..]);

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -155,7 +155,7 @@ impl Node {
             self.propagate_block(block, height, remote_address);
         }
 
-        metrics::histogram!(metrics::misc::BLOCK_PROCESSING_TIME, now.elapsed());
+        metrics::histogram!(metrics::blocks::INBOUND_PROCESSING_TIME, now.elapsed());
 
         Ok(())
     }

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -118,7 +118,7 @@ impl MinerInstance {
                     self.node.set_state(State::Idle);
                 }
 
-                metrics::increment_counter!(BLOCKS_MINED);
+                metrics::increment_counter!(metrics::blocks::MINED);
 
                 info!("Mined a new block: {:?}", hex::encode(block.header.hash().0));
 

--- a/network/src/sync/miner.rs
+++ b/network/src/sync/miner.rs
@@ -24,7 +24,7 @@ use tokio::{task, time::sleep};
 use tracing::*;
 
 use snarkos_consensus::MineContext;
-use snarkos_metrics::{self as metrics, misc::*};
+use snarkos_metrics::{self as metrics};
 
 use crate::{Node, State};
 

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -8,6 +8,12 @@ None
 
 | Parameter                        | Type | Description                                                                  |
 | :------------------------------: | :--: | :--------------------------------------------------------------------------: |
+| `blocks.height`                  | u32  | The current block height of the node                                         |
+| `blocks.mined`                   | u32  | The number of blocks the node has mined                                      |
+| `blocks.inbound_processing_time` | f64  | The average processing time of an inbound block in seconds                   |
+| `blocks.commit_time`             | f64  | The block verification and commit time in seconds                            |
+| `blocks.duplicates`              | u64  | The number of duplicate blocks received                                      |
+| `blocks.duplicates_sync`         | u64  | The number of duplicate sync blocks received                                 |
 | `connections.all_accepted`       | u64  | The number of connection requests the node has received                      |
 | `connections.all_initiated`      | u64  | The number of connection requests the node has made                          |
 | `connections.all_rejected`       | u64  | The number of connection requests the node has rejected                      |
@@ -40,12 +46,6 @@ None
 | `internal_rtt.getsync`           | f64  | The average internal RTT for GetSync messages in seconds                     |
 | `internal_rtt.getblocks`         | f64  | The average internal RTT for GetBlocks messages in seconds                   |
 | `internal_rtt.getmemorypool`     | f64  | The average internal RTT for GetMemoryPool messages in seconds               |
-| `misc.block_height`              | u32  | The current block height of the node                                         |
-| `misc.blocks_mined`              | u32  | The number of blocks the node has mined                                      |
-| `misc.block_processing_time`     | f64  | The average processing time of an inbound block in seconds                   |
-| `misc.block_commit_time`         | f64  | The block verification and commit time in seconds                            |
-| `misc.duplicate_blocks`          | u64  | The number of duplicate blocks received                                      |
-| `misc.duplicate_sync_blocks`     | u64  | The number of duplicate sync blocks received                                 |
 | `outbound.all_successes`         | u64  | The number of successfully sent messages                                     |
 | `outbound.all_failures`          | u64  | The number of failures to send messages                                      |
 | `queues.consensus`               | u64  | The number of queued consensus requests                                      |

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -46,6 +46,7 @@ None
 | `internal_rtt.getsync`           | f64  | The average internal RTT for GetSync messages in seconds                     |
 | `internal_rtt.getblocks`         | f64  | The average internal RTT for GetBlocks messages in seconds                   |
 | `internal_rtt.getmemorypool`     | f64  | The average internal RTT for GetMemoryPool messages in seconds               |
+| `misc.rpc_requests`              | f64  | The number of RPC requests received by the node                              |
 | `outbound.all_successes`         | u64  | The number of successfully sent messages                                     |
 | `outbound.all_failures`          | u64  | The number of failures to send messages                                      |
 | `queues.consensus`               | u64  | The number of queued consensus requests                                      |


### PR DESCRIPTION
Follow-up to #1170. Splits the block metrics out from `misc` into the `blocks` mod (and struct, for rpc metrics).
