### PR TITLE
Fix a stack overflow when an invalid block is encountered

### DIFF
--- a/consensus/src/consensus/inner/commit.rs
+++ b/consensus/src/consensus/inner/commit.rs
@@ -27,14 +27,7 @@ impl ConsensusInner {
         self.storage.insert_block(block).await?;
 
         let hash = block.header.hash();
-        match self.try_commit_block(&hash, block).await {
-            Err(ConsensusError::InvalidBlock(hash)) => {
-                self.storage.delete_block(&hash).await?;
-                return Err(ConsensusError::InvalidBlock(hash));
-            }
-            Ok(_) => {}
-            err => return err,
-        }
+        self.try_commit_block(&hash, block).await?;
 
         self.try_to_fast_forward().await?;
 


### PR DESCRIPTION
A call to `delete_block` is present in `verify_and_commit_block` (which IMO is the superior callsite), so we can remove it from `receive_block`. This change allowed me to continue syncing past the point where a stack overflow would occur otherwise (while still encountering the invalid block).

Appears to fix https://github.com/AleoHQ/snarkOS/issues/1251, will run my node for a bit longer just to be safe.