### PR TITLE
Version bump to `6`, include `NodeType` in `Ping`, unify `canon` in `Ledger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rand_chacha",
+ "rayon",
  "rusty-hook",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ version = "0.11"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.rayon]
+version = "1"
+
 [dependencies.self_update]
 version = "0.27"
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ enables applications to verify and store state in a publicly verifiable manner.
 
 Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
 
-### 2.1 Installation
+### 2.1 Requirements
+
+The following are the **minimum** requirements to run an Aleo node:
+ - 8-core CPU (16-core preferred)
+ - 16GB of RAM memory (32GB preferred)
+ - 128GB of disk space
+ - 50 Mbps of upload **and** download bandwidth
+
+Please note to run an Aleo mining node that is **competitive**, the machine will require more than these requirements.
+
+### 2.2 Installation
 
 Start by cloning the snarkOS Github repository:
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img alt="snarkOS" width="1412" src="https://cdn.aleo.org/snarkos/banner.png">
 </p>
 
-## Usage Guide
+## Build Guide
 
 Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ cd snarkOS
 ./testnet2_ubuntu.sh
 ```
 
-### Run an Aleo Client Node
+## Run an Aleo Client Node
 
 To start a client node, from the snarkOS directory, run:
 ```
 ./run-client.sh
 ```
 
-### Run an Aleo Mining Node
+## Run an Aleo Mining Node
 
 To generate an Aleo miner address, run:
 ```
@@ -61,13 +61,13 @@ Enter your Aleo miner address:
 {ALEO_ADDRESS}
 ```
 
-### Testnet2 FAQs
+## Testnet2 FAQs
 
 1. The node is unable to connect to peers on the network.
     - Ensure ports `4132/tcp` and `3032/tcp` are open on your router and OS firewall.
     - Ensure snarkOS is started using `run-client.sh` or `run-miner.sh`
 
-### Command Line Interface
+## Command Line Interface
 
 To run a node with custom settings, refer to the full list of options and flags available in the snarkOS CLI.
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Enter your Aleo miner address:
 
 ## Testnet2 FAQs
 
-1. The node is unable to connect to peers on the network.
-    - Ensure ports `4132/tcp` and `3032/tcp` are open on your router and OS firewall.
-    - Ensure snarkOS is started using `run-client.sh` or `run-miner.sh`
+### 1. The node is unable to connect to peers on the network.
+
+- Ensure ports `4132/tcp` and `3032/tcp` are open on your router and OS firewall.
+- Ensure snarkOS is started using `run-client.sh` or `run-miner.sh`
 
 ## Command Line Interface
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 * [1. Overview](#1-overview)
 * [2. Build Guide](#2-build-guide)
-    * [2.1 Installation](#21-installation)
+    * [2.1 Requirements](#21-requirements)
+    * [2.2 Installation](#22-installation)
 * [3a. Run an Aleo Client Node](#3a-run-an-aleo-client-node)
 * [3b. Run an Aleo Mining Node](#3a-run-an-aleo-mining-node)
 * [4. Testnet2 FAQs](#4-testnet2-faqs)

--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@ cd snarkOS
 
 ## Run an Aleo Client Node
 
-To start a client node, from the snarkOS directory, run:
+Start by following the instructions in the [Build Guide](#build-guide).
+
+Next, to start a client node, from the snarkOS directory, run:
 ```
 ./run-client.sh
 ```
 
 ## Run an Aleo Mining Node
 
-To generate an Aleo miner address, run:
+Start by following the instructions in the [Build Guide](#build-guide).
+
+Next, to generate an Aleo miner address, run:
 ```
 snarkos experimental new_account
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Usage Guide
 
+Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust v1.56.1 can be found here.](https://www.rust-lang.org/tools/install)
+
 ### Installation
 
 Start by cloning the snarkOS Github repository:
@@ -58,6 +60,12 @@ When prompted, enter your Aleo miner address:
 Enter your Aleo miner address:
 {ALEO_ADDRESS}
 ```
+
+### Testnet2 FAQs
+
+1. The node is unable to connect to peers on the network.
+    - Ensure ports `4132/tcp` and `3032/tcp` are open on your router and OS firewall.
+    - Ensure snarkOS is started using `run-client.sh` or `run-miner.sh`
 
 ### Command Line Interface
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
     <img alt="snarkOS" width="1412" src="https://cdn.aleo.org/snarkos/banner.png">
 </p>
 
+<p align="center">
+    <a href="https://circleci.com/gh/AleoHQ/snarkOS"><img src="https://circleci.com/gh/AleoHQ/snarkOS.svg?style=svg&circle-token=6e9ad6d39d95350544f352d34e0e5c62ef54db26"></a>
+    <a href="https://codecov.io/gh/AleoHQ/snarkOS"><img src="https://codecov.io/gh/AleoHQ/snarkOS/branch/master/graph/badge.svg?token=cck8tS9HpO"/></a>
+    <a href="https://discord.gg/5v2ynrw2ds"><img src="https://img.shields.io/discord/700454073459015690?logo=discord"/></a>
+</p>
+
 ## Build Guide
 
 Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Before beginning, please ensure your machine has `Rust v1.56+` installed. Instru
 
 ### 2.1 Requirements
 
-The following are the **minimum** requirements to run an Aleo node:
- - 8-core CPU (16-core preferred)
- - 16GB of RAM memory (32GB preferred)
- - 128GB of disk space
- - 50 Mbps of upload **and** download bandwidth
+The following are **minimum** requirements to run an Aleo node:
+ - **CPU**: 8-cores (16-cores preferred)
+ - **RAM**: 16GB of memory (32GB preferred)
+ - **Storage**: 128GB of disk space
+ - **Network**: 50 Mbps of upload **and** download bandwidth
 
 Please note to run an Aleo mining node that is **competitive**, the machine will require more than these requirements.
 

--- a/README.md
+++ b/README.md
@@ -2,38 +2,68 @@
     <img alt="snarkOS" width="1412" src="https://cdn.aleo.org/snarkos/banner.png">
 </p>
 
-## Development Guide
-
-In one terminal, start the first node by running:
-```
-cargo run --release -- --node 4135 --rpc 3035 --miner aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah
-```
-
-After the first node starts, in a second terminal, run:
-```
-cargo run --release
-```
-
 ## Usage Guide
 
-### Connecting to Aleo Testnet II
+### Installation
 
-To start a client node, run:
+Start by cloning the snarkOS Github repository:
 ```
-snarkos
-```
-
-To start a mining node, run:
-```
-snarkos --miner {ALEO_ADDRESS}
+git clone https://github.com/AleoHQ/snarkOS.git --depth 1
 ```
 
-To run a node with custom settings, refer to the full list of options and flags available in the CLI.
+Next, move into the snarkOS directory:
+```
+cd snarkOS
+```
+
+**[For Ubuntu users]** A helper script to install dependencies is available. From the snarkOS directory, run:
+```
+./testnet2_ubuntu.sh
+```
+
+### Run an Aleo Client Node
+
+To start a client node, from the snarkOS directory, run:
+```
+./run-client.sh
+```
+
+### Run an Aleo Mining Node
+
+To generate an Aleo miner address, run:
+```
+snarkos experimental new_account
+```
+or
+```
+cargo run --release -- experimental new_account
+```
+This will output a new Aleo account in the terminal. **Please remember to save** the account private key and view key.
+
+The following is an example output:
+```
+ Attention - Remember to store this account private key and view key.
+
+  Private Key  APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+     View Key  AViewKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Address  aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+To start a mining node, from the snarkOS directory, run:
+```
+./run-miner.sh
+```
+When prompted, enter your Aleo miner address:
+```
+Enter your Aleo miner address:
+{ALEO_ADDRESS}
+```
 
 ### Command Line Interface
 
-Full list of CLI flags and options can be viewed with `snarkos --help`:
+To run a node with custom settings, refer to the full list of options and flags available in the snarkOS CLI.
 
+The full list of CLI flags and options can be viewed with `snarkos --help`:
 ```
 snarkos
 The Aleo Team <hello@aleo.org>
@@ -53,9 +83,21 @@ OPTIONS:
         --rpc <rpc>                  Specify the port for the RPC server
         --username <rpc-username>    Specify the username for the RPC server [default: root]
         --password <rpc-password>    Specify the password for the RPC server [default: pass]
-        --verbosity <verbosity>      Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 3]
+        --verbosity <verbosity>      Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
 
 SUBCOMMANDS:
     help      Prints this message or the help of the given subcommand(s)
     update    Updates snarkOS to the latest version
+```
+
+## Development Guide
+
+In one terminal, start the first node by running:
+```
+cargo run --release -- --node 4135 --rpc 3035 --miner aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah
+```
+
+After the first node starts, in a second terminal, run:
+```
+cargo run --release
 ```

--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ After the first node starts, in a second terminal, run:
 ```
 cargo run --release
 ```
+
+## License
+
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ or
 ```
 cargo run --release -- experimental new_account
 ```
-This will output a new Aleo account in the terminal. **Please remember to save** the account private key and view key.
+This will output a new Aleo account in the terminal.
 
-The following is an example output:
+**Please remember to save the account private key and view key.** The following is an example output:
 ```
  Attention - Remember to store this account private key and view key.
 
-  Private Key  APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-     View Key  AViewKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  Private Key  APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  <-- Save Me
+     View Key  AViewKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  <-- Save Me
       Address  aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ This will output a new Aleo account in the terminal.
 
   Private Key  APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  <-- Save Me
      View Key  AViewKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  <-- Save Me
-      Address  aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      Address  aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  <-- Use Me For The Next Step
 ```
 
-To start a mining node, from the snarkOS directory, run:
+Next, to start a mining node, from the snarkOS directory, run:
 ```
 ./run-miner.sh
 ```
 When prompted, enter your Aleo miner address:
 ```
 Enter your Aleo miner address:
-{ALEO_ADDRESS}
+aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
 ## Testnet2 FAQs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Usage Guide
 
-Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust v1.56.1 can be found here.](https://www.rust-lang.org/tools/install)
+Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To generate an Aleo miner address, run:
 ```
 snarkos experimental new_account
 ```
-or
+or from the snarkOS directory, run:
 ```
 cargo run --release -- experimental new_account
 ```

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ After the first node starts, in a second terminal, run:
 cargo run --release
 ```
 
+We welcome all contributions to snarkOS. Please refer to the [license](#7-license) for the terms of contributions.
+
 ## 7. License
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,31 @@
     <a href="https://discord.gg/5v2ynrw2ds"><img src="https://img.shields.io/discord/700454073459015690?logo=discord"/></a>
 </p>
 
-## Build Guide
+## <a name='TableofContents'></a>Table of Contents
+
+* [1. Overview](#1-overview)
+* [2. Build Guide](#2-build-guide)
+    * [2.1 Installation](#21-installation)
+* [3a. Run an Aleo Client Node](#3a-run-an-aleo-client-node)
+* [3b. Run an Aleo Mining Node](#3a-run-an-aleo-mining-node)
+* [4. Testnet2 FAQs](#4-testnet2-faqs)
+* [5. Command Line Interface](#5-configuration-file)
+* [6. Development Guide](#6-development-guide)
+* [7. License](#7-license)
+
+[comment]: <> (* [4. JSON-RPC Interface]&#40;#4-json-rpc-interface&#41;)
+[comment]: <> (* [5. Additional Information]&#40;#5-additional-information&#41;)
+
+## 1. Overview
+
+__snarkOS__ is a decentralized operating system for private applications. It forms the backbone of [Aleo](https://aleo.org/) and
+enables applications to verify and store state in a publicly verifiable manner.
+
+## 2. Build Guide
 
 Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
 
-### Installation
+### 2.1 Installation
 
 Start by cloning the snarkOS Github repository:
 ```
@@ -29,18 +49,18 @@ cd snarkOS
 ./testnet2_ubuntu.sh
 ```
 
-## Run an Aleo Client Node
+## 3a. Run an Aleo Client Node
 
-Start by following the instructions in the [Build Guide](#build-guide).
+Start by following the instructions in the [Build Guide](#2-build-guide).
 
 Next, to start a client node, from the snarkOS directory, run:
 ```
 ./run-client.sh
 ```
 
-## Run an Aleo Mining Node
+## 3b. Run an Aleo Mining Node
 
-Start by following the instructions in the [Build Guide](#build-guide).
+Start by following the instructions in the [Build Guide](#2-build-guide).
 
 Next, to generate an Aleo miner address, run:
 ```
@@ -71,14 +91,14 @@ Enter your Aleo miner address:
 aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-## Testnet2 FAQs
+## 4. Testnet2 FAQs
 
 ### 1. The node is unable to connect to peers on the network.
 
 - Ensure ports `4132/tcp` and `3032/tcp` are open on your router and OS firewall.
 - Ensure snarkOS is started using `run-client.sh` or `run-miner.sh`
 
-## Command Line Interface
+## 5. Command Line Interface
 
 To run a node with custom settings, refer to the full list of options and flags available in the snarkOS CLI.
 
@@ -109,7 +129,7 @@ SUBCOMMANDS:
     update    Updates snarkOS to the latest version
 ```
 
-## Development Guide
+## 6. Development Guide
 
 In one terminal, start the first node by running:
 ```
@@ -121,6 +141,6 @@ After the first node starts, in a second terminal, run:
 cargo run --release
 ```
 
-## License
+## 7. License
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE.md)

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -41,7 +41,7 @@ use std::{
 const TWO_HOURS_UNIX: i64 = 7200;
 
 /// The maximum number of linear block locators.
-pub const MAXIMUM_LINEAR_BLOCK_LOCATORS: u32 = 256;
+pub const MAXIMUM_LINEAR_BLOCK_LOCATORS: u32 = 128;
 /// The maximum number of quadratic block locators.
 pub const MAXIMUM_QUADRATIC_BLOCK_LOCATORS: u32 = 64;
 /// The total maximum number of block locators.

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -516,7 +516,7 @@ impl<N: Network> LedgerState<N> {
             None => return Ok(false),
         };
 
-        for (block_height, (_block_hash, block_header)) in block_locators.iter().skip(num_linear_block_headers).rev() {
+        for (block_height, (_block_hash, block_header)) in block_locators.iter().rev().take(num_linear_block_headers) {
             // Check that the block height is decrementing.
             match last_block_height == *block_height {
                 true => last_block_height = block_height.saturating_sub(1),
@@ -537,11 +537,15 @@ impl<N: Network> LedgerState<N> {
 
         // Check that the remaining block hashes are formed correctly (power of two).
         if block_locators.len() > MAXIMUM_LINEAR_BLOCK_LOCATORS as usize {
-            let mut previous_block_height = u32::MAX;
-
             // Iterate through all the quadratic ranged block locators excluding the genesis locator.
-            for (block_height, (_block_hash, block_header)) in block_locators.iter().skip(1).take(num_quadratic_block_headers - 1).rev() {
-                // Check that the block heights increment by a power of two.
+            let mut previous_block_height = u32::MAX;
+            for (block_height, (_block_hash, block_header)) in block_locators
+                .iter()
+                .rev()
+                .skip(num_linear_block_headers + 1)
+                .take(num_quadratic_block_headers - 1)
+            {
+                // Check that the block heights decrement by a power of two.
                 if previous_block_height != u32::MAX && previous_block_height / 2 != *block_height {
                     return Ok(false);
                 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -71,7 +71,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The minimum number of peers required to maintain connections with.
     const MINIMUM_NUMBER_OF_PEERS: usize;
     /// The maximum number of peers permitted to maintain connections with.
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 15;
+    const MAXIMUM_NUMBER_OF_PEERS: usize = 9;
     /// The maximum number of connection failures permitted by an inbound connecting peer.
     const MAXIMUM_CONNECTION_FAILURES: u32 = 5;
     /// The maximum number of candidate peers permitted to be stored in the node.
@@ -114,7 +114,7 @@ impl<N: Network> Environment for SyncNode<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Sync;
     const MINIMUM_NUMBER_OF_PEERS: usize = 5;
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 1024;
+    const MAXIMUM_NUMBER_OF_PEERS: usize = 128;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -136,6 +136,6 @@ impl<N: Network> Environment for MinerTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Miner;
     const SYNC_NODES: [&'static str; 2] = ["144.126.219.193:4132", "165.232.145.194:4132"];
-    const MINIMUM_NUMBER_OF_PEERS: usize = 5;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 3;
     const COINBASE_IS_PUBLIC: bool = true;
 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -38,7 +38,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The specified type of node.
     const NODE_TYPE: NodeType;
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    const MESSAGE_VERSION: u32 = 5;
+    const MESSAGE_VERSION: u32 = 6;
 
     /// If `true`, a mining node will craft public coinbase transactions.
     const COINBASE_IS_PUBLIC: bool = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ fn main() -> Result<()> {
         .max_blocking_threads(num_cpus::get().saturating_sub(1).max(1)) // Don't use 100% of the cores
         .build()?;
 
+    // Initialize the parallelization parameters.
+    rayon::ThreadPoolBuilder::new().stack_size(8 * 1024 * 1024).build_global().unwrap();
+
     runtime.block_on(Node::from_args().start())?;
 
     Ok(())

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -82,9 +82,8 @@ pub enum LedgerRequest<N: Network, E: Environment> {
 pub struct Ledger<N: Network, E: Environment> {
     /// The status of the node.
     status: Status,
-    /// The canonical chain of block hashes.
-    canon_writer: LedgerState<N>,
-    canon_reader: LedgerState<N>,
+    /// The canonical chain of blocks.
+    canon: LedgerState<N>,
     /// A map of previous block hashes to unconfirmed blocks.
     unconfirmed_blocks: CircularMap<N::BlockHash, Block<N>, { MAXIMUM_UNCONFIRMED_BLOCKS }>,
     /// The pool of unconfirmed transactions.
@@ -110,8 +109,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     pub fn open<S: Storage, P: AsRef<Path> + Copy>(path: P, status: &Status) -> Result<Self> {
         Ok(Self {
             status: status.clone(),
-            canon_writer: LedgerState::open_writer::<S, P>(path)?,
-            canon_reader: LedgerState::open_reader::<S, P>(path)?,
+            canon: LedgerState::open_writer::<S, P>(path)?,
             unconfirmed_blocks: Default::default(),
             memory_pool: MemoryPool::new(),
             terminator: Arc::new(AtomicBool::new(false)),
@@ -175,7 +173,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 trace!(
                     "Status Report (status = {}, latest_block_height = {}, block_requests = {}, connected_peers = {})",
                     self.status,
-                    self.canon_writer.latest_block_height(),
+                    self.canon.latest_block_height(),
                     self.number_of_block_requests(),
                     self.peers_state.len()
                 );
@@ -192,7 +190,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             }
             LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
                 // Ensure the given block is new.
-                if let Ok(true) = self.canon_writer.contains_block_hash(&block.hash()) {
+                if let Ok(true) = self.canon.contains_block_hash(&block.hash()) {
                     trace!("Canon chain already contains block {}", block.height());
                 } else if self.unconfirmed_blocks.contains_key(&block.previous_block_hash()) {
                     trace!("Memory pool already contains unconfirmed block {}", block.height());
@@ -221,7 +219,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     fn update_ledger(&mut self) {
         // Check for candidate blocks to fast forward the ledger.
-        let mut block = &self.canon_writer.latest_block();
+        let mut block = &self.canon.latest_block();
         let unconfirmed_blocks = self.unconfirmed_blocks.clone();
         while let Some(unconfirmed_block) = unconfirmed_blocks.get(&block.hash()) {
             // Update the block iterator.
@@ -264,7 +262,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.unconfirmed_blocks = Default::default();
             self.memory_pool = MemoryPool::new();
             self.block_requests.values_mut().for_each(|requests| *requests = Default::default());
-            self.revert_to_block_height(self.canon_writer.latest_block_height().saturating_sub(1));
+            self.revert_to_block_height(self.canon.latest_block_height().saturating_sub(1));
         }
     }
 
@@ -295,7 +293,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             };
 
             // Retrieve the latest block height of this node.
-            let latest_block_height = self.canon_reader.latest_block_height();
+            let latest_block_height = self.canon.latest_block_height();
             // Iterate through the connected peers, to determine if the ledger state is out of date.
             for (_, ledger_state) in self.peers_state.iter() {
                 if let Some((_, block_height, _)) = ledger_state {
@@ -346,7 +344,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.status.update(State::Mining);
 
             // Prepare the unconfirmed transactions, terminator, and status.
-            let canon = self.canon_reader.clone();
+            let canon = self.canon.clone(); // This is *safe* as the ledger only reads.
             let unconfirmed_transactions = self.memory_pool.transactions();
             let terminator = self.terminator.clone();
             let status = self.status.clone();
@@ -389,14 +387,12 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         let _ = self.block_requests_lock.lock();
 
         // Ensure the given block is new.
-        if let Ok(true) = self.canon_writer.contains_block_hash(&block.hash()) {
+        if let Ok(true) = self.canon.contains_block_hash(&block.hash()) {
             trace!("Canon chain already contains block {}", block.height());
-        } else if block.height() == self.canon_writer.latest_block_height() + 1
-            && block.previous_block_hash() == self.canon_writer.latest_block_hash()
-        {
-            match self.canon_writer.add_next_block(&block) {
+        } else if block.height() == self.canon.latest_block_height() + 1 && block.previous_block_hash() == self.canon.latest_block_hash() {
+            match self.canon.add_next_block(&block) {
                 Ok(()) => {
-                    info!("Ledger successfully advanced to block {}", self.canon_writer.latest_block_height());
+                    info!("Ledger successfully advanced to block {}", self.canon.latest_block_height());
 
                     // Update the timestamp of the last block increment.
                     self.last_block_update_timestamp = Instant::now();
@@ -441,7 +437,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Process the unconfirmed transaction.
         trace!("Received unconfirmed transaction {} from {}", transaction.transaction_id(), peer_ip);
         // Ensure the unconfirmed transaction is new.
-        if let Ok(false) = self.canon_writer.contains_transaction(&transaction.transaction_id()) {
+        if let Ok(false) = self.canon.contains_transaction(&transaction.transaction_id()) {
             debug!("Adding unconfirmed transaction {} to memory pool", transaction.transaction_id());
             // Attempt to add the unconfirmed transaction to the memory pool.
             match self.memory_pool.add_transaction(&transaction) {
@@ -461,9 +457,9 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Reverts the ledger state back to height `block_height`, returning `true` on success.
     ///
     fn revert_to_block_height(&mut self, block_height: u32) -> bool {
-        match self.canon_writer.revert_to_block_height(block_height) {
+        match self.canon.revert_to_block_height(block_height) {
             Ok(removed_blocks) => {
-                info!("Ledger successfully reverted to block {}", self.canon_writer.latest_block_height());
+                info!("Ledger successfully reverted to block {}", self.canon.latest_block_height());
 
                 // Update the last block update timestamp.
                 self.last_block_update_timestamp = Instant::now();
@@ -524,7 +520,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.add_failure(peer_ip, "Received a sync response with no block locators".to_string());
         } else {
             // Ensure the peer provided well-formed block locators.
-            match self.canon_reader.check_block_locators(&block_locators) {
+            match self.canon.check_block_locators(&block_locators) {
                 Ok(is_valid) => {
                     if !is_valid {
                         warn!("Invalid block locators from {}", peer_ip);
@@ -543,7 +539,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Verify the integrity of the block hashes sent by the peer.
             for (block_height, (block_hash, _)) in block_locators.iter() {
                 // Ensure the block hash corresponds with the block height, if the block hash exists in this ledger.
-                if let Ok(expected_block_height) = self.canon_reader.get_block_height(block_hash) {
+                if let Ok(expected_block_height) = self.canon.get_block_height(block_hash) {
                     if expected_block_height != *block_height {
                         let error = format!("Invalid block height {} for block hash {}", expected_block_height, block_hash);
                         trace!("{}", error);
@@ -620,7 +616,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         let _ = self.block_requests_lock.lock();
 
         // Retrieve the latest block height of this ledger.
-        let latest_block_height = self.canon_writer.latest_block_height();
+        let latest_block_height = self.canon.latest_block_height();
 
         // Iterate through the peers to check if this node needs to catch up, and determine a peer to sync with.
         // Prioritize the sync nodes before regular peers.
@@ -668,7 +664,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Verify the integrity of the block hashes sent by the peer.
             for (block_height, (block_hash, _)) in maximum_block_locators.iter() {
                 // Ensure the block hash corresponds with the block height, if the block hash exists in this ledger.
-                if let Ok(expected_block_height) = self.canon_writer.get_block_height(block_hash) {
+                if let Ok(expected_block_height) = self.canon.get_block_height(block_hash) {
                     if expected_block_height != *block_height {
                         let error = format!("Invalid block height {} for block hash {}", expected_block_height, block_hash);
                         trace!("{}", error);

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::Environment;
+use crate::{Environment, NodeType};
 use snarkos_ledger::BlockLocators;
 use snarkvm::prelude::*;
 
@@ -39,8 +39,8 @@ pub enum Message<N: Network, E: Environment> {
     PeerRequest,
     /// PeerResponse := (\[peer_ip\])
     PeerResponse(Vec<SocketAddr>),
-    /// Ping := (version, block_height, block_hash)
-    Ping(u32, u32, N::BlockHash),
+    /// Ping := (version, node_type, block_height, block_hash)
+    Ping(u32, NodeType, u32, N::BlockHash),
     /// Pong := (is_fork, block_locators)
     Pong(Option<bool>, BlockLocators<N>),
     /// UnconfirmedBlock := (block)
@@ -104,7 +104,9 @@ impl<N: Network, E: Environment> Message<N, E> {
             Self::Disconnect => Ok(vec![]),
             Self::PeerRequest => Ok(vec![]),
             Self::PeerResponse(peer_ips) => Ok(bincode::serialize(peer_ips)?),
-            Self::Ping(version, block_height, block_hash) => Ok(to_bytes_le![version, block_height, block_hash]?),
+            Self::Ping(version, node_type, block_height, block_hash) => {
+                Ok(bincode::serialize(&(version, node_type, block_height, block_hash))?)
+            }
             Self::Pong(is_fork, block_locators) => {
                 let serialized_is_fork: u8 = match is_fork {
                     None => 0,
@@ -159,11 +161,10 @@ impl<N: Network, E: Environment> Message<N, E> {
                 false => return Err(anyhow!("Invalid 'PeerRequest' message: {:?} {:?}", buffer, data)),
             },
             6 => Self::PeerResponse(bincode::deserialize(data)?),
-            7 => Self::Ping(
-                bincode::deserialize(&data[0..4])?,
-                bincode::deserialize(&data[4..8])?,
-                bincode::deserialize(&data[8..])?,
-            ),
+            7 => {
+                let (version, node_type, block_height, block_hash) = bincode::deserialize(data)?;
+                Self::Ping(version, node_type, block_height, block_hash)
+            }
             8 => {
                 let is_fork = match data[0] {
                     0 => None,

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -252,6 +252,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     for peer_ip in peer_ips_to_disconnect {
                         info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
                         self.send(peer_ip, &Message::Disconnect).await;
+                        // Add an entry for this `Peer` in the restricted peers.
+                        self.restricted_peers.insert(peer_ip, Instant::now());
                     }
                 }
 

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -281,8 +281,8 @@ impl<N: Network, E: Environment> Server<N, E> {
                         if let Err(error) = ledger_router.send(request).await {
                             error!("Failed to send request to ledger: {}", error);
                         }
-                        // Sleep for 3 seconds.
-                        tokio::time::sleep(Duration::from_secs(3)).await;
+                        // Sleep for 2 seconds.
+                        tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }));
             } else {


### PR DESCRIPTION
## Motivation

This PR includes a version bump from `5` to `6`.

- Reduces number of linear block locators to `128`
- Include `NodeType` in `Ping`
- Unify `canon` in `Ledger`
- Fixes bug in `check_block_locators`