### PR TITLE
Fix the snarkos-testing setup, start logging earlier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,7 +1904,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkos-ledger",
- "snarkos-testing",
  "snarkvm",
  "structopt",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,10 +134,6 @@ version = "0.3"
 [dev-dependencies.rusty-hook]
 version = "0.11"
 
-[dev-dependencies.snarkos-testing]
-path = "./testing"
-version = "2.0.0"
-
 [dev-dependencies.tempfile]
 version = "3.2"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,14 @@ use structopt::StructOpt;
 use tokio::runtime;
 
 fn main() -> Result<()> {
+    // Parse the provided arguments.
+    let node = Node::from_args();
+
+    // Start logging, if enabled.
+    if !node.display {
+        node.initialize_logger();
+    }
+
     // Initialize the runtime configuration.
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
@@ -37,7 +45,7 @@ fn main() -> Result<()> {
         .unwrap();
 
     runtime.block_on(async move {
-        Node::from_args().start().await.expect("Failed to start the node");
+        node.start().await.expect("Failed to start the node");
         std::future::pending::<()>().await;
     });
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -98,27 +98,21 @@ impl Node {
     }
 
     /// Returns the storage path of the node.
-    pub(crate) fn storage_path(&self, local_ip: SocketAddr) -> String {
-        // TODO (howardwu): Remove this check after introducing proper configurations.
-        assert!(
-            self.node.port() >= 4130,
-            "Until configuration files are established, the node port must be at least 4130 or greater"
-        );
-        format!(".ledger-{}", (self.node.port() - 4130))
-        // cfg_if::cfg_if! {
-        //     if #[cfg(feature = "test")] {
-        //         // Tests may use any available ports, and removes the storage artifacts afterwards,
-        //         // so that there is no need to adhere to a specific number assignment logic.
-        //         format!("/tmp/snarkos-test-ledger-{}", local_ip.port())
-        //     } else {
-        //         // TODO (howardwu): Remove this check after introducing proper configurations.
-        //         assert!(
-        //             self.node.port() >= 4130,
-        //             "Until configuration files are established, the node port must be at least 4130 or greater"
-        //         );
-        //         format!(".ledger-{}", (self.node.port() - 4130))
-        //     }
-        // }
+    pub(crate) fn storage_path(&self, _local_ip: SocketAddr) -> String {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "test")] {
+                // Tests may use any available ports, and removes the storage artifacts afterwards,
+                // so that there is no need to adhere to a specific number assignment logic.
+                format!("/tmp/snarkos-test-ledger-{}", _local_ip.port())
+            } else {
+                // TODO (howardwu): Remove this check after introducing proper configurations.
+                assert!(
+                    self.node.port() >= 4130,
+                    "Until configuration files are established, the node port must be at least 4130 or greater"
+                );
+                format!(".ledger-{}", (self.node.port() - 4130))
+            }
+        }
     }
 
     async fn start_server<N: Network, E: Environment>(&self) -> Result<()> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -134,17 +134,13 @@ impl Node {
         // Initialize the tasks handler.
         let tasks = Tasks::new();
 
-        // Initialize either the display or logger.
-        let server = if self.display {
+        // Initialize the node's server.
+        let server = Server::<N, E>::initialize(self, miner, tasks.clone()).await?;
+
+        // Initialize the display, if enabled.
+        if self.display {
             println!("\nThe snarkOS console is initializing...\n");
-            // Initialize the node server.
-            let server = Server::<N, E>::initialize(self, miner, tasks.clone()).await?;
             let _display = Display::<N, E>::start(server.clone())?;
-            server
-        } else {
-            self.initialize_logger();
-            // Initialize the node server.
-            Server::<N, E>::initialize(self, miner, tasks.clone()).await?
         };
 
         // Connect to a peer if one was given as an argument.
@@ -160,7 +156,7 @@ impl Node {
         Ok(())
     }
 
-    fn initialize_logger(&self) {
+    pub fn initialize_logger(&self) {
         match self.verbosity {
             0 => std::env::set_var("RUST_LOG", "info"),
             1 => std::env::set_var("RUST_LOG", "debug"),


### PR DESCRIPTION
This PR removes the workspace dependency on `snarkos-testing` (which shouldn't be there, otherwise it auto-enables the `test` feature), and moves the initialization of the logger to `main`.