### PR TITLE
Calculate the internal mempool RTT even if no response is sent

### DIFF
--- a/network/src/sync/memory_pool.rs
+++ b/network/src/sync/memory_pool.rs
@@ -103,6 +103,10 @@ impl Node {
             self.peer_book
                 .send_to(remote_address, Payload::MemoryPool(transactions), time_received)
                 .await;
+        } else if let Some(time_received) = time_received {
+            // Even if there is no memory pool to respond with, calculate the related metric.
+            // If at some point an empty Payload::MemoryPool can be sent, this branch should be removed.
+            metrics::histogram!(snarkos_metrics::internal_rtt::GETMEMORYPOOL, time_received.elapsed());
         }
         Ok(())
     }


### PR DESCRIPTION
As anticipated, the fix is just an extra update in the event no response is sent - we still want to know how long it takes to obtain the (empty) result.