### PR TITLE
Refresh peers even when client node is at capacity

### DIFF
--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -84,7 +84,7 @@ impl Node {
                 0,
             )
         } else {
-            const REFRESH_RATE: u32 = 1;
+            const REFRESH_COUNT: u32 = 1;
 
             // Other nodes disconnect if above the max peer count...
             let mut number_to_disconnect = active_peer_count.saturating_sub(max_peers);
@@ -92,9 +92,9 @@ impl Node {
             let mut number_to_connect = min_peers.saturating_sub(active_peer_count);
 
             // If within normal operating values, refresh a few peers to avoid clustering.
-            if number_to_disconnect == 0 && number_to_connect == 0 && REFRESH_RATE < min_peers {
-                number_to_disconnect = REFRESH_RATE;
-                number_to_connect = REFRESH_RATE;
+            if number_to_disconnect == 0 && number_to_connect == 0 && REFRESH_COUNT < min_peers {
+                number_to_disconnect = REFRESH_COUNT;
+                number_to_connect = REFRESH_COUNT;
             }
 
             (number_to_disconnect, number_to_connect)

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -84,7 +84,7 @@ impl Node {
                 0,
             )
         } else {
-            const REFRESH_RATE: u32 = 2;
+            const REFRESH_RATE: u32 = 1;
 
             // Other nodes disconnect if above the max peer count...
             let mut number_to_disconnect = active_peer_count.saturating_sub(max_peers);
@@ -92,7 +92,7 @@ impl Node {
             let mut number_to_connect = min_peers.saturating_sub(active_peer_count);
 
             // If within normal operating values, refresh a few peers to avoid clustering.
-            if number_to_disconnect == 0 && number_to_connect == 0 {
+            if number_to_disconnect == 0 && number_to_connect == 0 && REFRESH_RATE < min_peers {
                 number_to_disconnect = REFRESH_RATE;
                 number_to_connect = REFRESH_RATE;
             }

--- a/network/src/peers/peers.rs
+++ b/network/src/peers/peers.rs
@@ -84,11 +84,12 @@ impl Node {
                 0,
             )
         } else {
+            const REFRESH_COUNT: u32 = 2;
             (
                 // Other nodes disconnect if above the max peer count...
-                active_peer_count.saturating_sub(max_peers),
+                active_peer_count.saturating_sub(max_peers) + REFRESH_COUNT,
                 // ...and connect if below the min peer count.
-                min_peers.saturating_sub(active_peer_count),
+                min_peers.saturating_sub(active_peer_count) + REFRESH_COUNT,
             )
         };
 


### PR DESCRIPTION
A node can often get stuck in a cluster of nodes that will block its sync progress. Refreshing a few peers when the node is at capacity aims to alleviate this.

More testing is needed, hence the draft. We may also prefer reconnecting to beacons periodically to refresh the list.
