### PR TITLE
Update ledger usage with performance improvements

### DIFF
--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -25,6 +25,7 @@ use circular_queue::CircularQueue;
 use itertools::Itertools;
 use parking_lot::RwLock;
 use rand::{CryptoRng, Rng};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -1022,7 +1023,7 @@ impl<N: Network> BlockState<N> {
         }
 
         (start_block_height..=end_block_height)
-            .into_iter()
+            .into_par_iter()
             .map(|height| self.get_block_header(height))
             .collect()
     }
@@ -1070,7 +1071,7 @@ impl<N: Network> BlockState<N> {
         }
 
         (start_block_height..=end_block_height)
-            .into_iter()
+            .into_par_iter()
             .map(|height| self.get_block(height))
             .collect()
     }

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -269,7 +269,7 @@ impl<N: Network> LedgerState<N> {
                             last_seen_block_height.store(latest_block_height, Ordering::SeqCst);
                         }
                     }
-                    thread::sleep(std::time::Duration::from_secs(8));
+                    thread::sleep(std::time::Duration::from_secs(6));
                 }
             });
         }

--- a/ledger/src/state/tests.rs
+++ b/ledger/src/state/tests.rs
@@ -28,14 +28,14 @@ fn temp_dir() -> std::path::PathBuf {
 }
 
 /// Initializes a new instance of the ledger.
-fn new_ledger<N: Network, S: Storage>() -> LedgerState<N> {
-    LedgerState::open::<S, _>(temp_dir(), false).expect("Failed to initialize ledger")
+fn create_new_ledger<N: Network, S: Storage>() -> LedgerState<N> {
+    LedgerState::open_writer::<S, _>(temp_dir()).expect("Failed to initialize ledger")
 }
 
 #[test]
 fn test_genesis() {
     // Initialize a new ledger.
-    let ledger = new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<Testnet2, RocksDB>();
 
     // Retrieve the genesis block.
     let genesis = Testnet2::genesis_block();
@@ -61,7 +61,7 @@ fn test_add_next_block() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = new_ledger::<Testnet2, RocksDB>();
+    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
@@ -107,7 +107,7 @@ fn test_remove_last_block() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = new_ledger::<Testnet2, RocksDB>();
+    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
@@ -151,7 +151,7 @@ fn test_remove_last_2_blocks() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = new_ledger::<Testnet2, RocksDB>();
+    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
@@ -200,7 +200,7 @@ fn test_get_block_locators() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = new_ledger::<Testnet2, RocksDB>();
+    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -80,7 +80,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The maximum size of a message that can be transmitted in the network.
     const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
     /// The maximum number of blocks that may be fetched in one request.
-    const MAXIMUM_BLOCK_REQUEST: u32 = 50;
+    const MAXIMUM_BLOCK_REQUEST: u32 = 100;
     /// The maximum number of failures tolerated before disconnecting from a peer.
     const MAXIMUM_NUMBER_OF_FAILURES: usize = 2400;
 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -64,7 +64,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const PING_SLEEP_IN_SECS: u64 = 12;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
-    const RADIO_SILENCE_IN_SECS: u64 = 120; // 2 minutes
+    const RADIO_SILENCE_IN_SECS: u64 = 150; // 2.5 minutes
     /// The duration in seconds after which to expire a failure from a peer.
     const FAILURE_EXPIRY_TIME_IN_SECS: u64 = 7200; // 2 hours
 

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -63,8 +63,6 @@ pub enum LedgerRequest<N: Network, E: Environment> {
     Ping(SocketAddr, u32, N::BlockHash),
     /// Pong := (peer_ip, is_fork, block_locators)
     Pong(SocketAddr, Option<bool>, BlockLocators<N>),
-    /// SendPing := (peer_ip)
-    SendPing(SocketAddr),
     /// UnconfirmedBlock := (peer_ip, block)
     UnconfirmedBlock(SocketAddr, Block<N>),
     /// UnconfirmedTransaction := (peer_ip, transaction)
@@ -248,18 +246,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                         warn!("[Ping] {}", error);
                     }
                 });
-            }
-            LedgerRequest::SendPing(peer_ip) => {
-                // Send a `Ping` request to the peer.
-                let message = Message::Ping(
-                    E::MESSAGE_VERSION,
-                    self.canon_reader.latest_block_height(),
-                    self.canon_reader.latest_block_hash(),
-                );
-                let request = PeersRequest::MessageSend(peer_ip, message);
-                if let Err(error) = peers_router.send(request).await {
-                    warn!("[Ping] {}", error);
-                }
             }
             LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
                 // Ensure the given block is new.

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -595,7 +595,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // trace!("STATUS {:?} {} {}", self.status(), self.latest_block_height(), self.number_of_block_requests());
             let fork_status = match is_fork {
                 Some(boolean) => format!("{}", boolean),
-                None => format!("unknown"),
+                None => "unknown".to_string(),
             };
             debug!(
                 "Peer {} is at block {} (is_fork = {}, common_ancestor = {})",

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -389,7 +389,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.status.store(Status::Mining as u8, Ordering::SeqCst);
 
             // Prepare the unconfirmed transactions, terminator, and status.
-            let canon = self.canon_writer.clone(); // This is safe as we only *read* LedgerState.
+            let canon = self.canon_reader.clone();
             let unconfirmed_transactions = self.memory_pool.transactions();
             let terminator = self.terminator.clone();
             let status = self.status.clone();

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -592,7 +592,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // trace!("STATUS {:?} {} {}", self.status(), self.latest_block_height(), self.number_of_block_requests());
             let fork_status = match is_fork {
                 Some(boolean) => format!("{}", boolean),
-                None => "unknown".to_string(),
+                None => "undecided".to_string(),
             };
             debug!(
                 "Peer {} is at block {} (is_fork = {}, common_ancestor = {})",

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -218,20 +218,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 self.initialize_peer(peer_ip);
                 // Process the pong.
                 self.update_peer(peer_ip, is_fork, block_locators).await;
-
-                // Spawn an asynchronous task for the `Ping` request, after sleeping.
-                let canon = self.canon_reader.clone();
-                let peers_router = peers_router.clone();
-                task::spawn(async move {
-                    // Sleep for the preset time before sending a `Ping` request.
-                    tokio::time::sleep(Duration::from_secs(E::PING_SLEEP_IN_SECS)).await;
-                    // Send a `Ping` request to the peer.
-                    let message = Message::Ping(E::MESSAGE_VERSION, canon.latest_block_height(), canon.latest_block_hash());
-                    let request = PeersRequest::MessageSend(peer_ip, message);
-                    if let Err(error) = peers_router.send(request).await {
-                        warn!("[Ping] {}", error);
-                    }
-                });
             }
             LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
                 // Ensure the given block is new.

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -120,7 +120,7 @@ pub struct Ledger<N: Network, E: Environment> {
 impl<N: Network, E: Environment> Ledger<N, E> {
     /// Initializes a new instance of the ledger.
     pub fn open<S: Storage, P: AsRef<Path>>(path: P) -> Result<Self> {
-        let canon = LedgerState::open::<S, P>(path, false)?;
+        let canon = LedgerState::open_writer::<S, P>(path)?;
         let last_block_update_timestamp = Instant::now();
         Ok(Self {
             canon,

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -407,7 +407,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
 
                 match result {
                     Ok(Ok(block)) => {
-                        debug!("Miner has found the next block");
+                        debug!("Miner has found an unconfirmed candidate for block {}", block.height());
                         // Broadcast the next block.
                         let request = LedgerRequest::UnconfirmedBlock(local_ip, block);
                         if let Err(error) = ledger_router.send(request).await {

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -93,7 +93,8 @@ pub enum Status {
 #[allow(clippy::type_complexity)]
 pub struct Ledger<N: Network, E: Environment> {
     /// The canonical chain of block hashes.
-    canon: LedgerState<N>,
+    canon_writer: LedgerState<N>,
+    canon_reader: LedgerState<N>,
     /// A map of previous block hashes to unconfirmed blocks.
     unconfirmed_blocks: CircularMap<N::BlockHash, Block<N>, { MAXIMUM_UNCONFIRMED_BLOCKS }>,
     /// The pool of unconfirmed transactions.
@@ -119,11 +120,10 @@ pub struct Ledger<N: Network, E: Environment> {
 
 impl<N: Network, E: Environment> Ledger<N, E> {
     /// Initializes a new instance of the ledger.
-    pub fn open<S: Storage, P: AsRef<Path>>(path: P) -> Result<Self> {
-        let canon = LedgerState::open_writer::<S, P>(path)?;
-        let last_block_update_timestamp = Instant::now();
+    pub fn open<S: Storage, P: AsRef<Path> + Copy>(path: P) -> Result<Self> {
         Ok(Self {
-            canon,
+            canon_writer: LedgerState::open_writer::<S, P>(path)?,
+            canon_reader: LedgerState::open_reader::<S, P>(path)?,
             unconfirmed_blocks: Default::default(),
             memory_pool: MemoryPool::new(),
 
@@ -132,7 +132,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             peers_state: Default::default(),
             block_requests: Default::default(),
             block_requests_lock: Arc::new(Mutex::new(true)),
-            last_block_update_timestamp,
+            last_block_update_timestamp: Instant::now(),
             failures: Default::default(),
             _phantom: PhantomData,
         })
@@ -165,16 +165,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.status() == Status::Syncing
     }
 
-    /// Returns the latest block height.
-    pub fn latest_block_height(&self) -> u32 {
-        self.canon.latest_block_height()
-    }
-
-    /// Returns the latest block hash.
-    pub fn latest_block_hash(&self) -> N::BlockHash {
-        self.canon.latest_block_hash()
-    }
-
     ///
     /// Performs the given `request` to the ledger.
     /// All requests must go through this `update`, so that a unified view is preserved.
@@ -191,7 +181,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     return;
                 }
                 // Retrieve the requested blocks.
-                let blocks = match self.canon.get_blocks(start_block_height, end_block_height) {
+                let blocks = match self.canon_reader.get_blocks(start_block_height, end_block_height) {
                     Ok(blocks) => blocks,
                     Err(error) => {
                         error!("{}", error);
@@ -252,12 +242,12 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             }
             LedgerRequest::Ping(peer_ip, block_height, block_hash) => {
                 // Determine if the peer is on a fork (or unknown).
-                let is_fork: Option<bool> = match self.canon.get_block_hash(block_height) {
+                let is_fork: Option<bool> = match self.canon_reader.get_block_hash(block_height) {
                     Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
                     Err(_) => None,
                 };
                 // Send a `Pong` message to the peer.
-                let request = PeersRequest::MessageSend(peer_ip, Message::Pong(is_fork, self.canon.latest_block_locators()));
+                let request = PeersRequest::MessageSend(peer_ip, Message::Pong(is_fork, self.canon_reader.latest_block_locators()));
                 if let Err(error) = peers_router.send(request).await {
                     warn!("[Pong] {}", error);
                 }
@@ -269,7 +259,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 self.update_peer(peer_ip, is_fork, block_locators).await;
 
                 // Spawn an asynchronous task for the `Ping` request, after sleeping.
-                let canon = self.canon.clone(); // This is safe as we only *read* LedgerState.
+                let canon = self.canon_writer.clone(); // This is safe as we only *read* LedgerState.
                 let peers_router = peers_router.clone();
                 task::spawn(async move {
                     // Sleep for the preset time before sending a `Ping` request.
@@ -284,7 +274,11 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             }
             LedgerRequest::SendPing(peer_ip) => {
                 // Send a `Ping` request to the peer.
-                let message = Message::Ping(E::MESSAGE_VERSION, self.canon.latest_block_height(), self.canon.latest_block_hash());
+                let message = Message::Ping(
+                    E::MESSAGE_VERSION,
+                    self.canon_reader.latest_block_height(),
+                    self.canon_reader.latest_block_hash(),
+                );
                 let request = PeersRequest::MessageSend(peer_ip, message);
                 if let Err(error) = peers_router.send(request).await {
                     warn!("[Ping] {}", error);
@@ -292,13 +286,13 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             }
             LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
                 // Ensure the given block is new.
-                if let Ok(true) = self.canon.contains_block_hash(&block.hash()) {
+                if let Ok(true) = self.canon_writer.contains_block_hash(&block.hash()) {
                     trace!("Canon chain already contains block {}", block.height());
                 } else if self.unconfirmed_blocks.contains_key(&block.previous_block_hash()) {
                     trace!("Memory pool already contains unconfirmed block {}", block.height());
                 } else if !(self.is_peering() || self.is_syncing()) {
                     // Ensure the unconfirmed block is at least within 3 blocks of the latest block height.
-                    if block.height() + 3 > self.latest_block_height() {
+                    if block.height() + 3 > self.canon_writer.latest_block_height() {
                         // Process the unconfirmed block.
                         self.add_block(block.clone());
                         // Propagate the unconfirmed block to the connected peers.
@@ -324,7 +318,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     fn update_ledger(&mut self) {
         // Check for candidate blocks to fast forward the ledger.
-        let mut block = &self.canon.latest_block();
+        let mut block = &self.canon_writer.latest_block();
         let unconfirmed_blocks = self.unconfirmed_blocks.clone();
         while let Some(unconfirmed_block) = unconfirmed_blocks.get(&block.hash()) {
             // Update the block iterator.
@@ -364,7 +358,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.unconfirmed_blocks = Default::default();
             self.memory_pool = MemoryPool::new();
             self.block_requests.values_mut().for_each(|requests| *requests = Default::default());
-            self.revert_to_block_height(self.latest_block_height().saturating_sub(1));
+            self.revert_to_block_height(self.canon_writer.latest_block_height().saturating_sub(1));
         }
     }
 
@@ -395,7 +389,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             };
 
             // Retrieve the latest block height of this node.
-            let latest_block_height = self.latest_block_height();
+            let latest_block_height = self.canon_reader.latest_block_height();
             // Iterate through the connected peers, to determine if the ledger state is out of date.
             for (_, ledger_state) in self.peers_state.iter() {
                 if let Some((_, block_height, _)) = ledger_state {
@@ -446,7 +440,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.status.store(Status::Mining as u8, Ordering::SeqCst);
 
             // Prepare the unconfirmed transactions, terminator, and status.
-            let canon = self.canon.clone(); // This is safe as we only *read* LedgerState.
+            let canon = self.canon_writer.clone(); // This is safe as we only *read* LedgerState.
             let unconfirmed_transactions = self.memory_pool.transactions();
             let terminator = self.terminator.clone();
             let status = self.status.clone();
@@ -489,12 +483,14 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         let _ = self.block_requests_lock.lock();
 
         // Ensure the given block is new.
-        if let Ok(true) = self.canon.contains_block_hash(&block.hash()) {
+        if let Ok(true) = self.canon_writer.contains_block_hash(&block.hash()) {
             trace!("Canon chain already contains block {}", block.height());
-        } else if block.height() == self.latest_block_height() + 1 && block.previous_block_hash() == self.latest_block_hash() {
-            match self.canon.add_next_block(&block) {
+        } else if block.height() == self.canon_writer.latest_block_height() + 1
+            && block.previous_block_hash() == self.canon_writer.latest_block_hash()
+        {
+            match self.canon_writer.add_next_block(&block) {
                 Ok(()) => {
-                    info!("Ledger advanced to block {}", self.latest_block_height());
+                    info!("Ledger advanced to block {}", self.canon_writer.latest_block_height());
 
                     // Update the timestamp of the last block increment.
                     self.last_block_update_timestamp = Instant::now();
@@ -539,7 +535,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Process the unconfirmed transaction.
         trace!("Received unconfirmed transaction {} from {}", transaction.transaction_id(), peer_ip);
         // Ensure the unconfirmed transaction is new.
-        if let Ok(false) = self.canon.contains_transaction(&transaction.transaction_id()) {
+        if let Ok(false) = self.canon_writer.contains_transaction(&transaction.transaction_id()) {
             debug!("Adding unconfirmed transaction {} to memory pool", transaction.transaction_id());
             // Attempt to add the unconfirmed transaction to the memory pool.
             match self.memory_pool.add_transaction(&transaction) {
@@ -559,9 +555,9 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Reverts the ledger state back to height `block_height`, returning `true` on success.
     ///
     fn revert_to_block_height(&mut self, block_height: u32) -> bool {
-        match self.canon.revert_to_block_height(block_height) {
+        match self.canon_writer.revert_to_block_height(block_height) {
             Ok(removed_blocks) => {
-                info!("Ledger successfully reverted to block {}", self.latest_block_height());
+                info!("Ledger successfully reverted to block {}", self.canon_writer.latest_block_height());
 
                 // Update the last block update timestamp.
                 self.last_block_update_timestamp = Instant::now();
@@ -622,7 +618,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.add_failure(peer_ip, "Received a sync response with no block locators".to_string());
         } else {
             // Ensure the peer provided well-formed block locators.
-            match self.canon.check_block_locators(&block_locators) {
+            match self.canon_reader.check_block_locators(&block_locators) {
                 Ok(is_valid) => {
                     if !is_valid {
                         warn!("Invalid block locators from {}", peer_ip);
@@ -641,7 +637,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Verify the integrity of the block hashes sent by the peer.
             for (block_height, (block_hash, _)) in block_locators.iter() {
                 // Ensure the block hash corresponds with the block height, if the block hash exists in this ledger.
-                if let Ok(expected_block_height) = self.canon.get_block_height(block_hash) {
+                if let Ok(expected_block_height) = self.canon_reader.get_block_height(block_hash) {
                     if expected_block_height != *block_height {
                         let error = format!("Invalid block height {} for block hash {}", expected_block_height, block_hash);
                         trace!("{}", error);
@@ -707,7 +703,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Prioritize the sync nodes before regular peers.
         let mut maximal_peer = None;
         let mut maximal_peer_is_fork = None;
-        let mut maximum_block_height = self.latest_block_height();
+        let mut maximum_block_height = self.canon_writer.latest_block_height();
         let mut maximum_block_locators = Default::default();
 
         // Determine if the peers state has any sync nodes.
@@ -735,7 +731,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         }
 
         // Case 1 - Ensure the peer has a higher block height than this ledger.
-        let latest_block_height = self.latest_block_height();
+        let latest_block_height = self.canon_writer.latest_block_height();
         if latest_block_height >= maximum_block_height {
             return;
         }
@@ -750,7 +746,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Verify the integrity of the block hashes sent by the peer.
             for (block_height, (block_hash, _)) in maximum_block_locators.iter() {
                 // Ensure the block hash corresponds with the block height, if the block hash exists in this ledger.
-                if let Ok(expected_block_height) = self.canon.get_block_height(block_hash) {
+                if let Ok(expected_block_height) = self.canon_writer.get_block_height(block_hash) {
                     if expected_block_height != *block_height {
                         let error = format!("Invalid block height {} for block hash {}", expected_block_height, block_hash);
                         trace!("{}", error);
@@ -776,7 +772,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             }
 
             // Ensure the latest common ancestor is not greater than the latest block request.
-            let latest_block_height = self.latest_block_height();
+            let latest_block_height = self.canon_writer.latest_block_height();
             if latest_block_height < maximum_common_ancestor {
                 warn!(
                     "The common ancestor {} cannot be greater than the latest block {}",

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -593,9 +593,13 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             }
 
             // trace!("STATUS {:?} {} {}", self.status(), self.latest_block_height(), self.number_of_block_requests());
+            let fork_status = match is_fork {
+                Some(boolean) => format!("{}", boolean),
+                None => format!("unknown"),
+            };
             debug!(
-                "Peer {} is at block {} (common_ancestor = {})",
-                peer_ip, latest_block_height_of_peer, common_ancestor,
+                "Peer {} is at block {} (is_fork = {}, common_ancestor = {})",
+                peer_ip, latest_block_height_of_peer, fork_status, common_ancestor,
             );
 
             match self.peers_state.get_mut(&peer_ip) {

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -226,15 +226,12 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 } else if self.unconfirmed_blocks.contains_key(&block.previous_block_hash()) {
                     trace!("Memory pool already contains unconfirmed block {}", block.height());
                 } else if !(self.is_peering() || self.is_syncing()) {
-                    // Ensure the unconfirmed block is at least within 3 blocks of the latest block height.
-                    if block.height() + 3 > self.canon_writer.latest_block_height() {
-                        // Process the unconfirmed block.
-                        self.add_block(block.clone());
-                        // Propagate the unconfirmed block to the connected peers.
-                        let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedBlock(block));
-                        if let Err(error) = peers_router.send(request).await {
-                            warn!("[UnconfirmedBlock] {}", error);
-                        }
+                    // Process the unconfirmed block.
+                    self.add_block(block.clone());
+                    // Propagate the unconfirmed block to the connected peers.
+                    let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedBlock(block));
+                    if let Err(error) = peers_router.send(request).await {
+                        warn!("[UnconfirmedBlock] {}", error);
                     }
                 }
             }
@@ -425,7 +422,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         {
             match self.canon_writer.add_next_block(&block) {
                 Ok(()) => {
-                    info!("Ledger advanced to block {}", self.canon_writer.latest_block_height());
+                    info!("Ledger successfully advanced to block {}", self.canon_writer.latest_block_height());
 
                     // Update the timestamp of the last block increment.
                     self.last_block_update_timestamp = Instant::now();

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -790,7 +790,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             let number_of_block_requests = std::cmp::min(maximum_block_height - latest_common_ancestor, E::MAXIMUM_BLOCK_REQUEST);
             let start_block_height = latest_common_ancestor + 1;
             let end_block_height = start_block_height + number_of_block_requests - 1;
-            debug!("Request blocks {} to {} from {}", start_block_height, end_block_height, peer_ip);
+            debug!("Requesting blocks {} to {} from {}", start_block_height, end_block_height, peer_ip);
 
             // Send a `BlockRequest` message to the peer.
             let request = PeersRequest::MessageSend(peer_ip, Message::BlockRequest(start_block_height, end_block_height));

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -24,4 +24,4 @@ pub(crate) mod peers;
 pub(crate) use peers::*;
 
 pub(crate) mod server;
-pub(crate) use server::Server;
+pub(crate) use server::{LedgerReader, Server};

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -757,8 +757,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     };
                                     // Send a `BlockResponse` message for each block to the peer.
                                     for block in blocks {
-                                        let request = PeersRequest::MessageSend(peer_ip, Message::BlockResponse(block));
-                                        if let Err(error) = peers_router.send(request).await {
+                                        trace!("Sending 'BlockResponse {}' to {}", block.height(), peer_ip);
+                                        if let Err(error) = peer.outbound_socket.send(Message::BlockResponse(block)).await {
                                             warn!("[BlockResponse] {}", error);
                                         }
                                     }

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -760,6 +760,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         trace!("Sending 'BlockResponse {}' to {}", block.height(), peer_ip);
                                         if let Err(error) = peer.outbound_socket.send(Message::BlockResponse(block)).await {
                                             warn!("[BlockResponse] {}", error);
+                                            break;
                                         }
                                     }
                                 },

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -93,7 +93,7 @@ impl<N: Network, E: Environment> Server<N, E> {
             username,
             password,
             &peers,
-            &Arc::new(RwLock::new(LedgerState::<N>::open_reader::<RocksDB, _>(storage_path)?)),
+            &ledger_reader,
             &ledger_router,
         ));
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -91,7 +91,7 @@ impl<N: Network, E: Environment> Server<N, E> {
             username,
             password,
             &peers,
-            LedgerState::open::<RocksDB, _>(&storage_path, true)?,
+            LedgerState::open_reader::<RocksDB, _>(&storage_path)?,
             &ledger_router,
         ));
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -268,8 +268,8 @@ impl<N: Network, E: Environment> Server<N, E> {
                         if let Err(error) = ledger_router.send(request).await {
                             error!("Failed to send request to ledger: {}", error);
                         }
-                        // Sleep for 2 seconds.
-                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        // Sleep for 3 seconds.
+                        tokio::time::sleep(Duration::from_secs(3)).await;
                     }
                 }));
             } else {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -93,7 +93,7 @@ impl<N: Network, E: Environment> Server<N, E> {
             username,
             password,
             &peers,
-            &ledger_reader,
+            &Arc::new(RwLock::new(LedgerState::<N>::open_reader::<RocksDB, _>(storage_path)?)),
             &ledger_router,
         ));
 

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -471,8 +471,8 @@ mod tests {
     /// Initializes a new instance of the ledger state.
     fn new_ledger_state<N: Network, S: Storage, P: AsRef<Path>>(path: Option<P>) -> LedgerState<N> {
         match path {
-            Some(path) => LedgerState::<N>::open::<S, _>(path, false).expect("Failed to initialize ledger"),
-            None => LedgerState::<N>::open::<S, _>(temp_dir(), false).expect("Failed to initialize ledger"),
+            Some(path) => LedgerState::<N>::open_writer::<S, _>(path).expect("Failed to initialize ledger"),
+            None => LedgerState::<N>::open_writer::<S, _>(temp_dir()).expect("Failed to initialize ledger"),
         }
     }
 

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -437,7 +437,7 @@ fn result_to_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ledger::Ledger, Client};
+    use crate::Client;
 
     use snarkos_ledger::{
         storage::{rocksdb::RocksDB, Storage},
@@ -474,11 +474,6 @@ mod tests {
             Some(path) => LedgerState::<N>::open_writer::<S, _>(path).expect("Failed to initialize ledger"),
             None => LedgerState::<N>::open_writer::<S, _>(temp_dir()).expect("Failed to initialize ledger"),
         }
-    }
-
-    /// Initializes a new instance of the ledger.
-    fn new_ledger<N: Network, E: Environment, S: Storage>() -> Ledger<N, E> {
-        Ledger::<N, E>::open::<S, _>(temp_dir()).expect("Failed to initialize ledger")
     }
 
     /// Initializes a new instance of the Peers.

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -21,11 +21,12 @@
 use crate::{
     rpc::{rpc::*, rpc_trait::RpcFunctions},
     Environment,
+    LedgerReader,
     LedgerRequest,
     LedgerRouter,
     Peers,
 };
-use snarkos_ledger::{LedgerState, Metadata};
+use snarkos_ledger::Metadata;
 use snarkvm::{
     dpc::{Block, BlockHeader, Network, RecordCiphertext, Transaction, Transactions, Transition},
     utilities::FromBytes,
@@ -63,7 +64,7 @@ impl From<RpcError> for std::io::Error {
 #[doc(hidden)]
 pub struct RpcInner<N: Network, E: Environment> {
     peers: Arc<RwLock<Peers<N, E>>>,
-    ledger: LedgerState<N>,
+    ledger: LedgerReader<N>,
     ledger_router: LedgerRouter<N, E>,
     /// RPC credentials for accessing guarded endpoints
     #[allow(unused)]
@@ -87,7 +88,7 @@ impl<N: Network, E: Environment> RpcImpl<N, E> {
     pub fn new(
         credentials: RpcCredentials,
         peers: Arc<RwLock<Peers<N, E>>>,
-        ledger: LedgerState<N>,
+        ledger: LedgerReader<N>,
         ledger_router: LedgerRouter<N, E>,
     ) -> Self {
         Self(Arc::new(RpcInner {
@@ -103,97 +104,97 @@ impl<N: Network, E: Environment> RpcImpl<N, E> {
 impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
     /// Returns the latest block from the canonical chain.
     async fn latest_block(&self) -> Result<Block<N>, RpcError> {
-        Ok(self.ledger.latest_block())
+        Ok(self.ledger.read().await.latest_block())
     }
 
     /// Returns the latest block height from the canonical chain.
     async fn latest_block_height(&self) -> Result<u32, RpcError> {
-        Ok(self.ledger.latest_block_height())
+        Ok(self.ledger.read().await.latest_block_height())
     }
 
     /// Returns the latest block hash from the canonical chain.
     async fn latest_block_hash(&self) -> Result<N::BlockHash, RpcError> {
-        Ok(self.ledger.latest_block_hash())
+        Ok(self.ledger.read().await.latest_block_hash())
     }
 
     /// Returns the latest block header from the canonical chain.
     async fn latest_block_header(&self) -> Result<BlockHeader<N>, RpcError> {
-        Ok(self.ledger.latest_block_header())
+        Ok(self.ledger.read().await.latest_block_header())
     }
 
     /// Returns the latest block transactions from the canonical chain.
     async fn latest_block_transactions(&self) -> Result<Transactions<N>, RpcError> {
-        Ok(self.ledger.latest_block_transactions())
+        Ok(self.ledger.read().await.latest_block_transactions())
     }
 
     /// Returns the latest ledger root from the canonical chain.
     async fn latest_ledger_root(&self) -> Result<N::LedgerRoot, RpcError> {
-        Ok(self.ledger.latest_ledger_root())
+        Ok(self.ledger.read().await.latest_ledger_root())
     }
 
     /// Returns the block given the block height.
     async fn get_block(&self, block_height: u32) -> Result<Block<N>, RpcError> {
-        Ok(self.ledger.get_block(block_height)?)
+        Ok(self.ledger.read().await.get_block(block_height)?)
     }
 
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` blocks from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        Ok(self.ledger.get_blocks(safe_start_height, end_block_height)?)
+        Ok(self.ledger.read().await.get_blocks(safe_start_height, end_block_height)?)
     }
 
     /// Returns the block height for the given the block hash.
     async fn get_block_height(&self, block_hash: serde_json::Value) -> Result<u32, RpcError> {
         let block_hash: N::BlockHash = serde_json::from_value(block_hash)?;
-        Ok(self.ledger.get_block_height(&block_hash)?)
+        Ok(self.ledger.read().await.get_block_height(&block_hash)?)
     }
 
     /// Returns the block hash for the given block height, if it exists in the canonical chain.
     async fn get_block_hash(&self, block_height: u32) -> Result<N::BlockHash, RpcError> {
-        Ok(self.ledger.get_block_hash(block_height)?)
+        Ok(self.ledger.read().await.get_block_hash(block_height)?)
     }
 
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` block hashes from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_block_hashes(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<N::BlockHash>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        Ok(self.ledger.get_block_hashes(safe_start_height, end_block_height)?)
+        Ok(self.ledger.read().await.get_block_hashes(safe_start_height, end_block_height)?)
     }
 
     /// Returns the block header for the given the block height.
     async fn get_block_header(&self, block_height: u32) -> Result<BlockHeader<N>, RpcError> {
-        Ok(self.ledger.get_block_header(block_height)?)
+        Ok(self.ledger.read().await.get_block_header(block_height)?)
     }
 
     /// Returns the transactions from the block of the given block height.
     async fn get_block_transactions(&self, block_height: u32) -> Result<Transactions<N>, RpcError> {
-        Ok(self.ledger.get_block_transactions(block_height)?)
+        Ok(self.ledger.read().await.get_block_transactions(block_height)?)
     }
 
     /// Returns the ciphertext given the ciphertext ID.
     async fn get_ciphertext(&self, ciphertext_id: serde_json::Value) -> Result<RecordCiphertext<N>, RpcError> {
         let ciphertext_id: N::CiphertextID = serde_json::from_value(ciphertext_id)?;
-        Ok(self.ledger.get_ciphertext(&ciphertext_id)?)
+        Ok(self.ledger.read().await.get_ciphertext(&ciphertext_id)?)
     }
 
     /// Returns the ledger proof for a given record commitment.
     async fn get_ledger_proof(&self, record_commitment: serde_json::Value) -> Result<String, RpcError> {
         let record_commitment: N::Commitment = serde_json::from_value(record_commitment)?;
-        let ledger_proof = self.ledger.get_ledger_inclusion_proof(record_commitment)?;
+        let ledger_proof = self.ledger.read().await.get_ledger_inclusion_proof(record_commitment)?;
         Ok(hex::encode(ledger_proof.to_bytes_le().expect("Failed to serialize ledger proof")))
     }
 
     /// Returns a transaction with metadata given the transaction ID.
     async fn get_transaction(&self, transaction_id: serde_json::Value) -> Result<Value, RpcError> {
         let transaction_id: N::TransactionID = serde_json::from_value(transaction_id)?;
-        let transaction: Transaction<N> = self.ledger.get_transaction(&transaction_id)?;
-        let metadata: Metadata<N> = self.ledger.get_transaction_metadata(&transaction_id)?;
+        let transaction: Transaction<N> = self.ledger.read().await.get_transaction(&transaction_id)?;
+        let metadata: Metadata<N> = self.ledger.read().await.get_transaction_metadata(&transaction_id)?;
         Ok(serde_json::json!({ "transaction": transaction, "metadata": metadata }))
     }
 
     /// Returns a transition given the transition ID.
     async fn get_transition(&self, transition_id: serde_json::Value) -> Result<Transition<N>, RpcError> {
         let transition_id: N::TransitionID = serde_json::from_value(transition_id)?;
-        Ok(self.ledger.get_transition(&transition_id)?)
+        Ok(self.ledger.read().await.get_transition(&transition_id)?)
     }
 
     async fn get_connected_peers(&self) -> Result<Vec<SocketAddr>, RpcError> {


### PR DESCRIPTION
## Motivation

TLDR - Syncing under optimal network conditions has improved from 60 blocks/minute to 200 blocks/minute.

- Increases maximum block request from `50` to `100`
- `getblocks` on 100 blocks now takes 1 second
- Splits `LedgerState::open` into `LedgerState::open_writer` and `LedgerState::open_reader`
- Switches processing of `BlockRequest`, `Ping`, and `Pong` messages to `LedgerReader<N>`
    - Removes `LedgerRequest::BlockRequest`, `LedgerRequest::Ping`, `LedgerRequest::SendPing`
    - `Pong` is now handled by both `Peer` and `Ledger` to optimize for performance

## Test Plan

- Updates RPC tests to use `LedgerState::open_writer`
