### PR TITLE
Remove the duplicate syncblocks metric

### DIFF
--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -212,14 +212,6 @@
         },
         {
           "exemplar": true,
-          "expr": "snarkos_blocks_duplicates_sync_total",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "duplicate SyncBlocks",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
           "expr": "snarkos_misc_rpc_requests_total",
           "hide": false,
           "interval": "",

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -74,7 +74,6 @@ pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
     pub const MINED: &str = "snarkos_blocks_mined_total";
     pub const DUPLICATES: &str = "snarkos_blocks_duplicates_total";
-    pub const DUPLICATES_SYNC: &str = "snarkos_blocks_duplicates_sync_total";
     pub const ORPHANS: &str = "snarkos_blocks_orphan_total";
     pub const INBOUND_PROCESSING_TIME: &str = "snarkos_blocks_inbound_processing_time";
     pub const COMMIT_TIME: &str = "snarkos_blocks_commit_time";

--- a/metrics/src/snapshots.rs
+++ b/metrics/src/snapshots.rs
@@ -149,8 +149,6 @@ pub struct NodeBlockStats {
     pub commit_time: f64,
     /// The number of duplicate blocks received.
     pub duplicates: u64,
-    /// The number of duplicate sync blocks received.
-    pub duplicates_sync: u64,
     /// The number of orphan blocks received.
     pub orphans: u64,
 }

--- a/metrics/src/stats.rs
+++ b/metrics/src/stats.rs
@@ -408,8 +408,6 @@ pub struct BlockStats {
     commit_time: CircularHistogram,
     /// The number of duplicate blocks received.
     duplicates: Counter,
-    /// The number of duplicate sync blocks received.
-    duplicates_sync: Counter,
     /// The number of orphan blocks received.
     orphans: Counter,
 }
@@ -422,7 +420,6 @@ impl BlockStats {
             inbound_processing_time: CircularHistogram::new(),
             commit_time: CircularHistogram::new(),
             duplicates: Counter::new(),
-            duplicates_sync: Counter::new(),
             orphans: Counter::new(),
         }
     }
@@ -434,7 +431,6 @@ impl BlockStats {
             inbound_processing_time: self.inbound_processing_time.average(),
             commit_time: self.commit_time.average(),
             duplicates: self.duplicates.read(),
-            duplicates_sync: self.duplicates_sync.read(),
             orphans: self.orphans.read(),
         }
     }
@@ -446,7 +442,6 @@ impl BlockStats {
         self.inbound_processing_time.clear();
         self.commit_time.clear();
         self.duplicates.clear();
-        self.duplicates_sync.clear();
         self.orphans.clear();
     }
 }
@@ -549,7 +544,6 @@ impl Recorder for Stats {
             // blocks
             blocks::MINED => &self.blocks.mined,
             blocks::DUPLICATES => &self.blocks.duplicates,
-            blocks::DUPLICATES_SYNC => &self.blocks.duplicates_sync,
             blocks::ORPHANS => &self.blocks.orphans,
             _ => {
                 return;

--- a/rpc/documentation/public_endpoints/getnodestats.md
+++ b/rpc/documentation/public_endpoints/getnodestats.md
@@ -13,7 +13,6 @@ None
 | `blocks.inbound_processing_time` | f64  | The average processing time of an inbound block in seconds                   |
 | `blocks.commit_time`             | f64  | The block verification and commit time in seconds                            |
 | `blocks.duplicates`              | u64  | The number of duplicate blocks received                                      |
-| `blocks.duplicates_sync`         | u64  | The number of duplicate sync blocks received                                 |
 | `connections.all_accepted`       | u64  | The number of connection requests the node has received                      |
 | `connections.all_initiated`      | u64  | The number of connection requests the node has made                          |
 | `connections.all_rejected`       | u64  | The number of connection requests the node has rejected                      |


### PR DESCRIPTION
Removes the duplicate syncblocks metric as it is unused and doesn't provide any added value currently. Re-propagated duplicates are the prime reason for the cache existing in the first place, syncblocks are requested by hash. 

Closes #1240. 
