### PR TITLE
Use hash_hasher in storage

### DIFF
--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{collections::HashMap, convert::TryInto, net::SocketAddr};
+use std::{convert::TryInto, net::SocketAddr};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
+use hash_hasher::HashedMap;
 use rusqlite::{params, OptionalExtension, Row, ToSql};
 use snarkvm_dpc::{AleoAmount, MerkleRootHash, Network, PedersenMerkleRootHash, ProofOfSuccinctWork};
 use tracing::*;
@@ -662,8 +663,8 @@ impl SyncStorage for SqliteStorage {
             .query_map([block_hash], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
             .collect::<rusqlite::Result<Vec<(Digest, Digest, u32)>>>()?;
 
-        let mut past_leaves = HashMap::<Digest, Vec<DigestTree>>::new();
-        let mut pending_leaves = HashMap::<Digest, Vec<DigestTree>>::new();
+        let mut past_leaves = HashedMap::<Digest, Vec<DigestTree>>::default();
+        let mut pending_leaves = HashedMap::<Digest, Vec<DigestTree>>::default();
         let mut current_tree_depth = None::<u32>;
         for (hash, parent_hash, tree_depth) in out.into_iter().rev() {
             if current_tree_depth.is_none() {

--- a/storage/src/storage/sync.rs
+++ b/storage/src/storage/sync.rs
@@ -14,12 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    net::SocketAddr,
-};
+use std::{collections::VecDeque, net::SocketAddr};
 
 use anyhow::*;
+use hash_hasher::{HashedMap, HashedSet};
 use tracing::{debug, trace};
 
 #[cfg(feature = "test")]
@@ -160,7 +158,7 @@ pub trait SyncStorage {
 
     /// Gets a tree structure representing all the descendents of [`block_hash`]
     fn get_block_digest_tree(&mut self, block_hash: &Digest) -> Result<DigestTree> {
-        let mut nodes: HashMap<Digest, Vec<Digest>> = HashMap::new();
+        let mut nodes: HashedMap<Digest, Vec<Digest>> = Default::default();
         let mut stack = vec![block_hash.clone()];
         while let Some(hash) = stack.pop() {
             let children = self.get_block_children(&hash)?;
@@ -172,9 +170,9 @@ pub trait SyncStorage {
         if nodes.is_empty() {
             return Ok(DigestTree::Leaf(block_hash.clone()));
         }
-        let mut node_entries: HashSet<Digest> = nodes.keys().cloned().collect();
+        let mut node_entries: HashedSet<Digest> = nodes.keys().cloned().collect();
 
-        let mut trees: HashMap<Digest, DigestTree> = HashMap::new();
+        let mut trees: HashedMap<Digest, DigestTree> = Default::default();
         while !nodes.is_empty() {
             nodes.retain(|hash, children| {
                 let mut new_children = vec![];


### PR DESCRIPTION
This PR uses `hash_hasher` in `snarkos_storage` for maps that already have hashes as keys in order to increase their `insert`/`collect` performance.