### PR TITLE
Blocked syncing

### DIFF
--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -34,13 +34,6 @@ impl ConsensusInner {
             self.commit_block(&hash, &block).await?;
         }
 
-        if let Err(e) = self.try_to_fast_forward().await {
-            match e {
-                ConsensusError::InvalidBlock(e) => debug!("invalid block in initial fast-forward: {}", e),
-                e => warn!("failed to perform initial fast-forward: {:?}", e),
-            }
-        };
-        info!("fastforwarding complete");
         Ok(())
     }
 

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -158,20 +158,14 @@ impl ConsensusInner {
             BlockStatus::Uncommitted => (),
         }
 
-        let start = Instant::now();
-
         // 1. Verify that the block valid
         if !self.verify_block(block).await? {
             return Err(ConsensusError::InvalidBlock(hash.clone()));
         }
-
-        info!("verify took {} ms", start.elapsed().as_millis());
         let start = Instant::now();
 
         // 2. Insert/canonize block
         self.commit_block(hash, block).await?;
-
-        info!("commit took {} ms", start.elapsed().as_millis());
 
         // 3. Remove transactions from the mempool
         for transaction in block.transactions.iter() {

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-
 use super::*;
 use crate::ledger::dummy::DummyLedger;
 use snarkos_metrics as metrics;

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::Instant;
 
 use super::*;
 use crate::ledger::dummy::DummyLedger;

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -162,7 +162,6 @@ impl ConsensusInner {
         if !self.verify_block(block).await? {
             return Err(ConsensusError::InvalidBlock(hash.clone()));
         }
-        let start = Instant::now();
 
         // 2. Insert/canonize block
         self.commit_block(hash, block).await?;

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::time::Instant;
+
 use super::*;
 use crate::ledger::dummy::DummyLedger;
 use snarkos_metrics as metrics;
@@ -156,13 +158,20 @@ impl ConsensusInner {
             BlockStatus::Uncommitted => (),
         }
 
+        let start = Instant::now();
+
         // 1. Verify that the block valid
         if !self.verify_block(block).await? {
             return Err(ConsensusError::InvalidBlock(hash.clone()));
         }
 
+        info!("verify took {} ms", start.elapsed().as_millis());
+        let start = Instant::now();
+
         // 2. Insert/canonize block
         self.commit_block(hash, block).await?;
+
+        info!("commit took {} ms", start.elapsed().as_millis());
 
         // 3. Remove transactions from the mempool
         for transaction in block.transactions.iter() {

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -18,7 +18,16 @@ use std::{convert::TryInto, sync::Arc};
 
 use rand::{thread_rng, Rng};
 use snarkos_metrics::wrapped_mpsc;
-use snarkos_storage::{Address, BlockStatus, Digest, DynStorage, SerialBlock, SerialRecord, SerialTransaction, VMRecord};
+use snarkos_storage::{
+    Address,
+    BlockStatus,
+    Digest,
+    DynStorage,
+    SerialBlock,
+    SerialRecord,
+    SerialTransaction,
+    VMRecord,
+};
 use snarkvm_algorithms::CRH;
 use snarkvm_dpc::{
     testnet1::{
@@ -84,7 +93,6 @@ impl Consensus {
             .agent(receiver)
             .await;
         });
-
 
         if let Err(e) = created.fast_forward().await {
             match e {

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -134,7 +134,13 @@ impl<P: MerkleParameters> Ledger for MerkleLedger<P> {
     }
 
     fn requires_async_task(&self, new_commitments_len: usize, new_serial_numbers_len: usize) -> bool {
-        (self.commitments.len() + new_commitments_len).is_power_of_two()
-            || (self.serial_numbers.len() + new_serial_numbers_len).is_power_of_two()
+        jumps_power_of_two(self.commitments.len(), new_commitments_len) || 
+        jumps_power_of_two(self.serial_numbers.len(), new_serial_numbers_len)
     }
+}
+
+fn jumps_power_of_two(start: usize, adding: usize) -> bool {
+    let prior_commitments_depth = (start as f64).log2() as usize;
+    let new_commitments_depth = ((start + adding) as f64).log2() as usize;
+    prior_commitments_depth != new_commitments_depth
 }

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -134,8 +134,8 @@ impl<P: MerkleParameters> Ledger for MerkleLedger<P> {
     }
 
     fn requires_async_task(&self, new_commitments_len: usize, new_serial_numbers_len: usize) -> bool {
-        jumps_power_of_two(self.commitments.len(), new_commitments_len) || 
-        jumps_power_of_two(self.serial_numbers.len(), new_serial_numbers_len)
+        jumps_power_of_two(self.commitments.len(), new_commitments_len)
+            || jumps_power_of_two(self.serial_numbers.len(), new_serial_numbers_len)
     }
 }
 

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -140,7 +140,7 @@ impl<P: MerkleParameters> Ledger for MerkleLedger<P> {
 }
 
 fn jumps_power_of_two(start: usize, adding: usize) -> bool {
-    let prior_commitments_depth = (start as f64).log2() as usize;
-    let new_commitments_depth = ((start + adding) as f64).log2() as usize;
-    prior_commitments_depth != new_commitments_depth
+    let prior_depth = (start as f64).log2() as usize;
+    let new_depth = ((start + adding) as f64).log2() as usize;
+    prior_depth != new_depth
 }

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -244,6 +244,9 @@ impl Node {
                             if let Err(e) = node_clone.run_sync().await {
                                 error!("failed sync process: {:?}", e);
                             }
+                            if let Err(e) = node_clone.expect_sync().consensus.fast_forward().await {
+                                error!("failed to initiate fast forward for sync: {:?}", e);
+                            };
                             node_clone.finished_syncing_blocks();
                         }
                     }

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -150,7 +150,7 @@ impl Node {
                 if previous_block_hash == canon.hash && self.state() == State::Mining {
                     self.terminator.store(true, Ordering::SeqCst);
                 }
-    
+
                 // This is a non-sync Block, send it to our peers.
                 self.propagate_block(block, height, remote_address);
             }

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -154,10 +154,8 @@ impl Node {
                 // This is a non-sync Block, send it to our peers.
                 self.propagate_block(block, height, remote_address);
             }
-        } else {
-            if let Err(e) = self.expect_sync().consensus.shallow_receive_block(block_struct).await {
-                debug!("failed receiving sync block: {:?}", e);
-            }
+        } else if let Err(e) = self.expect_sync().consensus.shallow_receive_block(block_struct).await {
+            debug!("failed receiving sync block: {:?}", e);
         }
 
         metrics::histogram!(metrics::blocks::INBOUND_PROCESSING_TIME, now.elapsed());

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -160,8 +160,6 @@ impl Node {
             }
         }
 
-        // Verify the block and insert it into the storage.
-
         metrics::histogram!(metrics::blocks::INBOUND_PROCESSING_TIME, now.elapsed());
 
         Ok(())

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -143,17 +143,24 @@ impl Node {
             canon.block_height,
         );
 
-        // Verify the block and insert it into the storage.
-        let block_validity = self.expect_sync().consensus.receive_block(block_struct).await;
+        if is_non_sync {
+            let block_validity = self.expect_sync().consensus.receive_block(block_struct).await;
 
-        if block_validity && is_non_sync {
-            if previous_block_hash == canon.hash && self.state() == State::Mining {
-                self.terminator.store(true, Ordering::SeqCst);
+            if block_validity {
+                if previous_block_hash == canon.hash && self.state() == State::Mining {
+                    self.terminator.store(true, Ordering::SeqCst);
+                }
+    
+                // This is a non-sync Block, send it to our peers.
+                self.propagate_block(block, height, remote_address);
             }
-
-            // This is a non-sync Block, send it to our peers.
-            self.propagate_block(block, height, remote_address);
+        } else {
+            if let Err(e) = self.expect_sync().consensus.shallow_receive_block(block_struct).await {
+                debug!("failed receiving sync block: {:?}", e);
+            }
         }
+
+        // Verify the block and insert it into the storage.
 
         metrics::histogram!(metrics::blocks::INBOUND_PROCESSING_TIME, now.elapsed());
 

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -182,7 +182,8 @@ pub async fn init_sync(config: &Config, storage: DynStorage) -> anyhow::Result<S
         ledger,
         storage.clone(),
         memory_pool,
-    ).await;
+    )
+    .await;
     info!("Loaded Ledger");
 
     if config.storage.scan_for_forks {

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -182,7 +182,7 @@ pub async fn init_sync(config: &Config, storage: DynStorage) -> anyhow::Result<S
         ledger,
         storage.clone(),
         memory_pool,
-    );
+    ).await;
     info!("Loaded Ledger");
 
     if config.storage.scan_for_forks {

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -105,7 +105,7 @@ async fn block_initiator_side() {
 
     // check the blocks have been added to the node's chain
     wait_until!(
-        5,
+        65,
         matches!(
             node.storage.get_block_state(&block_1_header_hash).await.unwrap(),
             BlockStatus::Committed(_)

--- a/testing/src/network/sync.rs
+++ b/testing/src/network/sync.rs
@@ -104,6 +104,7 @@ async fn block_initiator_side() {
     peer.write_message(&block_2).await;
 
     // check the blocks have been added to the node's chain
+    // can take a while since sync runs in 60 second rounds before committing anything.
     wait_until!(
         65,
         matches!(

--- a/testing/src/sync/mod.rs
+++ b/testing/src/sync/mod.rs
@@ -158,7 +158,8 @@ pub async fn create_test_consensus() -> Arc<snarkos_consensus::Consensus> {
         ledger,
         FIXTURE_VK.storage(),
         MemoryPool::new(),
-    ).await;
+    )
+    .await;
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // plenty of time to let consensus setup genesis block
     consensus
 }

--- a/testing/src/sync/mod.rs
+++ b/testing/src/sync/mod.rs
@@ -158,7 +158,7 @@ pub async fn create_test_consensus() -> Arc<snarkos_consensus::Consensus> {
         ledger,
         FIXTURE_VK.storage(),
         MemoryPool::new(),
-    );
+    ).await;
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // plenty of time to let consensus setup genesis block
     consensus
 }


### PR DESCRIPTION
This PR changes sync layer to only insert blocks into storage, not validate or attempt to commit them. After each sync round, a fast-forward is run. This eliminates high memory usage in testing, keep queue depth low for storage relatively, and should avoid putting too much pressure on the system. Lower sync pull rate is expected.