### PR TITLE
Introduce network integration tests (squashed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,9 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -1312,6 +1315,25 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "pea2pea"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e767de612eda2b1c42146b90ead2e67d8851b1b632023a071172ad91d1b3ab"
+dependencies = [
+ "async-trait",
+ "once_cell",
+ "parking_lot",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "peak_alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae5ca2a4f36e9bba393e6711350dde5d11f5aacca3660fcca7877fe6b6e9d98"
 
 [[package]]
 name = "peeking_take_while"
@@ -1881,6 +1903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkos-ledger",
+ "snarkos-testing",
  "snarkvm",
  "structopt",
  "tempfile",
@@ -1911,6 +1934,25 @@ dependencies = [
  "snarkvm",
  "tempfile",
  "tracing",
+]
+
+[[package]]
+name = "snarkos-testing"
+version = "2.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "pea2pea",
+ "peak_alloc",
+ "rand",
+ "snarkos",
+ "snarkos-ledger",
+ "snarkvm",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2319,6 +2361,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "tokio-macros",
  "winapi",
@@ -2437,6 +2480,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
  "matchers",
+ "parking_lot",
  "regex",
  "sharded-slab",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
+ "cfg-if",
  "chrono",
  "circular-queue",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ license = "GPL-3.0"
 edition = "2018"
 
 [workspace]
-members = ["ledger"]
+members = ["ledger", "testing"]
+
+[features]
+default = []
+test = []
 
 [dependencies]
 snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "040825e" }
@@ -31,6 +35,10 @@ tui = { version = "0.16.0", features = ["crossterm"] }
 
 [dependencies.snarkos-ledger]
 path = "./ledger"
+version = "2.0.0"
+
+[dev-dependencies.snarkos-testing]
+path = "./testing"
 version = "2.0.0"
 
 [dependencies.anyhow]
@@ -119,7 +127,7 @@ version = "0.1"
 
 [dependencies.tracing-subscriber]
 version = "0.3"
-features = ["env-filter"]
+features = ["env-filter", "parking_lot"]
 
 [dev-dependencies.rand_chacha]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,6 @@ tui = { version = "0.16.0", features = ["crossterm"] }
 path = "./ledger"
 version = "2.0.0"
 
-[dev-dependencies.snarkos-testing]
-path = "./testing"
-version = "2.0.0"
-
 [dependencies.anyhow]
 version = "1"
 
@@ -54,6 +50,9 @@ version = "1.0"
 version = "0.4"
 default-features = false
 features = [ "clock", "serde" ]
+
+[dependencies.cfg-if]
+version = "1.0"
 
 [dependencies.circular-queue]
 version = "0.2"
@@ -134,6 +133,10 @@ version = "0.3"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"
+
+[dev-dependencies.snarkos-testing]
+path = "./testing"
+version = "2.0.0"
 
 [dev-dependencies.tempfile]
 version = "3.2"

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ enables applications to verify and store state in a publicly verifiable manner.
 
 ## 2. Build Guide
 
-Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
-
 ### 2.1 Requirements
 
 The following are **minimum** requirements to run an Aleo node:
@@ -44,6 +42,8 @@ The following are **minimum** requirements to run an Aleo node:
 Please note to run an Aleo mining node that is **competitive**, the machine will require more than these requirements.
 
 ### 2.2 Installation
+
+Before beginning, please ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
 
 Start by cloning the snarkOS Github repository:
 ```
@@ -104,10 +104,16 @@ aleo1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ## 4. Testnet2 FAQs
 
-### 1. The node is unable to connect to peers on the network.
+### 1. My node is unable to compile.
+
+- Ensure your machine has `Rust v1.56+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
+- If large errors appear during compilation, try running `cargo clean`.
+- Ensure snarkOS is started using `./run-client.sh` or `./run-miner.sh`.
+
+### 2. My node is unable to connect to peers on the network.
 
 - Ensure ports `4132/tcp` and `3032/tcp` are open on your router and OS firewall.
-- Ensure snarkOS is started using `run-client.sh` or `run-miner.sh`
+- Ensure snarkOS is started using `./run-client.sh` or `./run-miner.sh`.
 
 ## 5. Command Line Interface
 
@@ -144,7 +150,7 @@ SUBCOMMANDS:
 
 In one terminal, start the first node by running:
 ```
-cargo run --release -- --node 4135 --rpc 3035 --miner aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah
+cargo run --release -- --node 0.0.0.0:4135 --rpc 0.0.0.0:3035 --miner aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah
 ```
 
 After the first node starts, in a second terminal, run:

--- a/README.md
+++ b/README.md
@@ -125,25 +125,28 @@ snarkos
 The Aleo Team <hello@aleo.org>
 
 USAGE:
-    snarkos [FLAGS] [OPTIONS]
+    snarkos [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
         --display    If the flag is set, the node will render a read-only display
     -h, --help       Prints help information
+        --norpc      If the flag is set, the node will not initialize the RPC server
     -V, --version    Prints version information
 
 OPTIONS:
+        --connect <connect>          Specify the IP address of a peer to connect to
         --miner <miner>              Specify this as a mining node, with the given miner address
     -n, --network <network>          Specify the network of this node [default: 2]
-        --node <node>                Specify the port for the node server
-        --rpc <rpc>                  Specify the port for the RPC server
-        --username <rpc-username>    Specify the username for the RPC server [default: root]
+        --node <node>                Specify the IP address and port for the node server [default: 0.0.0.0:4132]
+        --rpc <rpc>                  Specify the IP address and port for the RPC server [default: 0.0.0.0:3032]
         --password <rpc-password>    Specify the password for the RPC server [default: pass]
+        --username <rpc-username>    Specify the username for the RPC server [default: root]
         --verbosity <verbosity>      Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
 
 SUBCOMMANDS:
-    help      Prints this message or the help of the given subcommand(s)
-    update    Updates snarkOS to the latest version
+    experimental    Experimental features
+    help            Prints this message or the help of the given subcommand(s)
+    update          Updates snarkOS to the latest version
 ```
 
 ## 6. Development Guide

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-        --connect <connect>          Specify the IP address of a peer to connect to
+        --connect <connect>          Specify the IP address and port of a peer to connect to
         --miner <miner>              Specify this as a mining node, with the given miner address
     -n, --network <network>          Specify the network of this node [default: 2]
         --node <node>                Specify the IP address and port for the node server [default: 0.0.0.0:4132]

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -17,8 +17,8 @@
 pub mod circular_map;
 pub use circular_map::*;
 
-pub(crate) mod tasks;
-pub(crate) use tasks::*;
+pub mod tasks;
+pub use tasks::*;
 
 pub mod status;
 pub use status::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         .unwrap();
 
     runtime.block_on(async move {
-        Node::from_args().start().await.expect("Couldn't start the node!");
+        Node::from_args().start().await.expect("Failed to start the node");
         std::future::pending::<()>().await;
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,10 @@ fn main() -> Result<()> {
         .build_global()
         .unwrap();
 
-    runtime.block_on(Node::from_args().start())?;
+    runtime.block_on(async move {
+        Node::from_args().start().await.expect("Couldn't start the node!");
+        std::future::pending::<()>().await;
+    });
 
     Ok(())
 }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -45,6 +45,8 @@ pub type LedgerReader<N> = Arc<RwLock<LedgerState<N>>>;
 ///
 #[derive(Clone)]
 pub struct Server<N: Network, E: Environment> {
+    /// The local address of this node.
+    local_ip: SocketAddr,
     /// The status of the node.
     status: Status,
     /// The list of peers for the node.
@@ -123,6 +125,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         }
 
         Ok(Self {
+            local_ip,
             status,
             peers,
             peers_router,
@@ -130,6 +133,11 @@ impl<N: Network, E: Environment> Server<N, E> {
             ledger_router,
             tasks,
         })
+    }
+
+    /// Returns the IP address of this node.
+    fn local_ip(&self) -> SocketAddr {
+        self.local_ip
     }
 
     /// Returns the status of this node.

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -70,13 +70,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         };
 
         // Initialize the ledger storage path.
-        #[cfg(not(feature = "test"))]
-        let storage_path = format!(".ledger-{}", (node_port - 4130));
-        // Tests can use any available ports, and they remove the storage artifacts afterwards, so there
-        // is no need to adhere to a specific number assignment logic.
-        #[cfg(feature = "test")]
-        let storage_path = format!("/tmp/snarkos-test-ledger-{}", local_ip.port());
-
+        let storage_path = node.storage_path(local_ip);
         // Initialize the status indicator.
         let status = Status::new();
         // Initialize a new instance for managing peers.

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -63,11 +63,6 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     #[inline]
     pub async fn initialize(node: &Node, miner: Option<Address<N>>, mut tasks: Tasks<task::JoinHandle<()>>) -> Result<Self> {
-        assert!(
-            node.node.port() >= 4130,
-            "Until configuration files are established, the node port must be at least 4130 or greater"
-        );
-
         // Initialize a new TCP listener at the given IP.
         let (local_ip, listener) = match TcpListener::bind(node.node).await {
             Ok(listener) => (listener.local_addr().expect("Failed to fetch the local IP"), listener),

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -48,7 +48,7 @@ pub struct Server<N: Network, E: Environment> {
     /// The status of the node.
     status: Status,
     /// The list of peers for the node.
-    pub peers: Arc<RwLock<Peers<N, E>>>,
+    peers: Arc<RwLock<Peers<N, E>>>,
     /// The peers router of the node.
     peers_router: PeersRouter<N, E>,
     /// The ledger state of the node.
@@ -58,7 +58,7 @@ pub struct Server<N: Network, E: Environment> {
     /// The list of tasks spawned by the node.
     tasks: Tasks<task::JoinHandle<()>>,
     /// The node's local listening address.
-    pub local_ip: SocketAddr,
+    local_ip: SocketAddr,
 }
 
 impl<N: Network, E: Environment> Server<N, E> {

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -57,8 +57,6 @@ pub struct Server<N: Network, E: Environment> {
     ledger_router: LedgerRouter<N, E>,
     /// The list of tasks spawned by the node.
     tasks: Tasks<task::JoinHandle<()>>,
-    /// The node's local listening address.
-    local_ip: SocketAddr,
 }
 
 impl<N: Network, E: Environment> Server<N, E> {
@@ -131,7 +129,6 @@ impl<N: Network, E: Environment> Server<N, E> {
             ledger_reader,
             ledger_router,
             tasks,
-            local_ip,
         })
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -97,13 +97,25 @@ impl Node {
         }
     }
 
-    async fn start_server<N: Network, E: Environment>(&self) -> Result<()> {
-        // TODO (howardwu): Remove this check after introducing proper configurations.
-        assert!(
-            self.node.port() >= 4130,
-            "Until configuration files are established, the node port must be at least 4130 or greater"
-        );
+    /// Returns the storage path of the node.
+    pub(crate) fn storage_path(&self, local_ip: SocketAddr) -> String {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "test")] {
+                // Tests may use any available ports, and removes the storage artifacts afterwards,
+                // so that there is no need to adhere to a specific number assignment logic.
+                format!("/tmp/snarkos-test-ledger-{}", local_ip.port())
+            } else {
+                // TODO (howardwu): Remove this check after introducing proper configurations.
+                assert!(
+                    self.node.port() >= 4130,
+                    "Until configuration files are established, the node port must be at least 4130 or greater"
+                );
+                format!(".ledger-{}", (self.node.port() - 4130))
+            }
+        }
+    }
 
+    async fn start_server<N: Network, E: Environment>(&self) -> Result<()> {
         let miner = match (E::NODE_TYPE, &self.miner) {
             (NodeType::Miner, Some(address)) => {
                 let miner_address = Address::<N>::from_str(address)?;

--- a/src/node.rs
+++ b/src/node.rs
@@ -98,6 +98,12 @@ impl Node {
     }
 
     async fn start_server<N: Network, E: Environment>(&self) -> Result<()> {
+        // TODO (howardwu): Remove this check after introducing proper configurations.
+        assert!(
+            self.node.port() >= 4130,
+            "Until configuration files are established, the node port must be at least 4130 or greater"
+        );
+
         let miner = match (E::NODE_TYPE, &self.miner) {
             (NodeType::Miner, Some(address)) => {
                 let miner_address = Address::<N>::from_str(address)?;

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,7 +38,7 @@ use tracing_subscriber::EnvFilter;
 #[derive(StructOpt, Debug)]
 #[structopt(name = "snarkos", author = "The Aleo Team <hello@aleo.org>", setting = structopt::clap::AppSettings::ColoredHelp)]
 pub struct Node {
-    /// Specify the IP address of a peer to connect to.
+    /// Specify the IP address and port of a peer to connect to.
     #[structopt(long = "connect")]
     pub connect: Option<String>,
     /// Specify this as a mining node, with the given miner address.

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -103,18 +103,17 @@ pub async fn initialize_rpc_server<N: Network, E: Environment>(
 
     let server = Server::bind(&rpc_addr).serve(service);
 
-    let (tx, rx) = oneshot::channel();
-    let task_handle = tokio::spawn(async move {
+    // TODO (howardwu): I do not know what this section does. Someone document me please.
+    let (router, handler) = oneshot::channel();
+    let task = tokio::spawn(async move {
         // Notify the outer function that the task is ready.
-        let _ = tx.send(());
-
-        server.await.expect("The RPC server couldn't be started!");
+        let _ = router.send(());
+        server.await.expect("Failed to start the RPC server");
     });
-
     // Wait until the spawned task is ready.
-    let _ = rx.await;
+    let _ = handler.await;
 
-    task_handle
+    task
 }
 
 async fn handle_rpc<N: Network, E: Environment>(

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -36,7 +36,7 @@ use json_rpc_types as jrt;
 use jsonrpc_core::{Metadata, Params};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::sync::{oneshot, RwLock};
 
 /// Defines the authentication format for accessing private endpoints on the RPC server.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ const METHODS_EXPECTING_PARAMS: [&str; 12] = [
 
 /// Starts a local RPC HTTP server at `rpc_port` in a dedicated `tokio` task.
 /// RPC failures do not affect the rest of the node.
-pub fn initialize_rpc_server<N: Network, E: Environment>(
+pub async fn initialize_rpc_server<N: Network, E: Environment>(
     rpc_addr: SocketAddr,
     username: String,
     password: String,
@@ -103,9 +103,18 @@ pub fn initialize_rpc_server<N: Network, E: Environment>(
 
     let server = Server::bind(&rpc_addr).serve(service);
 
-    tokio::spawn(async move {
+    let (tx, rx) = oneshot::channel();
+    let task_handle = tokio::spawn(async move {
+        // Notify the outer function that the task is ready.
+        let _ = tx.send(());
+
         server.await.expect("The RPC server couldn't be started!");
-    })
+    });
+
+    // Wait until the spawned task is ready.
+    let _ = rx.await;
+
+    task_handle
 }
 
 async fn handle_rpc<N: Network, E: Environment>(

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -103,7 +103,6 @@ pub async fn initialize_rpc_server<N: Network, E: Environment>(
 
     let server = Server::bind(&rpc_addr).serve(service);
 
-    // TODO (howardwu): I do not know what this section does. Someone document me please.
     let (router, handler) = oneshot::channel();
     let task = tokio::spawn(async move {
         // Notify the outer function that the task is ready.

--- a/start
+++ b/start
@@ -5,4 +5,4 @@ mkdir -p /aleo/data/params/registry/src/github.com-1ecc6299db9ec823/snarkvm-para
 ln -s /aleo/data/ledger /.ledger-2 && \
 ln -s /aleo/data/params/git /usr/local/cargo/git && \
 ln -s /aleo/data/params/registry /usr/local/cargo/registry && \
-/aleo/bin/snarkos --node 4132 --rpc 3032 --verbosity 3 --trial
+/aleo/bin/snarkos --node 0.0.0.0:4132 --rpc 0.0.0.0:3032 --verbosity 3 --trial

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -16,16 +16,16 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2018"
 
-[dependencies.snarkvm]
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "040825e"
-
 [dependencies.snarkos]
 path = ".."
 features = ["test"]
 
 [dependencies.snarkos-ledger]
 path = "../ledger"
+
+[dependencies.snarkvm]
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "040825e"
 
 [dependencies.anyhow]
 version = "1"
@@ -45,12 +45,12 @@ version = "0.1"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.structopt]
+version = "0.3"
+
 [dependencies.tokio]
 version = "1"
 features = ["macros", "rt-multi-thread", "time"]
-
-[dependencies.structopt]
-version = "0.3"
 
 [dependencies.tracing]
 version = "0.1"

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "snarkos-testing"
+version = "2.0.0"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "A decentralized operating system"
+homepage = "https://aleo.org"
+repository = "https://github.com/AleoHQ/snarkOS"
+keywords = [
+    "aleo",
+    "cryptography",
+    "blockchain",
+    "decentralized",
+    "zero-knowledge"
+]
+categories = [ "cryptography", "operating-systems" ]
+license = "GPL-3.0"
+edition = "2018"
+
+[dependencies.snarkvm]
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "040825e"
+
+[dependencies.snarkos]
+path = ".."
+features = ["test"]
+
+[dependencies.snarkos-ledger]
+path = "../ledger"
+
+[dependencies.anyhow]
+version = "1"
+
+[dependencies.async-trait]
+version = "0.1"
+
+[dependencies.bincode]
+version = "1"
+
+[dependencies.pea2pea]
+version = "0.28"
+
+[dependencies.peak_alloc]
+version = "0.1"
+
+[dependencies.rand]
+version = "0.8"
+
+[dependencies.tokio]
+version = "1"
+features = ["macros", "rt-multi-thread", "time"]
+
+[dependencies.structopt]
+version = "0.3"
+
+[dependencies.tracing]
+version = "0.1"
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+features = ["env-filter", "parking_lot"]

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,2 @@
+# snarkOS-testing
+

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -49,7 +49,7 @@ impl ClientNode {
 
     /// Starts a snarkOS node with all the default characteristics from `ClientNode::with_args`.
     pub async fn default() -> Self {
-        ClientNode::with_args(&["--node", "127.0.0.1:4133"]).await
+        ClientNode::with_args(&["--node", "127.0.0.1:0"]).await
     }
 
     /// Starts a snarkOS node with a local address and the RPC server disabled;

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -49,13 +49,13 @@ impl ClientNode {
 
     /// Starts a snarkOS node with all the default characteristics from `ClientNode::with_args`.
     pub async fn default() -> Self {
-        ClientNode::with_args(&[]).await
+        ClientNode::with_args(&["--node", "127.0.0.1:4133"]).await
     }
 
     /// Starts a snarkOS node with a local address and the RPC server disabled;
     /// extra arguments may be passed via `extra_args`.
     pub async fn with_args(extra_args: &[&str]) -> Self {
-        let permanent_args = &["snarkos", "--norpc", "--node", "127.0.0.1:4132"];
+        let permanent_args = &["snarkos", "--norpc"];
         let combined_args = permanent_args.iter().chain(extra_args.iter());
         let config = snarkos::Node::from_iter(combined_args);
         let server = Server::<Testnet2, Client<Testnet2>>::initialize(&config, None, Tasks::new())

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -47,8 +47,7 @@ impl ClientNode {
         self.server.connect_to(addr).await
     }
 
-    /// Starts a snarkOS node with all the default characteristics from `ClientNode::with_args`,
-    /// and with any available port (as opposed to the default snarkOS network port).
+    /// Starts a snarkOS node with all the default characteristics from `ClientNode::with_args`.
     pub async fn default() -> Self {
         ClientNode::with_args(&[]).await
     }

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -50,7 +50,7 @@ impl ClientNode {
     /// Starts a snarkOS node with all the default characteristics from `ClientNode::with_args`,
     /// and with any available port (as opposed to the default snarkOS network port).
     pub async fn default() -> Self {
-        ClientNode::with_args(&["--node", "0"]).await
+        ClientNode::with_args(&[]).await
     }
 
     /// Starts a snarkOS node with a local address and the RPC server disabled;

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod snarkos_node;
-pub use snarkos_node::*;
+pub mod client_node;
+pub use client_node::*;
 
 pub mod test_node;
 pub use test_node::*;

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -14,14 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
+pub mod snarkos_node;
+pub use snarkos_node::*;
 
-pub mod message;
-pub use message::*;
-
-pub(crate) mod peers;
-pub(crate) use peers::*;
-
-pub mod server;
-pub use server::{LedgerReader, Server};
+pub mod test_node;
+pub use test_node::*;

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -1,0 +1,82 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkos::{helpers::Tasks, Client, Server};
+use snarkvm::dpc::testnet2::Testnet2;
+use structopt::StructOpt;
+
+use std::{fs, net::SocketAddr};
+
+/// A facade for a snarkOS node.
+pub struct SnarkosNode {
+    pub server: Server<Testnet2, Client<Testnet2>>,
+}
+
+impl SnarkosNode {
+    /// Returns the node's local listening address.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.server.local_ip
+    }
+
+    /// Returns the list of node's connected peers.
+    pub async fn connected_peers(&self) -> Vec<SocketAddr> {
+        self.server.peers.read().await.connected_peers()
+    }
+
+    /// Resets the node's known peers. This is practical, as it makes the node not reconnect
+    /// to known peers in test cases where it's undesirable.
+    pub async fn reset_known_peers(&self) {
+        self.server.peers.write().await.reset_known_peers()
+    }
+
+    /// Attempts to connect the node to the given address.
+    pub async fn connect(&self, addr: SocketAddr) -> anyhow::Result<()> {
+        self.server.connect_to(addr).await
+    }
+
+    /// Starts a snarkOS node with all the default characteristics from `SnarkosNode::with_args` and with
+    /// any available port (as opposed to the default snarkOS network port).
+    pub async fn default() -> Self {
+        SnarkosNode::with_args(&["--node", "0"]).await
+    }
+
+    /// Starts a snarkOS node with a local address and the RPC server disabled; extra arguments can be passed
+    /// via `extra_args`.
+    pub async fn with_args(extra_args: &[&str]) -> Self {
+        let permanent_args = &["snarkos", "--disable-rpc", "--ip", "127.0.0.1"];
+        let combined_args = permanent_args.iter().chain(extra_args.iter());
+        let config = snarkos::Node::from_iter(combined_args);
+
+        let server = Server::<Testnet2, Client<Testnet2>>::initialize(&config, None, Tasks::new())
+            .await
+            .unwrap();
+
+        SnarkosNode { server }
+    }
+}
+
+// Remove the storage artifacts after each test.
+impl Drop for SnarkosNode {
+    fn drop(&mut self) {
+        let db_path = format!("/tmp/snarkos-test-ledger-{}", self.local_addr().port());
+
+        assert!(
+            fs::remove_dir_all(&db_path).is_ok(),
+            "Storage cleanup failed! The expected path \"{}\" doesn't exist",
+            db_path
+        );
+    }
+}

--- a/testing/src/snarkos_node.rs
+++ b/testing/src/snarkos_node.rs
@@ -28,18 +28,18 @@ pub struct SnarkosNode {
 impl SnarkosNode {
     /// Returns the node's local listening address.
     pub fn local_addr(&self) -> SocketAddr {
-        self.server.local_ip
+        self.server.local_ip()
     }
 
     /// Returns the list of node's connected peers.
     pub async fn connected_peers(&self) -> Vec<SocketAddr> {
-        self.server.peers.read().await.connected_peers()
+        self.server.peers().read().await.connected_peers()
     }
 
     /// Resets the node's known peers. This is practical, as it makes the node not reconnect
     /// to known peers in test cases where it's undesirable.
     pub async fn reset_known_peers(&self) {
-        self.server.peers.write().await.reset_known_peers()
+        self.server.peers().write().await.reset_known_peers()
     }
 
     /// Attempts to connect the node to the given address.

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -1,0 +1,399 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use pea2pea::{
+    protocols::{Disconnect, Handshake, Reading, Writing},
+    Config,
+    Connection,
+    Node as Pea2PeaNode,
+    Pea2Pea,
+};
+use rand::{thread_rng, Rng};
+use snarkos::{
+    helpers::{State, Status},
+    Client,
+    Environment,
+    Message,
+    NodeType,
+};
+use snarkos_ledger::BlockLocators;
+use snarkvm::{dpc::testnet2::Testnet2, traits::Network};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+    task,
+};
+use tracing::*;
+
+use std::{
+    convert::TryInto,
+    io,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+// Consts & aliases.
+const MESSAGE_LENGTH_PREFIX_SIZE: usize = 4;
+const CHALLENGE_HEIGHT: u32 = 0;
+const PING_INTERVAL_SECS: u64 = 5;
+const PEER_INTERVAL_SECS: u64 = 3;
+const DESIRED_CONNECTIONS: usize = <Client<Testnet2>>::MINIMUM_NUMBER_OF_PEERS * 3;
+const MESSAGE_VERSION: u32 = <Client<Testnet2>>::MESSAGE_VERSION;
+
+pub const MAXIMUM_NUMBER_OF_PEERS: usize = <Client<Testnet2>>::MAXIMUM_NUMBER_OF_PEERS;
+
+type SnarkosMessage = Message<Testnet2, Client<Testnet2>>;
+pub type SnarkosNonce = u64;
+
+/// The test node; it consists of a `Node` that handles networking and `State`
+/// that can be extended freely based on test requirements.
+#[derive(Clone)]
+pub struct TestNode {
+    node: Pea2PeaNode,
+    state: SnarkosState,
+}
+
+/// Represents a connected snarkOS peer.
+pub struct SnarkosPeer {
+    connected_addr: SocketAddr,
+    listening_addr: SocketAddr,
+    nonce: SnarkosNonce,
+}
+
+/// snarkOS state required for test purposes.
+#[derive(Clone)]
+pub struct SnarkosState {
+    pub local_nonce: SnarkosNonce,
+    /// The list of known peers; `Pea2Pea` already has its own internal peer handling, but
+    /// snarkOS nodes expect to learn each other's listening address, and expect their connection
+    /// nonces to be unique; this collection facilitates the snarkOS peering experience during
+    /// tests and aligns it with snarkOS logic.
+    pub peers: Arc<Mutex<Vec<SnarkosPeer>>>,
+    pub status: Status,
+}
+
+impl Default for SnarkosState {
+    fn default() -> Self {
+        Self {
+            local_nonce: thread_rng().gen(),
+            peers: Default::default(),
+            status: Status::new(),
+        }
+    }
+}
+
+impl Pea2Pea for TestNode {
+    fn node(&self) -> &Pea2PeaNode {
+        &self.node
+    }
+}
+
+impl TestNode {
+    /// Creates a default test node with the most basic network protocols enabled.
+    pub async fn default() -> Self {
+        let config = Config {
+            listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            max_connections: MAXIMUM_NUMBER_OF_PEERS as u16,
+            ..Default::default()
+        };
+
+        let pea2pea_node = Pea2PeaNode::new(Some(config)).await.unwrap();
+        let snarkos_state = Default::default();
+        let node = Self::new(pea2pea_node, snarkos_state);
+
+        node.enable_disconnect();
+        node.enable_handshake();
+        node.enable_reading();
+        node.enable_writing();
+
+        node
+    }
+
+    /// Creates a test node using the given `Pea2Pea` node.
+    pub fn new(node: Pea2PeaNode, state: SnarkosState) -> Self {
+        Self { node, state }
+    }
+
+    fn node_type(&self) -> NodeType {
+        NodeType::Client
+    }
+
+    fn state(&self) -> State {
+        self.state.status.get()
+    }
+
+    /// Spawns a task dedicated to broadcasting Ping messages.
+    pub fn send_pings(&self) {
+        let node = self.clone();
+        task::spawn(async move {
+            let genesis = Testnet2::genesis_block();
+            let ping_msg = SnarkosMessage::Ping(MESSAGE_VERSION, node.node_type(), node.state(), genesis.height(), genesis.hash());
+
+            loop {
+                if node.node().num_connected() != 0 {
+                    info!(parent: node.node().span(), "sending out Pings");
+                    node.send_broadcast(ping_msg.clone());
+                }
+                tokio::time::sleep(Duration::from_secs(PING_INTERVAL_SECS)).await;
+            }
+        });
+    }
+
+    /// Spawns a task dedicated to peer maintenance.
+    pub fn update_peers(&self) {
+        let node = self.clone();
+        task::spawn(async move {
+            loop {
+                let num_conns = node.node().num_connected() + node.node().num_connecting();
+
+                if num_conns < DESIRED_CONNECTIONS && node.node().num_connected() != 0 {
+                    info!(parent: node.node().span(), "I'd like to have {} more peers; asking peers for their peers", DESIRED_CONNECTIONS - num_conns);
+                    node.send_broadcast(SnarkosMessage::PeerRequest);
+                }
+                tokio::time::sleep(Duration::from_secs(PEER_INTERVAL_SECS)).await;
+            }
+        });
+    }
+
+    /// Starts the usual periodic activities of a test node.
+    pub fn run_periodic_tasks(&self) {
+        self.send_pings();
+        self.update_peers();
+    }
+}
+
+/// Automated handshake handling for the test nodes.
+#[async_trait::async_trait]
+impl Handshake for TestNode {
+    async fn perform_handshake(&self, mut conn: Connection) -> io::Result<Connection> {
+        // Guard against double (two-sided) connections.
+        let mut locked_peers = self.state.peers.lock().await;
+
+        let own_addr = self.node().listening_addr()?;
+        let peer_addr = conn.addr;
+
+        let genesis_block_header = Testnet2::genesis_block().header();
+
+        // Send a challenge request to the peer.
+        let own_request = SnarkosMessage::ChallengeRequest(MESSAGE_VERSION, own_addr.port(), self.state.local_nonce, 0);
+        trace!(parent: self.node().span(), "sending a challenge request to {}", peer_addr);
+        let msg = own_request.serialize().unwrap();
+        let len = u32::to_le_bytes(msg.len() as u32);
+        conn.writer().write_all(&len).await?;
+        conn.writer().write_all(&msg).await?;
+
+        let mut buf = [0u8; 1024];
+
+        // Read the challenge request from the peer.
+        conn.reader().read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE]).await?;
+        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+        conn.reader().read_exact(&mut buf[..len]).await?;
+        let peer_request = SnarkosMessage::deserialize(&buf[..len]);
+
+        // Register peer's nonce.
+        let (peer_listening_addr, peer_nonce) =
+            if let Ok(Message::ChallengeRequest(peer_version, peer_listening_port, peer_nonce, _block_height)) = peer_request {
+                if peer_version < MESSAGE_VERSION {
+                    warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", peer_addr, peer_version);
+                    return Err(io::ErrorKind::InvalidData.into());
+                }
+
+                let peer_listening_addr = SocketAddr::from((peer_addr.ip(), peer_listening_port));
+
+                if locked_peers
+                    .iter()
+                    .any(|peer| peer.nonce == peer_nonce || peer.listening_addr == peer_listening_addr)
+                {
+                    return Err(io::ErrorKind::AlreadyExists.into());
+                }
+
+                trace!(parent: self.node().span(), "received a challenge request from {}", peer_addr);
+
+                (peer_listening_addr, peer_nonce)
+            } else {
+                error!(parent: self.node().span(), "invalid challenge request from {}", peer_addr);
+                return Err(io::ErrorKind::InvalidData.into());
+            };
+
+        // Respond with own challenge request.
+        let own_response = SnarkosMessage::ChallengeResponse(genesis_block_header.clone());
+        trace!(parent: self.node().span(), "sending a challenge response to {}", peer_addr);
+        let msg = own_response.serialize().unwrap();
+        let len = u32::to_le_bytes(msg.len() as u32);
+        conn.writer().write_all(&len).await?;
+        conn.writer().write_all(&msg).await?;
+
+        // Wait for the challenge response to come in.
+        conn.reader().read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE]).await?;
+        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+        conn.reader().read_exact(&mut buf[..len]).await?;
+        let peer_response = SnarkosMessage::deserialize(&buf[..len]);
+
+        if let Ok(Message::ChallengeResponse(block_header)) = peer_response {
+            trace!(parent: self.node().span(), "received a challenge response from {}", peer_addr);
+            if block_header.height() == CHALLENGE_HEIGHT && &block_header == genesis_block_header && block_header.is_valid() {
+                // Register the newly connected snarkOS peer.
+                locked_peers.push(SnarkosPeer {
+                    connected_addr: peer_addr,
+                    listening_addr: peer_listening_addr,
+                    nonce: peer_nonce,
+                });
+                debug!(parent: self.node().span(), "connected to {} (listening addr: {})", peer_addr, peer_listening_addr);
+
+                Ok(conn)
+            } else {
+                error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
+                Err(io::ErrorKind::InvalidData.into())
+            }
+        } else {
+            error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
+            Err(io::ErrorKind::InvalidData.into())
+        }
+    }
+}
+
+/// Inbound message processing logic for the test nodes.
+#[async_trait::async_trait]
+impl Reading for TestNode {
+    type Message = SnarkosMessage;
+
+    fn read_message<R: io::Read>(&self, source: SocketAddr, reader: &mut R) -> io::Result<Option<Self::Message>> {
+        // FIXME: use the maximum message size allowed by the protocol or (better) use streaming deserialization.
+        let mut buf = [0u8; 8 * 1024];
+
+        reader.read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE])?;
+        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+
+        if reader.read_exact(&mut buf[..len]).is_err() {
+            return Ok(None);
+        }
+
+        match SnarkosMessage::deserialize(&buf[..len]) {
+            Ok(msg) => {
+                info!(parent: self.node().span(), "received a {} from {}", msg.name(), source);
+                Ok(Some(msg))
+            }
+            Err(e) => {
+                error!("a message from {} failed to deserialize: {}", source, e);
+                Err(io::ErrorKind::InvalidData.into())
+            }
+        }
+    }
+
+    async fn process_message(&self, source: SocketAddr, message: Self::Message) -> io::Result<()> {
+        match message {
+            SnarkosMessage::BlockRequest(_start_block_height, _end_block_height) => {}
+            SnarkosMessage::BlockResponse(_block) => {}
+            SnarkosMessage::Disconnect => {}
+            SnarkosMessage::PeerRequest => self.process_peer_request(source).await?,
+            SnarkosMessage::PeerResponse(peer_addrs) => self.process_peer_response(source, peer_addrs).await?,
+            SnarkosMessage::Ping(version, _peer_type, _peer_state, block_height, _block_hash) => {
+                self.process_ping(source, version, block_height).await?
+            }
+            SnarkosMessage::Pong(_is_fork, _block_locators) => {}
+            SnarkosMessage::UnconfirmedBlock(_block) => {}
+            SnarkosMessage::UnconfirmedTransaction(_transaction) => {}
+            _ => return Err(io::ErrorKind::InvalidData.into()), // Peer is not following the protocol.
+        }
+
+        Ok(())
+    }
+}
+
+/// Outbound message processing logic for the test nodes.
+impl Writing for TestNode {
+    type Message = SnarkosMessage;
+
+    fn write_message<W: io::Write>(&self, _target: SocketAddr, payload: &Self::Message, writer: &mut W) -> io::Result<()> {
+        let serialized = payload.serialize().unwrap();
+        let len = u32::to_le_bytes(serialized.len() as u32);
+
+        writer.write_all(&len)?;
+        writer.write_all(&serialized)
+    }
+}
+
+/// Disconnect logic for the test nodes.
+#[async_trait::async_trait]
+impl Disconnect for TestNode {
+    async fn handle_disconnect(&self, disconnecting_addr: SocketAddr) {
+        let mut locked_peers = self.state.peers.lock().await;
+        let initial_len = locked_peers.len();
+        locked_peers.retain(|peer| peer.connected_addr != disconnecting_addr);
+        assert_eq!(locked_peers.len(), initial_len - 1)
+    }
+}
+
+// Helper methods.
+impl TestNode {
+    async fn process_peer_request(&self, source: SocketAddr) -> io::Result<()> {
+        let peers = self
+            .state
+            .peers
+            .lock()
+            .await
+            .iter()
+            .map(|peer| peer.listening_addr)
+            .collect::<Vec<_>>();
+        let msg = SnarkosMessage::PeerResponse(peers);
+        info!(parent: self.node().span(), "sending a PeerResponse to {}", source);
+
+        self.send_direct_message(source, msg)
+    }
+
+    async fn process_peer_response(&self, source: SocketAddr, peer_addrs: Vec<SocketAddr>) -> io::Result<()> {
+        let num_conns = self.node().num_connected() + self.node().num_connecting();
+
+        let node = self.clone();
+        task::spawn(async move {
+            for peer_addr in peer_addrs
+                .into_iter()
+                .filter(|addr| node.node().listening_addr().unwrap() != *addr)
+                .take(DESIRED_CONNECTIONS.saturating_sub(num_conns))
+            {
+                if !node.node().is_connected(peer_addr)
+                    && !node.state.peers.lock().await.iter().any(|peer| peer.listening_addr == peer_addr)
+                {
+                    info!(parent: node.node().span(), "trying to connect to {}'s peer {}", source, peer_addr);
+                    let _ = node.node().connect(peer_addr).await;
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn process_ping(&self, source: SocketAddr, version: u32, block_height: u32) -> io::Result<()> {
+        // Ensure the message protocol version is not outdated.
+        if version < <Client<Testnet2>>::MESSAGE_VERSION {
+            warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", source, version);
+            return Err(io::ErrorKind::InvalidData.into());
+        }
+
+        debug!(parent: self.node().span(), "peer {} is at height {}", source, block_height);
+
+        let genesis = Testnet2::genesis_block();
+        let msg = SnarkosMessage::Pong(
+            None,
+            BlockLocators::<Testnet2>::from(vec![(genesis.height(), (genesis.hash(), None))].into_iter().collect()),
+        );
+
+        info!(parent: self.node().span(), "sending a Pong to {}", source);
+
+        self.send_direct_message(source, msg)
+    }
+}

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -14,12 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_testing::test_node::{SnarkosNonce, SnarkosState, TestNode};
+use snarkos_testing::test_node::{ClientNonce, ClientState, TestNode};
 
 use pea2pea::{protocols::*, Config};
-use tracing_subscriber::filter::EnvFilter;
-
 use std::net::{IpAddr, Ipv4Addr};
+use tracing_subscriber::filter::EnvFilter;
 
 /// Starts a logger if a test node needs to be inspected in greater detail.
 // note: snarkOS node currently starts it by default, so it's not needed
@@ -32,24 +31,22 @@ pub fn start_logger() {
 }
 
 /// Spawns a `TestNode` with the given handshake nonce.
-pub async fn spawn_test_node_with_nonce(local_nonce: SnarkosNonce) -> TestNode {
+pub async fn spawn_test_node_with_nonce(local_nonce: ClientNonce) -> TestNode {
     let config = Config {
         listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         ..Default::default()
     };
 
     let pea2pea_node = pea2pea::Node::new(Some(config)).await.unwrap();
-    let snarkos_state = SnarkosState {
+    let client_state = ClientState {
         local_nonce,
         ..Default::default()
     };
 
-    let node = TestNode::new(pea2pea_node, snarkos_state);
-
+    let node = TestNode::new(pea2pea_node, client_state);
     node.enable_handshake();
     node.enable_reading();
     node.enable_writing();
-
     node
 }
 

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkos_testing::test_node::{SnarkosNonce, SnarkosState, TestNode};
+
+use pea2pea::{protocols::*, Config};
+use tracing_subscriber::filter::EnvFilter;
+
+use std::net::{IpAddr, Ipv4Addr};
+
+/// Starts a logger if a test node needs to be inspected in greater detail.
+// note: snarkOS node currently starts it by default, so it's not needed
+pub fn start_logger() {
+    let filter = match EnvFilter::try_from_default_env() {
+        Ok(filter) => filter.add_directive("mio=off".parse().unwrap()),
+        _ => EnvFilter::default().add_directive("mio=off".parse().unwrap()),
+    };
+    tracing_subscriber::fmt().with_env_filter(filter).with_target(false).init();
+}
+
+/// Spawns a `TestNode` with the given handshake nonce.
+pub async fn spawn_test_node_with_nonce(local_nonce: SnarkosNonce) -> TestNode {
+    let config = Config {
+        listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        ..Default::default()
+    };
+
+    let pea2pea_node = pea2pea::Node::new(Some(config)).await.unwrap();
+    let snarkos_state = SnarkosState {
+        local_nonce,
+        ..Default::default()
+    };
+
+    let node = TestNode::new(pea2pea_node, snarkos_state);
+
+    node.enable_handshake();
+    node.enable_reading();
+    node.enable_writing();
+
+    node
+}
+
+/// A helper function making memory use values more human-readable.
+pub fn display_bytes(bytes: f64) -> String {
+    const GB: f64 = 1_000_000_000.0;
+    const MB: f64 = 1_000_000.0;
+    const KB: f64 = 1_000.0;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes / KB)
+    } else {
+        format!("{:.2} B", bytes)
+    }
+}
+
+#[macro_export]
+macro_rules! wait_until {
+    ($limit_secs: expr, $condition: expr) => {
+        let now = std::time::Instant::now();
+        loop {
+            if $condition {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            assert!(now.elapsed() <= std::time::Duration::from_secs($limit_secs), "timed out!");
+        }
+    };
+}

--- a/testing/tests/network/basic_connectivity.rs
+++ b/testing/tests/network/basic_connectivity.rs
@@ -1,0 +1,206 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{common::spawn_test_node_with_nonce, wait_until};
+
+use pea2pea::Pea2Pea;
+use snarkos_testing::{SnarkosNode, TestNode, MAXIMUM_NUMBER_OF_PEERS};
+use tokio::task;
+
+use std::sync::{
+    atomic::{AtomicU8, Ordering::*},
+    Arc,
+};
+
+#[tokio::test]
+async fn snarkos_nodes_can_connect_to_each_other() {
+    // Start 2 snarkOS nodes.
+    let snarkos_node1 = SnarkosNode::default().await;
+    let snarkos_node2 = SnarkosNode::default().await;
+
+    // Connect one to the other.
+    snarkos_node1.connect(snarkos_node2.local_addr()).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_nodes_can_connect_to_each_other() {
+    // Start 2 test nodes.
+    let test_node0 = TestNode::default().await;
+    let test_node1 = TestNode::default().await;
+
+    // Ensure that the nodes have no active connections.
+    assert!(test_node0.node().num_connected() == 0 && test_node1.node().num_connected() == 0);
+
+    // Connect one to the other, performing the snarkOS handshake.
+    let test_node0_addr = test_node0.node().listening_addr().unwrap();
+    test_node1.node().connect(test_node0_addr).await.unwrap();
+
+    // Ensure that both nodes have an active connection now.
+    assert!(test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
+}
+
+#[tokio::test]
+async fn handshake_as_initiator_works() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+    let test_node_addr = test_node.node().listening_addr().unwrap();
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Connect the snarkOS node to the test node.
+    snarkos_node.connect(test_node_addr).await.unwrap();
+
+    // Double-check with the test node.
+    // note: the small wait is due to the handshake responder (test node) finishing
+    // the connection process a bit later than the initiator (snarkOs node).
+    wait_until!(1, test_node.node().num_connected() == 1);
+}
+
+#[tokio::test]
+async fn handshake_as_responder_works() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // The test node should be able to connect to the snarkOS node.
+    test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
+
+    // Double-check with the snarkOS node.
+    assert!(snarkos_node.connected_peers().await.len() == 1)
+}
+
+#[tokio::test]
+async fn node_cant_connect_to_itself() {
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Ensure it can't connect to itself
+    assert!(snarkos_node.connect(snarkos_node.local_addr()).await.is_err());
+}
+
+#[tokio::test]
+async fn node_cant_connect_to_another_twice() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+    let test_node_addr = test_node.node().listening_addr().unwrap();
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Connect the snarkOS node to the test node.
+    snarkos_node.connect(test_node_addr).await.unwrap();
+
+    // The second connection attempt should fail.
+    assert!(snarkos_node.connect(test_node_addr).await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_duplicate_connection_attempts_fail() {
+    // The number of concurrent connection attempts.
+    const NUM_CONCURRENT_ATTEMPTS: u8 = 5;
+
+    // Start the test nodes, all with the same handshake nonce.
+    let mut test_nodes = Vec::with_capacity(NUM_CONCURRENT_ATTEMPTS as usize);
+    for _ in 0..NUM_CONCURRENT_ATTEMPTS {
+        test_nodes.push(spawn_test_node_with_nonce(0).await);
+    }
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Register the snarkOS node address and prepare a connection error counter.
+    let snarkos_node_addr = snarkos_node.local_addr();
+    let error_count = Arc::new(AtomicU8::new(0));
+
+    // Concurrently connect to the snarkOS node, attempting to bypass the nonce uniqueness rule.
+    for test_node in &test_nodes {
+        let test_node = test_node.clone();
+        let error_count = error_count.clone();
+
+        task::spawn(async move {
+            if test_node.node().connect(snarkos_node_addr).await.is_err() {
+                error_count.fetch_add(1, Relaxed);
+            }
+        });
+    }
+
+    // Ensure that only a single connection was successful.
+    // note: counting errors instead of a single success ensures that all the attempts were concluded.
+    wait_until!(5, error_count.load(Relaxed) == NUM_CONCURRENT_ATTEMPTS - 1);
+}
+
+#[tokio::test]
+async fn connection_limits_are_obeyed() {
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Start the maximum number of test nodes the snarkOS node is permitted to connect to at once.
+    let mut test_nodes = Vec::with_capacity(MAXIMUM_NUMBER_OF_PEERS);
+    for _ in 0..MAXIMUM_NUMBER_OF_PEERS {
+        test_nodes.push(TestNode::default().await);
+    }
+
+    // All the test nodes should be able to connect to the snarkOS node.
+    for test_node in &test_nodes {
+        test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
+    }
+
+    // Create one additional test node.
+    let extra_test_node = TestNode::default().await;
+    let extra_test_node_addr = extra_test_node.node().listening_addr().unwrap();
+
+    // Assert that snarkOS can't connect to it.
+    assert!(snarkos_node.connect(extra_test_node_addr).await.is_err());
+
+    // Assert that the test node can't connect to the snarkOS node either.
+    assert!(extra_test_node.node().connect(snarkos_node.local_addr()).await.is_err());
+}
+
+#[tokio::test]
+async fn peer_accounting_works() {
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Start a test node.
+    let test_node = TestNode::default().await;
+    let test_node_addr = test_node.node().listening_addr().unwrap();
+
+    // Double-check that the initial list of peers is empty.
+    assert!(snarkos_node.connected_peers().await.is_empty());
+
+    // Perform the connect+disconnect routine a few fimes.
+    for _ in 0..3 {
+        // Connect the snarkOS node to the test node.
+        snarkos_node.connect(test_node_addr).await.unwrap();
+
+        // Verify that the list of peers is not empty anymore.
+        assert!(snarkos_node.connected_peers().await.len() == 1);
+
+        // The test node disconnects from the snarkOS node.
+        wait_until!(1, test_node.node().num_connected() == 1);
+        let snarkos_node_addr = test_node.node().connected_addrs()[0];
+        assert!(test_node.node().disconnect(snarkos_node_addr).await);
+
+        // The list of snarkOS peers should be empty again.
+        wait_until!(1, snarkos_node.connected_peers().await.is_empty());
+
+        // The snarkOS node should not attempt to connect on its own.
+        snarkos_node.reset_known_peers().await;
+    }
+}

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -1,0 +1,126 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{common::display_bytes, wait_until};
+
+use pea2pea::Pea2Pea;
+use peak_alloc::PeakAlloc;
+use snarkos_testing::{SnarkosNode, TestNode};
+
+// Configure a custom allocator that will measure memory use.
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+#[tokio::test]
+#[ignore = "this test is purely informational; latest result: 159.81 MB"]
+async fn measure_node_overhead() {
+    // Register initial memory use.
+    let initial_mem = PEAK_ALLOC.current_usage();
+
+    // Start a snarkOS node.
+    let _snarkos_node = SnarkosNode::default().await;
+
+    // Register memory use caused by the node.
+    let node_mem_use = PEAK_ALLOC.current_usage() - initial_mem;
+
+    // Display the result.
+    println!("snarkOS node memory use: {}", display_bytes(node_mem_use as f64));
+}
+
+#[tokio::test]
+#[ignore = "TODO: indicates a potential leak (13420B - around 1.3kB/connection); investigate further"]
+async fn inbound_connect_and_disconnect_doesnt_leak() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Register initial memory use.
+    let pre_connection_mem = PEAK_ALLOC.current_usage();
+
+    // Perform a connect and disconnect several times.
+    let mut first_conn_mem = None;
+    for i in 0..10 {
+        // Connect the test node to the snarkOS node (inbound for snarkOS).
+        test_node.node().connect(snarkos_node.local_addr()).await.unwrap();
+
+        // Disconnect the test node from the snarkOS node.
+        assert!(test_node.node().disconnect(snarkos_node.local_addr()).await);
+        wait_until!(1, snarkos_node.connected_peers().await.is_empty());
+        snarkos_node.reset_known_peers().await;
+
+        if i == 0 {
+            // Measure memory use caused by the 1st connect and disconnect.
+            first_conn_mem = Some(PEAK_ALLOC.current_usage());
+            println!(
+                "Memory increase after a single outbound connection: {}",
+                display_bytes((first_conn_mem.unwrap() - pre_connection_mem) as f64)
+            );
+        }
+    }
+
+    // Measure memory use after the repeated connections.
+    let final_mem = PEAK_ALLOC.current_usage();
+
+    // Check if there is a connection-related leak.
+    let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
+    assert_eq!(leaked_mem, 0);
+}
+
+#[tokio::test]
+#[ignore = "TODO: indicates a potential leak (12424B - around 1.2kB/connection); investigate further"]
+async fn outbound_connect_and_disconnect_doesnt_leak() {
+    // Start a snarkOS node.
+    let snarkos_node = SnarkosNode::default().await;
+
+    // Start a test node.
+    let test_node = TestNode::default().await;
+    let test_node_addr = test_node.node().listening_addr().unwrap();
+
+    // Register memory use before any connections.
+    let pre_connection_mem = PEAK_ALLOC.current_usage();
+
+    // Perform a connect and disconnect several times.
+    let mut first_conn_mem = None;
+    for i in 0..10 {
+        // Connect the snarkOS node to the test node (outbound for snarkOS).
+        snarkos_node.connect(test_node_addr).await.unwrap();
+
+        // Disconnect the test node from the snarkOS node.
+        wait_until!(1, test_node.node().num_connected() == 1);
+        let snarkos_node_addr = test_node.node().connected_addrs()[0];
+        assert!(test_node.node().disconnect(snarkos_node_addr).await);
+        wait_until!(1, snarkos_node.connected_peers().await.is_empty());
+        snarkos_node.reset_known_peers().await;
+
+        if i == 0 {
+            // Measure memory use caused by the 1st connect and disconnect.
+            first_conn_mem = Some(PEAK_ALLOC.current_usage());
+            println!(
+                "Memory increase after a single outbound connection: {}",
+                display_bytes((first_conn_mem.unwrap() - pre_connection_mem) as f64)
+            );
+        }
+    }
+
+    // Measure memory use after the repeated connections.
+    let final_mem = PEAK_ALLOC.current_usage();
+
+    // Check if there is a connection-related leak.
+    let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
+    assert_eq!(leaked_mem, 0);
+}

--- a/testing/tests/network/manual_testing.rs
+++ b/testing/tests/network/manual_testing.rs
@@ -1,0 +1,50 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::common::start_logger;
+
+use pea2pea::{
+    protocols::{Handshake, Reading, Writing},
+    Config,
+    Node as Pea2PeaNode,
+};
+use snarkos_testing::TestNode;
+
+use std::net::{IpAddr, Ipv4Addr};
+
+/// This test is intended to be run manually in order to monitor the behavior of
+/// a full snarkOS node started independently.
+#[ignore]
+#[tokio::test]
+async fn spawn_inert_node_at_port() {
+    start_logger();
+
+    const PORT: u16 = 4135;
+
+    let config = Config {
+        listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        desired_listening_port: Some(PORT),
+        ..Default::default()
+    };
+
+    let test_node = TestNode::new(Pea2PeaNode::new(Some(config)).await.unwrap(), Default::default());
+    test_node.enable_handshake();
+    test_node.enable_reading();
+    test_node.enable_writing();
+    // test_node.run_periodic_tasks();
+
+    std::future::pending::<()>().await;
+}

--- a/testing/tests/network/manual_testing.rs
+++ b/testing/tests/network/manual_testing.rs
@@ -15,14 +15,13 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::common::start_logger;
+use snarkos_testing::TestNode;
 
 use pea2pea::{
     protocols::{Handshake, Reading, Writing},
     Config,
     Node as Pea2PeaNode,
 };
-use snarkos_testing::TestNode;
-
 use std::net::{IpAddr, Ipv4Addr};
 
 /// This test is intended to be run manually in order to monitor the behavior of

--- a/testing/tests/network/mod.rs
+++ b/testing/tests/network/mod.rs
@@ -14,14 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
-
-pub mod message;
-pub use message::*;
-
-pub(crate) mod peers;
-pub(crate) use peers::*;
-
-pub mod server;
-pub use server::{LedgerReader, Server};
+mod basic_connectivity;
+mod cleanups;
+mod manual_testing;
+mod perf;

--- a/testing/tests/network/perf.rs
+++ b/testing/tests/network/perf.rs
@@ -14,14 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
+use snarkos_testing::SnarkosNode;
 
-pub mod message;
-pub use message::*;
+use std::time::Instant;
 
-pub(crate) mod peers;
-pub(crate) use peers::*;
+#[tokio::test]
+#[ignore = "this test is purely informational; latest result: ~675ms"]
+async fn measure_node_startup() {
+    let now = Instant::now();
 
-pub mod server;
-pub use server::{LedgerReader, Server};
+    // Start a snarkOS node.
+    let _snarkos_node = SnarkosNode::default().await;
+
+    // Display the result.
+    println!("snarkOS start-up time: {}ms", now.elapsed().as_millis());
+}

--- a/testing/tests/network/perf.rs
+++ b/testing/tests/network/perf.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_testing::SnarkosNode;
+use snarkos_testing::ClientNode;
 
 use std::time::Instant;
 
@@ -24,7 +24,7 @@ async fn measure_node_startup() {
     let now = Instant::now();
 
     // Start a snarkOS node.
-    let _snarkos_node = SnarkosNode::default().await;
+    let _snarkos_node = ClientNode::default().await;
 
     // Display the result.
     println!("snarkOS start-up time: {}ms", now.elapsed().as_millis());

--- a/testing/tests/tests.rs
+++ b/testing/tests/tests.rs
@@ -14,14 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub(crate) mod ledger;
-pub(crate) use ledger::{LedgerRequest, LedgerRouter};
-
-pub mod message;
-pub use message::*;
-
-pub(crate) mod peers;
-pub(crate) use peers::*;
-
-pub mod server;
-pub use server::{LedgerReader, Server};
+mod common;
+mod network;


### PR DESCRIPTION
This PR is the successor to both https://github.com/AleoHQ/snarkOS/pull/1286 and https://github.com/AleoHQ/snarkOS/pull/1301 that have become too tricky to keep rebasing with full history.

As before, the main purpose of this PR is to facilitate the node's integration tests. To do this, a new `snarkos-testing` workspace member is added, which contains all the newly added tests, as well as an implementation of a synthetic test node which is much leaner than the full node and provides the means to perform all kinds of integration tests on it.

In order to enable tests, the following main changes are introduced to the existing code:
- adding a `test` feature to allow `cfg` attributes to be used in tests
- using `tokio::sync::oneshot` during node's startup in order to learn whether it's fully ready
- using `tokio::sync::oneshot` in `PeersRequest::connect` to know if the connection request has concluded (and with what result)
- making some of the `Server`'s methods `pub` in order to be available in tests
- adjusting the position of the calls to `std::future::pending` that allow the `Server` to be introspected in tests, but also to be used as before in `main`
- adding the local listening address to the `Server` object
- adding `Server::reset_known_peers` that is available only in tests
- adding `norpc` to `Node`