### PR TITLE
Don't dedicate all the cores to mining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rand_chacha",
+ "rayon",
  "rusty-hook",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ version = "0.11"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.rayon]
+version = "1"
+
 [dependencies.self_update]
 version = "0.27"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ fn main() -> Result<()> {
         .max_blocking_threads(num_cpus::get().saturating_sub(1).max(1)) // Don't use 100% of the cores
         .build()?;
 
+    // don't use 100% of the cores for mining
+    rayon::ThreadPoolBuilder::new()
+        .num_threads((num_cpus::get() / 4 * 3).max(1))
+        .build_global()
+        .unwrap();
+
     runtime.block_on(Node::from_args().start())?;
 
     Ok(())


### PR DESCRIPTION
The node needs to have some resources left to be able to handle network operations.