### PR TITLE
Rayon limitation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rand 0.8.4",
+ "rayon",
  "self_update",
  "serde",
  "snarkos-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ version = "1.3.16"
 [dependencies.anyhow]
 version = "1.0"
 
+[dependencies.rayon]
+version = "1.5"
+
 [dependencies.clap]
 version = "2.33.3"
 

--- a/bin/snarkos.rs
+++ b/bin/snarkos.rs
@@ -90,8 +90,14 @@ fn main() -> Result<(), NodeError> {
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(8 * 1024 * 1024)
-        .max_blocking_threads(std::cmp::max(num_cpus::get().saturating_sub(2), 1)) // don't use 100% of the cores
+        .max_blocking_threads(num_cpus::get().saturating_sub(2).max(1)) // don't use 100% of the cores
         .build()?;
+
+    // don't use 100% of the cores for mining
+    rayon::ThreadPoolBuilder::new()
+        .num_threads((num_cpus::get() / 2).max(1))
+        .build_global()
+        .unwrap();
 
     runtime.block_on(start_server(config))?;
 


### PR DESCRIPTION
This PR limits rayon thread usage to 50% of available cpus. This is expected to help alleviate miner CPU exhaustion causing sync and responsiveness issues.