### PR TITLE
Allow node introspection in integration tests, add more network tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,9 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -1240,6 +1243,25 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "pea2pea"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e767de612eda2b1c42146b90ead2e67d8851b1b632023a071172ad91d1b3ab"
+dependencies = [
+ "async-trait",
+ "once_cell",
+ "parking_lot",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "peak_alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae5ca2a4f36e9bba393e6711350dde5d11f5aacca3660fcca7877fe6b6e9d98"
 
 [[package]]
 name = "peeking_take_while"
@@ -1780,6 +1802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkos-ledger",
+ "snarkos-testing",
  "snarkvm",
  "structopt",
  "tempfile",
@@ -1810,6 +1833,24 @@ dependencies = [
  "snarkvm",
  "tempfile",
  "tracing",
+]
+
+[[package]]
+name = "snarkos-testing"
+version = "2.0.0"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "pea2pea",
+ "peak_alloc",
+ "rand",
+ "snarkos",
+ "snarkos-ledger",
+ "snarkvm",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2206,6 +2247,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "tokio-macros",
  "winapi",
@@ -2324,6 +2366,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
  "matchers",
+ "parking_lot",
  "regex",
  "sharded-slab",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
 name = "snarkos-testing"
 version = "2.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "pea2pea",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ license = "GPL-3.0"
 edition = "2018"
 
 [workspace]
-members = ["ledger"]
+members = ["ledger", "testing"]
+
+[features]
+default = []
+test = []
 
 [dependencies]
 snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "e7266f9" }
@@ -31,6 +35,10 @@ tui = { version = "0.16.0", features = ["crossterm"] }
 
 [dependencies.snarkos-ledger]
 path = "./ledger"
+version = "2.0.0"
+
+[dev-dependencies.snarkos-testing]
+path = "./testing"
 version = "2.0.0"
 
 [dependencies.anyhow]
@@ -116,7 +124,7 @@ version = "0.1"
 
 [dependencies.tracing-subscriber]
 version = "0.3"
-features = ["env-filter"]
+features = ["env-filter", "parking_lot"]
 
 [dev-dependencies.rand_chacha]
 version = "0.3"

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -17,8 +17,8 @@
 pub mod circular_map;
 pub use circular_map::*;
 
-pub(crate) mod tasks;
-pub(crate) use tasks::*;
+pub mod tasks;
+pub use tasks::*;
 
 pub mod updater;
 pub use updater::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub use environment::*;
 
 pub mod helpers;
 
-pub(crate) mod network;
-pub(crate) use network::*;
+pub mod network;
+pub use network::*;
 
 pub mod node;
 pub use node::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,10 @@ fn main() -> Result<()> {
         .max_blocking_threads(num_cpus::get().saturating_sub(1).max(1)) // Don't use 100% of the cores
         .build()?;
 
-    runtime.block_on(Node::from_args().start())?;
+    runtime.block_on(async move {
+        Node::from_args().start().await.expect("Couldn't start the node!");
+        std::future::pending::<()>().await;
+    });
 
     Ok(())
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -23,5 +23,5 @@ pub use message::*;
 pub(crate) mod peers;
 pub(crate) use peers::*;
 
-pub(crate) mod server;
-pub(crate) use server::Server;
+pub mod server;
+pub use server::Server;

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -50,7 +50,7 @@ type PeersHandler<N, E> = mpsc::Receiver<PeersRequest<N, E>>;
 ///
 #[derive(Debug)]
 pub enum PeersRequest<N: Network, E: Environment> {
-    /// Connect := (peer_ip, ledger_router, result_notifier)
+    /// Connect := (peer_addr, ledger_router, result_notifier)
     Connect(SocketAddr, LedgerRouter<N, E>, oneshot::Sender<bool>),
     /// Heartbeat := (ledger_router)
     Heartbeat(LedgerRouter<N, E>),

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -496,6 +496,17 @@ impl<N: Network, E: Environment> Peers<N, E> {
             }
         }
     }
+
+    ///
+    /// Removes the addresses of all known peers.
+    ///
+    #[cfg(feature = "test")]
+    pub fn reset_known_peers(&mut self) {
+        self.candidate_peers.clear();
+        self.restricted_peers.clear();
+        self.seen_inbound_connections.clear();
+        self.seen_outbound_connections.clear();
+    }
 }
 
 // TODO (howardwu): Consider changing this to a random challenge height.

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -134,7 +134,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Returns the list of connected peers.
     ///
-    pub(crate) fn connected_peers(&self) -> Vec<SocketAddr> {
+    pub fn connected_peers(&self) -> Vec<SocketAddr> {
         self.connected_peers.keys().cloned().collect()
     }
 

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -674,7 +674,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
     ) {
         let connected_nonces = connected_nonces.cloned().collect::<Vec<u64>>();
         let peers_router = peers_router.clone();
-        task::spawn(async move {
+
+        let task_handle = task::spawn(async move {
             // Register our peer with state which internally sets up some channels.
             let mut peer = match Peer::new(stream, local_ip, local_nonce, &peers_router, &ledger_router, &connected_nonces).await {
                 Ok(peer) => peer,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -82,7 +82,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         // Tests can use any available ports, and they remove the storage artifacts afterwards, so there
         // is no need to adhere to a specific number assignment logic.
         #[cfg(feature = "test")]
-        let storage_path = format!(".ledger-{}", local_addr.port());
+        let storage_path = format!("/tmp/snarkos-test-ledger-{}", local_addr.port());
 
         // Initialize a new instance for managing peers.
         let (peers, peers_router) = Self::initialize_peers(&mut tasks, local_addr);

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -57,9 +57,9 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     #[inline]
     pub(crate) async fn initialize(node: &Node, miner: Option<Address<N>>, mut tasks: Tasks<task::JoinHandle<()>>) -> Result<Self> {
-        let node_ip = node.ip.clone();
+        let node_ip = node.ip;
         let node_port = node.node.unwrap_or(E::DEFAULT_NODE_PORT);
-        let rpc_ip = node.rpc_ip.clone();
+        let rpc_ip = node.rpc_ip;
         let rpc_port = node.rpc.unwrap_or(E::DEFAULT_RPC_PORT);
 
         #[cfg(not(feature = "test"))]
@@ -77,6 +77,8 @@ impl<N: Network, E: Environment> Server<N, E> {
         // Initialize the ledger storage path.
         #[cfg(not(feature = "test"))]
         let storage_path = format!(".ledger-{}", (node_port - 4130));
+        // Tests can use any available ports, and they remove the storage artifacts afterwards, so there
+        // is no need to adhere to a specific number assignment logic.
         #[cfg(feature = "test")]
         let storage_path = format!(".ledger-{}", node_port);
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -69,7 +69,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         );
 
         // Initialize a new TCP listener at the given IP.
-        let (local_ip, listener) = match TcpListener::bind(&format!("{}:{}", node_ip, node_port)).await {
+        let (local_ip, listener) = match TcpListener::bind(SocketAddr::from((node_ip, node_port))).await {
             Ok(listener) => (listener.local_addr().expect("Failed to fetch the local IP"), listener),
             Err(error) => panic!("Failed to bind listener: {:?}. Check if another Aleo node is running", error),
         };
@@ -98,7 +98,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         if !node.disable_rpc {
             // Initialize a new instance of the RPC server.
             tasks.append(initialize_rpc_server::<N, E>(
-                format!("{}:{}", rpc_ip, rpc_port).parse()?,
+                SocketAddr::from((rpc_ip, rpc_port)),
                 node.rpc_username.clone(),
                 node.rpc_password.clone(),
                 &peers,

--- a/src/node.rs
+++ b/src/node.rs
@@ -14,13 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{helpers::Updater, network::Server, Client, ClientTrial, Display, Environment, Miner, MinerTrial, NodeType, SyncNode};
+use crate::{
+    helpers::{Tasks, Updater},
+    network::Server,
+    Client,
+    ClientTrial,
+    Display,
+    Environment,
+    Miner,
+    MinerTrial,
+    NodeType,
+    SyncNode,
+};
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use anyhow::Result;
 use colored::*;
 use std::str::FromStr;
 use structopt::StructOpt;
+use tokio::task;
 use tracing_subscriber::EnvFilter;
 
 #[derive(StructOpt, Debug)]
@@ -35,9 +47,18 @@ pub struct Node {
     /// Specify the network of this node.
     #[structopt(default_value = "2", short = "n", long = "network")]
     pub network: u16,
+    /// The listener IP of the node.
+    #[structopt(default_value = "0:0:0:0", long = "ip")]
+    pub ip: String,
     /// Specify the port for the node server.
     #[structopt(long = "node")]
     pub node: Option<u16>,
+    /// Disable the RPC server.
+    #[structopt(long = "disable-rpc")]
+    pub disable_rpc: bool,
+    /// The IP address of the RPC server.
+    #[structopt(default_value = "0:0:0:0", long = "rpc-ip")]
+    pub rpc_ip: String,
     /// Specify the port for the RPC server.
     #[structopt(long = "rpc")]
     pub rpc: Option<u16>,
@@ -83,13 +104,6 @@ impl Node {
     }
 
     async fn start_server<N: Network, E: Environment>(&self) -> Result<()> {
-        let node_port = self.node.unwrap_or(E::DEFAULT_NODE_PORT);
-        let rpc_port = self.rpc.unwrap_or(E::DEFAULT_RPC_PORT);
-        assert!(
-            !(node_port < 4130),
-            "Until configuration files are established, the node port must be at least 4130 or greater"
-        );
-
         let miner = match (E::NODE_TYPE, &self.miner) {
             (NodeType::Miner, Some(address)) => {
                 let miner_address = Address::<N>::from_str(address)?;
@@ -105,25 +119,32 @@ impl Node {
             }
         };
 
+        // Initialize the tasks handler.
+        let tasks = Tasks::new();
+        let tasks_clone = tasks.clone();
+
+        let server = Server::<N, E>::initialize(self, miner, tasks_clone).await?;
+
         if self.display {
             println!("\nThe snarkOS console is initializing...\n");
-            let server =
-                Server::<N, E>::initialize(node_port, rpc_port, self.rpc_username.clone(), self.rpc_password.clone(), miner).await?;
-            if let Some(peer_ip) = &self.connect {
-                server.connect_to(peer_ip.parse().unwrap()).await?;
-            }
-            let _display = Display::<N, E>::start(server)?;
-            Ok(())
+
+            let server_clone = server.clone();
+            let _display = Display::<N, E>::start(server_clone)?;
         } else {
             self.initialize_logger();
-            let server =
-                Server::<N, E>::initialize(node_port, rpc_port, self.rpc_username.clone(), self.rpc_password.clone(), miner).await?;
-            if let Some(peer_ip) = &self.connect {
-                server.connect_to(peer_ip.parse().unwrap()).await?;
-            }
-            std::future::pending::<()>().await;
-            Ok(())
         }
+
+        if let Some(peer_ip) = &self.connect {
+            server.connect_to(peer_ip.parse().unwrap()).await?;
+        }
+
+        let server_task = task::spawn(async move {
+            let _server = server;
+            std::future::pending::<()>().await
+        });
+        tasks.append(server_task);
+
+        Ok(())
     }
 
     fn initialize_logger(&self) {
@@ -144,10 +165,10 @@ impl Node {
             .add_directive("hyper::proto::h1::role=off".parse().unwrap());
 
         // Initialize tracing.
-        tracing_subscriber::fmt()
+        let _ = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(self.verbosity == 3)
-            .init();
+            .try_init();
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -30,7 +30,7 @@ use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use anyhow::Result;
 use colored::*;
-use std::str::FromStr;
+use std::{net::IpAddr, str::FromStr};
 use structopt::StructOpt;
 use tokio::task;
 use tracing_subscriber::EnvFilter;
@@ -49,7 +49,7 @@ pub struct Node {
     pub network: u16,
     /// The listener IP of the node.
     #[structopt(default_value = "0:0:0:0", long = "ip")]
-    pub ip: String,
+    pub ip: IpAddr,
     /// Specify the port for the node server.
     #[structopt(long = "node")]
     pub node: Option<u16>,
@@ -57,8 +57,8 @@ pub struct Node {
     #[structopt(long = "disable-rpc")]
     pub disable_rpc: bool,
     /// The IP address of the RPC server.
-    #[structopt(default_value = "0:0:0:0", long = "rpc-ip")]
-    pub rpc_ip: String,
+    #[structopt(default_value = "0.0.0.0", long = "rpc-ip")]
+    pub rpc_ip: IpAddr,
     /// Specify the port for the RPC server.
     #[structopt(long = "rpc")]
     pub rpc: Option<u16>,

--- a/src/node.rs
+++ b/src/node.rs
@@ -135,7 +135,7 @@ impl Node {
         }
 
         if let Some(peer_ip) = &self.connect {
-            server.connect_to(peer_ip.parse().unwrap()).await?;
+            let _ = server.connect_to(peer_ip.parse().unwrap()).await;
         }
 
         let server_task = task::spawn(async move {

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -27,11 +27,14 @@ features = ["test"]
 [dependencies.snarkos-ledger]
 path = "../ledger"
 
+[dependencies.anyhow]
+version = "1"
+
 [dependencies.async-trait]
 version = "0.1"
 
 [dependencies.bincode]
-version = "1.0"
+version = "1"
 
 [dependencies.pea2pea]
 version = "0.28"
@@ -43,7 +46,7 @@ version = "0.1"
 version = "0.8"
 
 [dependencies.tokio]
-version = "1.0"
+version = "1"
 features = ["macros", "rt-multi-thread", "time"]
 
 [dependencies.structopt]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -36,6 +36,9 @@ version = "1.0"
 [dependencies.pea2pea]
 version = "0.28"
 
+[dependencies.peak_alloc]
+version = "0.1"
+
 [dependencies.rand]
 version = "0.8"
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "snarkos-testing"
+version = "2.0.0"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "A decentralized operating system"
+homepage = "https://aleo.org"
+repository = "https://github.com/AleoHQ/snarkOS"
+keywords = [
+    "aleo",
+    "cryptography",
+    "blockchain",
+    "decentralized",
+    "zero-knowledge"
+]
+categories = [ "cryptography", "operating-systems" ]
+license = "GPL-3.0"
+edition = "2018"
+
+[dependencies.snarkvm]
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "e7266f9"
+
+[dependencies.snarkos]
+path = ".."
+features = ["test"]
+
+[dependencies.snarkos-ledger]
+path = "../ledger"
+
+[dependencies.async-trait]
+version = "0.1"
+
+[dependencies.bincode]
+version = "1.0"
+
+[dependencies.pea2pea]
+version = "0.28"
+
+[dependencies.rand]
+version = "0.8"
+
+[dependencies.tokio]
+version = "1.0"
+features = ["macros", "rt-multi-thread", "time"]
+
+[dependencies.structopt]
+version = "0.3"
+
+[dependencies.tracing]
+version = "0.1"
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+features = ["env-filter", "parking_lot"]

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,2 @@
+# snarkOS-testing
+

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -14,14 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
+pub mod snarkos_node;
+pub use snarkos_node::*;
 
-pub mod message;
-pub use message::*;
-
-pub(crate) mod peers;
-pub(crate) use peers::*;
-
-pub(crate) mod server;
-pub(crate) use server::Server;
+pub mod test_node;
+pub use test_node::*;

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -62,8 +62,10 @@ impl Drop for SnarkosNode {
     fn drop(&mut self) {
         let db_path = format!("{}/.ledger-{}", env!("CARGO_MANIFEST_DIR"), self.server.local_addr.port());
 
-        if fs::remove_dir_all(&db_path).is_err() {
-            panic!("Storage cleanup failed! The expected path \"{}\" doesn't exist", db_path);
-        }
+        assert!(
+            fs::remove_dir_all(&db_path).is_ok(),
+            "Storage cleanup failed! The expected path \"{}\" doesn't exist",
+            db_path
+        );
     }
 }

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -66,7 +66,7 @@ impl SnarkosNode {
 // Remove the storage artifacts after each test.
 impl Drop for SnarkosNode {
     fn drop(&mut self) {
-        let db_path = format!("{}/.ledger-{}", env!("CARGO_MANIFEST_DIR"), self.server.local_addr.port());
+        let db_path = format!("/tmp/snarkos-test-ledger-{}", self.server.local_addr.port());
 
         assert!(
             fs::remove_dir_all(&db_path).is_ok(),

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -20,8 +20,7 @@ use tokio::net::TcpListener;
 use std::{fs, net::SocketAddr};
 
 /// A facade for a snarkOS node.
-// FIXME: there's not much room for introspection right now; it should be implemented
-// in the existing API.
+// FIXME: there's not much room for introspection right now; it should be implemented in the existing API.
 pub struct SnarkosNode {
     pub addr: SocketAddr,
 }
@@ -29,6 +28,9 @@ pub struct SnarkosNode {
 impl SnarkosNode {
     pub async fn default() -> Self {
         // Procure a free port number for the snarkOS node.
+        // FIXME: due to there being a delay between the port's discovery and its binding by the node, this
+        // method can cause an `AddrInUse` error to occur when multiple tests are run at the same time; only
+        // introspection of a ready node can fully avoid this.
         let free_port = {
             let temp_socket = TcpListener::bind("127.0.0.1:0").await.unwrap();
             temp_socket.local_addr().unwrap().port()

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -42,6 +42,11 @@ impl SnarkosNode {
         self.server.peers.write().await.reset_known_peers()
     }
 
+    /// Attempts to connect the node to the given address.
+    pub async fn connect(&self, addr: SocketAddr) -> anyhow::Result<()> {
+        self.server.connect_to(addr).await
+    }
+
     /// Starts a snarkOS node with all the default characteristics from `SnarkosNode::with_args` and with
     /// any available port (as opposed to the default snarkOS network port).
     pub async fn default() -> Self {

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -14,32 +14,32 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use snarkos::{helpers::Tasks, Client, Server};
+use snarkvm::dpc::testnet2::Testnet2;
 use structopt::StructOpt;
-use tokio::net::TcpListener;
 
 use std::{fs, net::SocketAddr};
 
 /// A facade for a snarkOS node.
-// FIXME: there's not much room for introspection right now; it should be implemented in the existing API.
 pub struct SnarkosNode {
-    pub addr: SocketAddr,
+    pub server: Server<Testnet2, Client<Testnet2>>,
 }
 
 impl SnarkosNode {
-    /// Starts a snarkOS node with all the default characteristics from `SnarkosNode::with_args` plus any
-    /// available port number picked for the listening address.
-    pub async fn default() -> Self {
-        // Procure a free port number for the snarkOS node.
-        // FIXME: due to there being a delay between the port's discovery and its binding by the node, this
-        // method can cause an `AddrInUse` error to occur when multiple tests are run at the same time; only
-        // introspection of a ready node can fully avoid this.
-        let free_port = {
-            let temp_socket = TcpListener::bind("127.0.0.1:0").await.unwrap();
-            temp_socket.local_addr().unwrap().port()
-        };
+    /// Returns the node's local listening address.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.server.local_addr
+    }
 
-        // Start a snarkOS node with that port.
-        SnarkosNode::with_args(&["--node", &free_port.to_string()]).await
+    /// Returns the list of node's connected peers.
+    pub async fn connected_peers(&self) -> Vec<SocketAddr> {
+        self.server.peers.read().await.connected_peers()
+    }
+
+    /// Starts a snarkOS node with all the default characteristics from `SnarkosNode::with_args` and with
+    /// any available port (as opposed to the default snarkOS network port).
+    pub async fn default() -> Self {
+        SnarkosNode::with_args(&["--node", "0"]).await
     }
 
     /// Starts a snarkOS node with a local address and the RPC server disabled; extra arguments can be passed
@@ -47,28 +47,20 @@ impl SnarkosNode {
     pub async fn with_args(extra_args: &[&str]) -> Self {
         let permanent_args = &["snarkos", "--disable-rpc", "--ip", "127.0.0.1"];
         let combined_args = permanent_args.iter().chain(extra_args.iter());
+        let config = snarkos::Node::from_iter(combined_args);
 
-        snarkos::Node::from_iter(combined_args).start().await.unwrap();
+        let server = Server::<Testnet2, Client<Testnet2>>::initialize(&config, None, Tasks::new())
+            .await
+            .unwrap();
 
-        let mut port = None;
-
-        for (i, arg) in extra_args.iter().enumerate() {
-            if *arg == "--node" {
-                port = extra_args.get(i + 1);
-                break;
-            }
-        }
-
-        let addr = format!("127.0.0.1:{}", port.unwrap().parse::<u16>().unwrap()).parse().unwrap();
-
-        SnarkosNode { addr }
+        SnarkosNode { server }
     }
 }
 
 // Remove the storage artifacts after each test.
 impl Drop for SnarkosNode {
     fn drop(&mut self) {
-        let db_path = format!("{}/.ledger-{}", env!("CARGO_MANIFEST_DIR"), self.addr.port());
+        let db_path = format!("{}/.ledger-{}", env!("CARGO_MANIFEST_DIR"), self.server.local_addr.port());
 
         if fs::remove_dir_all(&db_path).is_err() {
             panic!("Storage cleanup failed! The expected path \"{}\" doesn't exist", db_path);

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -36,6 +36,12 @@ impl SnarkosNode {
         self.server.peers.read().await.connected_peers()
     }
 
+    /// Resets the node's known peers. This is practical, as it makes the node not reconnect
+    /// to known peers in test cases where it's undesirable.
+    pub async fn reset_known_peers(&self) {
+        self.server.peers.write().await.reset_known_peers()
+    }
+
     /// Starts a snarkOS node with all the default characteristics from `SnarkosNode::with_args` and with
     /// any available port (as opposed to the default snarkOS network port).
     pub async fn default() -> Self {

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -1,0 +1,71 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use structopt::StructOpt;
+use tokio::net::TcpListener;
+
+use std::{fs, net::SocketAddr};
+
+/// A facade for a snarkOS node.
+// FIXME: there's not much room for introspection right now; it should be implemented
+// in the existing API.
+pub struct SnarkosNode {
+    pub addr: SocketAddr,
+}
+
+impl SnarkosNode {
+    pub async fn default() -> Self {
+        // Procure a free port number for the snarkOS node.
+        let free_port = {
+            let temp_socket = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            temp_socket.local_addr().unwrap().port()
+        };
+
+        // Start a snarkOS node with that port.
+        SnarkosNode::with_args(&["--node", &free_port.to_string()]).await
+    }
+
+    pub async fn with_args(extra_args: &[&str]) -> Self {
+        let permanent_args = &["snarkos", "--disable-rpc", "--ip", "127.0.0.1"];
+        let combined_args = permanent_args.iter().chain(extra_args.iter());
+
+        snarkos::Node::from_iter(combined_args).start().await.unwrap();
+
+        let mut port = None;
+
+        for (i, arg) in extra_args.iter().enumerate() {
+            if *arg == "--node" {
+                port = extra_args.get(i + 1);
+                break;
+            }
+        }
+
+        let addr = format!("127.0.0.1:{}", port.unwrap().parse::<u16>().unwrap()).parse().unwrap();
+
+        SnarkosNode { addr }
+    }
+}
+
+// Remove the storage artifacts after each test.
+impl Drop for SnarkosNode {
+    fn drop(&mut self) {
+        let db_path = format!("{}/.ledger-{}", env!("CARGO_MANIFEST_DIR"), self.addr.port());
+
+        if fs::remove_dir_all(&db_path).is_err() {
+            panic!("Storage cleanup failed! The expected path \"{}\" doesn't exist", db_path);
+        }
+    }
+}

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -26,6 +26,8 @@ pub struct SnarkosNode {
 }
 
 impl SnarkosNode {
+    /// Starts a snarkOS node with all the default characteristics from `SnarkosNode::with_args` plus any
+    /// available port number picked for the listening address.
     pub async fn default() -> Self {
         // Procure a free port number for the snarkOS node.
         // FIXME: due to there being a delay between the port's discovery and its binding by the node, this
@@ -40,6 +42,8 @@ impl SnarkosNode {
         SnarkosNode::with_args(&["--node", &free_port.to_string()]).await
     }
 
+    /// Starts a snarkOS node with a local address and the RPC server disabled; extra arguments can be passed
+    /// via `extra_args`.
     pub async fn with_args(extra_args: &[&str]) -> Self {
         let permanent_args = &["snarkos", "--disable-rpc", "--ip", "127.0.0.1"];
         let combined_args = permanent_args.iter().chain(extra_args.iter());

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -45,8 +45,10 @@ const MESSAGE_LENGTH_PREFIX_SIZE: usize = 4;
 const CHALLENGE_HEIGHT: u32 = 0;
 const PING_INTERVAL_SECS: u64 = 5;
 const PEER_INTERVAL_SECS: u64 = 3;
-const DESIRED_CONNECTIONS: usize = 10;
+const DESIRED_CONNECTIONS: usize = <Client<Testnet2>>::MINIMUM_NUMBER_OF_PEERS * 3;
 const MESSAGE_VERSION: u32 = <Client<Testnet2>>::MESSAGE_VERSION;
+
+pub const MAXIMUM_NUMBER_OF_PEERS: usize = <Client<Testnet2>>::MAXIMUM_NUMBER_OF_PEERS;
 
 type SnarkosMessage = Message<Testnet2, Client<Testnet2>>;
 pub type SnarkosNonce = u64;
@@ -97,6 +99,7 @@ impl TestNode {
     pub async fn default() -> Self {
         let config = Config {
             listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            max_connections: MAXIMUM_NUMBER_OF_PEERS as u16,
             ..Default::default()
         };
 

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -49,7 +49,7 @@ const DESIRED_CONNECTIONS: usize = 10;
 const MESSAGE_VERSION: u32 = <Client<Testnet2>>::MESSAGE_VERSION;
 
 type SnarkosMessage = Message<Testnet2, Client<Testnet2>>;
-type SnarkosNonce = u64;
+pub type SnarkosNonce = u64;
 
 /// The test node; it consists of a `Node` that handles networking and `State`
 /// that can be extended freely based on test requirements.
@@ -60,7 +60,7 @@ pub struct TestNode {
 }
 
 /// Represents a connected snarkOS peer.
-struct SnarkosPeer {
+pub struct SnarkosPeer {
     connected_addr: SocketAddr,
     listening_addr: SocketAddr,
     nonce: SnarkosNonce,
@@ -68,13 +68,13 @@ struct SnarkosPeer {
 
 /// snarkOS state required for test purposes.
 #[derive(Clone)]
-struct State {
-    local_nonce: SnarkosNonce,
+pub struct State {
+    pub local_nonce: SnarkosNonce,
     /// The list of known peers; `Pea2Pea` already has its own internal peer handling, but
     /// snarkOS nodes expect to learn each other's listening address, and expect their connection
     /// nonces to be unique; this collection facilitates the snarkOS peering experience during
     /// tests and aligns it with snarkOS logic.
-    peers: Arc<Mutex<Vec<SnarkosPeer>>>,
+    pub peers: Arc<Mutex<Vec<SnarkosPeer>>>,
 }
 
 impl Default for State {
@@ -100,7 +100,9 @@ impl TestNode {
             ..Default::default()
         };
 
-        let node = Self::new(Pea2PeaNode::new(Some(config)).await.unwrap());
+        let pea2pea_node = Pea2PeaNode::new(Some(config)).await.unwrap();
+        let snarkos_state = Default::default();
+        let node = Self::new(pea2pea_node, snarkos_state);
 
         node.enable_disconnect();
         node.enable_handshake();
@@ -111,11 +113,8 @@ impl TestNode {
     }
 
     /// Creates a test node using the given `Pea2Pea` node.
-    pub fn new(node: Pea2PeaNode) -> Self {
-        Self {
-            node,
-            state: Default::default(),
-        }
+    pub fn new(node: Pea2PeaNode, state: State) -> Self {
+        Self { node, state }
     }
 
     /// Spawns a task dedicated to broadcasting Ping messages.

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -1,0 +1,379 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use pea2pea::{
+    protocols::{Disconnect, Handshake, Reading, Writing},
+    Config,
+    Connection,
+    Node as Pea2PeaNode,
+    Pea2Pea,
+};
+use rand::{thread_rng, Rng};
+use snarkos::{Client, Environment, Message};
+use snarkos_ledger::BlockLocators;
+use snarkvm::{dpc::testnet2::Testnet2, traits::Network};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+    task,
+};
+use tracing::*;
+
+use std::{
+    convert::TryInto,
+    io,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+// Consts & aliases.
+const MESSAGE_LENGTH_PREFIX_SIZE: usize = 4;
+const CHALLENGE_HEIGHT: u32 = 0;
+const PING_INTERVAL_SECS: u64 = 5;
+const PEER_INTERVAL_SECS: u64 = 3;
+const DESIRED_CONNECTIONS: usize = 10;
+const MESSAGE_VERSION: u32 = <Client<Testnet2>>::MESSAGE_VERSION;
+
+type SnarkosMessage = Message<Testnet2, Client<Testnet2>>;
+type SnarkosNonce = u64;
+
+/// The test node; it consists of a `Node` that handles networking and `State`
+/// that can be extended freely based on test requirements.
+#[derive(Clone)]
+pub struct TestNode {
+    node: Pea2PeaNode,
+    state: State,
+}
+
+/// Represents a connected snarkOS peer.
+struct SnarkosPeer {
+    connected_addr: SocketAddr,
+    listening_addr: SocketAddr,
+    nonce: SnarkosNonce,
+}
+
+/// snarkOS state required for test purposes.
+#[derive(Clone)]
+struct State {
+    local_nonce: SnarkosNonce,
+    /// The list of known peers; `Pea2Pea` already has its own internal peer handling, but
+    /// snarkOS nodes expect to learn each other's listening address, and expect their connection
+    /// nonces to be unique; this collection facilitates the snarkOS peering experience during
+    /// tests and aligns it with snarkOS logic.
+    peers: Arc<Mutex<Vec<SnarkosPeer>>>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            local_nonce: thread_rng().gen(),
+            peers: Default::default(),
+        }
+    }
+}
+
+impl Pea2Pea for TestNode {
+    fn node(&self) -> &Pea2PeaNode {
+        &self.node
+    }
+}
+
+impl TestNode {
+    /// Creates a default test node with the most basic network protocols enabled.
+    pub async fn default() -> Self {
+        let config = Config {
+            listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            ..Default::default()
+        };
+
+        let node = Self::new(Pea2PeaNode::new(Some(config)).await.unwrap());
+
+        node.enable_disconnect();
+        node.enable_handshake();
+        node.enable_reading();
+        node.enable_writing();
+
+        node
+    }
+
+    /// Creates a test node using the given `Pea2Pea` node.
+    pub fn new(node: Pea2PeaNode) -> Self {
+        Self {
+            node,
+            state: Default::default(),
+        }
+    }
+
+    /// Spawns a task dedicated to broadcasting Ping messages.
+    pub fn send_pings(&self) {
+        let node = self.clone();
+        task::spawn(async move {
+            let genesis = Testnet2::genesis_block();
+            let ping_msg = SnarkosMessage::Ping(MESSAGE_VERSION, genesis.height(), genesis.hash());
+
+            loop {
+                if node.node().num_connected() != 0 {
+                    info!(parent: node.node().span(), "sending out Pings");
+                    node.send_broadcast(ping_msg.clone());
+                }
+                tokio::time::sleep(Duration::from_secs(PING_INTERVAL_SECS)).await;
+            }
+        });
+    }
+
+    /// Spawns a task dedicated to peer maintenance.
+    pub fn update_peers(&self) {
+        let node = self.clone();
+        task::spawn(async move {
+            loop {
+                let num_conns = node.node().num_connected() + node.node().num_connecting();
+
+                if num_conns < DESIRED_CONNECTIONS && node.node().num_connected() != 0 {
+                    info!(parent: node.node().span(), "I'd like to have {} more peers; asking peers for their peers", DESIRED_CONNECTIONS - num_conns);
+                    node.send_broadcast(SnarkosMessage::PeerRequest);
+                }
+                tokio::time::sleep(Duration::from_secs(PEER_INTERVAL_SECS)).await;
+            }
+        });
+    }
+
+    /// Starts the usual periodic activities of a test node.
+    pub fn run_periodic_tasks(&self) {
+        self.send_pings();
+        self.update_peers();
+    }
+}
+
+/// Automated handshake handling for the test nodes.
+#[async_trait::async_trait]
+impl Handshake for TestNode {
+    async fn perform_handshake(&self, mut conn: Connection) -> io::Result<Connection> {
+        // Guard against double (two-sided) connections.
+        let mut locked_peers = self.state.peers.lock().await;
+
+        let own_addr = self.node().listening_addr()?;
+        let peer_addr = conn.addr;
+
+        let genesis_block_header = Testnet2::genesis_block().header();
+
+        // Send a challenge request to the peer.
+        let own_request = SnarkosMessage::ChallengeRequest(MESSAGE_VERSION, own_addr.port(), self.state.local_nonce, 0);
+        trace!(parent: self.node().span(), "sending a challenge request to {}", peer_addr);
+        let msg = own_request.serialize().unwrap();
+        let len = u32::to_le_bytes(msg.len() as u32);
+        conn.writer().write_all(&len).await?;
+        conn.writer().write_all(&msg).await?;
+
+        let mut buf = [0u8; 1024];
+
+        // Read the challenge request from the peer.
+        conn.reader().read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE]).await?;
+        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+        conn.reader().read_exact(&mut buf[..len]).await?;
+        let peer_request = SnarkosMessage::deserialize(&buf[..len]);
+
+        // Register peer's nonce.
+        let (peer_listening_addr, peer_nonce) =
+            if let Ok(Message::ChallengeRequest(peer_version, peer_listening_port, peer_nonce, _block_height)) = peer_request {
+                if peer_version < MESSAGE_VERSION {
+                    warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", peer_addr, peer_version);
+                    return Err(io::ErrorKind::InvalidData.into());
+                }
+
+                let peer_listening_addr = SocketAddr::from((peer_addr.ip(), peer_listening_port));
+
+                if locked_peers
+                    .iter()
+                    .any(|peer| peer.nonce == peer_nonce || peer.listening_addr == peer_listening_addr)
+                {
+                    return Err(io::ErrorKind::AlreadyExists.into());
+                }
+
+                trace!(parent: self.node().span(), "received a challenge request from {}", peer_addr);
+
+                (peer_listening_addr, peer_nonce)
+            } else {
+                error!(parent: self.node().span(), "invalid challenge request from {}", peer_addr);
+                return Err(io::ErrorKind::InvalidData.into());
+            };
+
+        // Respond with own challenge request.
+        let own_response = SnarkosMessage::ChallengeResponse(genesis_block_header.clone());
+        trace!(parent: self.node().span(), "sending a challenge response to {}", peer_addr);
+        let msg = own_response.serialize().unwrap();
+        let len = u32::to_le_bytes(msg.len() as u32);
+        conn.writer().write_all(&len).await?;
+        conn.writer().write_all(&msg).await?;
+
+        // Wait for the challenge response to come in.
+        conn.reader().read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE]).await?;
+        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+        conn.reader().read_exact(&mut buf[..len]).await?;
+        let peer_response = SnarkosMessage::deserialize(&buf[..len]);
+
+        if let Ok(Message::ChallengeResponse(block_header)) = peer_response {
+            trace!(parent: self.node().span(), "received a challenge response from {}", peer_addr);
+            if block_header.height() == CHALLENGE_HEIGHT && &block_header == genesis_block_header && block_header.is_valid() {
+                // Register the newly connected snarkOS peer.
+                locked_peers.push(SnarkosPeer {
+                    connected_addr: peer_addr,
+                    listening_addr: peer_listening_addr,
+                    nonce: peer_nonce,
+                });
+                debug!(parent: self.node().span(), "connected to {} (listening addr: {})", peer_addr, peer_listening_addr);
+
+                Ok(conn)
+            } else {
+                error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
+                Err(io::ErrorKind::InvalidData.into())
+            }
+        } else {
+            error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
+            Err(io::ErrorKind::InvalidData.into())
+        }
+    }
+}
+
+/// Inbound message processing logic for the test nodes.
+#[async_trait::async_trait]
+impl Reading for TestNode {
+    type Message = SnarkosMessage;
+
+    fn read_message<R: io::Read>(&self, source: SocketAddr, reader: &mut R) -> io::Result<Option<Self::Message>> {
+        // FIXME: use the maximum message size allowed by the protocol or (better) use streaming deserialization.
+        let mut buf = [0u8; 8 * 1024];
+
+        reader.read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE])?;
+        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+
+        if reader.read_exact(&mut buf[..len]).is_err() {
+            return Ok(None);
+        }
+
+        match SnarkosMessage::deserialize(&buf[..len]) {
+            Ok(msg) => {
+                info!(parent: self.node().span(), "received a {} from {}", msg.name(), source);
+                Ok(Some(msg))
+            }
+            Err(e) => {
+                error!("a message from {} failed to deserialize: {}", source, e);
+                Err(io::ErrorKind::InvalidData.into())
+            }
+        }
+    }
+
+    async fn process_message(&self, source: SocketAddr, message: Self::Message) -> io::Result<()> {
+        match message {
+            SnarkosMessage::BlockRequest(_start_block_height, _end_block_height) => {}
+            SnarkosMessage::BlockResponse(_block) => {}
+            SnarkosMessage::Disconnect => {}
+            SnarkosMessage::PeerRequest => self.process_peer_request(source).await?,
+            SnarkosMessage::PeerResponse(peer_addrs) => self.process_peer_response(source, peer_addrs).await?,
+            SnarkosMessage::Ping(version, block_height, _block_hash) => self.process_ping(source, version, block_height).await?,
+            SnarkosMessage::Pong(_is_fork, _block_locators) => {}
+            SnarkosMessage::UnconfirmedBlock(_block) => {}
+            SnarkosMessage::UnconfirmedTransaction(_transaction) => {}
+            _ => return Err(io::ErrorKind::InvalidData.into()), // Peer is not following the protocol.
+        }
+
+        Ok(())
+    }
+}
+
+/// Outbound message processing logic for the test nodes.
+impl Writing for TestNode {
+    type Message = SnarkosMessage;
+
+    fn write_message<W: io::Write>(&self, _target: SocketAddr, payload: &Self::Message, writer: &mut W) -> io::Result<()> {
+        let serialized = payload.serialize().unwrap();
+        let len = u32::to_le_bytes(serialized.len() as u32);
+
+        writer.write_all(&len)?;
+        writer.write_all(&serialized)
+    }
+}
+
+/// Disconnect logic for the test nodes.
+#[async_trait::async_trait]
+impl Disconnect for TestNode {
+    async fn handle_disconnect(&self, disconnecting_addr: SocketAddr) {
+        let mut locked_peers = self.state.peers.lock().await;
+        let initial_len = locked_peers.len();
+        locked_peers.retain(|peer| peer.connected_addr != disconnecting_addr);
+        assert_eq!(locked_peers.len(), initial_len - 1)
+    }
+}
+
+// Helper methods.
+impl TestNode {
+    async fn process_peer_request(&self, source: SocketAddr) -> io::Result<()> {
+        let peers = self
+            .state
+            .peers
+            .lock()
+            .await
+            .iter()
+            .map(|peer| peer.listening_addr)
+            .collect::<Vec<_>>();
+        let msg = SnarkosMessage::PeerResponse(peers);
+        info!(parent: self.node().span(), "sending a PeerResponse to {}", source);
+
+        self.send_direct_message(source, msg)
+    }
+
+    async fn process_peer_response(&self, source: SocketAddr, peer_addrs: Vec<SocketAddr>) -> io::Result<()> {
+        let num_conns = self.node().num_connected() + self.node().num_connecting();
+
+        let node = self.clone();
+        task::spawn(async move {
+            for peer_addr in peer_addrs
+                .into_iter()
+                .filter(|addr| node.node().listening_addr().unwrap() != *addr)
+                .take(DESIRED_CONNECTIONS.saturating_sub(num_conns))
+            {
+                if !node.node().is_connected(peer_addr)
+                    && !node.state.peers.lock().await.iter().any(|peer| peer.listening_addr == peer_addr)
+                {
+                    info!(parent: node.node().span(), "trying to connect to {}'s peer {}", source, peer_addr);
+                    let _ = node.node().connect(peer_addr).await;
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn process_ping(&self, source: SocketAddr, version: u32, block_height: u32) -> io::Result<()> {
+        // Ensure the message protocol version is not outdated.
+        if version < <Client<Testnet2>>::MESSAGE_VERSION {
+            warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", source, version);
+            return Err(io::ErrorKind::InvalidData.into());
+        }
+
+        debug!(parent: self.node().span(), "peer {} is at height {}", source, block_height);
+
+        let genesis = Testnet2::genesis_block();
+        let msg = SnarkosMessage::Pong(
+            None,
+            BlockLocators::<Testnet2>::from(vec![(genesis.height(), (genesis.hash(), None))].into_iter().collect()),
+        );
+
+        info!(parent: self.node().span(), "sending a Pong to {}", source);
+
+        self.send_direct_message(source, msg)
+    }
+}

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -62,9 +62,7 @@ macro_rules! wait_until {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            if now.elapsed() > std::time::Duration::from_secs($limit_secs) {
-                panic!("timed out!");
-            }
+            assert!(now.elapsed() <= std::time::Duration::from_secs($limit_secs), "timed out!");
         }
     };
 }

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -53,6 +53,23 @@ pub async fn spawn_test_node_with_nonce(local_nonce: SnarkosNonce) -> TestNode {
     node
 }
 
+/// A helper function making memory use values more human-readable.
+pub fn display_bytes(bytes: f64) -> String {
+    const GB: f64 = 1_000_000_000.0;
+    const MB: f64 = 1_000_000.0;
+    const KB: f64 = 1_000.0;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes / KB)
+    } else {
+        format!("{:.2} B", bytes)
+    }
+}
+
 #[macro_export]
 macro_rules! wait_until {
     ($limit_secs: expr, $condition: expr) => {

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use tracing_subscriber::filter::EnvFilter;
+
+/// Starts a logger if a test node needs to be inspected in greater detail.
+// note: snarkOS node currently starts it by default, so it's not needed
+pub fn start_logger() {
+    let filter = match EnvFilter::try_from_default_env() {
+        Ok(filter) => filter.add_directive("mio=off".parse().unwrap()),
+        _ => EnvFilter::default().add_directive("mio=off".parse().unwrap()),
+    };
+    tracing_subscriber::fmt().with_env_filter(filter).with_target(false).init();
+}
+
+#[macro_export]
+macro_rules! wait_until {
+    ($limit_secs: expr, $condition: expr) => {
+        let now = std::time::Instant::now();
+        loop {
+            if $condition {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            if now.elapsed() > std::time::Duration::from_secs($limit_secs) {
+                panic!("timed out!");
+            }
+        }
+    };
+}

--- a/testing/tests/network/basic_connectivity.rs
+++ b/testing/tests/network/basic_connectivity.rs
@@ -32,14 +32,14 @@ async fn test_nodes_can_connect_to_each_other() {
     let test_node1 = TestNode::default().await;
 
     // Ensure that the nodes have no active connections.
-    crate::wait_until!(1, test_node0.node().num_connected() == 0 && test_node1.node().num_connected() == 0);
+    wait_until!(1, test_node0.node().num_connected() == 0 && test_node1.node().num_connected() == 0);
 
     // Connect one to the other, performing the snarkOS handshake.
     let test_node0_addr = test_node0.node().listening_addr().unwrap();
     assert!(test_node1.node().connect(test_node0_addr).await.is_ok());
 
     // Ensure that both nodes have an active connection now.
-    crate::wait_until!(1, test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
+    wait_until!(1, test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -52,7 +52,7 @@ async fn handshake_as_initiator_works() {
     SnarkosNode::with_args(&["--node", "0", "--connect", &test_node_addr.to_string()]).await;
 
     // The snarkOS node should have connected to the test node.
-    crate::wait_until!(5, test_node.node().num_connected() != 0);
+    wait_until!(5, test_node.node().num_connected() != 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -114,7 +114,6 @@ async fn concurrent_duplicate_connection_attempts_fail() {
 async fn connection_limits_are_obeyed() {
     // Start a snarkOS node.
     let snarkos_node = SnarkosNode::default().await;
-    let snarkos_node_addr = snarkos_node.addr;
 
     // Start more test nodes than the snarkOS node is permitted to connect to at once.
     let mut test_nodes = Vec::with_capacity(MAXIMUM_NUMBER_OF_PEERS + 1);

--- a/testing/tests/network/basic_connectivity.rs
+++ b/testing/tests/network/basic_connectivity.rs
@@ -32,7 +32,7 @@ async fn snarkos_nodes_can_connect_to_each_other() {
     let snarkos_node2 = SnarkosNode::default().await;
 
     // Connect one to the other.
-    snarkos_node1.server.connect_to(snarkos_node2.local_addr()).await.unwrap();
+    snarkos_node1.connect(snarkos_node2.local_addr()).await.unwrap();
 }
 
 #[tokio::test]
@@ -62,7 +62,7 @@ async fn handshake_as_initiator_works() {
     let snarkos_node = SnarkosNode::default().await;
 
     // Connect the snarkOS node to the test node.
-    snarkos_node.server.connect_to(test_node_addr).await.unwrap();
+    snarkos_node.connect(test_node_addr).await.unwrap();
 
     // Double-check with the test node.
     // note: the small wait is due to the handshake responder (test node) finishing
@@ -91,7 +91,7 @@ async fn node_cant_connect_to_itself() {
     let snarkos_node = SnarkosNode::default().await;
 
     // Ensure it can't connect to itself
-    assert!(snarkos_node.server.connect_to(snarkos_node.local_addr()).await.is_err());
+    assert!(snarkos_node.connect(snarkos_node.local_addr()).await.is_err());
 }
 
 #[tokio::test]
@@ -104,10 +104,10 @@ async fn node_cant_connect_to_another_twice() {
     let snarkos_node = SnarkosNode::default().await;
 
     // Connect the snarkOS node to the test node.
-    snarkos_node.server.connect_to(test_node_addr).await.unwrap();
+    snarkos_node.connect(test_node_addr).await.unwrap();
 
     // The second connection attempt should fail.
-    assert!(snarkos_node.server.connect_to(test_node_addr).await.is_err());
+    assert!(snarkos_node.connect(test_node_addr).await.is_err());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -166,7 +166,7 @@ async fn connection_limits_are_obeyed() {
     let extra_test_node_addr = extra_test_node.node().listening_addr().unwrap();
 
     // Assert that snarkOS can't connect to it.
-    assert!(snarkos_node.server.connect_to(extra_test_node_addr).await.is_err());
+    assert!(snarkos_node.connect(extra_test_node_addr).await.is_err());
 
     // Assert that the test node can't connect to the snarkOS node either.
     assert!(extra_test_node.node().connect(snarkos_node.local_addr()).await.is_err());
@@ -187,7 +187,7 @@ async fn peer_accounting_works() {
     // Perform the connect+disconnect routine a few fimes.
     for _ in 0..3 {
         // Connect the snarkOS node to the test node.
-        snarkos_node.server.connect_to(test_node_addr).await.unwrap();
+        snarkos_node.connect(test_node_addr).await.unwrap();
 
         // Verify that the list of peers is not empty anymore.
         assert!(snarkos_node.connected_peers().await.len() == 1);

--- a/testing/tests/network/basic_connectivity.rs
+++ b/testing/tests/network/basic_connectivity.rs
@@ -1,0 +1,60 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use pea2pea::Pea2Pea;
+use snarkos_testing::{SnarkosNode, TestNode};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nodes_can_connect_to_each_other() {
+    // Start 2 test nodes.
+    let test_node0 = TestNode::default().await;
+    let test_node1 = TestNode::default().await;
+
+    // Ensure that the nodes have no active connections.
+    crate::wait_until!(1, test_node0.node().num_connected() == 0 && test_node1.node().num_connected() == 0);
+
+    // Connect one to the other, performing the snarkOS handshake.
+    let test_node0_addr = test_node0.node().listening_addr().unwrap();
+    assert!(test_node1.node().connect(test_node0_addr).await.is_ok());
+
+    // Ensure that both nodes have an active connection now.
+    crate::wait_until!(1, test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn handshake_as_initiator_works() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Start a snarkOS node.
+    let test_node_addr = test_node.node().listening_addr().unwrap();
+    SnarkosNode::with_args(&["--node", "0", "--connect", &test_node_addr.to_string()]).await;
+
+    // The snarkOS node should have connected to the test node.
+    crate::wait_until!(5, test_node.node().num_connected() != 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn handshake_as_responder_works() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // The test node should be able to connect to the snarkOS node.
+    assert!(test_node.node().connect(snarkos_node.addr).await.is_ok());
+}

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -19,7 +19,7 @@ use peak_alloc::PeakAlloc;
 use snarkos_testing::{SnarkosNode, TestNode};
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "this test is currently non-deterministic; needs more tinkering"]
+#[ignore = "FIXME: this test is currently non-deterministic; needs more tinkering"]
 async fn inbound_connect_and_disconnect_doesnt_leak() {
     // Configure a custom allocator that will measure memory use.
     #[global_allocator]
@@ -73,5 +73,5 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "currently not possible to connect on demand"]
+#[ignore = "TODO: currently not possible to connect on demand"]
 async fn outbound_connect_and_disconnect_doesnt_leak() {}

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -46,10 +46,10 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
     );
 
     // Connect the test node to the snarkOS node (inbound for snarkOS).
-    test_node.node().connect(snarkos_node.addr).await.unwrap();
+    test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
 
     // Disconnect the test node from the snarkOS node.
-    assert!(test_node.node().disconnect(snarkos_node.addr).await);
+    assert!(test_node.node().disconnect(snarkos_node.local_addr()).await);
 
     // Measure memory use after the 1st connect and disconnect.
     let first_conn_mem = PEAK_ALLOC.current_usage();
@@ -60,8 +60,8 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
 
     // Perform a connect and disconnect a few more times.
     for _ in 0..5 {
-        test_node.node().connect(snarkos_node.addr).await.unwrap();
-        assert!(test_node.node().disconnect(snarkos_node.addr).await);
+        test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
+        assert!(test_node.node().disconnect(snarkos_node.local_addr()).await);
     }
 
     // Measure memory use after the repeated connections.
@@ -73,5 +73,5 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "TODO: currently not possible to connect on demand"]
+#[ignore = "TODO: the call to Server::connect_to doesn't return the result of the connection"]
 async fn outbound_connect_and_disconnect_doesnt_leak() {}

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -115,7 +115,7 @@ async fn outbound_connect_and_disconnect_doesnt_leak() {
     let mut first_conn_mem = None;
     for i in 0..10 {
         // Connect the snarkOS node to the test node (outbound for snarkOS).
-        snarkos_node.server.connect_to(test_node_addr).await.unwrap();
+        snarkos_node.connect(test_node_addr).await.unwrap();
 
         // Disconnect the test node from the snarkOS node.
         wait_until!(1, test_node.node().num_connected() == 1);

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -14,64 +14,130 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::wait_until;
+
 use pea2pea::Pea2Pea;
 use peak_alloc::PeakAlloc;
 use snarkos_testing::{SnarkosNode, TestNode};
 
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "FIXME: this test is currently non-deterministic; needs more tinkering"]
-async fn inbound_connect_and_disconnect_doesnt_leak() {
-    // Configure a custom allocator that will measure memory use.
-    #[global_allocator]
-    static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+// Configure a custom allocator that will measure memory use.
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
+// A helper function making memory use more human-readable.
+fn display_bytes(bytes: f64) -> String {
+    const GB: f64 = 1_000_000_000.0;
+    const MB: f64 = 1_000_000.0;
+    const KB: f64 = 1_000.0;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes / KB)
+    } else {
+        format!("{:.2} B", bytes)
+    }
+}
+
+#[tokio::test]
+#[ignore = "this test is purely informational; latest result: 159.81 MB"]
+async fn measure_node_overhead() {
     // Register initial memory use.
     let initial_mem = PEAK_ALLOC.current_usage();
 
+    // Start a snarkOS node.
+    let _snarkos_node = SnarkosNode::default().await;
+
+    // Register memory use caused by the node.
+    let node_mem_use = PEAK_ALLOC.current_usage() - initial_mem;
+
+    // Display the result.
+    println!("snarkOS node memory use: {}", display_bytes(node_mem_use as f64));
+}
+
+#[tokio::test]
+#[ignore = "TODO: indicates a potential leak (13420B - around 1.3kB/connection); investigate further"]
+async fn inbound_connect_and_disconnect_doesnt_leak() {
     // Start a test node.
     let test_node = TestNode::default().await;
-
-    // Register memory use by the test node.
-    let post_test_node_mem = PEAK_ALLOC.current_usage();
-    println!("Memory increase from the test node: {}B", post_test_node_mem - initial_mem);
 
     // Start a snarkOS node.
     let snarkos_node = SnarkosNode::default().await;
 
-    // Register memory use before any connections.
+    // Register initial memory use.
     let pre_connection_mem = PEAK_ALLOC.current_usage();
-    println!(
-        "Memory increase from the snarkOS node: {}B",
-        pre_connection_mem - post_test_node_mem
-    );
 
-    // Connect the test node to the snarkOS node (inbound for snarkOS).
-    test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
-
-    // Disconnect the test node from the snarkOS node.
-    assert!(test_node.node().disconnect(snarkos_node.local_addr()).await);
-
-    // Measure memory use after the 1st connect and disconnect.
-    let first_conn_mem = PEAK_ALLOC.current_usage();
-    println!(
-        "Memory increase from a single inbound connection: {}B",
-        first_conn_mem - pre_connection_mem
-    );
-
-    // Perform a connect and disconnect a few more times.
-    for _ in 0..5 {
+    // Perform a connect and disconnect several times.
+    let mut first_conn_mem = None;
+    for i in 0..10 {
+        // Connect the test node to the snarkOS node (inbound for snarkOS).
         test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
+
+        // Disconnect the test node from the snarkOS node.
         assert!(test_node.node().disconnect(snarkos_node.local_addr()).await);
+        wait_until!(1, snarkos_node.connected_peers().await.is_empty());
+        snarkos_node.reset_known_peers().await;
+
+        if i == 0 {
+            // Measure memory use caused by the 1st connect and disconnect.
+            first_conn_mem = Some(PEAK_ALLOC.current_usage());
+            println!(
+                "Memory increase after a single outbound connection: {}",
+                display_bytes((first_conn_mem.unwrap() - pre_connection_mem) as f64)
+            );
+        }
     }
 
     // Measure memory use after the repeated connections.
     let final_mem = PEAK_ALLOC.current_usage();
 
     // Check if there is a connection-related leak.
-    let leaked_mem = final_mem.saturating_sub(first_conn_mem);
+    let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
     assert_eq!(leaked_mem, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "TODO: the call to Server::connect_to doesn't return the result of the connection"]
-async fn outbound_connect_and_disconnect_doesnt_leak() {}
+#[tokio::test]
+#[ignore = "TODO: indicates a potential leak (12424B - around 1.2kB/connection); investigate further"]
+async fn outbound_connect_and_disconnect_doesnt_leak() {
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Start a test node.
+    let test_node = TestNode::default().await;
+    let test_node_addr = test_node.node().listening_addr().unwrap();
+
+    // Register memory use before any connections.
+    let pre_connection_mem = PEAK_ALLOC.current_usage();
+
+    // Perform a connect and disconnect several times.
+    let mut first_conn_mem = None;
+    for i in 0..10 {
+        // Connect the snarkOS node to the test node (outbound for snarkOS).
+        snarkos_node.server.connect_to(test_node_addr).await.unwrap();
+
+        // Disconnect the test node from the snarkOS node.
+        wait_until!(1, test_node.node().num_connected() == 1);
+        let snarkos_node_addr = test_node.node().connected_addrs()[0];
+        assert!(test_node.node().disconnect(snarkos_node_addr).await);
+        wait_until!(1, snarkos_node.connected_peers().await.is_empty());
+        snarkos_node.reset_known_peers().await;
+
+        if i == 0 {
+            // Measure memory use caused by the 1st connect and disconnect.
+            first_conn_mem = Some(PEAK_ALLOC.current_usage());
+            println!(
+                "Memory increase after a single outbound connection: {}",
+                display_bytes((first_conn_mem.unwrap() - pre_connection_mem) as f64)
+            );
+        }
+    }
+
+    // Measure memory use after the repeated connections.
+    let final_mem = PEAK_ALLOC.current_usage();
+
+    // Check if there is a connection-related leak.
+    let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
+    assert_eq!(leaked_mem, 0);
+}

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::wait_until;
+use crate::{common::display_bytes, wait_until};
 
 use pea2pea::Pea2Pea;
 use peak_alloc::PeakAlloc;
@@ -23,23 +23,6 @@ use snarkos_testing::{SnarkosNode, TestNode};
 // Configure a custom allocator that will measure memory use.
 #[global_allocator]
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
-
-// A helper function making memory use more human-readable.
-fn display_bytes(bytes: f64) -> String {
-    const GB: f64 = 1_000_000_000.0;
-    const MB: f64 = 1_000_000.0;
-    const KB: f64 = 1_000.0;
-
-    if bytes >= GB {
-        format!("{:.2} GB", bytes / GB)
-    } else if bytes >= MB {
-        format!("{:.2} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{:.2} KB", bytes / KB)
-    } else {
-        format!("{:.2} B", bytes)
-    }
-}
 
 #[tokio::test]
 #[ignore = "this test is purely informational; latest result: 159.81 MB"]

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use pea2pea::Pea2Pea;
+use peak_alloc::PeakAlloc;
+use snarkos_testing::{SnarkosNode, TestNode};
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "this test is currently non-deterministic; needs more tinkering"]
+async fn inbound_connect_and_disconnect_doesnt_leak() {
+    // Configure a custom allocator that will measure memory use.
+    #[global_allocator]
+    static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+    // Register initial memory use.
+    let initial_mem = PEAK_ALLOC.current_usage();
+
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Register memory use by the test node.
+    let post_test_node_mem = PEAK_ALLOC.current_usage();
+    println!("Memory increase from the test node: {}B", post_test_node_mem - initial_mem);
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Register memory use before any connections.
+    let pre_connection_mem = PEAK_ALLOC.current_usage();
+    println!(
+        "Memory increase from the snarkOS node: {}B",
+        pre_connection_mem - post_test_node_mem
+    );
+
+    // Connect the test node to the snarkOS node (inbound for snarkOS).
+    test_node.node().connect(snarkos_node.addr).await.unwrap();
+
+    // Disconnect the test node from the snarkOS node.
+    assert!(test_node.node().disconnect(snarkos_node.addr).await);
+
+    // Measure memory use after the 1st connect and disconnect.
+    let first_conn_mem = PEAK_ALLOC.current_usage();
+    println!(
+        "Memory increase from a single inbound connection: {}B",
+        first_conn_mem - pre_connection_mem
+    );
+
+    // Perform a connect and disconnect a few more times.
+    for _ in 0..5 {
+        test_node.node().connect(snarkos_node.addr).await.unwrap();
+        assert!(test_node.node().disconnect(snarkos_node.addr).await);
+    }
+
+    // Measure memory use after the repeated connections.
+    let final_mem = PEAK_ALLOC.current_usage();
+
+    // Check if there is a connection-related leak.
+    let leaked_mem = final_mem.saturating_sub(first_conn_mem);
+    assert_eq!(leaked_mem, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "currently not possible to connect on demand"]
+async fn outbound_connect_and_disconnect_doesnt_leak() {}

--- a/testing/tests/network/manual_testing.rs
+++ b/testing/tests/network/manual_testing.rs
@@ -40,7 +40,7 @@ async fn spawn_inert_node_at_port() {
         ..Default::default()
     };
 
-    let test_node = TestNode::new(Pea2PeaNode::new(Some(config)).await.unwrap());
+    let test_node = TestNode::new(Pea2PeaNode::new(Some(config)).await.unwrap(), Default::default());
     test_node.enable_handshake();
     test_node.enable_reading();
     test_node.enable_writing();

--- a/testing/tests/network/manual_testing.rs
+++ b/testing/tests/network/manual_testing.rs
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::common::start_logger;
+
+use pea2pea::{
+    protocols::{Handshake, Reading, Writing},
+    Config,
+    Node as Pea2PeaNode,
+};
+use snarkos_testing::TestNode;
+
+use std::net::{IpAddr, Ipv4Addr};
+
+/// This test is intended to be run manually in order to monitor the behavior of
+/// a full snarkOS node started independently.
+#[ignore]
+#[tokio::test]
+async fn spawn_inert_node_at_port() {
+    start_logger();
+
+    const PORT: u16 = 4135;
+
+    let config = Config {
+        listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        desired_listening_port: Some(PORT),
+        ..Default::default()
+    };
+
+    let test_node = TestNode::new(Pea2PeaNode::new(Some(config)).await.unwrap());
+    test_node.enable_handshake();
+    test_node.enable_reading();
+    test_node.enable_writing();
+    // test_node.run_periodic_tasks();
+
+    std::future::pending::<()>().await;
+}

--- a/testing/tests/network/mod.rs
+++ b/testing/tests/network/mod.rs
@@ -15,4 +15,5 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod basic_connectivity;
+mod cleanups;
 mod manual_testing;

--- a/testing/tests/network/mod.rs
+++ b/testing/tests/network/mod.rs
@@ -14,14 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
-
-pub mod message;
-pub use message::*;
-
-pub(crate) mod peers;
-pub(crate) use peers::*;
-
-pub(crate) mod server;
-pub(crate) use server::Server;
+mod basic_connectivity;
+mod manual_testing;

--- a/testing/tests/network/perf.rs
+++ b/testing/tests/network/perf.rs
@@ -19,7 +19,7 @@ use snarkos_testing::SnarkosNode;
 use std::time::Instant;
 
 #[tokio::test]
-#[ignore = "this test is purely informational; latest result: ~770ms"]
+#[ignore = "this test is purely informational; latest result: ~675ms"]
 async fn measure_node_startup() {
     let now = Instant::now();
 

--- a/testing/tests/network/perf.rs
+++ b/testing/tests/network/perf.rs
@@ -14,7 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod basic_connectivity;
-mod cleanups;
-mod manual_testing;
-mod perf;
+use snarkos_testing::SnarkosNode;
+
+use std::time::Instant;
+
+#[tokio::test]
+#[ignore = "this test is purely informational; latest result: ~770ms"]
+async fn measure_node_startup() {
+    let now = Instant::now();
+
+    // Start a snarkOS node.
+    let _snarkos_node = SnarkosNode::default().await;
+
+    // Display the result.
+    println!("snarkOS start-up time: {}ms", now.elapsed().as_millis());
+}

--- a/testing/tests/tests.rs
+++ b/testing/tests/tests.rs
@@ -14,14 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
-
-pub mod message;
-pub use message::*;
-
-pub(crate) mod peers;
-pub(crate) use peers::*;
-
-pub(crate) mod server;
-pub(crate) use server::Server;
+mod common;
+mod network;


### PR DESCRIPTION
This PR builds on https://github.com/AleoHQ/snarkOS/pull/1286 ([exact diff](https://github.com/ljedrz/snarkOS/compare/testnet2_testing_framework...ljedrz:testnet2_node_introspection?expand=1)), providing tests with greater node introspection abilities (by directly using the `Server` object and making some methods `pub`) and enhancing the calls to `Server::connect_to` with information whether (and indirectly _when_) they succeeded or not.

Using these new features, more network integration tests are possible, and new ones were added. In addition, they should now never fail due to `AddrInUse` errors.

Marking this PR as a draft until the first integration test PR gets merged; until then, additional tests and tweaks may follow.