### PR TITLE
Fix some dangling metrics

### DIFF
--- a/metrics/src/wrapped_mpsc.rs
+++ b/metrics/src/wrapped_mpsc.rs
@@ -137,7 +137,9 @@ pub fn channel<T: Send>(metrics_tracker: &'static str, buffer: usize) -> (Sender
 
 impl<T: Send> Drop for Receiver<T> {
     fn drop(&mut self) {
-        let count = self.tracker.swap(0, Ordering::SeqCst) as f64;
-        metrics::decrement_gauge!(self.metrics_tracker, count);
+        let count = self.tracker.swap(0, Ordering::SeqCst);
+        if count != 0 {
+            metrics::decrement_gauge!(self.metrics_tracker, count as f64);
+        }
     }
 }


### PR DESCRIPTION
The `wrapped_mpsc` helper objects, `Sender` and `Receiver`, automatically modify the related queue metrics, and they share a related atomic. `Sender::send` eagerly bumps the metric in order to show that the queue utilization grows, even if it's at its capacity (which is a desirable feature).

However, it's possible for this operation to happen after the `Receiver` side had already been dropped, which means we can have dangling values that never get decremented.

This PR ensures that the `Sender`-side of the `wrapped_mpsc` notices if it had incremented a metric after the `Receiver` had already been dropped, and decrements it.

Fixes https://github.com/AleoHQ/snarkOS/issues/1210.