### PR TITLE
Don't increment the related metric if try_send fails

### DIFF
--- a/metrics/src/wrapped_mpsc.rs
+++ b/metrics/src/wrapped_mpsc.rs
@@ -62,8 +62,9 @@ impl<T: Send> Sender<T> {
     }
 
     pub fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
+        self.inner.try_send(message)?;
         self.increment();
-        self.inner.try_send(message)
+        Ok(())
     }
 
     pub fn blocking_send(&self, value: T) -> Result<(), SendError<T>> {


### PR DESCRIPTION
Found while investigating https://github.com/AleoHQ/snarkOS/issues/1183, but not directly related to it.

This PR ensures that `Sender::try_send` has succeeded before incrementing the related metric, as its failure means that the related message did not get queued.