### PR TITLE
snarkos update

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo +nightly clippy && cargo +nightly fmt --all -- --check"
+#pre-commit = "cargo +nightly clippy && cargo +nightly fmt --all -- --check"
 
 [logging]
 verbose = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +91,12 @@ name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
@@ -165,6 +180,12 @@ checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -268,10 +289,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -443,10 +495,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "funty"
@@ -586,6 +678,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "h2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +773,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -676,6 +788,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +822,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +841,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -716,6 +870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -823,6 +986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +1005,12 @@ checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -857,6 +1032,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -921,6 +1114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+
+[[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +1136,20 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -993,6 +1206,21 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1070,6 +1298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1176,6 +1413,8 @@ version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1204,6 +1443,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,7 +1499,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -1251,10 +1525,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "self_update"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c"
+dependencies = [
+ "hyper",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "semver 0.11.0",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1282,6 +1614,18 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1378,6 +1722,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rand_chacha",
+ "self_update",
  "serde",
  "serde_json",
  "snarkos-ledger",
@@ -1722,6 +2067,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +2127,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +2167,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1941,6 +2321,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +2358,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vcpkg"
@@ -1993,6 +2406,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2502,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,9 @@ version = "0.3.1"
 [dev-dependencies.tempfile]
 version = "3.2"
 
+[dependencies.self_update]
+version = "0.27"
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -54,4 +54,8 @@ OPTIONS:
         --username <rpc-username>    Specify the username for the RPC server [default: root]
         --password <rpc-password>    Specify the password for the RPC server [default: pass]
         --verbosity <verbosity>      Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 3]
+
+SUBCOMMANDS:
+    help      Prints this message or the help of the given subcommand(s)
+    update    Updates snarkOS to the latest version
 ```

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -19,3 +19,6 @@ pub use circular_map::*;
 
 pub(crate) mod tasks;
 pub(crate) use tasks::*;
+
+pub mod updater;
+pub use updater::*;

--- a/src/helpers/updater.rs
+++ b/src/helpers/updater.rs
@@ -1,0 +1,104 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use colored::Colorize;
+use self_update::{backends::github, version::bump_is_greater, Status};
+
+pub struct Updater;
+
+// TODO Add logic for users to easily select release versions.
+impl Updater {
+    const SNARKOS_BIN_NAME: &'static str = "snarkos";
+    const SNARKOS_REPO_NAME: &'static str = "snarkOS";
+    const SNARKOS_REPO_OWNER: &'static str = "AleoHQ";
+
+    /// Show all available releases for `snarkos`.
+    pub fn show_available_releases() -> Result<String, UpdaterError> {
+        let releases = github::ReleaseList::configure()
+            .repo_owner(Self::SNARKOS_REPO_OWNER)
+            .repo_name(Self::SNARKOS_REPO_NAME)
+            .build()?
+            .fetch()?;
+
+        let mut output = "List of available versions\n".to_string();
+        for release in releases {
+            output += &format!("  * {}\n", release.version);
+        }
+        Ok(output)
+    }
+
+    /// Update `aleo` to the latest release.
+    pub fn update_to_latest_release(show_output: bool) -> Result<Status, UpdaterError> {
+        let status = github::Update::configure()
+            .repo_owner(Self::SNARKOS_REPO_OWNER)
+            .repo_name(Self::SNARKOS_REPO_NAME)
+            .bin_name(Self::SNARKOS_BIN_NAME)
+            .current_version(env!("CARGO_PKG_VERSION"))
+            .show_download_progress(show_output)
+            .no_confirm(true)
+            .show_output(show_output)
+            .build()?
+            .update()?;
+
+        Ok(status)
+    }
+
+    /// Check if there is an available update for `aleo` and return the newest release.
+    pub fn update_available() -> Result<String, UpdaterError> {
+        let updater = github::Update::configure()
+            .repo_owner(Self::SNARKOS_REPO_OWNER)
+            .repo_name(Self::SNARKOS_REPO_NAME)
+            .bin_name(Self::SNARKOS_BIN_NAME)
+            .current_version(env!("CARGO_PKG_VERSION"))
+            .build()?;
+
+        let current_version = updater.current_version();
+        let latest_release = updater.get_latest_release()?;
+
+        if bump_is_greater(&current_version, &latest_release.version)? {
+            Ok(latest_release.version)
+        } else {
+            Err(UpdaterError::OldReleaseVersion(current_version, latest_release.version))
+        }
+    }
+
+    /// Display the CLI message.
+    pub fn print_cli() -> String {
+        if let Ok(latest_version) = Self::update_available() {
+            let mut output = "🟢 A new version is available! Run".bold().green().to_string();
+            output += &" `aleo update` ".bold().white();
+            output += &format!("to update to v{}.", latest_version).bold().green();
+            output
+        } else {
+            format!("")
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum UpdaterError {
+    #[error("{}: {}", _0, _1)]
+    Crate(&'static str, String),
+
+    #[error("The current version {} is more recent than the release version {}", _0, _1)]
+    OldReleaseVersion(String, String),
+}
+
+impl From<self_update::errors::Error> for UpdaterError {
+    fn from(error: self_update::errors::Error) -> Self {
+        UpdaterError::Crate("self_update", error.to_string())
+    }
+}

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -430,19 +430,15 @@ fn result_to_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Client;
-    use crate::ledger::Ledger;
+    use crate::{ledger::Ledger, Client};
 
     use snarkos_ledger::{
         storage::{rocksdb::RocksDB, Storage},
         LedgerState,
     };
     use snarkvm::{
-        dpc::testnet2::Testnet2,
+        dpc::{testnet2::Testnet2, AccountScheme, AleoAmount, RecordCiphertext, Transaction, Transactions, Transition},
         prelude::{Account, Block, BlockHeader},
-    };
-    use snarkvm::{
-        dpc::{AccountScheme, AleoAmount, RecordCiphertext, Transaction, Transactions, Transition},
         utilities::ToBytes,
     };
 
@@ -526,7 +522,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block.
         let actual: Block<Testnet2> = process_response(response).await;
@@ -551,7 +549,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block height.
         let actual: u32 = process_response(response).await;
@@ -576,7 +576,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block hash.
         let actual: <Testnet2 as Network>::BlockHash = process_response(response).await;
@@ -601,7 +603,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block header.
         let actual: BlockHeader<Testnet2> = process_response(response).await;
@@ -626,7 +630,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into transactions.
         let actual: Transactions<Testnet2> = process_response(response).await;
@@ -652,7 +658,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a ledger root.
         let actual: <Testnet2 as Network>::LedgerRoot = process_response(response).await;
@@ -679,7 +687,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block.
         let actual: Block<Testnet2> = process_response(response).await;
@@ -742,7 +752,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into blocks.
         let actual: Vec<Block<Testnet2>> = process_response(response).await;
@@ -772,7 +784,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block height.
         let actual: u32 = process_response(response).await;
@@ -800,7 +814,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block hash.
         let actual: <Testnet2 as Network>::BlockHash = process_response(response).await;
@@ -863,7 +879,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into block hashes.
         let actual: Vec<<Testnet2 as Network>::BlockHash> = process_response(response).await;
@@ -893,7 +911,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a block header.
         let actual: BlockHeader<Testnet2> = process_response(response).await;
@@ -921,7 +941,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into transactions.
         let actual: Transactions<Testnet2> = process_response(response).await;
@@ -949,7 +971,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a ciphertext.
         let actual: RecordCiphertext<Testnet2> = process_response(response).await;
@@ -1027,7 +1051,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a ledger proof string.
         let actual: String = process_response(response).await;
@@ -1065,7 +1091,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a transaction and transaction metadata.
         let actual: GetTransactionResponse = process_response(response).await;
@@ -1101,7 +1129,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a transition.
         let actual: Transition<Testnet2> = process_response(response).await;
@@ -1147,7 +1177,9 @@ mod tests {
         ));
 
         // Send the request to the rpc.
-        let response = handle_rpc(caller(), rpc, request).await.expect("Test rpc failed to process request");
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test rpc failed to process request");
 
         // Process the response into a ciphertext.
         let actual: <Testnet2 as Network>::TransactionID = process_response(response).await;


### PR DESCRIPTION
```bash
snarkos-update 2.0.0
Updates snarkOS to the latest version

USAGE:
    snarkos update [FLAGS]

FLAGS:
    -h, --help       Prints help information
    -l, --list       Lists all available versions of snarkOS
    -q, --quiet      Suppress outputs to terminal
    -V, --version    Prints version information
```
