### PR TITLE
Fix fork point check

### DIFF
--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -56,10 +56,7 @@ impl ConsensusInner {
                 return Ok(());
             }
             _ => {
-                let fork_path = self
-                    .storage
-                    .get_fork_path(hash, crate::OLDEST_FORK_THRESHOLD)
-                    .await?;
+                let fork_path = self.storage.get_fork_path(hash, crate::OLDEST_FORK_THRESHOLD).await?;
                 match fork_path {
                     ForkDescription::Path(fork_path) => {
                         let new_block_number = fork_path.base_index + fork_path.path.len() as u32;

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -58,7 +58,7 @@ impl ConsensusInner {
             _ => {
                 let fork_path = self
                     .storage
-                    .get_fork_path(&block.header.previous_block_hash, crate::OLDEST_FORK_THRESHOLD)
+                    .get_fork_path(hash, crate::OLDEST_FORK_THRESHOLD)
                     .await?;
                 match fork_path {
                     ForkDescription::Path(fork_path) => {

--- a/consensus/tests/consensus_sidechain.rs
+++ b/consensus/tests/consensus_sidechain.rs
@@ -149,7 +149,7 @@ mod consensus_sidechain {
 
         new_block_height = consensus.storage.canon().await.unwrap().block_height;
 
-        assert_eq!(old_block_height, new_block_height);
+        assert_eq!(old_block_height + 1, new_block_height);
 
         // 4. Receive valid canon block 1 and accept the previous irrelevant block 2
 
@@ -159,7 +159,7 @@ mod consensus_sidechain {
 
         new_block_height = consensus.storage.canon().await.unwrap().block_height;
 
-        assert_eq!(old_block_height + 1, new_block_height);
+        assert_eq!(old_block_height, new_block_height);
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR changes the point for which to scan for forks for reversion to the latest received block in a prospective fork, as opposed to the parent hash.

This prevents us from reverting and ending up on the same chain that we are on in fresh-fork scenarios off old canon blocks.

This also indicates some nodes that should be syncing are mining -- which is likely due to the race condition present in node status.