### PR TITLE
Update miner script and clean up `peers_state`

### DIFF
--- a/run-miner.sh
+++ b/run-miner.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-COMMAND='cargo run --release -- --miner aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah --trial'
+echo "Enter your miner address:";
+read MINER_ADDRESS
+
+if [ "${MINER_ADDRESS}" == "" ]
+then
+  MINER_ADDRESS="aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah"
+fi
+
+COMMAND="cargo run --release -- --miner ${MINER_ADDRESS} --trial"
 
 function exit_node()
 {

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -17,7 +17,7 @@
 use snarkvm::dpc::Network;
 
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, marker::PhantomData, time::Duration};
+use std::{fmt::Debug, marker::PhantomData};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[repr(u8)]

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -720,7 +720,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Case 2 - Proceed to send block requests, as the peer is ahead of this ledger.
         if let (Some(peer_ip), Some(is_fork)) = (maximal_peer, maximal_peer_is_fork) {
             // Determine the common ancestor block height between this ledger and the peer.
-            let mut maximum_common_ancestor = maximum_common_ancestor;
+            let mut maximum_common_ancestor = 0;
             // Determine the first locator (smallest height) that does not exist in this ledger.
             let mut first_deviating_locator = None;
 
@@ -752,10 +752,13 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 }
             }
 
-            // Ensure the latest_common_ancestor is not greater than the latest_block_height.
+            // Ensure the latest common ancestor is not greater than the latest block request.
             let latest_block_height = self.latest_block_height();
             if latest_block_height < maximum_common_ancestor {
-                info!("Found a longer chain starting from block {}", maximum_common_ancestor);
+                warn!(
+                    "The maximum common ancestor {} can't be greater than the latest block {}",
+                    maximum_common_ancestor, latest_block_height
+                );
                 return;
             }
 

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -103,8 +103,8 @@ pub struct Ledger<N: Network, E: Environment> {
     status: Arc<AtomicU8>,
     /// A terminator bit for the miner.
     terminator: Arc<AtomicBool>,
-    /// The map of each peer to their ledger state := (is_fork, common_ancestor, latest_block_height, block_locators).
-    peers_state: HashMap<SocketAddr, Option<(Option<bool>, u32, u32, BlockLocators<N>)>>,
+    /// The map of each peer to their ledger state := (is_fork, latest_block_height, block_locators).
+    peers_state: HashMap<SocketAddr, Option<(Option<bool>, u32, BlockLocators<N>)>>,
     /// The map of each peer to their block requests := HashMap<(block_height, block_hash), timestamp>
     block_requests: HashMap<SocketAddr, HashMap<(u32, Option<N::BlockHash>), i64>>,
     /// A lock to ensure methods that need to be mutually-exclusive are enforced.
@@ -363,7 +363,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             let latest_block_height = self.latest_block_height();
             // Iterate through the connected peers, to determine if the ledger state is out of date.
             for (_, ledger_state) in self.peers_state.iter() {
-                if let Some((_, _, block_height, _)) = ledger_state {
+                if let Some((_, block_height, _)) = ledger_state {
                     if *block_height > latest_block_height {
                         // Sync if this ledger has fallen behind by 3 or more blocks.
                         if block_height - latest_block_height > 2 {
@@ -633,7 +633,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             );
 
             match self.peers_state.get_mut(&peer_ip) {
-                Some(status) => *status = Some((is_fork, common_ancestor, latest_block_height_of_peer, block_locators)),
+                Some(status) => *status = Some((is_fork, latest_block_height_of_peer, block_locators)),
                 None => self.add_failure(peer_ip, format!("Missing ledger state for {}", peer_ip)),
             };
         }
@@ -682,7 +682,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Prioritize the sync nodes before regular peers.
         let mut maximal_peer = None;
         let mut maximal_peer_is_fork = None;
-        let mut maximum_common_ancestor = 0;
         let mut maximum_block_height = self.latest_block_height();
         let mut maximum_block_locators = Default::default();
 
@@ -697,13 +696,12 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         for (peer_ip, ledger_state) in self.peers_state.iter() {
             // Only update the maximal peer if there are no sync nodes or the peer is a sync node.
             if !peers_contains_sync_node || sync_nodes.contains(peer_ip) {
-                if let Some((is_fork, common_ancestor, block_height, block_locators)) = ledger_state {
+                if let Some((is_fork, block_height, block_locators)) = ledger_state {
                     // Update the maximal peer state if the peer is ahead and the peer knows if you are a fork or not.
                     // This accounts for (Case 1 and Case 2(a))
                     if *block_height > maximum_block_height && is_fork.is_some() {
                         maximal_peer = Some(*peer_ip);
                         maximal_peer_is_fork = *is_fork;
-                        maximum_common_ancestor = *common_ancestor;
                         maximum_block_height = *block_height;
                         maximum_block_locators = block_locators.clone();
                     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `run-miner.sh` script to prompt for an address, and defaults to a given address if nothing was entered.

Additionally, this PR removes the stored "common_ancestor" in `peers_state` and opts to recalculate on the fly.