### PR TITLE
Add Sync node type

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -109,6 +109,15 @@ impl<N: Network> Environment for Miner<N> {
 }
 
 #[derive(Clone, Debug, Default)]
+pub struct SyncNode<N: Network>(PhantomData<N>);
+
+#[rustfmt::skip]
+impl<N: Network> Environment for SyncNode<N> {
+    type Network = N;
+    const NODE_TYPE: NodeType = NodeType::Sync;
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct ClientTrial<N: Network>(PhantomData<N>);
 
 #[rustfmt::skip]

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -205,10 +205,9 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     false => return,
                 };
 
-                let sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-
                 // If the current node is not a sync node, add the sync nodes to the list of candidate peers.
                 if E::NODE_TYPE != NodeType::Sync {
+                    let sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
                     self.add_candidate_peers(&sync_nodes);
                 }
 

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Environment, LedgerRequest, LedgerRouter, Message};
+use crate::{Environment, LedgerRequest, LedgerRouter, Message, NodeType};
 use snarkvm::dpc::prelude::*;
 
 use anyhow::{anyhow, Result};
 use futures::SinkExt;
-use rand::{thread_rng, Rng};
+use rand::{prelude::IteratorRandom, rngs::OsRng, thread_rng, Rng};
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
@@ -205,16 +205,23 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     false => return,
                 };
 
-                // Add the sync nodes to the list of candidate peers.
                 let sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-                self.add_candidate_peers(&sync_nodes);
+
+                // If the current node is not a sync node, add the sync nodes to the list of candidate peers.
+                if E::NODE_TYPE != NodeType::Sync {
+                    self.add_candidate_peers(&sync_nodes);
+                }
 
                 // Add the peer nodes to the list of candidate peers.
                 let peer_nodes: Vec<SocketAddr> = E::PEER_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
                 self.add_candidate_peers(&peer_nodes);
 
                 // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
-                for peer_ip in self.candidate_peers().iter().take(E::MINIMUM_NUMBER_OF_PEERS) {
+                for peer_ip in self
+                    .candidate_peers()
+                    .iter()
+                    .choose_multiple(&mut OsRng::default(), E::MINIMUM_NUMBER_OF_PEERS)
+                {
                     if !self.is_connected_to(*peer_ip) {
                         trace!("Attempting connection to {}...", peer_ip);
                         let request = PeersRequest::Connect(*peer_ip, ledger_router.clone());

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -217,6 +217,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 self.add_candidate_peers(&peer_nodes);
 
                 // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
+                // Select the peers randomly from the list of candidate peers.
                 for peer_ip in self
                     .candidate_peers()
                     .iter()


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR introduces the option to run your node as a sync node, which will prevent it from trying to connect to other sync nodes.

Additionally, candidate peers are now chosen at random when connection requests are made.
