### PR TITLE
Remove the sqlite cli flag

### DIFF
--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -444,7 +444,6 @@ impl CLI for ConfigCli {
         flag::IS_MINER,
         flag::TRIM_STORAGE,
         flag::VALIDATE_STORAGE,
-        flag::SQLITE,
     ];
     const NAME: NameType = "snarkOS";
     const OPTIONS: &'static [OptionType] = &[

--- a/snarkos/parameters/flag.rs
+++ b/snarkos/parameters/flag.rs
@@ -25,6 +25,3 @@ pub const LIST: &str = "[list] -l --list 'List all available releases of snarkOS
 pub const TRIM_STORAGE: &str = "[trim-storage] --trim-storage 'Remove non-canon items from the node's storage'";
 
 pub const VALIDATE_STORAGE: &str = "[validate-storage] --validate-storage 'Check the integrity of the node's storage and attempt to fix encountered issues'";
-
-pub const SQLITE: &str =
-    "[sqlite] --sqlite 'Uses a sqlite backend instead of rocksdb. Requires `sqlite` compilation feature.'";


### PR DESCRIPTION
This is no longer needed, removing this flag will avoid further confusion (the question was raised on Discord by a community member).
