### PR TITLE
Track rolled back blocks

### DIFF
--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -537,6 +537,8 @@ impl<N: Network> LedgerState<N> {
         // Construct the new block transactions.
         let transactions = Transactions::from(&[&[coinbase_transaction], transactions].concat())?;
 
+        debug!("Mining block {}", block_height);
+
         // Mine the next block.
         match Block::mine(
             previous_block_hash,
@@ -548,7 +550,10 @@ impl<N: Network> LedgerState<N> {
             terminator,
             rng,
         ) {
-            Ok(block) => Ok(block),
+            Ok(block) => {
+                debug!("Mined block {}", block_height);
+                Ok(block)
+            }
             Err(error) => Err(anyhow!("Unable to mine the next block: {}", error)),
         }
     }

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -537,7 +537,7 @@ impl<N: Network> LedgerState<N> {
         // Construct the new block transactions.
         let transactions = Transactions::from(&[&[coinbase_transaction], transactions].concat())?;
 
-        debug!("Mining block {}", block_height);
+        trace!("Mining block {}", block_height);
 
         // Mine the next block.
         match Block::mine(
@@ -550,10 +550,7 @@ impl<N: Network> LedgerState<N> {
             terminator,
             rng,
         ) {
-            Ok(block) => {
-                debug!("Mined block {}", block_height);
-                Ok(block)
-            }
+            Ok(block) => Ok(block),
             Err(error) => Err(anyhow!("Unable to mine the next block: {}", error)),
         }
     }

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -707,7 +707,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                             self.unconfirmed_blocks.remove(&block_hash);
                         }
 
-                        // Add the block hash to block_requests if the request exists.
+                        // Add the block hash to block_requests if the requests exists.
                         if let Some(requests) = self.block_requests.get_mut(&peer_ip) {
                             requests.insert((removed_block.height(), Some(block_hash)));
                         }

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -709,7 +709,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
 
                         // Add the block hash to block_requests if the request exists.
                         if let Some(requests) = self.block_requests.get_mut(&peer_ip) {
-                            requests.remove(&(removed_block.height(), None));
                             requests.insert((removed_block.height(), Some(block_hash)));
                         }
                     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds the block hash of rolled back blocks to the `block_requests` to prevent the `update_ledger` from re-canonizing blocks that were already rolled back.
