### PR TITLE
Non-blocking block serialization

### DIFF
--- a/network/src/errors/network.rs
+++ b/network/src/errors/network.rs
@@ -41,6 +41,7 @@ pub enum NetworkError {
     PeerIsDisconnected,
     SelfConnectAttempt,
     SenderError(tokio::sync::mpsc::error::SendError<Message>),
+    TaskPanicked(tokio::task::JoinError),
     TooManyConnections,
     OutboundChannelMissing,
     ReceiverFailedToParse,
@@ -134,6 +135,12 @@ impl From<std::io::Error> for NetworkError {
 impl From<tokio::sync::mpsc::error::SendError<Message>> for NetworkError {
     fn from(error: tokio::sync::mpsc::error::SendError<Message>) -> Self {
         NetworkError::SenderError(error)
+    }
+}
+
+impl From<tokio::task::JoinError> for NetworkError {
+    fn from(error: tokio::task::JoinError) -> Self {
+        NetworkError::TaskPanicked(error)
     }
 }
 

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -164,20 +164,24 @@ impl Node {
     pub(crate) async fn received_get_blocks(
         &self,
         remote_address: SocketAddr,
-        header_hashes: Vec<Digest>,
+        mut header_hashes: Vec<Digest>,
         time_received: Option<Instant>,
     ) -> Result<(), NetworkError> {
-        for (i, hash) in header_hashes
-            .into_iter()
-            .take(crate::MAX_BLOCK_SYNC_COUNT as usize)
-            .map(|x| -> Digest { x.0.into() })
-            .enumerate()
-        {
+        header_hashes.truncate(crate::MAX_BLOCK_SYNC_COUNT as usize);
+
+        let mut blocks = Vec::with_capacity(header_hashes.len());
+        for hash in &header_hashes {
+            let block = self.storage.get_block(hash).await?;
+            blocks.push(block);
+        }
+        let blocks: Vec<_> =
+            task::spawn_blocking(move || blocks.into_iter().map(|block| block.serialize()).collect()).await?;
+
+        for (i, (block, hash)) in blocks.into_iter().zip(header_hashes.into_iter()).enumerate() {
             let height = match self.storage.get_block_state(&hash).await? {
                 BlockStatus::Committed(h) => Some(h as u32),
                 _ => None,
             };
-            let block = self.storage.get_block(&hash).await?;
 
             // Only stop the clock on internal RTT for the last block in the response.
             let time_received = if i == crate::MAX_BLOCK_SYNC_COUNT as usize - 1 {
@@ -188,11 +192,7 @@ impl Node {
 
             // Send a `SyncBlock` message to the connected peer.
             self.peer_book
-                .send_to(
-                    remote_address,
-                    Payload::SyncBlock(block.serialize(), height),
-                    time_received,
-                )
+                .send_to(remote_address, Payload::SyncBlock(block, height), time_received)
                 .await;
         }
 


### PR DESCRIPTION
Profiling indicates that block serialization for the purposes of sync provision can block the async executor even for several seconds. The solution is to use a blocking task to serialize all the blocks during that operation.