### PR TITLE
A more thorough storage trim

### DIFF
--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -248,18 +248,17 @@ impl Node {
             } else {
                 // Floored if count is odd.
                 let random_count = count / 2;
-                let random_picks: Vec<Peer> = candidates
-                    .iter()
-                    .choose_multiple(&mut SmallRng::from_entropy(), random_count)
+                let random_picks = candidates
+                    .clone()
                     .into_iter()
-                    .cloned()
-                    .collect();
+                    .choose_multiple(&mut SmallRng::from_entropy(), random_count)
+                    .into_iter();
                 candidates.sort_unstable_by(|x, y| y.quality.block_height.cmp(&x.quality.block_height));
 
                 candidates.truncate(count - random_count);
                 candidates
                     .into_iter()
-                    .chain(random_picks.into_iter())
+                    .chain(random_picks)
                     .unique_by(|x| x.address)
                     .collect::<Vec<Peer>>()
             }

--- a/storage/src/digest.rs
+++ b/storage/src/digest.rs
@@ -50,7 +50,7 @@ impl<'de> Deserialize<'de> for Digest {
         let name = String::deserialize(deserializer)?;
 
         Ok(Self(InnerType::from(
-            hex::decode(&name).map_err(|e| serde::de::Error::custom(e))?,
+            hex::decode(&name).map_err(serde::de::Error::custom)?,
         )))
     }
 }

--- a/storage/src/storage/async_adapter.rs
+++ b/storage/src/storage/async_adapter.rs
@@ -83,6 +83,7 @@ enum Message {
     DeleteItem(KeyValueColumn, Vec<u8>),
     #[cfg(feature = "test")]
     Reset(),
+    Trim(),
 }
 
 impl fmt::Display for Message {
@@ -149,6 +150,7 @@ impl fmt::Display for Message {
             Message::DeleteItem(col, key) => write!(f, "DeleteItem({:?}, {:?})", col, key),
             #[cfg(feature = "test")]
             Message::Reset() => write!(f, "Reset()"),
+            Message::Trim() => write!(f, "Trim()"),
         }
     }
 }
@@ -219,6 +221,7 @@ impl<S: SyncStorage + 'static> Agent<S> {
             Message::DeleteItem(col, key) => Box::new(self.wrap(move |f| f.delete_item(col, key))),
             #[cfg(feature = "test")]
             Message::Reset() => Box::new(self.inner.reset()),
+            Message::Trim() => Box::new(self.inner.trim()),
         }
     }
 
@@ -421,5 +424,9 @@ impl Storage for AsyncStorage {
     #[cfg(feature = "test")]
     async fn reset(&self) -> Result<()> {
         self.send(Message::Reset()).await
+    }
+
+    async fn trim(&self) -> Result<()> {
+        self.send(Message::Trim()).await
     }
 }

--- a/storage/src/storage/key_value/store.rs
+++ b/storage/src/storage/key_value/store.rs
@@ -733,4 +733,8 @@ impl<S: KeyValueStorage + Validator + 'static> SyncStorage for KeyValueStore<S> 
     fn reset(&mut self) -> Result<()> {
         unimplemented!();
     }
+
+    fn trim(&mut self) -> Result<()> {
+        unimplemented!();
+    }
 }

--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -1204,9 +1204,9 @@ impl SyncStorage for SqliteStorage {
             WHERE id IN (
                 SELECT transactions.id
                 FROM transactions
-                INNER JOIN transaction_blocks on transaction_blocks.transaction_id = transactions.id
-                INNER JOIN blocks on blocks.id = transaction_blocks.block_id
-                WHERE blocks.canon_height IS NULL
+                LEFT JOIN transaction_blocks on transaction_blocks.transaction_id = transactions.id
+                LEFT JOIN blocks on blocks.id = transaction_blocks.block_id
+                WHERE transaction_blocks.transaction_id IS NULL OR blocks.canon_height IS NULL
             )
         ",
             [],

--- a/storage/src/storage/storage.rs
+++ b/storage/src/storage/storage.rs
@@ -223,6 +223,9 @@ pub trait Storage: Send + Sync {
 
     #[cfg(feature = "test")]
     async fn reset(&self) -> Result<()>;
+
+    /// Removes non-canon blocks and transactions from the storage.
+    async fn trim(&self) -> Result<()>;
 }
 
 /// A wrapper over storage implementations

--- a/storage/src/storage/sync.rs
+++ b/storage/src/storage/sync.rs
@@ -409,4 +409,7 @@ pub trait SyncStorage {
     /// Fully resets the storage.
     #[cfg(feature = "test")]
     fn reset(&mut self) -> Result<()>;
+
+    /// Removes non-canon blocks and transactions from the storage.
+    fn trim(&mut self) -> Result<()>;
 }

--- a/storage/src/trim.rs
+++ b/storage/src/trim.rs
@@ -33,18 +33,9 @@ struct StorageTrimSummary {
 pub async fn trim(storage: DynStorage) -> Result<()> {
     info!("Checking for obsolete objects in the storage...");
 
-    let non_canon_hashes = storage.get_block_hashes(None, crate::BlockFilter::NonCanonOnly).await?;
+    storage.trim().await?;
 
-    info!("found {} obsolete blocks, removing...", non_canon_hashes.len());
-
-    for hash in &non_canon_hashes {
-        storage.delete_block(hash).await?;
-    }
-
-    info!(
-        "The storage was trimmed successfully ({} items removed)!",
-        non_canon_hashes.len()
-    );
+    info!("The storage was trimmed successfully!");
 
     Ok(())
 }


### PR DESCRIPTION
This PR makes the `--trim-storage` functionality remove transactions that don't belong to canon blocks in addition to removing non-canon blocks. The resulting reduction in database size is significant.

~In order to be able to remove the obsolete transactions, we need to ensure that every tx belonging to a canon block is stored. To do this, the block commit operation is extended with an update to the transaction location table, so that cases where a transaction first delivered in a non-canon block is later followed by a competing block containing the same transaction which becomes canon don't lead to the transaction being removed due to its location not being canon in the end.~

~Filing this as a draft in order to run some more tests and to decide if we want to migrate the current storage (which would require all the existing canon blocks to be partially canonized again) or just wait until testnet2, where no such migration would be necessary.~

Actually, this was much easier than I initially thought, as the transaction locations are connected to transactions and blocks based on their database ids as opposed to hashes, meaning we neither need to perform any migration nor update transaction locations upon commits - this is also part of the reason why this extended trim is so important - all transactions coming from all blocks have their respective locations stored individually, which uses plenty of space.