### PR TITLE
Use more fine-grained locks for Ledger and Peers

### DIFF
--- a/ledger/src/state/ledger.rs
+++ b/ledger/src/state/ledger.rs
@@ -77,24 +77,24 @@ impl<N: Network> Metadata<N> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct LedgerState<N: Network> {
     /// The current ledger tree of block hashes.
-    ledger_tree: Arc<RwLock<LedgerTree<N>>>,
+    ledger_tree: RwLock<LedgerTree<N>>,
     /// The latest block of the ledger.
-    latest_block: Arc<RwLock<Block<N>>>,
+    latest_block: RwLock<Block<N>>,
     /// The latest block hashes of the ledger.
-    latest_block_hashes: Arc<RwLock<CircularQueue<N::BlockHash>>>,
+    latest_block_hashes: RwLock<CircularQueue<N::BlockHash>>,
     /// The latest block headers of the ledger.
-    latest_block_headers: Arc<RwLock<CircularQueue<BlockHeader<N>>>>,
+    latest_block_headers: RwLock<CircularQueue<BlockHeader<N>>>,
     /// The block locators from the latest block of the ledger.
-    latest_block_locators: Arc<RwLock<BlockLocators<N>>>,
+    latest_block_locators: RwLock<BlockLocators<N>>,
     /// The ledger root corresponding to each block height.
     ledger_roots: DataMap<N::LedgerRoot, u32>,
     /// The blocks of the ledger in storage.
     blocks: BlockState<N>,
     /// The indicator bit and tracker for a ledger in read-only mode.
-    read_only: (bool, Arc<AtomicU32>, Option<Arc<JoinHandle<()>>>),
+    read_only: (bool, Arc<AtomicU32>, RwLock<Option<Arc<JoinHandle<()>>>>),
 }
 
 impl<N: Network> LedgerState<N> {
@@ -112,15 +112,15 @@ impl<N: Network> LedgerState<N> {
         let storage = S::open(path, context, is_read_only)?;
 
         // Initialize the ledger.
-        let mut ledger = Self {
-            ledger_tree: Arc::new(RwLock::new(LedgerTree::<N>::new()?)),
-            latest_block: Arc::new(RwLock::new(N::genesis_block().clone())),
-            latest_block_hashes: Arc::new(RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize))),
-            latest_block_headers: Arc::new(RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize))),
+        let ledger = Self {
+            ledger_tree: RwLock::new(LedgerTree::<N>::new()?),
+            latest_block: RwLock::new(N::genesis_block().clone()),
+            latest_block_hashes: RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize)),
+            latest_block_headers: RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize)),
             latest_block_locators: Default::default(),
             ledger_roots: storage.open_map("ledger_roots")?,
             blocks: BlockState::open(storage)?,
-            read_only: (is_read_only, Arc::new(AtomicU32::new(0)), None),
+            read_only: (is_read_only, Arc::new(AtomicU32::new(0)), RwLock::new(None)),
         };
 
         // Determine the latest block height.
@@ -197,23 +197,23 @@ impl<N: Network> LedgerState<N> {
     /// A writable instance of `LedgerState` possesses full functionality, whereas
     /// a read-only instance of `LedgerState` may only call immutable methods.
     ///
-    pub fn open_reader<S: Storage, P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn open_reader<S: Storage, P: AsRef<Path>>(path: P) -> Result<Arc<Self>> {
         // Open storage.
         let context = N::NETWORK_ID;
         let is_read_only = true;
         let storage = S::open(path, context, is_read_only)?;
 
         // Initialize the ledger.
-        let mut ledger = Self {
-            ledger_tree: Arc::new(RwLock::new(LedgerTree::<N>::new()?)),
-            latest_block: Arc::new(RwLock::new(N::genesis_block().clone())),
-            latest_block_hashes: Arc::new(RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize))),
-            latest_block_headers: Arc::new(RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize))),
+        let ledger = Arc::new(Self {
+            ledger_tree: RwLock::new(LedgerTree::<N>::new()?),
+            latest_block: RwLock::new(N::genesis_block().clone()),
+            latest_block_hashes: RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize)),
+            latest_block_headers: RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize)),
             latest_block_locators: Default::default(),
             ledger_roots: storage.open_map("ledger_roots")?,
             blocks: BlockState::open(storage)?,
-            read_only: (is_read_only, Arc::new(AtomicU32::new(0)), None),
-        };
+            read_only: (is_read_only, Arc::new(AtomicU32::new(0)), RwLock::new(None)),
+        });
 
         // Determine the latest block height.
         let latest_block_height = match (ledger.ledger_roots.values().max(), ledger.blocks.block_heights.keys().max()) {
@@ -242,7 +242,7 @@ impl<N: Network> LedgerState<N> {
         // Update the ledger tree state.
         ledger.regenerate_ledger_tree()?;
         // As the ledger is in read-only mode, proceed to start a process to keep the reader in sync.
-        ledger.read_only.2 = Some(Arc::new(ledger.initialize_reader_heartbeat(latest_block_height)?));
+        *ledger.read_only.2.write() = Some(Arc::new(ledger.initialize_reader_heartbeat(latest_block_height)?));
 
         trace!("[Read-Only] Ledger successfully loaded at block {}", ledger.latest_block_height());
         Ok(ledger)
@@ -601,7 +601,7 @@ impl<N: Network> LedgerState<N> {
     }
 
     /// Adds the given block as the next block in the ledger to storage.
-    pub fn add_next_block(&mut self, block: &Block<N>) -> Result<()> {
+    pub fn add_next_block(&self, block: &Block<N>) -> Result<()> {
         // If the storage is in read-only mode, this method cannot be called.
         if self.is_read_only() {
             return Err(anyhow!("Ledger is in read-only mode"));
@@ -720,7 +720,7 @@ impl<N: Network> LedgerState<N> {
     }
 
     /// Reverts the ledger state back to the given block height, returning the removed blocks on success.
-    pub fn revert_to_block_height(&mut self, block_height: u32) -> Result<Vec<Block<N>>> {
+    pub fn revert_to_block_height(&self, block_height: u32) -> Result<Vec<Block<N>>> {
         // If the storage is in read-only mode, this method cannot be called.
         if self.is_read_only() {
             return Err(anyhow!("Ledger is in read-only mode"));
@@ -853,7 +853,7 @@ impl<N: Network> LedgerState<N> {
     }
 
     /// Updates the latest block hashes and block headers.
-    fn regenerate_latest_ledger_state(&mut self) -> Result<()> {
+    fn regenerate_latest_ledger_state(&self) -> Result<()> {
         // Compute the start block height and end block height (inclusive).
         let end_block_height = self.latest_block_height();
         let start_block_height = end_block_height.saturating_sub(MAXIMUM_LINEAR_BLOCK_LOCATORS - 1);
@@ -886,7 +886,7 @@ impl<N: Network> LedgerState<N> {
 
     // TODO (raychu86): Make this more efficient.
     /// Updates the ledger tree.
-    fn regenerate_ledger_tree(&mut self) -> Result<()> {
+    fn regenerate_ledger_tree(&self) -> Result<()> {
         // Acquire the ledger tree write lock.
         let mut ledger_tree = self.ledger_tree.write();
 
@@ -907,13 +907,13 @@ impl<N: Network> LedgerState<N> {
     }
 
     /// Initializes a heartbeat to keep the ledger reader in sync, with the given starting block height.
-    fn initialize_reader_heartbeat(&self, starting_block_height: u32) -> Result<JoinHandle<()>> {
+    fn initialize_reader_heartbeat(self: &Arc<Self>, starting_block_height: u32) -> Result<JoinHandle<()>> {
         // If the storage is *not* in read-only mode, this method cannot be called.
         if !self.is_read_only() {
             return Err(anyhow!("Ledger must be read-only to initialize a reader heartbeat"));
         }
 
-        let mut ledger = self.clone();
+        let ledger = self.clone();
         Ok(thread::spawn(move || {
             let last_seen_block_height = ledger.read_only.1.clone();
             ledger.read_only.1.store(starting_block_height, Ordering::SeqCst);

--- a/ledger/src/state/tests.rs
+++ b/ledger/src/state/tests.rs
@@ -61,7 +61,7 @@ fn test_add_next_block() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
@@ -107,7 +107,7 @@ fn test_remove_last_block() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
@@ -151,7 +151,7 @@ fn test_remove_last_2_blocks() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
@@ -200,7 +200,7 @@ fn test_get_block_locators() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let mut ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<Testnet2, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.

--- a/src/helpers/circular_map.rs
+++ b/src/helpers/circular_map.rs
@@ -77,11 +77,15 @@ impl<K: Clone + PartialEq, V: Clone, const N: u32> CircularMap<K, V, N> {
     }
 
     ///
-    /// Inserts the given key-value pair into the circular map.
+    /// Inserts the given key-value pair into the circular map, returning a `bool`
+    /// indicating whether the insertion took place.
     ///
-    pub fn insert(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, key: K, value: V) -> bool {
         if !self.contains_key(&key) {
             self.queue.push((key, value));
+            true
+        } else {
+            false
         }
     }
 

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -427,14 +427,14 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 Err(error) => warn!("{}", error),
             }
         } else {
-            // Register the block's height.
+            // Retrieve the unconfirmed block height.
             let block_height = block.height();
 
             // Add the block to the unconfirmed blocks.
-            if !self.unconfirmed_blocks.write().await.insert(block.previous_block_hash(), block) {
-                trace!("Memory pool already contains unconfirmed block {}", block_height);
-            } else {
+            if self.unconfirmed_blocks.write().await.insert(block.previous_block_hash(), block) {
                 trace!("Added unconfirmed block {} to memory pool", block_height);
+            } else {
+                trace!("Memory pool already contains unconfirmed block {}", block_height);
             }
         }
         false

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -616,7 +616,6 @@ impl<N: Network, E: Environment> Peer<N, E> {
         // Send the first `Ping` message to the peer.
         {
             // Retrieve the latest ledger state.
-            let ledger_reader = ledger_reader.read().await;
             let latest_block_height = ledger_reader.latest_block_height();
             let latest_block_hash = ledger_reader.latest_block_hash();
 
@@ -866,7 +865,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         continue;
                                     }
                                     // Retrieve the requested blocks.
-                                    let blocks = match ledger_reader.read().await.get_blocks(start_block_height, end_block_height) {
+                                    let blocks = match ledger_reader.get_blocks(start_block_height, end_block_height) {
                                         Ok(blocks) => blocks,
                                         Err(error) => {
                                             // Route a `Failure` to the ledger.
@@ -929,7 +928,6 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     peer.status.update(status);
 
                                     // Determine if the peer is on a fork (or unknown).
-                                    let ledger_reader = ledger_reader.read().await;
                                     let is_fork = match ledger_reader.get_block_hash(block_height) {
                                         Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
                                         Err(_) => None,
@@ -954,7 +952,6 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         tokio::time::sleep(Duration::from_secs(E::PING_SLEEP_IN_SECS)).await;
 
                                         // Retrieve the latest ledger state.
-                                        let ledger_reader = ledger_reader.read().await;
                                         let latest_block_height = ledger_reader.latest_block_height();
                                         let latest_block_hash = ledger_reader.latest_block_hash();
 
@@ -987,7 +984,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
 
                                     // Ensure the unconfirmed block is at least within 3 blocks of the latest block height.
                                     // If it is stale, skip the routing of this unconfirmed block to the ledger.
-                                    let is_fresh_state = block.height() + 3 > ledger_reader.read().await.latest_block_height();
+                                    let is_fresh_state = block.height() + 3 > ledger_reader.latest_block_height();
 
                                     // Ensure the node is not peering.
                                     let is_node_ready = !local_status.is_peering();

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use tokio::{
     net::TcpStream,
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, RwLock},
     task,
     time::timeout,
 };
@@ -86,19 +86,19 @@ pub struct Peers<N: Network, E: Environment> {
     /// The local status of this node.
     local_status: Status,
     /// The map connected peer IPs to their nonce and outbound message router.
-    connected_peers: HashMap<SocketAddr, (u64, OutboundRouter<N, E>)>,
+    connected_peers: RwLock<HashMap<SocketAddr, (u64, OutboundRouter<N, E>)>>,
     /// The set of candidate peer IPs.
-    candidate_peers: HashSet<SocketAddr>,
+    candidate_peers: RwLock<HashSet<SocketAddr>>,
     /// The set of restricted peer IPs.
-    restricted_peers: HashMap<SocketAddr, Instant>,
+    restricted_peers: RwLock<HashMap<SocketAddr, Instant>>,
     /// The map of peers to their first-seen port number, number of attempts, and timestamp of the last inbound connection request.
-    seen_inbound_connections: HashMap<SocketAddr, ((u16, u32), SystemTime)>,
+    seen_inbound_connections: RwLock<HashMap<SocketAddr, ((u16, u32), SystemTime)>>,
     /// The map of peers to a map of block hashes to their last seen timestamp.
-    seen_outbound_blocks: HashMap<SocketAddr, HashMap<N::BlockHash, SystemTime>>,
+    seen_outbound_blocks: RwLock<HashMap<SocketAddr, HashMap<N::BlockHash, SystemTime>>>,
     /// The map of peers to the timestamp of their last outbound connection request.
-    seen_outbound_connections: HashMap<SocketAddr, SystemTime>,
+    seen_outbound_connections: RwLock<HashMap<SocketAddr, SystemTime>>,
     /// The map of peers to a map of transaction IDs to their last seen timestamp.
-    seen_outbound_transactions: HashMap<SocketAddr, HashMap<N::TransactionID, SystemTime>>,
+    seen_outbound_transactions: RwLock<HashMap<SocketAddr, HashMap<N::TransactionID, SystemTime>>>,
 }
 
 impl<N: Network, E: Environment> Peers<N, E> {
@@ -128,15 +128,15 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Returns `true` if the node is connected to the given IP.
     ///
-    pub(crate) fn is_connected_to(&self, ip: SocketAddr) -> bool {
-        self.connected_peers.contains_key(&ip)
+    pub(crate) async fn is_connected_to(&self, ip: SocketAddr) -> bool {
+        self.connected_peers.read().await.contains_key(&ip)
     }
 
     ///
     /// Returns `true` if the given IP is restricted.
     ///
-    pub(crate) fn is_restricted(&self, ip: SocketAddr) -> bool {
-        match self.restricted_peers.get(&ip) {
+    pub(crate) async fn is_restricted(&self, ip: SocketAddr) -> bool {
+        match self.restricted_peers.read().await.get(&ip) {
             Some(timestamp) => timestamp.elapsed().as_secs() < E::RADIO_SILENCE_IN_SECS,
             None => false,
         }
@@ -145,43 +145,48 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Returns the list of connected peers.
     ///
-    pub fn connected_peers(&self) -> Vec<SocketAddr> {
-        self.connected_peers.keys().cloned().collect()
+    pub async fn connected_peers(&self) -> Vec<SocketAddr> {
+        self.connected_peers.read().await.keys().copied().collect()
     }
 
     ///
     /// Returns the list of nonces for the connected peers.
     ///
-    pub(crate) fn connected_nonces(&self) -> impl Iterator<Item = &u64> + '_ {
-        self.connected_peers.values().map(|(peer_nonce, _)| peer_nonce)
+    pub(crate) async fn connected_nonces(&self) -> Vec<u64> {
+        self.connected_peers
+            .read()
+            .await
+            .values()
+            .map(|(peer_nonce, _)| *peer_nonce)
+            .collect()
     }
 
     ///
     /// Returns the list of candidate peers.
     ///
-    pub(crate) fn candidate_peers(&self) -> &HashSet<SocketAddr> {
-        &self.candidate_peers
+    pub(crate) async fn candidate_peers(&self) -> HashSet<SocketAddr> {
+        self.candidate_peers.read().await.clone()
     }
 
     ///
     /// Returns the number of connected peers.
     ///
-    pub(crate) fn number_of_connected_peers(&self) -> usize {
-        self.connected_peers.len()
+    pub(crate) async fn number_of_connected_peers(&self) -> usize {
+        self.connected_peers.read().await.len()
     }
 
     ///
     /// Returns the number of candidate peers.
     ///
-    pub(crate) fn number_of_candidate_peers(&self) -> usize {
-        self.candidate_peers.len()
+    pub(crate) async fn number_of_candidate_peers(&self) -> usize {
+        self.candidate_peers.read().await.len()
     }
 
     ///
     /// Performs the given `request` to the peers.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(&mut self, request: PeersRequest<N, E>, peers_router: &PeersRouter<N, E>) {
+    pub(super) async fn update(&self, request: PeersRequest<N, E>, peers_router: &PeersRouter<N, E>) {
         match request {
             PeersRequest::Connect(peer_ip, ledger_reader, ledger_router, connection_result) => {
                 // Ensure the peer IP is not this node.
@@ -191,28 +196,35 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
                 }
                 // Ensure the node does not surpass the maximum number of peer connections.
-                else if self.number_of_connected_peers() >= E::MAXIMUM_NUMBER_OF_PEERS {
+                else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
                     debug!("Skipping connection request to {} (maximum peers reached)", peer_ip);
                 }
                 // Ensure the peer is a new connection.
-                else if self.is_connected_to(peer_ip) {
+                else if self.is_connected_to(peer_ip).await {
                     debug!("Skipping connection request to {} (already connected)", peer_ip);
                 }
                 // Ensure the peer is not restricted.
-                else if self.is_restricted(peer_ip) {
+                else if self.is_restricted(peer_ip).await {
                     debug!("Skipping connection request to {} (restricted)", peer_ip);
                 }
                 // Attempt to open a TCP stream.
                 else {
+                    // Lock seen_outbound_connections for further processing.
+                    let mut seen_outbound_connections = self.seen_outbound_connections.write().await;
+
                     // Ensure the node respects the connection frequency limit.
-                    let last_seen = self.seen_outbound_connections.entry(peer_ip).or_insert(SystemTime::UNIX_EPOCH);
+                    let last_seen = seen_outbound_connections.entry(peer_ip).or_insert(SystemTime::UNIX_EPOCH);
                     let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
                     if elapsed < E::RADIO_SILENCE_IN_SECS {
                         trace!("Skipping connection request to {} (tried {} secs ago)", peer_ip, elapsed);
                     } else {
                         debug!("Connecting to {}...", peer_ip);
                         // Update the last seen timestamp for this peer.
-                        *last_seen = SystemTime::now();
+                        seen_outbound_connections.insert(peer_ip, SystemTime::now());
+
+                        // Release the lock over seen_outbound_connections.
+                        drop(seen_outbound_connections);
+
                         // Initialize the peer handler.
                         match timeout(Duration::from_secs(E::CONNECTION_TIMEOUT_IN_SECS), TcpStream::connect(peer_ip)).await {
                             Ok(stream) => match stream {
@@ -225,19 +237,19 @@ impl<N: Network, E: Environment> Peers<N, E> {
                                         peers_router,
                                         ledger_reader,
                                         ledger_router,
-                                        &mut self.connected_nonces(),
+                                        self.connected_nonces().await,
                                         Some(connection_result),
                                     )
                                     .await
                                 }
                                 Err(error) => {
                                     trace!("Failed to connect to '{}': '{:?}'", peer_ip, error);
-                                    self.candidate_peers.remove(&peer_ip);
+                                    self.candidate_peers.write().await.remove(&peer_ip);
                                 }
                             },
                             Err(error) => {
                                 error!("Unable to reach '{}': '{:?}'", peer_ip, error);
-                                self.candidate_peers.remove(&peer_ip);
+                                self.candidate_peers.write().await.remove(&peer_ip);
                             }
                         };
                     }
@@ -245,13 +257,15 @@ impl<N: Network, E: Environment> Peers<N, E> {
             }
             PeersRequest::Heartbeat(ledger_reader, ledger_router) => {
                 // Ensure the number of connected peers is below the maximum threshold.
-                if self.number_of_connected_peers() > E::MAXIMUM_NUMBER_OF_PEERS {
+                if self.number_of_connected_peers().await > E::MAXIMUM_NUMBER_OF_PEERS {
                     debug!("Exceeded maximum number of connected peers");
 
                     // Determine the peers to disconnect from.
-                    let num_excess_peers = self.number_of_connected_peers().saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
+                    let num_excess_peers = self.number_of_connected_peers().await.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
                     let peer_ips_to_disconnect = self
                         .connected_peers
+                        .read()
+                        .await
                         .iter()
                         .filter(|(&peer_ip, _)| {
                             let peer_str = peer_ip.to_string();
@@ -266,33 +280,34 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
                         self.send(peer_ip, &Message::Disconnect).await;
                         // Add an entry for this `Peer` in the restricted peers.
-                        self.restricted_peers.insert(peer_ip, Instant::now());
+                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
                     }
                 }
 
                 // Skip if the number of connected peers is above the minimum threshold.
-                match self.number_of_connected_peers() < E::MINIMUM_NUMBER_OF_PEERS {
+                match self.number_of_connected_peers().await < E::MINIMUM_NUMBER_OF_PEERS {
                     true => trace!("Sending request for more peer connections"),
                     false => return,
                 };
 
                 // Add the sync nodes to the list of candidate peers.
                 let sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-                self.add_candidate_peers(&sync_nodes);
+                self.add_candidate_peers(&sync_nodes).await;
 
                 // Add the peer nodes to the list of candidate peers.
                 let peer_nodes: Vec<SocketAddr> = E::PEER_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-                self.add_candidate_peers(&peer_nodes);
+                self.add_candidate_peers(&peer_nodes).await;
 
                 // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
                 // Select the peers randomly from the list of candidate peers.
                 for peer_ip in self
                     .candidate_peers()
+                    .await
                     .iter()
                     .copied()
                     .choose_multiple(&mut OsRng::default(), E::MINIMUM_NUMBER_OF_PEERS)
                 {
-                    if !self.is_connected_to(peer_ip) {
+                    if !self.is_connected_to(peer_ip).await {
                         trace!("Attempting connection to {}...", peer_ip);
 
                         // Initialize the connection process.
@@ -308,7 +323,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     }
                 }
                 // Request more peers if the number of connected peers is below the threshold.
-                for peer_ip in self.connected_peers().iter().choose_multiple(&mut OsRng::default(), 1) {
+                for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 1) {
                     self.send(*peer_ip, &Message::PeerRequest).await;
                 }
             }
@@ -326,15 +341,15 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
                 }
                 // Ensure the node does not surpass the maximum number of peer connections.
-                else if self.number_of_connected_peers() >= E::MAXIMUM_NUMBER_OF_PEERS {
+                else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
                     debug!("Dropping connection request from {} (maximum peers reached)", peer_ip);
                 }
                 // Ensure the node is not already connected to this peer.
-                else if self.is_connected_to(peer_ip) {
+                else if self.is_connected_to(peer_ip).await {
                     debug!("Dropping connection request from {} (already connected)", peer_ip);
                 }
                 // Ensure the peer is not restricted.
-                else if self.is_restricted(peer_ip) {
+                else if self.is_restricted(peer_ip).await {
                     debug!("Dropping connection request from {} (restricted)", peer_ip);
                 }
                 // Spawn a handler to be run asynchronously.
@@ -347,9 +362,11 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         false => (SocketAddr::new(peer_ip.ip(), u16::MAX), peer_ip.port()),
                     };
 
+                    // Lock seen_inbound_connections for further processing.
+                    let mut seen_inbound_connections = self.seen_inbound_connections.write().await;
+
                     // Fetch the inbound tracker entry for this peer.
-                    let ((initial_port, num_attempts), last_seen) = self
-                        .seen_inbound_connections
+                    let ((initial_port, num_attempts), last_seen) = seen_inbound_connections
                         .entry(peer_lookup)
                         .or_insert(((peer_port, 0), SystemTime::UNIX_EPOCH));
                     let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
@@ -371,6 +388,10 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         debug!("Received a connection request from {}", peer_ip);
                         // Update the number of attempts for this peer.
                         *num_attempts += 1;
+
+                        // Release the lock over seen_inbound_connections.
+                        drop(seen_inbound_connections);
+
                         // Initialize the peer handler.
                         Peer::handler(
                             stream,
@@ -380,7 +401,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                             peers_router,
                             ledger_reader,
                             ledger_router,
-                            &mut self.connected_nonces(),
+                            self.connected_nonces().await,
                             None,
                         )
                         .await;
@@ -389,38 +410,39 @@ impl<N: Network, E: Environment> Peers<N, E> {
             }
             PeersRequest::PeerConnected(peer_ip, peer_nonce, outbound) => {
                 // Add an entry for this `Peer` in the connected peers.
-                self.connected_peers.insert(peer_ip, (peer_nonce, outbound));
+                self.connected_peers.write().await.insert(peer_ip, (peer_nonce, outbound));
                 // Remove an entry for this `Peer` in the candidate peers, if it exists.
-                self.candidate_peers.remove(&peer_ip);
+                self.candidate_peers.write().await.remove(&peer_ip);
             }
             PeersRequest::PeerDisconnected(peer_ip) => {
                 // Remove an entry for this `Peer` in the connected peers, if it exists.
-                self.connected_peers.remove(&peer_ip);
+                self.connected_peers.write().await.remove(&peer_ip);
                 // Add an entry for this `Peer` in the candidate peers.
-                self.candidate_peers.insert(peer_ip);
+                self.candidate_peers.write().await.insert(peer_ip);
 
                 // Remove an entry for this `Peer` from the seen blocks.
-                self.seen_outbound_blocks.remove(&peer_ip);
+                self.seen_outbound_blocks.write().await.remove(&peer_ip);
                 // Remove an entry for this `Peer` from the seen transactions.
-                self.seen_outbound_transactions.remove(&peer_ip);
+                self.seen_outbound_transactions.write().await.remove(&peer_ip);
             }
             PeersRequest::PeerRestricted(peer_ip) => {
                 // Remove an entry for this `Peer` in the connected peers, if it exists.
-                self.connected_peers.remove(&peer_ip);
+                self.connected_peers.write().await.remove(&peer_ip);
                 // Add an entry for this `Peer` in the restricted peers.
-                self.restricted_peers.insert(peer_ip, Instant::now());
+                self.restricted_peers.write().await.insert(peer_ip, Instant::now());
 
                 // Remove an entry for this `Peer` from the seen blocks.
-                self.seen_outbound_blocks.remove(&peer_ip);
+                self.seen_outbound_blocks.write().await.remove(&peer_ip);
                 // Remove an entry for this `Peer` from the seen transactions.
-                self.seen_outbound_transactions.remove(&peer_ip);
+                self.seen_outbound_transactions.write().await.remove(&peer_ip);
             }
             PeersRequest::SendPeerResponse(recipient) => {
                 // Send a `PeerResponse` message.
-                self.send(recipient, &Message::PeerResponse(self.connected_peers())).await;
+                let connected_peers = self.connected_peers().await;
+                self.send(recipient, &Message::PeerResponse(connected_peers)).await;
             }
             PeersRequest::ReceivePeerResponse(peer_ips) => {
-                self.add_candidate_peers(&peer_ips);
+                self.add_candidate_peers(&peer_ips).await;
             }
         }
     }
@@ -431,16 +453,17 @@ impl<N: Network, E: Environment> Peers<N, E> {
     /// This method skips adding any given peers if the combined size exceeds the threshold,
     /// as the peer providing this list could be subverting the protocol.
     ///
-    fn add_candidate_peers(&mut self, peers: &[SocketAddr]) {
+    async fn add_candidate_peers(&self, peers: &[SocketAddr]) {
+        let mut candidate_peers = self.candidate_peers.write().await;
         // Ensure the combined number of peers does not surpass the threshold.
-        if self.candidate_peers.len() + peers.len() < E::MAXIMUM_CANDIDATE_PEERS {
+        if candidate_peers.len() + peers.len() < E::MAXIMUM_CANDIDATE_PEERS {
             // Proceed to insert each new candidate peer IP.
             for peer_ip in peers.iter().take(E::MAXIMUM_CANDIDATE_PEERS) {
                 // Ensure the peer is not self and is a new candidate peer.
                 let is_self = *peer_ip == self.local_ip
                     || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port();
-                if !is_self && !self.is_connected_to(*peer_ip) && !self.candidate_peers.contains(peer_ip) {
-                    self.candidate_peers.insert(*peer_ip);
+                if !is_self && !self.is_connected_to(*peer_ip).await {
+                    candidate_peers.insert(*peer_ip);
                 }
             }
         }
@@ -449,14 +472,18 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Sends the given message to specified peer.
     ///
-    async fn send(&mut self, peer: SocketAddr, message: &Message<N, E>) {
-        match self.connected_peers.get(&peer) {
+    async fn send(&self, peer: SocketAddr, message: &Message<N, E>) {
+        let target_peer = self.connected_peers.read().await.get(&peer).cloned();
+        match target_peer {
             Some((_, outbound)) => {
                 // Ensure sufficient time has passed before needing to send the message.
                 let is_ready_to_send = match message {
                     Message::UnconfirmedBlock(block) => {
+                        // Lock seen_outbound_blocks for further processing.
+                        let mut seen_outbound_blocks = self.seen_outbound_blocks.write().await;
+
                         // Retrieve the last seen timestamp of this block for this peer.
-                        let seen_blocks = self.seen_outbound_blocks.entry(peer).or_insert_with(Default::default);
+                        let seen_blocks = seen_outbound_blocks.entry(peer).or_insert_with(Default::default);
                         let last_seen = seen_blocks.entry(block.hash()).or_insert(SystemTime::UNIX_EPOCH);
                         let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
 
@@ -469,8 +496,11 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         is_ready_to_send
                     }
                     Message::UnconfirmedTransaction(transaction) => {
+                        // Lock seen_outbound_transactions for further processing.
+                        let mut seen_outbound_transactions = self.seen_outbound_transactions.write().await;
+
                         // Retrieve the last seen timestamp of this transaction for this peer.
-                        let seen_transactions = self.seen_outbound_transactions.entry(peer).or_insert_with(Default::default);
+                        let seen_transactions = seen_outbound_transactions.entry(peer).or_insert_with(Default::default);
                         let last_seen = seen_transactions
                             .entry(transaction.transaction_id())
                             .or_insert(SystemTime::UNIX_EPOCH);
@@ -495,7 +525,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 if is_ready_to_send {
                     if let Err(error) = outbound.send(message.clone()).await {
                         trace!("Outbound channel failed: {}", error);
-                        self.connected_peers.remove(&peer);
+                        self.connected_peers.write().await.remove(&peer);
                     }
                 }
             }
@@ -506,13 +536,20 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Sends the given message to every connected peer, excluding the sender.
     ///
-    async fn propagate(&mut self, sender: SocketAddr, message: &Message<N, E>) {
+    async fn propagate(&self, sender: SocketAddr, message: &Message<N, E>) {
         // Iterate through all peers that are not the sender, sync node, or peer node.
-        for peer in self.connected_peers().iter().filter(|peer_ip| {
-            let peer_str = peer_ip.to_string();
-            *peer_ip != &sender && !E::SYNC_NODES.contains(&peer_str.as_str()) && !E::PEER_NODES.contains(&peer_str.as_str())
-        }) {
-            self.send(*peer, message).await;
+        for peer in self
+            .connected_peers()
+            .await
+            .iter()
+            .filter(|peer_ip| {
+                let peer_str = peer_ip.to_string();
+                *peer_ip != &sender && !E::SYNC_NODES.contains(&peer_str.as_str()) && !E::PEER_NODES.contains(&peer_str.as_str())
+            })
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.send(peer, message).await;
         }
     }
 
@@ -520,11 +557,11 @@ impl<N: Network, E: Environment> Peers<N, E> {
     /// Removes the addresses of all known peers.
     ///
     #[cfg(feature = "test")]
-    pub fn reset_known_peers(&mut self) {
-        self.candidate_peers.clear();
-        self.restricted_peers.clear();
-        self.seen_inbound_connections.clear();
-        self.seen_outbound_connections.clear();
+    pub async fn reset_known_peers(&self) {
+        self.candidate_peers.write().await.clear();
+        self.restricted_peers.write().await.clear();
+        self.seen_inbound_connections.write().await.clear();
+        self.seen_outbound_connections.write().await.clear();
     }
 }
 
@@ -732,7 +769,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
 
     /// A handler to process an individual peer.
     #[allow(clippy::too_many_arguments)]
-    async fn handler<'a, T: Iterator<Item = &'a u64> + Send>(
+    async fn handler(
         stream: TcpStream,
         local_ip: SocketAddr,
         local_nonce: u64,
@@ -740,10 +777,9 @@ impl<N: Network, E: Environment> Peer<N, E> {
         peers_router: &PeersRouter<N, E>,
         ledger_reader: LedgerReader<N>,
         ledger_router: LedgerRouter<N, E>,
-        connected_nonces: &mut T,
+        connected_nonces: Vec<u64>,
         connection_result: Option<ConnectionResult>,
     ) {
-        let connected_nonces = connected_nonces.cloned().collect::<Vec<u64>>();
         let peers_router = peers_router.clone();
 
         task::spawn(async move {
@@ -865,7 +901,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     if let Err(error) = ledger_router.send(LedgerRequest::Disconnect(peer_ip)).await {
                                         warn!("[Disconnect] {}", error);
                                     }
-                                    break;
+                                    return;
                                 }
                                 Message::PeerRequest => {
                                     // Send a `PeerResponse` message.

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -46,7 +46,7 @@ pub struct Server<N: Network, E: Environment> {
     /// The status of the node.
     status: Status,
     /// The list of peers for the node.
-    peers: Arc<RwLock<Peers<N, E>>>,
+    peers: Arc<Peers<N, E>>,
     /// The peers router of the node.
     peers_router: PeersRouter<N, E>,
     /// The ledger state of the node.
@@ -109,7 +109,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     }
 
     /// Returns the peer manager of this node.
-    pub fn peers(&self) -> Arc<RwLock<Peers<N, E>>> {
+    pub fn peers(&self) -> Arc<Peers<N, E>> {
         self.peers.clone()
     }
 
@@ -147,9 +147,9 @@ impl<N: Network, E: Environment> Server<N, E> {
         tasks: &mut Tasks<task::JoinHandle<()>>,
         local_ip: SocketAddr,
         local_status: Status,
-    ) -> (Arc<RwLock<Peers<N, E>>>, PeersRouter<N, E>) {
+    ) -> (Arc<Peers<N, E>>, PeersRouter<N, E>) {
         // Initialize the `Peers` struct.
-        let peers = Arc::new(RwLock::new(Peers::new(local_ip, None, local_status)));
+        let peers = Arc::new(Peers::new(local_ip, None, local_status));
 
         // Initialize an mpsc channel for sending requests to the `Peers` struct.
         let (peers_router, mut peers_handler) = mpsc::channel(1024);
@@ -170,7 +170,7 @@ impl<N: Network, E: Environment> Server<N, E> {
                     // Asynchronously process a peers request.
                     tasks_clone.append(task::spawn(async move {
                         // Hold the peers write lock briefly, to update the state of the peers.
-                        peers.write().await.update(request, &peers_router).await;
+                        peers.update(request, &peers_router).await;
                     }));
                 }
             }));
@@ -345,7 +345,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         tasks: &mut Tasks<task::JoinHandle<()>>,
         node: &Node,
         status: &Status,
-        peers: &Arc<RwLock<Peers<N, E>>>,
+        peers: &Arc<Peers<N, E>>,
         ledger_reader: &LedgerReader<N>,
         ledger_router: &LedgerRouter<N, E>,
     ) {

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -36,7 +36,7 @@ use json_rpc_types as jrt;
 use jsonrpc_core::{Metadata, Params};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::oneshot;
 
 /// Defines the authentication format for accessing private endpoints on the RPC server.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -88,7 +88,7 @@ pub async fn initialize_rpc_server<N: Network, E: Environment>(
     username: String,
     password: String,
     status: &Status,
-    peers: &Arc<RwLock<Peers<N, E>>>,
+    peers: &Arc<Peers<N, E>>,
     ledger: &LedgerReader<N>,
     ledger_router: &LedgerRouter<N, E>,
 ) -> tokio::task::JoinHandle<()> {
@@ -442,7 +442,7 @@ mod tests {
         str::FromStr,
         sync::atomic::AtomicBool,
     };
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, RwLock};
 
     fn temp_dir() -> std::path::PathBuf {
         tempfile::tempdir().expect("Failed to open temporary directory").into_path()
@@ -454,8 +454,8 @@ mod tests {
     }
 
     /// Initializes a new instance of the `Peers` struct.
-    fn peers<N: Network, E: Environment>() -> Arc<RwLock<Peers<N, E>>> {
-        Arc::new(RwLock::new(Peers::new("0.0.0.0:4130".parse().unwrap(), None, Status::new())))
+    fn peers<N: Network, E: Environment>() -> Arc<Peers<N, E>> {
+        Arc::new(Peers::new("0.0.0.0:4130".parse().unwrap(), None, Status::new()))
     }
 
     /// Initializes a new instance of the ledger state.

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -442,7 +442,7 @@ mod tests {
         str::FromStr,
         sync::atomic::AtomicBool,
     };
-    use tokio::sync::{mpsc, RwLock};
+    use tokio::sync::mpsc;
 
     fn temp_dir() -> std::path::PathBuf {
         tempfile::tempdir().expect("Failed to open temporary directory").into_path()
@@ -472,7 +472,7 @@ mod tests {
             username: "root".to_string(),
             password: "pass".to_string(),
         };
-        let ledger = Arc::new(RwLock::new(new_ledger_state::<N, S, P>(path)));
+        let ledger = Arc::new(new_ledger_state::<N, S, P>(path));
 
         // Create a dummy mpsc channel for Ledger requests. todo (@collinc97): only get requests will work until this is changed
         let (ledger_router, _ledger_handler) = mpsc::channel(1024);
@@ -707,7 +707,7 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let mut ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
+        let ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
@@ -823,7 +823,7 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let mut ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
+        let ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
@@ -975,7 +975,7 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let mut ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
+        let ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -107,97 +107,97 @@ impl<N: Network, E: Environment> RpcImpl<N, E> {
 impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
     /// Returns the latest block from the canonical chain.
     async fn latest_block(&self) -> Result<Block<N>, RpcError> {
-        Ok(self.ledger.read().await.latest_block())
+        Ok(self.ledger.latest_block())
     }
 
     /// Returns the latest block height from the canonical chain.
     async fn latest_block_height(&self) -> Result<u32, RpcError> {
-        Ok(self.ledger.read().await.latest_block_height())
+        Ok(self.ledger.latest_block_height())
     }
 
     /// Returns the latest block hash from the canonical chain.
     async fn latest_block_hash(&self) -> Result<N::BlockHash, RpcError> {
-        Ok(self.ledger.read().await.latest_block_hash())
+        Ok(self.ledger.latest_block_hash())
     }
 
     /// Returns the latest block header from the canonical chain.
     async fn latest_block_header(&self) -> Result<BlockHeader<N>, RpcError> {
-        Ok(self.ledger.read().await.latest_block_header())
+        Ok(self.ledger.latest_block_header())
     }
 
     /// Returns the latest block transactions from the canonical chain.
     async fn latest_block_transactions(&self) -> Result<Transactions<N>, RpcError> {
-        Ok(self.ledger.read().await.latest_block_transactions())
+        Ok(self.ledger.latest_block_transactions())
     }
 
     /// Returns the latest ledger root from the canonical chain.
     async fn latest_ledger_root(&self) -> Result<N::LedgerRoot, RpcError> {
-        Ok(self.ledger.read().await.latest_ledger_root())
+        Ok(self.ledger.latest_ledger_root())
     }
 
     /// Returns the block given the block height.
     async fn get_block(&self, block_height: u32) -> Result<Block<N>, RpcError> {
-        Ok(self.ledger.read().await.get_block(block_height)?)
+        Ok(self.ledger.get_block(block_height)?)
     }
 
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` blocks from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        Ok(self.ledger.read().await.get_blocks(safe_start_height, end_block_height)?)
+        Ok(self.ledger.get_blocks(safe_start_height, end_block_height)?)
     }
 
     /// Returns the block height for the given the block hash.
     async fn get_block_height(&self, block_hash: serde_json::Value) -> Result<u32, RpcError> {
         let block_hash: N::BlockHash = serde_json::from_value(block_hash)?;
-        Ok(self.ledger.read().await.get_block_height(&block_hash)?)
+        Ok(self.ledger.get_block_height(&block_hash)?)
     }
 
     /// Returns the block hash for the given block height, if it exists in the canonical chain.
     async fn get_block_hash(&self, block_height: u32) -> Result<N::BlockHash, RpcError> {
-        Ok(self.ledger.read().await.get_block_hash(block_height)?)
+        Ok(self.ledger.get_block_hash(block_height)?)
     }
 
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` block hashes from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_block_hashes(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<N::BlockHash>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        Ok(self.ledger.read().await.get_block_hashes(safe_start_height, end_block_height)?)
+        Ok(self.ledger.get_block_hashes(safe_start_height, end_block_height)?)
     }
 
     /// Returns the block header for the given the block height.
     async fn get_block_header(&self, block_height: u32) -> Result<BlockHeader<N>, RpcError> {
-        Ok(self.ledger.read().await.get_block_header(block_height)?)
+        Ok(self.ledger.get_block_header(block_height)?)
     }
 
     /// Returns the transactions from the block of the given block height.
     async fn get_block_transactions(&self, block_height: u32) -> Result<Transactions<N>, RpcError> {
-        Ok(self.ledger.read().await.get_block_transactions(block_height)?)
+        Ok(self.ledger.get_block_transactions(block_height)?)
     }
 
     /// Returns the ciphertext given the ciphertext ID.
     async fn get_ciphertext(&self, ciphertext_id: serde_json::Value) -> Result<RecordCiphertext<N>, RpcError> {
         let ciphertext_id: N::CiphertextID = serde_json::from_value(ciphertext_id)?;
-        Ok(self.ledger.read().await.get_ciphertext(&ciphertext_id)?)
+        Ok(self.ledger.get_ciphertext(&ciphertext_id)?)
     }
 
     /// Returns the ledger proof for a given record commitment.
     async fn get_ledger_proof(&self, record_commitment: serde_json::Value) -> Result<String, RpcError> {
         let record_commitment: N::Commitment = serde_json::from_value(record_commitment)?;
-        let ledger_proof = self.ledger.read().await.get_ledger_inclusion_proof(record_commitment)?;
+        let ledger_proof = self.ledger.get_ledger_inclusion_proof(record_commitment)?;
         Ok(hex::encode(ledger_proof.to_bytes_le().expect("Failed to serialize ledger proof")))
     }
 
     /// Returns a transaction with metadata given the transaction ID.
     async fn get_transaction(&self, transaction_id: serde_json::Value) -> Result<Value, RpcError> {
         let transaction_id: N::TransactionID = serde_json::from_value(transaction_id)?;
-        let transaction: Transaction<N> = self.ledger.read().await.get_transaction(&transaction_id)?;
-        let metadata: Metadata<N> = self.ledger.read().await.get_transaction_metadata(&transaction_id)?;
+        let transaction: Transaction<N> = self.ledger.get_transaction(&transaction_id)?;
+        let metadata: Metadata<N> = self.ledger.get_transaction_metadata(&transaction_id)?;
         Ok(serde_json::json!({ "transaction": transaction, "metadata": metadata }))
     }
 
     /// Returns a transition given the transition ID.
     async fn get_transition(&self, transition_id: serde_json::Value) -> Result<Transition<N>, RpcError> {
         let transition_id: N::TransitionID = serde_json::from_value(transition_id)?;
-        Ok(self.ledger.read().await.get_transition(&transition_id)?)
+        Ok(self.ledger.get_transition(&transition_id)?)
     }
 
     /// Returns the peers currently connected to this node.
@@ -215,7 +215,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         Ok(serde_json::json!({
             "candidate_peers": candidate_peers,
             "connected_peers": connected_peers,
-            "latest_block_height": self.ledger.read().await.latest_block_height(),
+            "latest_block_height": self.ledger.latest_block_height(),
             "number_of_candidate_peers": number_of_candidate_peers,
             "number_of_connected_peers": number_of_connected_peers,
             "status": self.status.to_string(),

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -33,13 +33,13 @@ impl ClientNode {
 
     /// Returns the list of connected peers of the node.
     pub async fn connected_peers(&self) -> Vec<SocketAddr> {
-        self.server.peers().read().await.connected_peers()
+        self.server.peers().connected_peers().await
     }
 
     /// Resets the node's known peers. This is practical, as it makes the node not reconnect
     /// to known peers in test cases where it's undesirable.
     pub async fn reset_known_peers(&self) {
-        self.server.peers().write().await.reset_known_peers()
+        self.server.peers().reset_known_peers().await
     }
 
     /// Attempts to connect the node to the given address.


### PR DESCRIPTION
The current code uses write locks over the entire `Ledger` and `Peers` objects to process any requests related to them. This effectively causes them to be processed in a sequential fashion, but many (especially the ones related to `Peers`) can be processed concurrently instead.

In addition, this PR enforces `Ledger.block_requests_lock`, which is currently dropped immediately.