### PR TITLE
Testnet2 clippy lints

### DIFF
--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -985,8 +985,7 @@ mod tests {
                 .first()
                 .unwrap()
                 .ciphertexts()
-                .find(|expected| **expected == actual)
-                .is_some()
+                .any(|expected| *expected == actual)
         );
     }
 
@@ -1015,7 +1014,7 @@ mod tests {
 
         // Get the record commitment.
         let decrypted_records = block_1.transactions().first().unwrap().to_decrypted_records(account.view_key());
-        assert!(decrypted_records.len() > 0);
+        assert!(!decrypted_records.is_empty());
         let record_commitment = decrypted_records[0].commitment();
 
         // Get the ledger proof.
@@ -1143,9 +1142,8 @@ mod tests {
                 .first()
                 .unwrap()
                 .transitions()
-                .into_iter()
-                .find(|expected| **expected == actual)
-                .is_some()
+                .iter()
+                .any(|expected| *expected == actual)
         );
     }
 


### PR DESCRIPTION
Fixes the most recent clippy lints. This doesn't fix any of the _unused_ fields or functions in case these are still needed. 