### PR TITLE
Version bump to `7`, adds status in `Ping` messages

### DIFF
--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -508,7 +508,7 @@ impl<N: Network> LedgerState<N> {
         // Check that the remaining block hashes are formed correctly (power of two).
         if block_locators.len() > MAXIMUM_LINEAR_BLOCK_LOCATORS as usize {
             // Iterate through all the quadratic ranged block locators excluding the genesis locator.
-            let mut previous_block_height = u32::MAX;
+            let mut _previous_block_height = u32::MAX;
             for (block_height, (_block_hash, block_header)) in block_locators
                 .iter()
                 .rev()
@@ -525,7 +525,7 @@ impl<N: Network> LedgerState<N> {
                     return Ok(false);
                 }
 
-                previous_block_height = *block_height;
+                // previous_block_height = *block_height;
             }
         }
 

--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -509,7 +509,7 @@ impl<N: Network> LedgerState<N> {
         if block_locators.len() > MAXIMUM_LINEAR_BLOCK_LOCATORS as usize {
             // Iterate through all the quadratic ranged block locators excluding the genesis locator.
             let mut _previous_block_height = u32::MAX;
-            for (block_height, (_block_hash, block_header)) in block_locators
+            for (_block_height, (_block_hash, block_header)) in block_locators
                 .iter()
                 .rev()
                 .skip(num_linear_block_headers + 1)

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -38,7 +38,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The specified type of node.
     const NODE_TYPE: NodeType;
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    const MESSAGE_VERSION: u32 = 6;
+    const MESSAGE_VERSION: u32 = 7;
 
     /// If `true`, a mining node will craft public coinbase transactions.
     const COINBASE_IS_PUBLIC: bool = false;

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -17,7 +17,10 @@
 use snarkvm::dpc::Network;
 
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, marker::PhantomData};
+use std::{
+    fmt::{self, Debug},
+    marker::PhantomData,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[repr(u8)]
@@ -30,6 +33,12 @@ pub enum NodeType {
     Peer,
     /// A sync node is a discovery node, capable of syncing nodes for the network.
     Sync,
+}
+
+impl fmt::Display for NodeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[rustfmt::skip]

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -116,7 +116,7 @@ impl<N: Network> Environment for SyncNode<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Sync;
     const SYNC_NODES: [&'static str; 3] = ["159.223.117.248:4132", "206.189.97.241:4132", "128.199.11.231:4132"];
-    const MINIMUM_NUMBER_OF_PEERS: usize = 5;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 7;
     const MAXIMUM_NUMBER_OF_PEERS: usize = 128;
 }
 
@@ -128,7 +128,7 @@ impl<N: Network> Environment for ClientTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Client;
     const SYNC_NODES: [&'static str; 3] = ["144.126.219.193:4132", "165.232.145.194:4132", "143.198.164.241:4132"];
-    const MINIMUM_NUMBER_OF_PEERS: usize = 5;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 7;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -139,6 +139,6 @@ impl<N: Network> Environment for MinerTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Miner;
     const SYNC_NODES: [&'static str; 3] = ["144.126.219.193:4132", "165.232.145.194:4132", "143.198.164.241:4132"];
-    const MINIMUM_NUMBER_OF_PEERS: usize = 5;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 7;
     const COINBASE_IS_PUBLIC: bool = true;
 }

--- a/src/helpers/status.rs
+++ b/src/helpers/status.rs
@@ -38,6 +38,12 @@ pub enum State {
     ShuttingDown,
 }
 
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Status(Arc<AtomicU8>);
 

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -189,7 +189,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 self.update_peer(peer_ip, is_fork, block_locators).await;
             }
             LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
-                // Ensure the ledger is not peering or syncing.
+                // Ensure the node is not peering or syncing.
                 if !(self.status.is_peering() || self.status.is_syncing()) {
                     // Process the unconfirmed block.
                     self.add_block(block.clone());
@@ -201,7 +201,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 }
             }
             LedgerRequest::UnconfirmedTransaction(peer_ip, transaction) => {
-                // Ensure the ledger is not peering or syncing.
+                // Ensure the node is not peering or syncing.
                 if !(self.status.is_peering() || self.status.is_syncing()) {
                     // Process the unconfirmed transaction.
                     self.add_unconfirmed_transaction(peer_ip, transaction, peers_router).await

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -583,7 +583,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             };
             debug!(
                 "Peer {} is at block {} (type = {}, status = {}, is_fork = {}, common_ancestor = {})",
-                peer_ip, node_type, status, latest_block_height_of_peer, fork_status, common_ancestor,
+                peer_ip, latest_block_height_of_peer, node_type, status, fork_status, common_ancestor,
             );
 
             match self.peers_state.get_mut(&peer_ip) {

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -66,8 +66,8 @@ pub enum LedgerRequest<N: Network, E: Environment> {
     Heartbeat(LedgerRouter<N, E>),
     /// Mine := (local_ip, miner_address, ledger_router)
     Mine(SocketAddr, Address<N>, LedgerRouter<N, E>),
-    /// Pong := (peer_ip, is_fork, block_locators)
-    Pong(SocketAddr, Option<bool>, BlockLocators<N>),
+    /// Pong := (peer_ip, node_type, status, is_fork, block_locators)
+    Pong(SocketAddr, NodeType, State, Option<bool>, BlockLocators<N>),
     /// UnconfirmedBlock := (peer_ip, block)
     UnconfirmedBlock(SocketAddr, Block<N>),
     /// UnconfirmedTransaction := (peer_ip, transaction)
@@ -90,8 +90,8 @@ pub struct Ledger<N: Network, E: Environment> {
     memory_pool: MemoryPool<N>,
     /// A terminator bit for the miner.
     terminator: Arc<AtomicBool>,
-    /// The map of each peer to their ledger state := (is_fork, latest_block_height, block_locators).
-    peers_state: HashMap<SocketAddr, Option<(Option<bool>, u32, BlockLocators<N>)>>,
+    /// The map of each peer to their ledger state := (node_type, status, is_fork, latest_block_height, block_locators).
+    peers_state: HashMap<SocketAddr, Option<(NodeType, State, Option<bool>, u32, BlockLocators<N>)>>,
     /// The map of each peer to their block requests := HashMap<(block_height, block_hash), timestamp>
     block_requests: HashMap<SocketAddr, HashMap<(u32, Option<N::BlockHash>), i64>>,
     /// A lock to ensure methods that need to be mutually-exclusive are enforced.
@@ -182,11 +182,11 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 // Process the request to mine the next block.
                 self.mine_next_block(local_ip, recipient, ledger_router).await;
             }
-            LedgerRequest::Pong(peer_ip, is_fork, block_locators) => {
+            LedgerRequest::Pong(peer_ip, node_type, status, is_fork, block_locators) => {
                 // Ensure the peer has been initialized in the ledger.
                 self.initialize_peer(peer_ip);
                 // Process the pong.
-                self.update_peer(peer_ip, is_fork, block_locators).await;
+                self.update_peer(peer_ip, node_type, status, is_fork, block_locators).await;
             }
             LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
                 // Ensure the node is not peering or syncing.
@@ -291,8 +291,8 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Retrieve the latest block height of this node.
             let latest_block_height = self.canon.latest_block_height();
             // Iterate through the connected peers, to determine if the ledger state is out of date.
-            for (_, ledger_state) in self.peers_state.iter() {
-                if let Some((_, block_height, _)) = ledger_state {
+            for (_, peer_state) in self.peers_state.iter() {
+                if let Some((_, _, _, block_height, _)) = peer_state {
                     if *block_height > latest_block_height {
                         // Sync if this ledger has fallen behind by 3 or more blocks.
                         if block_height - latest_block_height > 2 {
@@ -503,7 +503,14 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     /// Updates the state of the given peer.
     ///
-    async fn update_peer(&mut self, peer_ip: SocketAddr, is_fork: Option<bool>, block_locators: BlockLocators<N>) {
+    async fn update_peer(
+        &mut self,
+        peer_ip: SocketAddr,
+        node_type: NodeType,
+        status: State,
+        is_fork: Option<bool>,
+        block_locators: BlockLocators<N>,
+    ) {
         // Ensure the list of block locators is not empty.
         if block_locators.is_empty() {
             self.add_failure(peer_ip, "Received a sync response with no block locators".to_string());
@@ -575,12 +582,12 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 None => "undecided".to_string(),
             };
             debug!(
-                "Peer {} is at block {} (is_fork = {}, common_ancestor = {})",
-                peer_ip, latest_block_height_of_peer, fork_status, common_ancestor,
+                "Peer {} is at block {} (type = {}, status = {}, is_fork = {}, common_ancestor = {})",
+                peer_ip, node_type, status, latest_block_height_of_peer, fork_status, common_ancestor,
             );
 
             match self.peers_state.get_mut(&peer_ip) {
-                Some(status) => *status = Some((is_fork, latest_block_height_of_peer, block_locators)),
+                Some(peer_state) => *peer_state = Some((node_type, status, is_fork, latest_block_height_of_peer, block_locators)),
                 None => self.add_failure(peer_ip, format!("Missing ledger state for {}", peer_ip)),
             };
         }
@@ -633,10 +640,10 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         }
 
         // Check if any of the peers are ahead and have a larger block height.
-        for (peer_ip, ledger_state) in self.peers_state.iter() {
+        for (peer_ip, peer_state) in self.peers_state.iter() {
             // Only update the maximal peer if there are no sync nodes or the peer is a sync node.
             if !peers_contains_sync_node || sync_nodes.contains(peer_ip) {
-                if let Some((is_fork, block_height, block_locators)) = ledger_state {
+                if let Some((_, _, is_fork, block_height, block_locators)) = peer_state {
                     // Update the maximal peer state if the peer is ahead and the peer knows if you are a fork or not.
                     // This accounts for (Case 1 and Case 2(a))
                     if *block_height > maximum_block_height && is_fork.is_some() {

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -559,6 +559,17 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 },
             };
 
+            // If the given fork status is None, check if it can be updated.
+            let is_fork = match is_fork {
+                Some(is_fork) => Some(is_fork),
+                None => match common_ancestor == self.canon.latest_block_height() {
+                    // If the common ancestor matches the latest block height of this node,
+                    // the peer is likely on the same canonical chain as this node.
+                    true => Some(false),
+                    false => None,
+                },
+            };
+
             let fork_status = match is_fork {
                 Some(boolean) => format!("{}", boolean),
                 None => "undecided".to_string(),

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Environment, NodeType};
+use crate::{helpers::State, Environment, NodeType};
 use snarkos_ledger::BlockLocators;
 use snarkvm::prelude::*;
 
@@ -39,8 +39,8 @@ pub enum Message<N: Network, E: Environment> {
     PeerRequest,
     /// PeerResponse := (\[peer_ip\])
     PeerResponse(Vec<SocketAddr>),
-    /// Ping := (version, node_type, block_height, block_hash)
-    Ping(u32, NodeType, u32, N::BlockHash),
+    /// Ping := (version, node_type, status, block_height, block_hash)
+    Ping(u32, NodeType, State, u32, N::BlockHash),
     /// Pong := (is_fork, block_locators)
     Pong(Option<bool>, BlockLocators<N>),
     /// UnconfirmedBlock := (block)
@@ -104,8 +104,8 @@ impl<N: Network, E: Environment> Message<N, E> {
             Self::Disconnect => Ok(vec![]),
             Self::PeerRequest => Ok(vec![]),
             Self::PeerResponse(peer_ips) => Ok(bincode::serialize(peer_ips)?),
-            Self::Ping(version, node_type, block_height, block_hash) => {
-                Ok(bincode::serialize(&(version, node_type, block_height, block_hash))?)
+            Self::Ping(version, node_type, status, block_height, block_hash) => {
+                Ok(bincode::serialize(&(version, node_type, status, block_height, block_hash))?)
             }
             Self::Pong(is_fork, block_locators) => {
                 let serialized_is_fork: u8 = match is_fork {
@@ -162,8 +162,8 @@ impl<N: Network, E: Environment> Message<N, E> {
             },
             6 => Self::PeerResponse(bincode::deserialize(data)?),
             7 => {
-                let (version, node_type, block_height, block_hash) = bincode::deserialize(data)?;
-                Self::Ping(version, node_type, block_height, block_hash)
+                let (version, node_type, status, block_height, block_hash) = bincode::deserialize(data)?;
+                Self::Ping(version, node_type, status, block_height, block_hash)
             }
             8 => {
                 let is_fork = match data[0] {

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -702,7 +702,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
     }
 
     /// A handler to process an individual peer.
-    #[allow(clippy::type_complexity)]
+    #[allow(clippy::too_many_arguments)]
     async fn handler<'a, T: Iterator<Item = &'a u64> + Send>(
         stream: TcpStream,
         local_ip: SocketAddr,

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -860,7 +860,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                 },
                                 Message::Pong(is_fork, block_locators) => {
                                     // Route the `Pong` to the ledger.
-                                    if let Err(error) = ledger_router.send(LedgerRequest::Pong(peer_ip, is_fork, block_locators)).await {
+                                    let request = LedgerRequest::Pong(peer_ip, peer.node_type, peer.status, is_fork, block_locators);
+                                    if let Err(error) = ledger_router.send(request).await {
                                         warn!("[Pong] {}", error);
                                     }
                                     // Spawn an asynchronous task for the `Ping` request.

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -14,7 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Environment, LedgerReader, LedgerRequest, LedgerRouter, Message, NodeType};
+use crate::{
+    helpers::{State, Status},
+    Environment,
+    LedgerReader,
+    LedgerRequest,
+    LedgerRouter,
+    Message,
+    NodeType,
+};
 use snarkvm::dpc::prelude::*;
 
 use anyhow::{anyhow, Result};
@@ -75,6 +83,8 @@ pub struct Peers<N: Network, E: Environment> {
     local_ip: SocketAddr,
     /// The local nonce for this node session.
     local_nonce: u64,
+    /// The local status of this node.
+    local_status: Status,
     /// The map connected peer IPs to their nonce and outbound message router.
     connected_peers: HashMap<SocketAddr, (u64, OutboundRouter<N, E>)>,
     /// The set of candidate peer IPs.
@@ -95,7 +105,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Initializes a new instance of `Peers`.
     ///
-    pub(crate) fn new(local_ip: SocketAddr, local_nonce: Option<u64>) -> Self {
+    pub(crate) fn new(local_ip: SocketAddr, local_nonce: Option<u64>, local_status: Status) -> Self {
         let local_nonce = match local_nonce {
             Some(nonce) => nonce,
             None => thread_rng().gen(),
@@ -104,6 +114,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
         Self {
             local_ip,
             local_nonce,
+            local_status,
             connected_peers: Default::default(),
             candidate_peers: Default::default(),
             restricted_peers: Default::default(),
@@ -210,6 +221,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                                         stream,
                                         self.local_ip,
                                         self.local_nonce,
+                                        self.local_status.clone(),
                                         peers_router,
                                         ledger_reader,
                                         ledger_router,
@@ -353,6 +365,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                             stream,
                             self.local_ip,
                             self.local_nonce,
+                            self.local_status.clone(),
                             peers_router,
                             ledger_reader,
                             ledger_router,
@@ -500,6 +513,8 @@ struct Peer<N: Network, E: Environment> {
     version: u32,
     /// The node type of the peer.
     node_type: NodeType,
+    /// The node type of the peer.
+    status: State,
     /// The timestamp of the last message received from this peer.
     last_seen: Instant,
     /// The TCP socket that handles sending and receiving data with this peer.
@@ -519,6 +534,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
         stream: TcpStream,
         local_ip: SocketAddr,
         local_nonce: u64,
+        local_status: &Status,
         peers_router: &PeersRouter<N, E>,
         ledger_reader: &LedgerReader<N>,
         connected_nonces: &[u64],
@@ -537,7 +553,13 @@ impl<N: Network, E: Environment> Peer<N, E> {
             let latest_block_hash = ledger_reader.latest_block_hash();
 
             // Send a `Ping` request to the peer.
-            let message = Message::Ping(E::MESSAGE_VERSION, E::NODE_TYPE, latest_block_height, latest_block_hash);
+            let message = Message::Ping(
+                E::MESSAGE_VERSION,
+                E::NODE_TYPE,
+                local_status.get(),
+                latest_block_height,
+                latest_block_hash,
+            );
             trace!("Sending '{}' to {}", message.name(), peer_ip);
             outbound_socket.send(message).await?;
         }
@@ -554,6 +576,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
             listener_ip: peer_ip,
             version: 0,
             node_type: NodeType::Client,
+            status: State::Peering,
             last_seen: Instant::now(),
             outbound_socket,
             outbound_handler,
@@ -681,6 +704,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
         stream: TcpStream,
         local_ip: SocketAddr,
         local_nonce: u64,
+        local_status: Status,
         peers_router: &PeersRouter<N, E>,
         ledger_reader: LedgerReader<N>,
         ledger_router: LedgerRouter<N, E>,
@@ -690,7 +714,17 @@ impl<N: Network, E: Environment> Peer<N, E> {
         let peers_router = peers_router.clone();
         task::spawn(async move {
             // Register our peer with state which internally sets up some channels.
-            let mut peer = match Peer::new(stream, local_ip, local_nonce, &peers_router, &ledger_reader, &connected_nonces).await {
+            let mut peer = match Peer::new(
+                stream,
+                local_ip,
+                local_nonce,
+                &local_status,
+                &peers_router,
+                &ledger_reader,
+                &connected_nonces,
+            )
+            .await
+            {
                 Ok(peer) => peer,
                 Err(error) => {
                     trace!("{}", error);
@@ -797,7 +831,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         warn!("[PeerResponse] {}", error);
                                     }
                                 }
-                                Message::Ping(version, node_type, block_height, block_hash) => {
+                                Message::Ping(version, node_type, status, block_height, block_hash) => {
                                     // Ensure the message protocol version is not outdated.
                                     if version < E::MESSAGE_VERSION {
                                         warn!("Dropping {} on version {} (outdated)", peer_ip, version);
@@ -807,6 +841,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     peer.version = version;
                                     // Update the node type of the peer.
                                     peer.node_type = node_type;
+                                    // Update the status of the peer.
+                                    peer.status = status;
 
                                     // Determine if the peer is on a fork (or unknown).
                                     let ledger_reader = ledger_reader.read().await;
@@ -825,8 +861,9 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         warn!("[Pong] {}", error);
                                     }
                                     // Spawn an asynchronous task for the `Ping` request.
-                                    let ledger_reader = ledger_reader.clone();
+                                    let local_status = local_status.clone();
                                     let peers_router = peers_router.clone();
+                                    let ledger_reader = ledger_reader.clone();
                                     task::spawn(async move {
                                         // Sleep for the preset time before sending a `Ping` request.
                                         tokio::time::sleep(Duration::from_secs(E::PING_SLEEP_IN_SECS)).await;
@@ -837,7 +874,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         let latest_block_hash = ledger_reader.latest_block_hash();
 
                                         // Send a `Ping` request to the peer.
-                                        let message = Message::Ping(E::MESSAGE_VERSION, E::NODE_TYPE, latest_block_height, latest_block_hash);
+                                        let message = Message::Ping(E::MESSAGE_VERSION, E::NODE_TYPE, local_status.get(), latest_block_height, latest_block_hash);
                                         let request = PeersRequest::MessageSend(peer_ip, message);
                                         if let Err(error) = peers_router.send(request).await {
                                             warn!("[Ping] {}", error);

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -848,10 +848,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     let ledger_reader = ledger_reader.read().await;
                                     let is_fork = match ledger_reader.get_block_hash(block_height) {
                                         Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
-                                        Err(error) => {
-                                            trace!("is_fork error: {}", error);
-                                            None
-                                        },
+                                        Err(error) => None,
                                     };
                                     // Send a `Pong` message to the peer.
                                     if let Err(error) = peer.send(Message::Pong(is_fork, ledger_reader.latest_block_locators())).await {

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -848,7 +848,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     let ledger_reader = ledger_reader.read().await;
                                     let is_fork = match ledger_reader.get_block_hash(block_height) {
                                         Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
-                                        Err(error) => None,
+                                        Err(_) => None,
                                     };
                                     // Send a `Pong` message to the peer.
                                     if let Err(error) = peer.send(Message::Pong(is_fork, ledger_reader.latest_block_locators())).await {

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -299,7 +299,9 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     }
                 }
                 // Request more peers if the number of connected peers is below the threshold.
-                self.propagate(self.local_ip, &Message::PeerRequest).await;
+                for peer_ip in self.connected_peers().iter().choose_multiple(&mut OsRng::default(), 1) {
+                    self.send(*peer_ip, &Message::PeerRequest).await;
+                }
             }
             PeersRequest::MessagePropagate(sender, message) => {
                 self.propagate(sender, &message).await;
@@ -700,6 +702,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
     }
 
     /// A handler to process an individual peer.
+    #[allow(clippy::type_complexity)]
     async fn handler<'a, T: Iterator<Item = &'a u64> + Send>(
         stream: TcpStream,
         local_ip: SocketAddr,

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -848,7 +848,10 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     let ledger_reader = ledger_reader.read().await;
                                     let is_fork = match ledger_reader.get_block_hash(block_height) {
                                         Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
-                                        Err(_) => None,
+                                        Err(error) => {
+                                            trace!("is_fork error: {}", error);
+                                            None
+                                        },
                                     };
                                     // Send a `Pong` message to the peer.
                                     if let Err(error) = peer.send(Message::Pong(is_fork, ledger_reader.latest_block_locators())).await {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -177,7 +177,6 @@ impl<N: Network, E: Environment> Server<N, E> {
     /// Initialize a new instance for managing the ledger.
     ///
     #[inline]
-    #[allow(clippy::type_complexity)]
     fn initialize_ledger(
         tasks: &mut Tasks<task::JoinHandle<()>>,
         storage_path: &str,

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -81,7 +81,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         let mut tasks = Tasks::new();
 
         // Initialize a new instance for managing peers.
-        let (peers, peers_router) = Self::initialize_peers(&mut tasks, local_ip);
+        let (peers, peers_router) = Self::initialize_peers(&mut tasks, local_ip, status.clone());
         // Initialize a new instance for managing the ledger.
         let (ledger_reader, ledger_router) = Self::initialize_ledger(&mut tasks, &storage_path, &status, &peers_router)?;
 
@@ -142,9 +142,13 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     #[inline]
     #[allow(clippy::type_complexity)]
-    fn initialize_peers(tasks: &mut Tasks<task::JoinHandle<()>>, local_ip: SocketAddr) -> (Arc<RwLock<Peers<N, E>>>, PeersRouter<N, E>) {
+    fn initialize_peers(
+        tasks: &mut Tasks<task::JoinHandle<()>>,
+        local_ip: SocketAddr,
+        local_status: Status,
+    ) -> (Arc<RwLock<Peers<N, E>>>, PeersRouter<N, E>) {
         // Initialize the `Peers` struct.
-        let peers = Arc::new(RwLock::new(Peers::new(local_ip, None)));
+        let peers = Arc::new(RwLock::new(Peers::new(local_ip, None, local_status)));
 
         // Initialize an mpsc channel for sending requests to the `Peers` struct.
         let (peers_router, mut peers_handler) = mpsc::channel(1024);

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -448,7 +448,7 @@ mod tests {
 
     /// Initializes a new instance of the `Peers` struct.
     fn peers<N: Network, E: Environment>() -> Arc<RwLock<Peers<N, E>>> {
-        Arc::new(RwLock::new(Peers::new("0.0.0.0:4130".parse().unwrap(), None)))
+        Arc::new(RwLock::new(Peers::new("0.0.0.0:4130".parse().unwrap(), None, Status::new())))
     }
 
     /// Initializes a new instance of the ledger state.


### PR DESCRIPTION
## Motivation

Version bump to `7`, adds status in `Ping` messages

This PR introduces improved state logging of peers:
```
Peer x.x.x.x:xxxx is at block 24232 (type = Miner, status = Peering, is_fork = false, common_ancestor = 24226)
```