### PR TITLE
Sqlite write-ahead-log mode

### DIFF
--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -185,7 +185,7 @@ impl SyncStorage for SqliteStorage {
             self.migrate(current_index)?;
         }
         self.conn.execute(r"PRAGMA OPTIMIZE;", [])?;
-        self.conn.execute(r"PRAGMA journal_mode=WAL;", [])?;
+        self.conn.query_row(r"PRAGMA journal_mode=WAL;", [], |_| Ok(()))?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR sets sqlite to use WAL mode, to allow reads concurrent with writes and generally better performance.

This PR also adds logic to run `PRAGMA optimize;` every 15 minutes. It apparently benefits greatly from running periodically, according to sqlite docs.