### PR TITLE
Misc clippy lints

### DIFF
--- a/consensus/src/consensus/inner/transaction.rs
+++ b/consensus/src/consensus/inner/transaction.rs
@@ -114,7 +114,7 @@ impl ConsensusInner {
             request
                 .old_records
                 .iter()
-                .map(|x| <DPCRecord<Components> as VMRecord>::deserialize(x))
+                .map(<DPCRecord<Components> as VMRecord>::deserialize)
                 .collect::<Result<Vec<_>, _>>()?,
             request
                 .new_records

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -56,18 +56,24 @@ impl MemoryPool {
         match self.transactions.remove(transaction_id) {
             Some(entry) => {
                 for commitment in &entry.transaction.new_commitments {
-                    if !self.commitments.remove(commitment) {
-                        panic!("missing commitment from memory pool during removal");
-                    }
+                    assert!(
+                        self.commitments.remove(commitment),
+                        "missing commitment from memory pool during removal"
+                    );
                 }
+
                 for serial in &entry.transaction.old_serial_numbers {
-                    if !self.serial_numbers.remove(serial) {
-                        panic!("missing serial from memory pool during removal");
-                    }
+                    assert!(
+                        self.serial_numbers.remove(serial),
+                        "missing serial from memory pool during removal"
+                    );
                 }
-                if !self.memos.remove(&entry.transaction.memorandum) {
-                    panic!("missing memo from memory pool during removal");
-                }
+
+                assert!(
+                    self.memos.remove(&entry.transaction.memorandum),
+                    "missing memo from memory pool during removal"
+                );
+
                 Ok(Some(entry.transaction))
             }
             None => Ok(None),

--- a/network/src/node.rs
+++ b/network/src/node.rs
@@ -153,9 +153,8 @@ impl Node {
     }
 
     pub fn set_sync(&mut self, sync: Sync) {
-        if self.sync.set(Arc::new(sync)).is_err() {
-            panic!("sync was set more than once!");
-        }
+        // Panic if the sync was set more than once.
+        assert!(self.sync.set(Arc::new(sync)).is_ok(), "sync was set more than once!");
     }
 
     /// Returns a reference to the sync objects.

--- a/rpc/src/transaction_kernel_builder.rs
+++ b/rpc/src/transaction_kernel_builder.rs
@@ -370,6 +370,6 @@ impl FromStr for TransactionKernel {
 
 impl fmt::Display for TransactionKernel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.transaction_kernel.to_string())
+        write!(f, "{}", self.transaction_kernel)
     }
 }

--- a/storage/src/storage/async_adapter.rs
+++ b/storage/src/storage/async_adapter.rs
@@ -43,7 +43,7 @@ use crate::{
 };
 
 enum Message {
-    InsertBlock(SerialBlock),
+    InsertBlock(Box<SerialBlock>),
     DeleteBlock(Digest),
     GetBlockHash(u32),
     GetBlockHeader(Digest),
@@ -268,7 +268,7 @@ impl AsyncStorage {
 #[async_trait::async_trait]
 impl Storage for AsyncStorage {
     async fn insert_block(&self, block: &SerialBlock) -> Result<()> {
-        self.send(Message::InsertBlock(block.clone())).await
+        self.send(Message::InsertBlock(Box::new(block.clone()))).await
     }
 
     async fn delete_block(&self, hash: &Digest) -> Result<()> {

--- a/storage/src/storage/rocks.rs
+++ b/storage/src/storage/rocks.rs
@@ -158,7 +158,7 @@ impl RocksDb {
         let mut cf_names: Vec<String> = Vec::with_capacity(cfs.len());
 
         for column in 0..num_cfs {
-            let column_name = format!("col{}", column.to_string());
+            let column_name = format!("col{}", column);
 
             let mut cf_opts = Options::default();
             cf_opts.set_max_write_buffer_number(16);

--- a/storage/src/trim.rs
+++ b/storage/src/trim.rs
@@ -19,14 +19,6 @@ use crate::DynStorage;
 use anyhow::*;
 use tracing::*;
 
-#[derive(Debug, Default)]
-struct StorageTrimSummary {
-    all_ops: usize,
-    obsolete_blocks: usize,
-    obsolete_txs: usize,
-    updated_parents: usize,
-}
-
 /// Removes obsolete objects from the database; can be used for cleanup purposes, but it can also provide
 /// some insight into the features of the chain, e.g. the number of blocks and transactions that were
 /// ultimately not accepted into the canonical chain.

--- a/storage/src/validator.rs
+++ b/storage/src/validator.rs
@@ -220,11 +220,10 @@ impl<T: KeyValueStorage + Send + 'static> Validator for T {
     /// the validation process should also attempt to fix the issues it encounters. The validator temporarily takes
     /// ownership of the storage, and later returns it in a tuple, together with a vector of errors it has detected
     async fn validate(mut self, limit: Option<u32>, fix_mode: FixMode) -> (Vec<ValidatorError>, Self) {
-        if limit.is_some() && [FixMode::SuperfluousTestnet1TxComponents, FixMode::Everything].contains(&fix_mode) {
-            panic!(
-                "The validator can perform the specified fixes only if there is no limit on the number of blocks to process"
-            );
-        }
+        assert!(
+            !(limit.is_some() && [FixMode::SuperfluousTestnet1TxComponents, FixMode::Everything].contains(&fix_mode)),
+            "The validator can perform the specified fixes only if there is no limit on the number of blocks to process"
+        );
 
         info!("Validating the storage...");
 


### PR DESCRIPTION
Mostly straigthforward clippy lints. Of particular note, is opting to `Box` the large storage message enum variant, as it is reasonable to assume the smaller variants make up a significant proportion of the instances. 
