### PR TITLE
Add an automatic port forwarding feature, discover node's external address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
+dependencies = [
+ "http",
+ "log",
+ "url 2.2.2",
+ "wildmatch",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1223,19 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "igd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4e7ee8b51e541486d7040883fe1f00e2a9954bcc24fd155b7e4f03ed4b93dd"
+dependencies = [
+ "attohttpc",
+ "log",
+ "rand 0.8.4",
+ "url 2.2.2",
+ "xmltree",
 ]
 
 [[package]]
@@ -2675,6 +2700,7 @@ dependencies = [
  "colored",
  "dirs",
  "hex",
+ "igd",
  "num_cpus",
  "parking_lot",
  "rand 0.8.4",
@@ -2789,6 +2815,7 @@ dependencies = [
  "futures 0.3.17",
  "hash_hasher",
  "hex",
+ "igd",
  "indexmap",
  "itertools",
  "log",
@@ -3741,6 +3768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3795,6 +3828,21 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,9 @@ version = "4.0"
 [dependencies.hex]
 version = "0.4.1"
 
+[dependencies.igd]
+version = "0.12"
+
 [dependencies.num_cpus]
 version = "1"
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -94,6 +94,9 @@ version = "1.3.16"
 [dependencies.defer]
 version = "0.1"
 
+[dependencies.igd]
+version = "0.12"
+
 [dependencies.async-trait]
 version = "0.1"
 

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -59,6 +59,8 @@ pub struct Config {
     peer_sync_interval: Duration,
     /// Details of the node's network gateway, if it's UPnP-enabled.
     pub gateway: Option<Gateway>,
+    /// Indicates whether the node should attempt to automatically forward its listening port.
+    pub auto_port_forwarding: bool,
 }
 
 impl Config {
@@ -74,6 +76,7 @@ impl Config {
         sync_provider_addresses: Vec<String>,
         peer_sync_interval: Duration,
         gateway: Option<Gateway>,
+        auto_port_forwarding: bool,
     ) -> Result<Self, NetworkError> {
         // Convert the given seeded nodes into socket addresses.
         let beacons: Vec<SocketAddr> = beacon_addresses
@@ -96,6 +99,7 @@ impl Config {
             sync_providers: ArcSwap::new(Arc::new(sync_providers)),
             peer_sync_interval,
             gateway,
+            auto_port_forwarding,
         })
     }
 

--- a/network/src/config.rs
+++ b/network/src/config.rs
@@ -17,6 +17,7 @@
 use crate::NetworkError;
 
 use arc_swap::ArcSwap;
+use igd::Gateway;
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
@@ -56,6 +57,8 @@ pub struct Config {
     sync_providers: ArcSwap<Vec<SocketAddr>>,
     /// The interval between each peer sync.
     peer_sync_interval: Duration,
+    /// Details of the node's network gateway, if it's UPnP-enabled.
+    pub gateway: Option<Gateway>,
 }
 
 impl Config {
@@ -70,6 +73,7 @@ impl Config {
         beacon_addresses: Vec<String>,
         sync_provider_addresses: Vec<String>,
         peer_sync_interval: Duration,
+        gateway: Option<Gateway>,
     ) -> Result<Self, NetworkError> {
         // Convert the given seeded nodes into socket addresses.
         let beacons: Vec<SocketAddr> = beacon_addresses
@@ -91,6 +95,7 @@ impl Config {
             beacons: ArcSwap::new(Arc::new(beacons)),
             sync_providers: ArcSwap::new(Arc::new(sync_providers)),
             peer_sync_interval,
+            gateway,
         })
     }
 

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -26,17 +26,19 @@ use crate::{errors::NetworkError, Node};
 impl Node {
     /// This method handles new inbound connection requests.
     pub async fn listen(&self) -> Result<(), NetworkError> {
-        if let Some(ref gateway) = self.config.gateway {
-            if let SocketAddr::V4(internal_addr) = self.config.desired_address {
-                let external_port = internal_addr.port();
+        if self.config.auto_port_forwarding {
+            if let Some(ref gateway) = self.config.gateway {
+                if let SocketAddr::V4(internal_addr) = self.config.desired_address {
+                    let external_port = internal_addr.port();
 
-                match gateway.add_port(PortMappingProtocol::TCP, external_port, internal_addr, 0, "snarkOS") {
-                    Err(AddPortError::PortInUse) => warn!("Port {} is already forwarded", external_port),
-                    Err(e) => error!(
-                        "Can't map external port {} to address {}: {}",
-                        external_port, internal_addr, e
-                    ),
-                    Ok(_) => info!("Enabled port forwarding via UPnP"),
+                    match gateway.add_port(PortMappingProtocol::TCP, external_port, internal_addr, 0, "snarkOS") {
+                        Err(AddPortError::PortInUse) => warn!("Port {} is already forwarded", external_port),
+                        Err(e) => error!(
+                            "Can't map external port {} to address {}: {}",
+                            external_port, internal_addr, e
+                        ),
+                        Ok(_) => info!("Enabled port forwarding via UPnP"),
+                    }
                 }
             }
         }

--- a/network/src/inbound/inbound.rs
+++ b/network/src/inbound/inbound.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
+use igd::{AddPortError, PortMappingProtocol};
 use tokio::{net::TcpListener, task};
 
 use snarkos_metrics::{self as metrics, connections};
@@ -25,6 +26,21 @@ use crate::{errors::NetworkError, Node};
 impl Node {
     /// This method handles new inbound connection requests.
     pub async fn listen(&self) -> Result<(), NetworkError> {
+        if let Some(ref gateway) = self.config.gateway {
+            if let SocketAddr::V4(internal_addr) = self.config.desired_address {
+                let external_port = internal_addr.port();
+
+                match gateway.add_port(PortMappingProtocol::TCP, external_port, internal_addr, 0, "snarkOS") {
+                    Err(AddPortError::PortInUse) => warn!("Port {} is already forwarded", external_port),
+                    Err(e) => error!(
+                        "Can't map external port {} to address {}: {}",
+                        external_port, internal_addr, e
+                    ),
+                    Ok(_) => info!("Enabled port forwarding via UPnP"),
+                }
+            }
+        }
+
         let listener = TcpListener::bind(&self.config.desired_address).await?;
 
         // Update the node's listening address.

--- a/snarkos/config.rs
+++ b/snarkos/config.rs
@@ -82,6 +82,7 @@ pub struct Node {
     pub db: String,
     pub ip: String,
     pub port: u16,
+    pub auto_port_forwarding: bool,
     pub verbose: u8,
 }
 
@@ -133,6 +134,7 @@ impl Default for Config {
                 db: "snarkos_testnet1".into(),
                 ip: "0.0.0.0".into(),
                 port: 4131,
+                auto_port_forwarding: false,
                 verbose: 2,
             },
             miner: Miner {
@@ -238,6 +240,7 @@ impl Config {
     fn parse(&mut self, arguments: &ArgMatches, options: &[&str]) {
         options.iter().for_each(|option| match *option {
             // Flags
+            "auto-port-forwarding" => self.auto_port_forwarding(arguments.is_present(option)),
             "is-miner" => self.is_miner(arguments.is_present(option)),
             "no-jsonrpc" => self.no_jsonrpc(arguments.is_present(option)),
             "trim-storage" => self.trim_storage(arguments.is_present(option)),
@@ -310,6 +313,10 @@ impl Config {
         if let Some(path) = argument {
             self.storage.import = Some(path.to_owned().into());
         }
+    }
+
+    fn auto_port_forwarding(&mut self, argument: bool) {
+        self.node.auto_port_forwarding = argument;
     }
 
     fn is_miner(&mut self, argument: bool) {
@@ -440,6 +447,7 @@ impl CLI for ConfigCli {
 
     const ABOUT: AboutType = "Run an Aleo node (include -h for more options)";
     const FLAGS: &'static [FlagType] = &[
+        flag::AUTO_PORT_FORWARDING,
         flag::NO_JSONRPC,
         flag::IS_MINER,
         flag::TRIM_STORAGE,
@@ -471,6 +479,7 @@ impl CLI for ConfigCli {
     fn parse(arguments: &ArgMatches) -> Result<Self::Config, CliError> {
         let mut config = Config::read_config()?;
         config.parse(arguments, &[
+            "auto-port-forwarding",
             "network",
             "no-jsonrpc",
             "export-canon-blocks",

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -238,7 +238,7 @@ pub async fn init_node(config: &Config, storage: DynStorage) -> anyhow::Result<N
 
     let gateway = igd::search_gateway(gateway_search_opts)
         .map_err(|e| {
-            error!(
+            warn!(
                 "Can't obtain the node's gateway details: {}; perhaps it's not UPnP-enabled?",
                 e
             )

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -256,6 +256,7 @@ pub async fn init_node(config: &Config, storage: DynStorage) -> anyhow::Result<N
         // Set sync intervals for peers.
         Duration::from_secs(config.p2p.peer_sync_interval.into()),
         gateway,
+        config.node.auto_port_forwarding,
     )?;
 
     let node = Node::new(node_config, storage).await?;

--- a/snarkos/parameters/flag.rs
+++ b/snarkos/parameters/flag.rs
@@ -25,3 +25,6 @@ pub const LIST: &str = "[list] -l --list 'List all available releases of snarkOS
 pub const TRIM_STORAGE: &str = "[trim-storage] --trim-storage 'Remove non-canon items from the node's storage'";
 
 pub const VALIDATE_STORAGE: &str = "[validate-storage] --validate-storage 'Check the integrity of the node's storage and attempt to fix encountered issues'";
+
+pub const AUTO_PORT_FORWARDING: &str =
+    "[auto-port-forwarding] --auto-port-forwarding 'Automatically forward the node's listening port using UPnP'";

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -176,6 +176,7 @@ pub fn test_config(setup: TestSetup) -> Config {
         setup.beacons,
         setup.sync_providers,
         Duration::from_secs(setup.peer_sync_interval),
+        None,
     )
     .unwrap()
 }

--- a/testing/src/network/mod.rs
+++ b/testing/src/network/mod.rs
@@ -177,6 +177,7 @@ pub fn test_config(setup: TestSetup) -> Config {
         setup.sync_providers,
         Duration::from_secs(setup.peer_sync_interval),
         None,
+        false,
     )
     .unwrap()
 }


### PR DESCRIPTION
This PR takes advantage of the gateway's UPnP (if available) in order to enable:
- automatic port forwarding (via `--auto-port-forwarding`; disabled by default)
- the discovery of the node's external IP address

Closes https://github.com/AleoHQ/snarkOS/issues/423.