### PR TITLE
Internal state check for block state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,6 +2888,7 @@ dependencies = [
  "hash_hasher",
  "hex",
  "indexmap",
+ "metrics",
  "num_enum",
  "parking_lot",
  "rand 0.8.4",

--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -67,14 +67,11 @@ impl ConsensusInner {
                     }
                     Err(e) => {
                         match e {
-                            ConsensusError::PreExistingBlock => {
-                                trace!("failed receiving block: {:?}", e);
-                            }
                             ConsensusError::InvalidBlock(e) => {
                                 debug!("failed receiving block: {:?}", e);
                             }
                             e => {
-                                warn!("failed receiving block: {:?}", e);
+                                debug!("failed receiving block: {:?}", e);
                             }
                         }
                         response.send(Box::new(false)).ok();

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -20,7 +20,6 @@ use rand::{thread_rng, Rng};
 use snarkos_metrics::wrapped_mpsc;
 use snarkos_storage::{
     Address,
-    BlockStatus,
     Digest,
     DynStorage,
     SerialBlock,

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -18,15 +18,7 @@ use std::{convert::TryInto, sync::Arc};
 
 use rand::{thread_rng, Rng};
 use snarkos_metrics::wrapped_mpsc;
-use snarkos_storage::{
-    Address,
-    Digest,
-    DynStorage,
-    SerialBlock,
-    SerialRecord,
-    SerialTransaction,
-    VMRecord,
-};
+use snarkos_storage::{Address, Digest, DynStorage, SerialBlock, SerialRecord, SerialTransaction, VMRecord};
 use snarkvm_algorithms::CRH;
 use snarkvm_dpc::{
     testnet1::{

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -135,14 +135,6 @@ impl Consensus {
     }
 
     pub async fn shallow_receive_block(&self, block: SerialBlock) -> Result<()> {
-        let hash = block.header.hash();
-        match self.storage.get_block_state(&hash).await? {
-            BlockStatus::Unknown => (),
-            BlockStatus::Committed(_) | BlockStatus::Uncommitted => {
-                metrics::increment_counter!(snarkos_metrics::blocks::DUPLICATES);
-                return Err(ConsensusError::PreExistingBlock.into());
-            }
-        }
         self.storage.insert_block(&block).await?;
         Ok(())
     }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -29,6 +29,9 @@ version = "0.25"
 optional = true
 features = [ "bundled" ]
 
+[dependencies.metrics]
+version = "0.17"
+
 [dependencies.snarkvm-algorithms]
 version = "=0.7.9"
 

--- a/storage/src/storage/async_adapter.rs
+++ b/storage/src/storage/async_adapter.rs
@@ -17,8 +17,7 @@
 use std::{any::Any, fmt, net::SocketAddr};
 
 use anyhow::*;
-use metrics::wrapped_mpsc;
-use snarkos_metrics::{self as metrics, queues};
+use snarkos_metrics::{queues, wrapped_mpsc};
 use tokio::sync::oneshot;
 use tracing::log::trace;
 


### PR DESCRIPTION
This PR fixes #1197. It also is a candidate fix for similar user reported errors.

Root issue is that storage only guarantees consensus within a specific storage call, not between storage calls. We moved the block state check within insert state to provide a better error message and avoid consistency issues.