### PR TITLE
Fix sync & trim

### DIFF
--- a/consensus/src/consensus/inner/agent.rs
+++ b/consensus/src/consensus/inner/agent.rs
@@ -98,6 +98,10 @@ impl ConsensusInner {
                     let out = self.try_to_fast_forward().await;
                     response.send(Box::new(out)).ok();
                 }
+                ConsensusMessage::Revalidate() => {
+                    let out = self.revalidate().await;
+                    response.send(Box::new(out)).ok();
+                }
                 #[cfg(feature = "test")]
                 ConsensusMessage::Reset() => {
                     response

--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -17,7 +17,7 @@
 use super::*;
 use crate::ledger::dummy::DummyLedger;
 use snarkos_metrics as metrics;
-use snarkos_storage::DigestTree;
+use snarkos_storage::{DigestTree, SerialBlockHeader};
 use snarkvm_dpc::AleoAmount;
 use tokio::task;
 
@@ -153,8 +153,16 @@ impl ConsensusInner {
             BlockStatus::Uncommitted => (),
         }
 
+        let canon = self.storage.canon().await?;
+        let canon_header = self.storage.get_block_header(&canon.hash).await?;
+
         // 1. Verify that the block valid
-        if !self.verify_block(block).await? {
+        if !self
+            .verify_block(block, canon_header, canon.block_height as u32)
+            .await?
+        {
+            debug!("failed to validate block '{}', deleting from storage...", hash);
+            self.storage.delete_block(hash).await?;
             return Err(ConsensusError::InvalidBlock(hash.clone()));
         }
 
@@ -173,10 +181,14 @@ impl ConsensusInner {
 
     /// Check if the block is valid.
     /// Verify transactions and transaction fees.
-    pub(super) async fn verify_block(&mut self, block: &SerialBlock) -> Result<bool, ConsensusError> {
-        let canon = self.storage.canon().await?;
+    pub(super) async fn verify_block(
+        &mut self,
+        block: &SerialBlock,
+        parent_header: SerialBlockHeader,
+        parent_height: u32,
+    ) -> Result<bool, ConsensusError> {
         // Verify the block header
-        if block.header.previous_block_hash != canon.hash {
+        if block.header.previous_block_hash != parent_header.hash() {
             return Err(anyhow!("attempted to commit a block that wasn't a direct child of tip of canon").into());
         }
 
@@ -204,7 +216,7 @@ impl ConsensusInner {
 
         // Check that there is only 1 coinbase transaction
         // Check that the block value balances are correct
-        let expected_block_reward = crate::get_block_reward(canon.block_height as u32).0;
+        let expected_block_reward = crate::get_block_reward(parent_height).0;
         if total_value_balance.0 + expected_block_reward != 0 {
             trace!("total_value_balance: {:?}", total_value_balance);
             trace!("expected_block_reward: {:?}", expected_block_reward);
@@ -213,7 +225,6 @@ impl ConsensusInner {
         }
 
         let block_header = block.header.clone();
-        let parent_header = self.storage.get_block_header(&canon.hash).await?;
         let transaction_ids: Vec<[u8; 32]> = block.transactions.iter().map(|x| x.id).collect();
         let consensus = self.public.clone();
 
@@ -338,6 +349,27 @@ impl ConsensusInner {
         }
         self.cleanse_memory_pool()?;
         Ok(out)
+    }
+
+    pub(super) async fn revalidate(&mut self) -> Result<(), ConsensusError> {
+        let blocks = self.storage.get_canon_blocks(None).await?;
+        let mut last_header = None;
+        for (i, block) in blocks.into_iter().enumerate() {
+            if i == 0 {
+                last_header = Some(block.header);
+                continue;
+            }
+            if !self
+                .verify_block(&block, last_header.take().unwrap(), i as u32 - 1)
+                .await?
+            {
+                info!("found invalid block in canon chain at height {}, decomitting...", i);
+                self.decommit_ledger_block(&block.header.hash()).await?;
+                break;
+            }
+            last_header = Some(block.header);
+        }
+        Ok(())
     }
 
     pub(super) async fn try_to_fast_forward(&mut self) -> Result<(), ConsensusError> {

--- a/consensus/src/consensus/message.rs
+++ b/consensus/src/consensus/message.rs
@@ -46,6 +46,7 @@ pub(super) enum ConsensusMessage {
     CreatePartialTransaction(CreatePartialTransactionRequest),
     ForceDecommit(Vec<u8>),
     FastForward(),
+    Revalidate(),
     #[cfg(feature = "test")]
     Reset(),
 }

--- a/snarkos/init.rs
+++ b/snarkos/init.rs
@@ -182,6 +182,7 @@ pub async fn init_sync(config: &Config, storage: DynStorage) -> anyhow::Result<S
         ledger,
         storage.clone(),
         memory_pool,
+        config.storage.validate,
     )
     .await;
     info!("Loaded Ledger");

--- a/storage/src/storage/sqlite/sync.rs
+++ b/storage/src/storage/sqlite/sync.rs
@@ -328,6 +328,29 @@ impl SyncStorage for SqliteStorage {
         ",
             [hash],
         )?;
+
+        // clean messy sqlite fk constraints
+        self.conn.execute(
+            r"
+            DELETE FROM transaction_blocks
+            WHERE id IN (
+                SELECT tb.id FROM transaction_blocks tb
+                LEFT JOIN blocks b ON b.id = tb.block_id WHERE b.id IS NULL
+            );
+        ",
+            [],
+        )?;
+
+        self.conn.execute(
+            r"
+            DELETE FROM transactions
+            WHERE id IN (
+                SELECT t.id FROM transactions t
+                LEFT JOIN transaction_blocks tb ON tb.transaction_id = t.id WHERE tb.id IS NULL
+            );
+        ",
+            [],
+        )?;
         Ok(())
     }
 
@@ -1306,24 +1329,32 @@ impl SyncStorage for SqliteStorage {
     }
 
     fn trim(&mut self) -> Result<()> {
-        // Remove transactions belonging to non-canon blocks.
+        // Remove non-canon blocks.
+        self.conn
+            .execute(r"DELETE FROM blocks WHERE blocks.canon_height IS NULL", [])?;
+
+        // Remove hanging transactions
         self.conn.execute(
             r"
-            DELETE FROM transactions
+            DELETE FROM transaction_blocks
             WHERE id IN (
-                SELECT transactions.id
-                FROM transactions
-                LEFT JOIN transaction_blocks on transaction_blocks.transaction_id = transactions.id
-                LEFT JOIN blocks on blocks.id = transaction_blocks.block_id
-                WHERE transaction_blocks.transaction_id IS NULL OR blocks.canon_height IS NULL
-            )
+                SELECT tb.id FROM transaction_blocks tb
+                LEFT JOIN blocks b ON b.id = tb.block_id WHERE b.id IS NULL
+            );
         ",
             [],
         )?;
 
-        // Remove non-canon blocks.
-        self.conn
-            .execute(r"DELETE FROM blocks WHERE blocks.canon_height IS NULL", [])?;
+        self.conn.execute(
+            r"
+            DELETE FROM transactions
+            WHERE id IN (
+                SELECT t.id FROM transactions t
+                LEFT JOIN transaction_blocks tb ON tb.transaction_id = t.id WHERE tb.id IS NULL
+            );
+        ",
+            [],
+        )?;
 
         // Compact the storage file.
         self.conn.execute("VACUUM", [])?;

--- a/testing/src/sync/mod.rs
+++ b/testing/src/sync/mod.rs
@@ -158,6 +158,7 @@ pub async fn create_test_consensus() -> Arc<snarkos_consensus::Consensus> {
         ledger,
         FIXTURE_VK.storage(),
         MemoryPool::new(),
+        false,
     )
     .await;
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // plenty of time to let consensus setup genesis block


### PR DESCRIPTION
This PR:
* Fixes trim behavior to not remove transactions from canon blocks if linked to a non-canon block
* Adds logic to decommit blocks on validate calls when there are invalid blocks in canon (to fix databases from above issue)
* Fixes infinite sync cycle requiring reboots or network timeouts to die.
* Fixes consensus not removing invalid blocks causing sync stalls.