### PR TITLE
Connection metrics tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,10 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- --nocapture --skip metrics && RUST_MIN_STACK=8388608 cargo test --release metrics -- --test-threads 1
+          command: |
+            cd testing
+            RUST_MIN_STACK=8388608 cargo test --release -- --nocapture --skip metrics
+            cargo test --release metrics -- --test-threads 1
       - clear_environment:
           cache_key: snarkos-testing-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- --nocapture
+          command: cd testing && RUST_MIN_STACK=8388608 cargo test --release -- --nocapture --skip metrics && RUST_MIN_STACK=8388608 cargo test --release metrics -- --test-threads 1
       - clear_environment:
           cache_key: snarkos-testing-cache
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,6 +2920,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "snarkos-consensus",
+ "snarkos-metrics",
  "snarkos-network",
  "snarkos-parameters",
  "snarkos-storage",

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 [features]
 std = [ ]
 prometheus = [ "metrics-exporter-prometheus" ]
+test = [ ]
 
 [dependencies.circular-queue]
 version = "0.2"

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -99,7 +99,13 @@ pub fn initialize() -> Option<tokio::task::JoinHandle<()>> {
 
 #[cfg(not(feature = "prometheus"))]
 pub fn initialize() -> Option<tokio::task::JoinHandle<()>> {
+    #[cfg(not(feature = "test"))]
     metrics::set_recorder(&crate::stats::NODE_STATS).expect("couldn't initialize the metrics recorder!");
+
+    // Let the errors through in case the recorder has already been set as is likely when running
+    // multiple metrics tests.
+    #[cfg(feature = "test")]
+    let _ = metrics::set_recorder(&crate::stats::NODE_STATS);
 
     None
 }

--- a/metrics/src/metric_types.rs
+++ b/metrics/src/metric_types.rs
@@ -37,6 +37,11 @@ impl Counter {
     pub fn read(&self) -> u64 {
         self.0.load(Ordering::Relaxed)
     }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.0.store(0, Ordering::Relaxed);
+    }
 }
 
 /// Mimics a [`metrics-core`] arbitrarily increasing & decreasing [`Gauge`]
@@ -70,6 +75,11 @@ impl DiscreteGauge {
     #[inline]
     pub fn read(&self) -> u64 {
         self.0.load(Ordering::Relaxed)
+    }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.0.store(0, Ordering::Relaxed);
     }
 }
 
@@ -159,8 +169,18 @@ impl CircularHistogram {
             .get_or_init(|| RwLock::new(CircularQueue::with_capacity(QUEUE_CAPACITY)))
             .read();
 
+        // FIXME: early return if queue is empty.
+
         let sum: f64 = queue_r.iter().copied().sum();
 
         sum / queue_r.len() as f64
+    }
+
+    #[cfg(feature = "test")]
+    pub(crate) fn clear(&self) {
+        // Reset the queue only if it has previously been initialised.
+        if let Some(queue) = self.0.get() {
+            *queue.write() = CircularQueue::with_capacity(QUEUE_CAPACITY);
+        }
     }
 }

--- a/metrics/src/metric_types.rs
+++ b/metrics/src/metric_types.rs
@@ -169,10 +169,11 @@ impl CircularHistogram {
             .get_or_init(|| RwLock::new(CircularQueue::with_capacity(QUEUE_CAPACITY)))
             .read();
 
-        // FIXME: early return if queue is empty.
+        if queue_r.is_empty() {
+            return 0.0;
+        }
 
         let sum: f64 = queue_r.iter().copied().sum();
-
         sum / queue_r.len() as f64
     }
 

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -77,6 +77,8 @@ pub struct NodeOutboundStats {
     pub all_successes: u64,
     /// The number of messages that failed to be sent to peers.
     pub all_failures: u64,
+    /// The number of messages that were going to be sent to a peer, but was blocked at the last minute by a cache.
+    pub all_cache_hits: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -79,6 +79,19 @@ impl Stats {
             internal_rtt: self.internal_rtt.snapshot(),
         }
     }
+
+    // TODO: conditional compilation?
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.inbound.clear();
+        self.outbound.clear();
+        self.connections.clear();
+        self.handshakes.clear();
+        self.queues.clear();
+        self.misc.clear();
+        self.blocks.clear();
+        self.internal_rtt.clear();
+    }
 }
 
 pub struct InboundStats {
@@ -154,6 +167,25 @@ impl InboundStats {
             unknown: self.unknown.read(),
         }
     }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.all_successes.clear();
+        self.all_failures.clear();
+        self.blocks.clear();
+        self.getblocks.clear();
+        self.getmemorypool.clear();
+        self.getpeers.clear();
+        self.getsync.clear();
+        self.memorypool.clear();
+        self.peers.clear();
+        self.pings.clear();
+        self.pongs.clear();
+        self.syncs.clear();
+        self.syncblocks.clear();
+        self.transactions.clear();
+        self.unknown.clear();
+    }
 }
 
 pub struct OutboundStats {
@@ -178,7 +210,15 @@ impl OutboundStats {
         NodeOutboundStats {
             all_successes: self.all_successes.read(),
             all_failures: self.all_failures.read(),
+            // FIXME: add missing metric?
         }
+    }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.all_successes.clear();
+        self.all_failures.clear();
+        self.all_cache_hits.clear();
     }
 }
 
@@ -223,6 +263,17 @@ impl ConnectionStats {
             disconnected_peers: self.disconnected_peers.read() as u32,
         }
     }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.all_accepted.clear();
+        self.all_initiated.clear();
+        self.all_rejected.clear();
+        self.duration.clear();
+        self.connecting_peers.clear();
+        self.connected_peers.clear();
+        self.disconnected_peers.clear();
+    }
 }
 
 pub struct HandshakeStats {
@@ -261,6 +312,16 @@ impl HandshakeStats {
             timeouts_init: self.timeouts_init.read(),
             timeouts_resp: self.timeouts_resp.read(),
         }
+    }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.successes_init.clear();
+        self.successes_resp.clear();
+        self.failures_init.clear();
+        self.failures_resp.clear();
+        self.timeouts_init.clear();
+        self.timeouts_resp.clear();
     }
 }
 
@@ -301,6 +362,16 @@ impl QueueStats {
             sync_items: self.sync_items.read(),
         }
     }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.consensus.clear();
+        self.inbound.clear();
+        self.outbound.clear();
+        self.peer_events.clear();
+        self.storage.clear();
+        self.sync_items.clear();
+    }
 }
 
 pub struct MiscStats {
@@ -319,6 +390,11 @@ impl MiscStats {
         NodeMiscStats {
             rpc_requests: self.rpc_requests.read(),
         }
+    }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.rpc_requests.clear();
     }
 }
 
@@ -363,6 +439,17 @@ impl BlockStats {
             orphans: self.orphans.read(),
         }
     }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.height.clear();
+        self.mined.clear();
+        self.inbound_processing_time.clear();
+        self.commit_time.clear();
+        self.duplicates.clear();
+        self.duplicates_sync.clear();
+        self.orphans.clear();
+    }
 }
 
 /// Each histogram holds the last `QUEUE_CAPACITY` (see `metric_types` mod) measurements for internal RTT for the indicated message
@@ -391,6 +478,14 @@ impl InternalRtt {
             getblocks: self.getblocks.average(),
             getmemorypool: self.getmemorypool.average(),
         }
+    }
+
+    #[cfg(feature = "test")]
+    pub fn clear(&self) {
+        self.getpeers.clear();
+        self.getsync.clear();
+        self.getblocks.clear();
+        self.getmemorypool.clear();
     }
 }
 

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -80,7 +80,6 @@ impl Stats {
         }
     }
 
-    // TODO: conditional compilation?
     #[cfg(feature = "test")]
     pub fn clear(&self) {
         self.inbound.clear();

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -209,7 +209,7 @@ impl OutboundStats {
         NodeOutboundStats {
             all_successes: self.all_successes.read(),
             all_failures: self.all_failures.read(),
-            // FIXME: add missing metric?
+            all_cache_hits: self.all_cache_hits.read(),
         }
     }
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -51,6 +51,11 @@ path = "../consensus"
 version = "1.3.16"
 features = [ "test" ]
 
+[dependencies.snarkos-metrics]
+path = "../metrics"
+version = "1.3.16"
+features = [ "test" ]
+
 [dependencies.snarkos-network]
 path = "../network"
 version = "1.3.16"

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -18,9 +18,9 @@
 #![forbid(unsafe_code)]
 
 pub mod dpc;
+pub mod metrics;
 pub mod mining;
 #[cfg(feature = "network")]
 pub mod network;
 pub mod storage;
 pub mod sync;
-pub mod metrics;

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -18,6 +18,7 @@
 #![forbid(unsafe_code)]
 
 pub mod dpc;
+#[cfg(test)]
 pub mod metrics;
 pub mod mining;
 #[cfg(feature = "network")]

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -23,3 +23,4 @@ pub mod mining;
 pub mod network;
 pub mod storage;
 pub mod sync;
+pub mod metrics;

--- a/testing/src/metrics/mod.rs
+++ b/testing/src/metrics/mod.rs
@@ -15,10 +15,15 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    network::{handshaken_peer, test_node, TestSetup},
+    network::{handshaken_peer, test_node, FakeNode, TestSetup},
     wait_until,
 };
 use snarkos_metrics::stats::NODE_STATS;
+use snarkos_network::Version;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
 
 #[tokio::test]
 async fn connect_and_disconnect_responder_side() {
@@ -38,6 +43,81 @@ async fn connect_and_disconnect_responder_side() {
     assert_eq!(metrics.connections.all_accepted, 1);
     assert_eq!(metrics.connections.connected_peers, 1);
     assert_eq!(metrics.handshakes.successes_resp, 1);
+
+    // Break the connection by dropping the peer.
+    drop(peer);
+
+    // Wait until the node has handled the broken connection.
+    wait_until!(5, node.peer_book.get_connected_peer_count() == 0);
+
+    let metrics = NODE_STATS.snapshot();
+
+    assert_eq!(metrics.connections.connected_peers, 0);
+    assert_eq!(metrics.connections.disconnected_peers, 1);
+
+    // Make sure the global metrics state is reset as it will leak.
+    NODE_STATS.clear();
+}
+
+#[tokio::test]
+async fn connect_and_disconnect_initiator_side() {
+    let setup: TestSetup = Default::default();
+    let node = test_node(setup).await;
+    node.initialize_metrics().await.unwrap();
+
+    // Start a fake peer which is just a socket.
+    let peer_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let peer_address = peer_listener.local_addr().unwrap();
+
+    node.connect_to_addresses(&[peer_address]).await;
+
+    // Accept the node's connection on peer side.
+    let (mut peer_stream, _node_address) = peer_listener.accept().await.unwrap();
+
+    let builder = snow::Builder::with_resolver(
+        snarkos_network::HANDSHAKE_PATTERN.parse().unwrap(),
+        Box::new(snow::resolvers::SodiumResolver),
+    );
+    let static_key = builder.generate_keypair().unwrap().private;
+    let noise_builder = builder
+        .local_private_key(&static_key)
+        .psk(3, snarkos_network::HANDSHAKE_PSK);
+    let mut noise = noise_builder.build_responder().unwrap();
+    let mut buffer: Box<[u8]> = vec![0u8; snarkos_network::NOISE_BUF_LEN].into();
+    let mut buf = [0u8; snarkos_network::NOISE_BUF_LEN]; // a temporary intermediate buffer to decrypt from
+
+    // <- e
+    peer_stream.read_exact(&mut buf[..1]).await.unwrap();
+    let len = buf[0] as usize;
+    let len = peer_stream.read_exact(&mut buf[..len]).await.unwrap();
+    noise.read_message(&buf[..len], &mut buffer).unwrap();
+
+    // -> e, ee, s, es
+    let peer_version =
+        Version::serialize(&Version::new(snarkos_network::PROTOCOL_VERSION, peer_address.port(), 0)).unwrap();
+    let len = noise.write_message(&peer_version, &mut buffer).unwrap();
+    peer_stream.write_all(&[len as u8]).await.unwrap();
+    peer_stream.write_all(&buffer[..len]).await.unwrap();
+
+    // <- s, se, psk
+    peer_stream.read_exact(&mut buf[..1]).await.unwrap();
+    let len = buf[0] as usize;
+    let len = peer_stream.read_exact(&mut buf[..len]).await.unwrap();
+    let len = noise.read_message(&buf[..len], &mut buffer).unwrap();
+    let _node_version = Version::deserialize(&buffer[..len]).unwrap();
+
+    let noise = noise.into_transport_mode().unwrap();
+    let peer = FakeNode::new(peer_stream, peer_address, noise);
+
+    // Needed to make sure the values have been updated.
+    wait_until!(5, node.peer_book.get_connected_peer_count() == 1);
+
+    // ...the metrics should reflect this.
+    let metrics = NODE_STATS.snapshot();
+
+    assert_eq!(metrics.connections.all_initiated, 1);
+    assert_eq!(metrics.connections.connected_peers, 1);
+    assert_eq!(metrics.handshakes.successes_init, 1);
 
     // Break the connection by dropping the peer.
     drop(peer);

--- a/testing/src/metrics/mod.rs
+++ b/testing/src/metrics/mod.rs
@@ -41,8 +41,13 @@ async fn connect_and_disconnect_responder_side() {
     let metrics = NODE_STATS.snapshot();
 
     assert_eq!(metrics.connections.all_accepted, 1);
-    assert_eq!(metrics.connections.connected_peers, 1);
+    assert_eq!(metrics.connections.all_initiated, 0);
     assert_eq!(metrics.handshakes.successes_resp, 1);
+    assert_eq!(metrics.handshakes.successes_init, 0);
+
+    assert_eq!(metrics.connections.connected_peers, 1);
+    assert_eq!(metrics.connections.connecting_peers, 0);
+    assert_eq!(metrics.connections.disconnected_peers, 0);
 
     // Break the connection by dropping the peer.
     drop(peer);
@@ -115,9 +120,14 @@ async fn connect_and_disconnect_initiator_side() {
     // ...the metrics should reflect this.
     let metrics = NODE_STATS.snapshot();
 
+    assert_eq!(metrics.connections.all_accepted, 0);
     assert_eq!(metrics.connections.all_initiated, 1);
-    assert_eq!(metrics.connections.connected_peers, 1);
+    assert_eq!(metrics.handshakes.successes_resp, 0);
     assert_eq!(metrics.handshakes.successes_init, 1);
+
+    assert_eq!(metrics.connections.connected_peers, 1);
+    assert_eq!(metrics.connections.connecting_peers, 0);
+    assert_eq!(metrics.connections.disconnected_peers, 0);
 
     // Break the connection by dropping the peer.
     drop(peer);

--- a/testing/src/metrics/mod.rs
+++ b/testing/src/metrics/mod.rs
@@ -1,0 +1,55 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    network::{handshaken_peer, test_node, TestSetup},
+    wait_until,
+};
+use snarkos_metrics::stats::NODE_STATS;
+
+#[tokio::test]
+async fn connect_and_disconnect_responder_side() {
+    let setup: TestSetup = Default::default();
+    let node = test_node(setup).await;
+    node.initialize_metrics().await.unwrap();
+
+    // The fake node connects to the node's listener...
+    let peer = handshaken_peer(node.expect_local_addr()).await;
+
+    // Needed to make sure the values have been updated.
+    wait_until!(5, node.peer_book.get_connected_peer_count() == 1);
+
+    // ...the metrics should reflect this.
+    let metrics = NODE_STATS.snapshot();
+
+    assert_eq!(metrics.connections.all_accepted, 1);
+    assert_eq!(metrics.connections.connected_peers, 1);
+    assert_eq!(metrics.handshakes.successes_resp, 1);
+
+    // Break the connection by dropping the peer.
+    drop(peer);
+
+    // Wait until the node has handled the broken connection.
+    wait_until!(5, node.peer_book.get_connected_peer_count() == 0);
+
+    let metrics = NODE_STATS.snapshot();
+
+    assert_eq!(metrics.connections.connected_peers, 0);
+    assert_eq!(metrics.connections.disconnected_peers, 1);
+
+    // Make sure the global metrics state is reset as it will leak.
+    NODE_STATS.clear();
+}


### PR DESCRIPTION
Introduces the first few metrics tests (keeping this PR small as it includes other changes). This PR also fixes the cache hits metric which had been forgotten.

Because of how state is tracked globally in the metrics, this PR introduces some functions to clear the state after each test. In addition, these tests will need to be run on a single-threaded executor, otherwise state will leak. 