### PR TITLE
Update `remove_last_blocks` to `return_to_block_height`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,6 @@ name = "snarkvm"
 version = "0.7.5"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e7266f9#e7266f993378bcf5b08111edd3b580cd63c218da"
 dependencies = [
- "snarkvm-algorithms",
  "snarkvm-dpc",
  "snarkvm-utilities",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["ledger"]
 
 [dependencies]
 snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "e7266f9" }
-#snarkvm = { path = "../snarkVM", features = ["parameters"] }
+#snarkvm = { path = "../snarkVM" }
 
 bytes = "1.0.0"
 futures = { version = "0.3.0", features = ["thread-pool"]}
@@ -144,6 +144,7 @@ debug-assertions = false
 opt-level = 3
 lto = "thin"
 incremental = true
+debug-assertions = false
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,4 +151,4 @@ opt-level = 3
 lto = "thin"
 incremental = true
 debug = true
-debug-assertions = false
+debug-assertions = true

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -17,7 +17,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "e7266f9", features = ["algorithms"] }
+snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "e7266f9" }
 #snarkvm = { path = "../../snarkVM" }
 
 [dependencies.anyhow]

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -672,29 +672,31 @@ impl<N: Network> LedgerState<N> {
         Ok(())
     }
 
-    /// Removes the latest `num_blocks` from storage, returning the removed blocks on success.
-    pub fn remove_last_blocks(&mut self, num_blocks: u32) -> Result<Vec<Block<N>>> {
+    /// Updates the ledger state back to the given block height, returning the removed blocks on success.
+    pub fn return_to_block_height(&mut self, block_height: u32) -> Result<Vec<Block<N>>> {
         // If the storage is in read-only mode, this method cannot be called.
         if self.is_read_only() {
             return Err(anyhow!("Ledger is in read-only mode"));
         }
 
+        let latest_block_height = self.latest_block_height();
+
         // Ensure the number of blocks to remove is within a permitted range.
-        if num_blocks == 0 || num_blocks > N::ALEO_MAXIMUM_FORK_DEPTH {
-            return Err(anyhow!("Attempted to remove {} blocks, which is invalid", num_blocks));
+        if block_height >= latest_block_height
+            || self.get_block_hash(block_height).is_err()
+            || latest_block_height.saturating_sub(block_height) > N::ALEO_MAXIMUM_FORK_DEPTH
+        {
+            return Err(anyhow!("Attempted to return to block height {}, which is invalid", block_height));
         }
 
         // Initialize a list of the removed blocks.
-        let mut blocks = Vec::with_capacity(num_blocks as usize);
+        let mut blocks = Vec::with_capacity(latest_block_height.saturating_sub(block_height) as usize);
 
         {
             // Acquire the write lock on the latest block.
             let mut latest_block = self.latest_block.write();
 
-            // Initialize the block to remove.
-            let mut remaining_blocks = num_blocks;
-
-            while latest_block.height() > 0 && remaining_blocks > 0 {
+            while latest_block.height() > block_height {
                 // Update the internal state of the ledger, except for the ledger tree.
                 self.blocks.remove_block(latest_block.height())?;
                 self.ledger_roots.remove(&latest_block.previous_ledger_root())?;
@@ -706,9 +708,6 @@ impl<N: Network> LedgerState<N> {
                     true => N::genesis_block().clone(),
                     false => self.get_block(latest_block.height() - 1)?,
                 };
-
-                // Decrement the remaining blocks by 1.
-                remaining_blocks -= 1;
             }
         }
 

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -170,6 +170,8 @@ impl<N: Network> LedgerState<N> {
             let mut ledger = ledger.clone();
             thread::spawn(move || {
                 let last_seen_block_height = ledger.read_only.1.clone();
+                ledger.read_only.1.store(latest_block_height, Ordering::SeqCst);
+
                 loop {
                     // Refresh the ledger storage state.
                     if ledger.ledger_roots.refresh() {

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -674,26 +674,24 @@ impl<N: Network> LedgerState<N> {
         Ok(())
     }
 
-    /// Updates the ledger state back to the given block height, returning the removed blocks on success.
-    pub fn return_to_block_height(&mut self, block_height: u32) -> Result<Vec<Block<N>>> {
+    /// Reverts the ledger state back to the given block height, returning the removed blocks on success.
+    pub fn revert_to_block_height(&mut self, block_height: u32) -> Result<Vec<Block<N>>> {
         // If the storage is in read-only mode, this method cannot be called.
         if self.is_read_only() {
             return Err(anyhow!("Ledger is in read-only mode"));
         }
 
+        // Determine the number of blocks to remove.
         let latest_block_height = self.latest_block_height();
+        let number_of_blocks = latest_block_height.saturating_sub(block_height);
 
-        // Ensure the number of blocks to remove is within a permitted range.
-        if block_height >= latest_block_height
-            || self.get_block_hash(block_height).is_err()
-            || latest_block_height.saturating_sub(block_height) > N::ALEO_MAXIMUM_FORK_DEPTH
-        {
+        // Ensure the reverted block height is within a permitted range and well-formed.
+        if block_height >= latest_block_height || number_of_blocks > N::ALEO_MAXIMUM_FORK_DEPTH || self.get_block(block_height).is_err() {
             return Err(anyhow!("Attempted to return to block height {}, which is invalid", block_height));
         }
 
         // Initialize a list of the removed blocks.
-        let mut blocks = Vec::with_capacity(latest_block_height.saturating_sub(block_height) as usize);
-
+        let mut blocks = Vec::with_capacity(number_of_blocks as usize);
         {
             // Acquire the write lock on the latest block.
             let mut latest_block = self.latest_block.write();
@@ -708,7 +706,7 @@ impl<N: Network> LedgerState<N> {
 
                 *latest_block = match latest_block.height() == 0 {
                     true => N::genesis_block().clone(),
-                    false => self.get_block(latest_block.height() - 1)?,
+                    false => self.get_block(latest_block.height().saturating_sub(1))?,
                 };
             }
         }

--- a/ledger/src/state/tests.rs
+++ b/ledger/src/state/tests.rs
@@ -124,7 +124,7 @@ fn test_remove_last_block() {
 
     // Remove the last block.
     let blocks = ledger
-        .return_to_block_height(ledger.latest_block_height() - 1)
+        .revert_to_block_height(ledger.latest_block_height() - 1)
         .expect("Failed to remove the last block");
     assert_eq!(vec![block], blocks);
 
@@ -173,7 +173,7 @@ fn test_remove_last_2_blocks() {
 
     // Remove the last block.
     let blocks = ledger
-        .return_to_block_height(ledger.latest_block_height() - 2)
+        .revert_to_block_height(ledger.latest_block_height() - 2)
         .expect("Failed to remove the last two blocks");
     assert_eq!(vec![block_1, block_2], blocks);
 

--- a/ledger/src/state/tests.rs
+++ b/ledger/src/state/tests.rs
@@ -124,7 +124,7 @@ fn test_remove_last_block() {
 
     // Remove the last block.
     let blocks = ledger
-        .test_return_to_block_height(ledger.latest_block_height() - 1)
+        .return_to_block_height(ledger.latest_block_height() - 1)
         .expect("Failed to remove the last block");
     assert_eq!(vec![block], blocks);
 
@@ -173,7 +173,7 @@ fn test_remove_last_2_blocks() {
 
     // Remove the last block.
     let blocks = ledger
-        .test_return_to_block_height(ledger.latest_block_height() - 2)
+        .return_to_block_height(ledger.latest_block_height() - 2)
         .expect("Failed to remove the last two blocks");
     assert_eq!(vec![block_1, block_2], blocks);
 

--- a/ledger/src/state/tests.rs
+++ b/ledger/src/state/tests.rs
@@ -123,7 +123,9 @@ fn test_remove_last_block() {
     assert_eq!(1, ledger.latest_block_height());
 
     // Remove the last block.
-    let blocks = ledger.remove_last_blocks(1).expect("Failed to remove the last block");
+    let blocks = ledger
+        .test_return_to_block_height(ledger.latest_block_height() - 1)
+        .expect("Failed to remove the last block");
     assert_eq!(vec![block], blocks);
 
     // Retrieve the genesis block.
@@ -170,7 +172,9 @@ fn test_remove_last_2_blocks() {
     assert_eq!(2, ledger.latest_block_height());
 
     // Remove the last block.
-    let blocks = ledger.remove_last_blocks(2).expect("Failed to remove the last block");
+    let blocks = ledger
+        .test_return_to_block_height(ledger.latest_block_height() - 2)
+        .expect("Failed to remove the last two blocks");
     assert_eq!(vec![block_1, block_2], blocks);
 
     // Retrieve the genesis block.

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -209,7 +209,7 @@ impl<N: Network, E: Environment> Server<N, E> {
                     Err(error) => error!("Failed to accept a connection: {}", error),
                 }
                 // Add a small delay to prevent overloading the network from handshakes.
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(150)).await;
             }
         }));
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the usage of `remove_last_blocks` to `return_to_block_height`. This means every rollback requires a specific height to roll back to.