### PR TITLE
feat: add timestamp to failures, expire failures after some time, dis…

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -81,13 +81,9 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The maximum number of blocks that may be fetched in one request.
     const MAXIMUM_BLOCK_REQUEST: u32 = 50;
 
-    /// The duration in seconds after which a block request is considered expired
-    /// if no block has been received in the meantime.
-    const BLOCK_REQUEST_TIMEOUT_IN_SECS: u64 = 90; // 1 minute 30 seconds
-
-    /// The duration in seconds after which to expire a failure from a peer
-    const FAILURE_EXPIRY_TIME: u64 = 120 * 60;
-    /// The failure count threshold which determines when to disconnect a peer
+    /// The duration in seconds after which to expire a failure from a peer.
+    const FAILURE_EXPIRY_TIME_IN_SECS: u64 = 120 * 60;
+    /// The failure count threshold which determines when to disconnect from a peer.
     const FAILURE_THRESHOLD: usize = 2400;
 }
 

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -17,7 +17,7 @@
 use snarkvm::dpc::Network;
 
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, marker::PhantomData, time::Duration};
+use std::{fmt::Debug, marker::PhantomData};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[repr(u8)]
@@ -84,8 +84,10 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// if no block has been received in the meantime.
     const BLOCK_REQUEST_TIMEOUT_IN_SECS: u64 = 90; // 1 minute 30 seconds
 
-    const FAILURE_EXPIRY_TIME: Duration = Duration::from_secs(15 * 60);
-    const FAILURE_THRESHOLD: usize = 5;
+    /// The duration in seconds after which to expire a failure from a peer
+    const FAILURE_EXPIRY_TIME: u64 = 120 * 60;
+    /// The failure count threshold which determines when to disconnect a peer
+    const FAILURE_THRESHOLD: usize = 2400;
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -56,7 +56,7 @@ pub enum LedgerRequest<N: Network, E: Environment> {
     /// Disconnect := (peer_ip)
     Disconnect(SocketAddr),
     /// Heartbeat := ()
-    Heartbeat,
+    Heartbeat(LedgerRouter<N, E>),
     /// Mine := (local_ip, miner_address, ledger_router)
     Mine(SocketAddr, Address<N>, LedgerRouter<N, E>),
     /// Ping := (peer_ip, block_height, block_hash)
@@ -112,8 +112,8 @@ pub struct Ledger<N: Network, E: Environment> {
     block_requests_lock: Arc<Mutex<bool>>,
     /// The timestamp of the last successful block update.
     last_block_update_timestamp: Instant,
-    /// The map of each peer to their failure messages.
-    failures: HashMap<SocketAddr, Vec<String>>,
+    /// The map of each peer to their failure messages := (failure_message, timestamp).
+    failures: HashMap<SocketAddr, Vec<(String, i64)>>,
     _phantom: PhantomData<E>,
 }
 
@@ -232,13 +232,17 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     warn!("[Disconnect] {}", error);
                 }
             }
-            LedgerRequest::Heartbeat => {
+            LedgerRequest::Heartbeat(ledger_router) => {
                 // Update the ledger.
                 self.update_ledger();
                 // Update the status of the ledger.
                 self.update_status();
                 // Remove expired block requests.
                 self.remove_expired_block_requests();
+                // Remove expired failures.
+                self.remove_expired_failures();
+                // Disconnect from peers with more than E::FAILURE_THRESHOLD failures.
+                self.disconnect_from_failing_peers(&ledger_router).await;
                 // Update the block requests.
                 self.update_block_requests(peers_router).await;
             }
@@ -649,6 +653,31 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         });
     }
 
+    /// Removes failures that have expired.
+    fn remove_expired_failures(&mut self) {
+        let now = Utc::now().timestamp();
+
+        // Clear the expired failures that have lived longer than `E::FAILURE_EXPIRY_TIME`.
+        self.failures
+            .iter_mut()
+            .for_each(|(_, failures)| failures.retain(|(_, timestamp)| now - timestamp > E::FAILURE_EXPIRY_TIME.as_secs() as i64));
+    }
+
+    /// Disconnects from peers with more than E::FAILURE_THRESHOLD peers
+    async fn disconnect_from_failing_peers(&self, ledger_router: &LedgerRouter<N, E>) {
+        let peers_to_disconnect = self
+            .failures
+            .iter()
+            .filter(|(_, failures)| failures.len() > E::FAILURE_THRESHOLD)
+            .map(|(peer_ip, _)| peer_ip);
+        for peer_ip in peers_to_disconnect {
+            let request = LedgerRequest::Disconnect(*peer_ip);
+            if let Err(error) = ledger_router.send(request).await {
+                warn!("Failed to send disconnect message to failing peer {}: {}", peer_ip, error);
+            }
+        }
+    }
+
     ///
     /// Proceeds to send block requests to a connected peer, if the ledger is out of date.
     ///
@@ -897,7 +926,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     fn add_failure(&mut self, peer_ip: SocketAddr, failure: String) {
         trace!("Adding failure for {}: {}", peer_ip, failure);
         match self.failures.get_mut(&peer_ip) {
-            Some(failures) => failures.push(failure),
+            Some(failures) => failures.push((failure, Utc::now().timestamp())),
             None => error!("Missing failure entry for {}", peer_ip),
         };
     }

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -660,7 +660,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Clear the expired failures that have lived longer than `E::FAILURE_EXPIRY_TIME`.
         self.failures
             .iter_mut()
-            .for_each(|(_, failures)| failures.retain(|(_, timestamp)| now - timestamp > E::FAILURE_EXPIRY_TIME.as_secs() as i64));
+            .for_each(|(_, failures)| failures.retain(|(_, timestamp)| now - timestamp > E::FAILURE_EXPIRY_TIME as i64));
     }
 
     /// Disconnects from peers with more than E::FAILURE_THRESHOLD peers

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -229,7 +229,7 @@ impl<N: Network, E: Environment> Server<N, E> {
                     error!("Failed to send heartbeat to peers: {}", error)
                 }
                 // Transmit a heartbeat request to the ledger.
-                let request = LedgerRequest::Heartbeat;
+                let request = LedgerRequest::Heartbeat(ledger_router.clone());
                 if let Err(error) = ledger_router.send(request).await {
                     error!("Failed to send heartbeat to ledger: {}", error)
                 }


### PR DESCRIPTION
…connect peers after failure threshold is exceeded

<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

When a peer has too many failures, we want to disconnect from them. We also want to ensure that long-lived peers don't get dropped if they have infrequent failures. The solution we are using here is to add timestamps to failures, clear out expired failures on LedgerRequest::Heartbeat, and disconnect from peers with too many failures on LedgerRequest::Heartbeat. 
