### PR TITLE
Sync tweaks

### DIFF
--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -225,7 +225,6 @@ impl Node {
         // Local address must be known by now.
         let own_address = self.expect_local_addr();
 
-        // If this node is not a bootnode, attempt to satisfy the minimum number of peer connections.
         let random_peers: Vec<SocketAddr> = {
             trace!(
                 "Connecting to {} disconnected peers",

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -244,8 +244,6 @@ impl Node {
                 candidates.sort_unstable_by_key(|peer| peer.quality.last_connected);
             }
 
-            // let addr_iter = candidates.into_iter(); // .iter().map(|peer| peer.address);
-
             if !self.is_of_type(NodeType::Client) {
                 candidates.into_iter().take(count).collect()
             } else {

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -269,7 +269,6 @@ impl Node {
         .iter()
         .map(|peer| peer.address)
         .collect();
-        info!("peer heights: {:?}", random_peers);
 
         for remote_address in random_peers {
             let node = self.clone();

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -246,6 +246,7 @@ impl Node {
             if !self.is_of_type(NodeType::Client) {
                 candidates.into_iter().take(count).collect()
             } else {
+                // Floored if count is odd.
                 let random_count = count / 2;
                 let random_picks: Vec<Peer> = candidates
                     .iter()

--- a/storage/src/digest.rs
+++ b/storage/src/digest.rs
@@ -16,7 +16,7 @@
 
 use std::{fmt, io, ops::Deref};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use snarkvm_utilities::{ToBytes, Write};
 
@@ -42,6 +42,16 @@ impl fmt::Debug for Digest {
 impl Serialize for Digest {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let name = String::deserialize(deserializer)?;
+
+        Ok(Self(InnerType::from(
+            hex::decode(&name).map_err(|e| serde::de::Error::custom(e))?,
+        )))
     }
 }
 

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -83,12 +83,15 @@ async fn block_initiator_side() {
     let sync = Payload::Sync(block_header_hashes);
     peer.write_message(&sync).await;
 
+    assert!(matches!(peer.read_payload().await.unwrap(), Payload::GetSync(_)));
+
     // make sure both GetBlock messages are received
     let payload = peer.read_payload().await.unwrap();
+
     let block_hashes = if let Payload::GetBlocks(block_hashes) = payload {
         block_hashes
     } else {
-        unreachable!();
+        panic!("unexpected payload in test: {:?}", payload);
     };
 
     assert!(block_hashes.contains(&block_1_header_hash) && block_hashes.contains(&block_2_header_hash));


### PR DESCRIPTION
This PR:
* Splits reconnections to disconnected nodes between the highest claimed block count, and random. This provides us a higher chance to pull a longer chain, but still providing noise and distributing blocks.
* Makes aggro sync rounds last up to 60 seconds, removed interim block locator hash update (was pointless since we just restart after 15, now 60 seconds)
* Allows chain-scanning behavior in aggro sync (was disabled in a regression)
* Adjusts block locator hashes to put proportional hashes first, and makes quadratic hashes look at the the blocks closer to the origin of the chain.

