### PR TITLE
Speed up indexed maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "chrono",
  "criterion",
  "futures 0.3.17",
+ "hash_hasher",
  "hex",
  "indexmap",
  "lazy_static",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -66,6 +66,9 @@ version = "0.4"
 default-features = false
 features = [ "serde", "clock" ]
 
+[dependencies.hash_hasher]
+version = "2"
+
 [dependencies.hex]
 version = "0.4.2"
 

--- a/consensus/src/ledger/indexed_digests.rs
+++ b/consensus/src/ledger/indexed_digests.rs
@@ -15,12 +15,13 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use anyhow::*;
+use hash_hasher::HashBuildHasher;
 use indexmap::IndexSet;
 use snarkos_storage::Digest;
 
 #[derive(Clone)]
 pub struct IndexedDigests {
-    indexed_digests: IndexSet<Digest>,
+    indexed_digests: IndexSet<Digest, HashBuildHasher>,
 }
 
 impl IndexedDigests {

--- a/consensus/src/ledger/merkle.rs
+++ b/consensus/src/ledger/merkle.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use crate::{IndexedDigests, Ledger};
 use anyhow::*;
+use hash_hasher::HashBuildHasher;
 use indexmap::IndexSet;
 use snarkos_storage::Digest;
 use snarkvm_algorithms::MerkleParameters;
@@ -25,7 +26,7 @@ use snarkvm_algorithms::MerkleParameters;
 use super::indexed_merkle_tree::IndexedMerkleTree;
 
 pub struct MerkleLedger<P: MerkleParameters + 'static> {
-    ledger_digests: IndexSet<Digest>,
+    ledger_digests: IndexSet<Digest, HashBuildHasher>,
     commitments: IndexedMerkleTree<P>,
     serial_numbers: IndexedMerkleTree<P>,
     memos: IndexedDigests,

--- a/consensus/src/memory_pool.rs
+++ b/consensus/src/memory_pool.rs
@@ -19,6 +19,7 @@
 //! `MemoryPool` keeps a vector of transactions seen by the miner.
 
 use crate::error::ConsensusError;
+use hash_hasher::HashBuildHasher;
 use indexmap::{IndexMap, IndexSet};
 use snarkos_storage::{Digest, SerialTransaction};
 use snarkvm_dpc::BlockHeader;
@@ -35,10 +36,10 @@ pub(crate) struct MempoolEntry {
 #[derive(Debug, Default)]
 pub struct MemoryPool {
     /// The mapping of all unconfirmed transaction IDs to their corresponding transaction data.
-    pub(crate) transactions: IndexMap<Digest, MempoolEntry>,
-    pub(crate) commitments: IndexSet<Digest>,
-    pub(crate) serial_numbers: IndexSet<Digest>,
-    pub(crate) memos: IndexSet<Digest>,
+    pub(crate) transactions: IndexMap<Digest, MempoolEntry, HashBuildHasher>,
+    pub(crate) commitments: IndexSet<Digest, HashBuildHasher>,
+    pub(crate) serial_numbers: IndexSet<Digest, HashBuildHasher>,
+    pub(crate) memos: IndexSet<Digest, HashBuildHasher>,
 }
 
 const BLOCK_HEADER_SIZE: usize = BlockHeader::size();


### PR DESCRIPTION
The node does a lot of work handling its Merkle trees; we can speed those operation up by reducing the amount of hashing needed when using already-hashed digests.

In addition, the same can be done to the memory pool.