### PR TITLE
Fix secondary database catch-ups

### DIFF
--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -175,7 +175,6 @@ impl<N: Network> LedgerState<N> {
         if ledger.is_read_only() {
             debug!("Loading ledger in read-only mode");
             let mut ledger = ledger.clone();
-            let primary_latest_block = primary_latest_block.clone();
             thread::spawn(move || {
                 let last_seen_block_height = ledger.read_only.1.clone();
                 ledger.read_only.1.store(latest_block_height, Ordering::SeqCst);

--- a/ledger/src/state/tests.rs
+++ b/ledger/src/state/tests.rs
@@ -29,7 +29,7 @@ fn temp_dir() -> std::path::PathBuf {
 
 /// Initializes a new instance of the ledger.
 fn new_ledger<N: Network, S: Storage>() -> LedgerState<N> {
-    LedgerState::open::<S, _>(temp_dir(), false).expect("Failed to initialize ledger")
+    LedgerState::open::<S, _>(temp_dir(), false, None).expect("Failed to initialize ledger")
 }
 
 #[test]

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -20,7 +20,7 @@ use snarkvm::dpc::prelude::*;
 
 use anyhow::Result;
 use chrono::Utc;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use rand::thread_rng;
 use std::{
     collections::HashMap,
@@ -120,7 +120,7 @@ pub struct Ledger<N: Network, E: Environment> {
 impl<N: Network, E: Environment> Ledger<N, E> {
     /// Initializes a new instance of the ledger.
     pub fn open<S: Storage, P: AsRef<Path>>(path: P) -> Result<Self> {
-        let canon = LedgerState::open::<S, P>(path, false)?;
+        let canon = LedgerState::open::<S, P>(path, false, None)?;
         let last_block_update_timestamp = Instant::now();
         Ok(Self {
             canon,
@@ -163,6 +163,11 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Returns `true` if the ledger is currently syncing.
     pub fn is_syncing(&self) -> bool {
         self.status() == Status::Syncing
+    }
+
+    /// Returns the latest block object.
+    pub fn latest_block(&self) -> Arc<RwLock<Block<N>>> {
+        self.canon.latest_block_object()
     }
 
     /// Returns the latest block height.

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -466,7 +466,7 @@ mod tests {
 
     /// Initializes a new instance of the ledger state.
     fn new_ledger_state<N: Network, S: Storage>() -> LedgerState<N> {
-        LedgerState::<N>::open::<S, _>(temp_dir(), false).expect("Failed to initialize ledger")
+        LedgerState::<N>::open::<S, _>(temp_dir(), false, None).expect("Failed to initialize ledger")
     }
 
     /// Initializes a new instance of the ledger.
@@ -721,7 +721,7 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let mut ledger_state = LedgerState::open::<RocksDB, _>(directory.clone(), false).expect("Failed to initialize ledger");
+        let mut ledger_state = LedgerState::open::<RocksDB, _>(directory.clone(), false, None).expect("Failed to initialize ledger");
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
@@ -746,7 +746,7 @@ mod tests {
             };
 
             // Open a ledger at the temporary directory.
-            let ledger = LedgerState::open::<RocksDB, _>(directory, false).expect("Failed to initialize ledger");
+            let ledger = LedgerState::open::<RocksDB, _>(directory, false, None).expect("Failed to initialize ledger");
             let (ledger_router, _ledger_handler) = mpsc::channel(1024);
             let peers = new_peers();
 
@@ -849,7 +849,8 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let mut ledger_state = LedgerState::<Testnet2>::open::<RocksDB, _>(directory.clone(), false).expect("Failed to initialize ledger");
+        let mut ledger_state =
+            LedgerState::<Testnet2>::open::<RocksDB, _>(directory.clone(), false, None).expect("Failed to initialize ledger");
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
@@ -875,7 +876,7 @@ mod tests {
             let peers = new_peers();
 
             // Open a ledger at the temporary directory.
-            let ledger = LedgerState::<Testnet2>::open::<RocksDB, _>(directory, false).expect("Failed to initialize ledger");
+            let ledger = LedgerState::<Testnet2>::open::<RocksDB, _>(directory, false, None).expect("Failed to initialize ledger");
             let (ledger_router, _ledger_handler) = mpsc::channel(1024);
 
             RpcImpl::<Testnet2, Client<Testnet2>>::new(credentials, peers, ledger, ledger_router)
@@ -1013,7 +1014,7 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let mut ledger_state = LedgerState::open::<RocksDB, _>(directory.clone(), false).expect("Failed to initialize ledger");
+        let mut ledger_state = LedgerState::open::<RocksDB, _>(directory.clone(), false, None).expect("Failed to initialize ledger");
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
@@ -1047,7 +1048,7 @@ mod tests {
             let peers = new_peers();
 
             // Open a ledger at the temporary directory.
-            let ledger = LedgerState::<Testnet2>::open::<RocksDB, _>(directory, false).expect("Failed to initialize ledger");
+            let ledger = LedgerState::<Testnet2>::open::<RocksDB, _>(directory, false, None).expect("Failed to initialize ledger");
             let (ledger_router, _ledger_handler) = mpsc::channel(1024);
 
             RpcImpl::<Testnet2, Client<Testnet2>>::new(credentials, peers, ledger, ledger_router)


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR circumvents the issues in #1290. The real issue lies in a bug in RocksDB, which was fixed in `v6.25.0`, however the latest Rust `rocksdb v0.17` crate only supports RocksDB `v6.20.3`. 

The issue of the secondary database state rolling back occurred only when calling `try_catch_up_secondary` when the secondary was already caught up with the primary. To get around this, the PR gives the secondary database access to the primary database's latest block. This allows us to call `try_catch_up_secondary` only when there is actual state to be updated.
