### PR TITLE
Recommit blocks

### DIFF
--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -86,11 +86,11 @@ impl ConsensusInner {
                     response.send(Box::new(out)).ok();
                 }
                 ConsensusMessage::CreateTransaction(request) => {
-                    let out = self.create_transaction(*request);
+                    let out = self.create_transaction(*request).await;
                     response.send(Box::new(out)).ok();
                 }
                 ConsensusMessage::CreatePartialTransaction(request) => {
-                    let out = self.create_partial_transaction(request);
+                    let out = self.create_partial_transaction(request).await;
                     response.send(Box::new(out)).ok();
                 }
                 ConsensusMessage::ForceDecommit(hash) => {

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -107,12 +107,12 @@ impl ConsensusInner {
 
                             self.storage.recommit_blockchain(&fork_path.path[0]).await?;
                             let committed_blocks =
-                                self.storage.canon().await?.block_height as u32 - canon_branch_number;
+                                self.storage.canon().await?.block_height - canon_branch_number as usize;
                             if committed_blocks > 0 && self.recommit_taint.is_none() {
                                 self.recommit_taint = Some(canon_branch_number);
                             }
 
-                            for block_hash in &fork_path.path[committed_blocks as usize..] {
+                            for block_hash in &fork_path.path[committed_blocks.min(fork_path.path.len())..] {
                                 if block_hash == hash {
                                     self.verify_and_commit_block(hash, block).await?;
                                 } else {

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -150,7 +150,7 @@ impl ConsensusInner {
     ) -> Result<(), ConsensusError> {
         let now = std::time::Instant::now();
 
-        match self.storage.get_block_state(hash).await? {
+        match self.recommit_block(hash).await? {
             BlockStatus::Committed(_) => return Ok(()),
             BlockStatus::Unknown => return Err(ConsensusError::InvalidBlock(hash.clone())),
             BlockStatus::Uncommitted => (),
@@ -244,17 +244,33 @@ impl ConsensusInner {
         self.verify_transactions(block.transactions.clone()).await
     }
 
-    pub(super) async fn commit_block(&mut self, hash: &Digest, block: &SerialBlock) -> Result<(), ConsensusError> {
+    async fn resolve_recommit_taint(&mut self, commitments: &mut Vec<Digest>, serial_numbers: &mut Vec<Digest>, memos: &mut Vec<Digest>) -> Result<Vec<Digest>, ConsensusError> {
+        let mut ledger_digests = vec![];
+
+        if let Some(taint_source) = self.recommit_taint.take() {
+            commitments.extend(self.storage.get_commitments(taint_source).await?);
+            serial_numbers.extend(self.storage.get_serial_numbers(taint_source).await?);
+            memos.extend(self.storage.get_memos(taint_source).await?);
+            ledger_digests.extend(self.storage.get_ledger_digests(taint_source).await?)
+        }
+        Ok(ledger_digests)
+    }
+
+    pub(crate) async fn push_recommit_taint(&mut self) -> Result<()> {
         let mut commitments = vec![];
         let mut serial_numbers = vec![];
         let mut memos = vec![];
-        for transaction in block.transactions.iter() {
-            commitments.extend_from_slice(&transaction.new_commitments[..]);
-            serial_numbers.extend_from_slice(&transaction.old_serial_numbers[..]);
-            memos.push(transaction.memorandum.clone());
+        let resolved_digests = self.resolve_recommit_taint(&mut commitments, &mut serial_numbers, &mut memos).await?;
+        if resolved_digests.is_empty() {
+            return Ok(());
         }
+        self.ledger.push_interim_digests(&resolved_digests[..])?;
+        self.extend_ledger(commitments, serial_numbers, memos).await?;
+        Ok(())
+    }
 
-        let digest = if self.ledger.requires_async_task(commitments.len(), serial_numbers.len()) {
+    async fn extend_ledger(&mut self, commitments: Vec<Digest>, serial_numbers: Vec<Digest>, memos: Vec<Digest>) -> Result<Digest, ConsensusError> {
+        Ok(if self.ledger.requires_async_task(commitments.len(), serial_numbers.len()) {
             let mut ledger = std::mem::replace(&mut self.ledger, DynLedger(Box::new(DummyLedger)));
             let (digest, ledger) = tokio::task::spawn_blocking(move || {
                 let digest = ledger.extend(&commitments[..], &serial_numbers[..], &memos[..]);
@@ -268,10 +284,47 @@ impl ConsensusInner {
             digest?
         } else {
             self.ledger.extend(&commitments[..], &serial_numbers[..], &memos[..])?
-        };
+        })
+    }
+
+    async fn inner_commit_block(&mut self, block: &SerialBlock) -> Result<Digest, ConsensusError> {
+        let mut commitments = vec![];
+        let mut serial_numbers = vec![];
+        let mut memos = vec![];
+        let resolved_digests = self.resolve_recommit_taint(&mut commitments, &mut serial_numbers, &mut memos).await?;
+        for transaction in block.transactions.iter() {
+            commitments.extend_from_slice(&transaction.new_commitments[..]);
+            serial_numbers.extend_from_slice(&transaction.old_serial_numbers[..]);
+            memos.push(transaction.memorandum.clone());
+        }
+
+        self.ledger.push_interim_digests(&resolved_digests[..])?;
+
+        let digest = self.extend_ledger(commitments, serial_numbers, memos).await?;
+
+        Ok(digest)
+    }
+
+    pub(super) async fn commit_block(&mut self, hash: &Digest, block: &SerialBlock) -> Result<(), ConsensusError> {
+        let digest = self.inner_commit_block(block).await?;
 
         self.storage.commit_block(hash, digest).await?;
         self.cleanse_memory_pool()
+    }
+
+    pub(super) async fn recommit_block(&mut self, hash: &Digest) -> Result<BlockStatus, ConsensusError> {
+        let initial_state = self.storage.get_block_state(hash).await?;
+        if initial_state != BlockStatus::Uncommitted {
+            return Ok(initial_state); 
+        }
+        let out = self.storage.recommit_block(hash).await?;
+        if let BlockStatus::Committed(n) = out {
+            if self.recommit_taint.is_none() {
+                self.recommit_taint = Some(n as u32);
+            }
+        }
+        self.cleanse_memory_pool()?;
+        Ok(out)
     }
 
     pub(super) async fn try_to_fast_forward(&mut self) -> Result<(), ConsensusError> {
@@ -330,7 +383,8 @@ impl ConsensusInner {
                 memos.push(transaction.memorandum.clone());
             }
         }
-
+        self.push_recommit_taint().await?;
+        
         self.ledger
             .rollback(&commitments[..], &serial_numbers[..], &memos[..])?;
         self.cleanse_memory_pool()

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -55,6 +55,7 @@ pub struct ConsensusInner {
     pub ledger: DynLedger,
     pub memory_pool: MemoryPool,
     pub storage: DynStorage,
+    pub recommit_taint: Option<u32>, // height of first recommitted block
 }
 
 impl ConsensusInner {
@@ -71,6 +72,8 @@ impl ConsensusInner {
         {
             return Ok(None);
         }
+
+        //todo: partial ledger fix
 
         for sn in &transaction.old_serial_numbers {
             if self.ledger.contains_serial(sn) || self.memory_pool.serial_numbers.contains(sn) {

--- a/consensus/src/consensus/inner/mod.rs
+++ b/consensus/src/consensus/inner/mod.rs
@@ -73,8 +73,6 @@ impl ConsensusInner {
             return Ok(None);
         }
 
-        //todo: partial ledger fix
-
         for sn in &transaction.old_serial_numbers {
             if self.ledger.contains_serial(sn) || self.memory_pool.serial_numbers.contains(sn) {
                 return Ok(None);

--- a/consensus/src/consensus/mod.rs
+++ b/consensus/src/consensus/mod.rs
@@ -89,6 +89,7 @@ impl Consensus {
                 ledger,
                 storage,
                 memory_pool,
+                recommit_taint: None,
             }
             .agent(receiver)
             .await;

--- a/consensus/src/ledger/dummy.rs
+++ b/consensus/src/ledger/dummy.rs
@@ -27,6 +27,13 @@ impl Ledger for DummyLedger {
         unimplemented!()
     }
 
+    fn push_interim_digests(
+        &mut self,
+        _new_ledger_digests: &[Digest],
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
     fn rollback(&mut self, _commitments: &[Digest], _serial_numbers: &[Digest], _memos: &[Digest]) -> Result<()> {
         unimplemented!()
     }

--- a/consensus/src/ledger/dummy.rs
+++ b/consensus/src/ledger/dummy.rs
@@ -27,10 +27,7 @@ impl Ledger for DummyLedger {
         unimplemented!()
     }
 
-    fn push_interim_digests(
-        &mut self,
-        _new_ledger_digests: &[Digest],
-    ) -> Result<()> {
+    fn push_interim_digests(&mut self, _new_ledger_digests: &[Digest]) -> Result<()> {
         unimplemented!()
     }
 

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -65,6 +65,14 @@ impl<P: MerkleParameters> Ledger for MerkleLedger<P> {
         Ok(new_digest)
     }
 
+    fn push_interim_digests(
+        &mut self,
+        new_ledger_digests: &[Digest],
+    ) -> Result<()> {
+        self.ledger_digests.extend(new_ledger_digests.iter().cloned());
+        Ok(())
+    }
+
     fn rollback(&mut self, commitments: &[Digest], serial_numbers: &[Digest], memos: &[Digest]) -> Result<()> {
         debug!(
             "rolling back merkle ledger: {} commitments, {} serial numbers, {} memos",

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -65,10 +65,7 @@ impl<P: MerkleParameters> Ledger for MerkleLedger<P> {
         Ok(new_digest)
     }
 
-    fn push_interim_digests(
-        &mut self,
-        new_ledger_digests: &[Digest],
-    ) -> Result<()> {
+    fn push_interim_digests(&mut self, new_ledger_digests: &[Digest]) -> Result<()> {
         self.ledger_digests.extend(new_ledger_digests.iter().cloned());
         Ok(())
     }

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -57,10 +57,7 @@ pub trait Ledger: Send + Sync {
     ) -> Result<Digest>;
 
     /// Pushes raw ledger digests into the ledger -- used when committing multiple blocks at a time
-    fn push_interim_digests(
-        &mut self,
-        new_ledger_digests: &[Digest],
-    ) -> Result<()>;
+    fn push_interim_digests(&mut self, new_ledger_digests: &[Digest]) -> Result<()>;
 
     fn rollback(&mut self, commitments: &[Digest], serial_numbers: &[Digest], memos: &[Digest]) -> Result<()>;
 

--- a/consensus/src/ledger/mod.rs
+++ b/consensus/src/ledger/mod.rs
@@ -56,6 +56,12 @@ pub trait Ledger: Send + Sync {
         new_memos: &[Digest],
     ) -> Result<Digest>;
 
+    /// Pushes raw ledger digests into the ledger -- used when committing multiple blocks at a time
+    fn push_interim_digests(
+        &mut self,
+        new_ledger_digests: &[Digest],
+    ) -> Result<()>;
+
     fn rollback(&mut self, commitments: &[Digest], serial_numbers: &[Digest], memos: &[Digest]) -> Result<()>;
 
     fn clear(&mut self);

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -159,10 +159,10 @@ pub async fn init_sync(config: &Config, storage: DynStorage) -> anyhow::Result<S
         Arc::new(Parameters::from(crh))
     };
     info!("Loading Ledger");
-    let ledger_digests = storage.get_ledger_digests().await?;
-    let commitments = storage.get_commitments().await?;
-    let serial_numbers = storage.get_serial_numbers().await?;
-    let memos = storage.get_memos().await?;
+    let ledger_digests = storage.get_ledger_digests(0).await?;
+    let commitments = storage.get_commitments(0).await?;
+    let serial_numbers = storage.get_serial_numbers(0).await?;
+    let memos = storage.get_memos(0).await?;
     info!("Initializing Ledger");
     let ledger = DynLedger(Box::new(MerkleLedger::new(
         ledger_parameters,

--- a/storage/src/storage/key_value/store.rs
+++ b/storage/src/storage/key_value/store.rs
@@ -449,6 +449,10 @@ impl<S: KeyValueStorage + Validator + 'static> SyncStorage for KeyValueStore<S> 
         unimplemented!()
     }
 
+    fn recommit_blockchain(&mut self, _root_hash: &Digest) -> Result<()> {
+        unimplemented!()
+    }
+
     fn commit_block(&mut self, block_hash: &Digest, ledger_digest: &Digest) -> Result<BlockStatus> {
         let canon = self.canon()?;
         let block = self.get_block(block_hash)?;

--- a/storage/src/storage/key_value/store.rs
+++ b/storage/src/storage/key_value/store.rs
@@ -445,6 +445,10 @@ impl<S: KeyValueStorage + Validator + 'static> SyncStorage for KeyValueStore<S> 
         Ok(hashes)
     }
 
+    fn recommit_block(&mut self, _block_hash: &Digest) -> Result<BlockStatus> {
+        unimplemented!()
+    }
+
     fn commit_block(&mut self, block_hash: &Digest, ledger_digest: &Digest) -> Result<BlockStatus> {
         let canon = self.canon()?;
         let block = self.get_block(block_hash)?;
@@ -648,7 +652,10 @@ impl<S: KeyValueStorage + Validator + 'static> SyncStorage for KeyValueStore<S> 
         Ok(())
     }
 
-    fn get_ledger_digests(&mut self) -> Result<Vec<Digest>> {
+    fn get_ledger_digests(&mut self, block_start: u32) -> Result<Vec<Digest>> {
+        if block_start != 0 {
+            unimplemented!();
+        }
         let mut keys = self
             .inner()
             .get_column(KeyValueColumn::DigestIndex)?
@@ -706,15 +713,24 @@ impl<S: KeyValueStorage + Validator + 'static> SyncStorage for KeyValueStore<S> 
         }
     }
 
-    fn get_commitments(&mut self) -> Result<Vec<Digest>> {
+    fn get_commitments(&mut self, block_start: u32) -> Result<Vec<Digest>> {
+        if block_start != 0 {
+            unimplemented!();
+        }
         self.get_digest_keys(KeyValueColumn::Commitment)
     }
 
-    fn get_serial_numbers(&mut self) -> Result<Vec<Digest>> {
+    fn get_serial_numbers(&mut self, block_start: u32) -> Result<Vec<Digest>> {
+        if block_start != 0 {
+            unimplemented!();
+        }
         self.get_digest_keys(KeyValueColumn::SerialNumber)
     }
 
-    fn get_memos(&mut self) -> Result<Vec<Digest>> {
+    fn get_memos(&mut self, block_start: u32) -> Result<Vec<Digest>> {
+        if block_start != 0 {
+            unimplemented!();
+        }
         self.get_digest_keys(KeyValueColumn::Memo)
     }
 

--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -14,11 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-    collections::HashMap,
-    convert::TryInto,
-    net::SocketAddr,
-};
+use std::{collections::HashMap, convert::TryInto, net::SocketAddr};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use rusqlite::{params, OptionalExtension, Row, ToSql};

--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -666,7 +666,6 @@ impl SyncStorage for SqliteStorage {
                 past_leaves.clear();
                 std::mem::swap(&mut past_leaves, &mut pending_leaves);
             }
-            // pending_leaves.entry(parent_hash).and_modify(|inner| inner.push_child(hash)).or_insert_with(|| DigestTree::Leaf(hash));
             let waiting_children = past_leaves.remove(&hash).unwrap_or_default();
             let node = if !waiting_children.is_empty() {
                 let max_dist = waiting_children.iter().map(|x| x.longest_length()).max().unwrap_or(0);

--- a/storage/src/storage/storage.rs
+++ b/storage/src/storage/storage.rs
@@ -118,6 +118,9 @@ pub trait Storage: Send + Sync {
     /// Commits a block into canon.
     async fn commit_block(&self, hash: &Digest, digest: Digest) -> Result<BlockStatus>;
 
+    /// Attempts to recommit a block into canon if it has a ledger digest.
+    async fn recommit_block(&self, hash: &Digest) -> Result<BlockStatus>;
+
     /// Decommits a block and all descendent blocks, returning them in ascending order
     async fn decommit_blocks(&self, hash: &Digest) -> Result<Vec<SerialBlock>>;
 
@@ -175,16 +178,16 @@ pub trait Storage: Send + Sync {
     async fn store_records(&self, records: &[SerialRecord]) -> Result<()>;
 
     /// Gets all known commitments for canon chain in block-number ascending order
-    async fn get_commitments(&self) -> Result<Vec<Digest>>;
+    async fn get_commitments(&self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Gets all known serial numbers for canon chain in block-number ascending order
-    async fn get_serial_numbers(&self) -> Result<Vec<Digest>>;
+    async fn get_serial_numbers(&self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Gets all known memos for canon chain in block-number ascending order
-    async fn get_memos(&self) -> Result<Vec<Digest>>;
+    async fn get_memos(&self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Gets all known ledger digests for canon chain in block-number ascending order
-    async fn get_ledger_digests(&self) -> Result<Vec<Digest>>;
+    async fn get_ledger_digests(&self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Resets stored ledger state. A maintenance function, not intended for general use.
     async fn reset_ledger(

--- a/storage/src/storage/storage.rs
+++ b/storage/src/storage/storage.rs
@@ -118,6 +118,9 @@ pub trait Storage: Send + Sync {
     /// Commits a block into canon.
     async fn commit_block(&self, hash: &Digest, digest: Digest) -> Result<BlockStatus>;
 
+    /// Attempts to recommit a block and its longest descendent chains blocks into canon, until there are no more ledger digests.
+    async fn recommit_blockchain(&self, hash: &Digest) -> Result<()>;
+
     /// Attempts to recommit a block into canon if it has a ledger digest.
     async fn recommit_block(&self, hash: &Digest) -> Result<BlockStatus>;
 

--- a/storage/src/storage/sync.rs
+++ b/storage/src/storage/sync.rs
@@ -120,6 +120,8 @@ pub trait SyncStorage {
     /// Commits a block into canon.
     fn commit_block(&mut self, hash: &Digest, digest: &Digest) -> Result<BlockStatus>;
 
+    fn recommit_blockchain(&mut self, root_hash: &Digest) -> Result<()>;
+
     /// Attempts to recommit a block into canon if it has a ledger digest.
     fn recommit_block(&mut self, hash: &Digest) -> Result<BlockStatus>;
 

--- a/storage/src/storage/sync.rs
+++ b/storage/src/storage/sync.rs
@@ -120,6 +120,9 @@ pub trait SyncStorage {
     /// Commits a block into canon.
     fn commit_block(&mut self, hash: &Digest, digest: &Digest) -> Result<BlockStatus>;
 
+    /// Attempts to recommit a block into canon if it has a ledger digest.
+    fn recommit_block(&mut self, hash: &Digest) -> Result<BlockStatus>;
+
     /// Decommits a block and all descendent blocks, returning them in ascending order
     fn decommit_blocks(&mut self, hash: &Digest) -> Result<Vec<SerialBlock>>;
 
@@ -363,16 +366,16 @@ pub trait SyncStorage {
     fn store_records(&mut self, records: &[SerialRecord]) -> Result<()>;
 
     /// Gets all known commitments for canon chain in block-number ascending order
-    fn get_commitments(&mut self) -> Result<Vec<Digest>>;
+    fn get_commitments(&mut self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Gets all known serial numbers for canon chain in block-number ascending order
-    fn get_serial_numbers(&mut self) -> Result<Vec<Digest>>;
+    fn get_serial_numbers(&mut self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Gets all known memos for canon chain in block-number ascending order
-    fn get_memos(&mut self) -> Result<Vec<Digest>>;
+    fn get_memos(&mut self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Gets all known ledger digests for canon chain in block-number ascending order
-    fn get_ledger_digests(&mut self) -> Result<Vec<Digest>>;
+    fn get_ledger_digests(&mut self, block_start: u32) -> Result<Vec<Digest>>;
 
     /// Resets stored ledger state. A maintenance function, not intended for general use.
     fn reset_ledger(


### PR DESCRIPTION
This PR:
* Introduces the notion of recommitting, which is asserting that if a block was valid in the past, it's always going to be valid if part of canon. We can avoid revalidating, and if there is a chain of recommittable blocks, then we can skip intermediate hashing by using past-calculated ledger digests.
* Introduces an optimization for recommitting large chains of blocks.

The motivation behind this PR is to resolve an observed phenomenon when syncing at ~400k blocks, where there are 2 valid chains seen based on block 43k competing. This PR should help eliminate that fork by allowing peers to not be stuck recommitting for hours each time they sync a few blocks from one of these forks, and it overtakes the other.

Has been running locally for almost a week, been keeping at canon tip much more reliably.