### PR TITLE
Check if Server frees its resources on shutdown

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -133,7 +133,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     /// Disconnects from peers and proceeds to shut down the node.
     ///
     #[inline]
-    pub(crate) fn shut_down(&self) {
+    pub fn shut_down(&self) {
         info!("Shutting down...");
         self.tasks.flush();
     }

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -69,6 +69,8 @@ impl ClientNode {
 // Remove the storage artifacts after each test.
 impl Drop for ClientNode {
     fn drop(&mut self) {
+        self.server.shut_down();
+
         let db_path = format!("/tmp/snarkos-test-ledger-{}", self.local_addr().port());
         assert!(
             fs::remove_dir_all(&db_path).is_ok(),

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -124,3 +124,23 @@ async fn outbound_connect_and_disconnect_doesnt_leak() {
     let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
     assert_eq!(leaked_mem, 0);
 }
+
+#[tokio::test]
+#[ignore = "TODO: currently fails"]
+async fn node_shutdown_doesnt_leak() {
+    // Register initial memory use.
+    let initial_mem = PEAK_ALLOC.current_usage();
+
+    // Start a snarkOS node.
+    let client_node = ClientNode::default().await;
+
+    // Trigger `Server::shut_down` via the `Drop` impl.
+    drop(client_node);
+
+    // Measure memory use after the shutdown.
+    let final_mem = PEAK_ALLOC.current_usage();
+
+    // Check if there are any leaks.
+    let leaked_mem = final_mem.saturating_sub(initial_mem);
+    assert_eq!(leaked_mem, 0);
+}


### PR DESCRIPTION
This PR adds a new cleanup test to the integration test suite. It is currently `#[ignore]`d, as the shutdown process needs to be polished first, and this test is aimed at helping with those efforts.

Cc @raychu86 