### PR TITLE
Calculate the getblocks internal RTT even if theres no reply, adjust its measurement

### DIFF
--- a/network/src/peers/peer/outbound_handler.rs
+++ b/network/src/peers/peer/outbound_handler.rs
@@ -115,7 +115,6 @@ impl Peer {
                 if let (Some(time_received), Some(histogram)) = (time_received, match &message {
                     Payload::Peers(_) => Some(metrics::internal_rtt::GETPEERS),
                     Payload::Sync(_) => Some(metrics::internal_rtt::GETSYNC),
-                    Payload::SyncBlock(_, _) => Some(metrics::internal_rtt::GETBLOCKS),
                     Payload::MemoryPool(_) => Some(metrics::internal_rtt::GETMEMORYPOOL),
                     _ => None,
                 }) {

--- a/network/src/sync/blocks/interface.rs
+++ b/network/src/sync/blocks/interface.rs
@@ -208,6 +208,10 @@ impl Node {
                 .await;
         }
 
+        if let Some(time_received) = time_received {
+            metrics::histogram!(snarkos_metrics::internal_rtt::GETBLOCKS, time_received.elapsed());
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Similarly to https://github.com/AleoHQ/snarkOS/pull/1238 - albeit more rarely - the internal RTT for the `getblocks` request can become inaccurate if the node is still syncing and thus doesn't have too many blocks to offer to its peers, and this PR adjusts the calculation of the metric in those situations. As a drive-by, the node no longer spawns a blocking task if there are no blocks to serialize for the purposes of the replies.

In addition, since many messages can be sent in response to this requests, a more appropriate place to put the calculation of the associated metric is after the sending loop is over, as opposed to per each message sent, as it happens right now.