### PR TITLE
Fix `check_block_locators` and introduce connection limits to sync nodes.

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -85,6 +85,8 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const MAXIMUM_CONNECTION_FAILURES: u32 = 5;
     /// The maximum number of candidate peers permitted to be stored in the node.
     const MAXIMUM_CANDIDATE_PEERS: usize = 10_000;
+    /// The maximum number of sync nodes that the node may be connected to at any time.
+    const MAXIMUM_CONNECTED_SYNC_NODES: usize = 2;
 
     /// The maximum size of a message that can be transmitted in the network.
     const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -296,8 +296,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 };
 
                 // Add the sync nodes to the list of candidate peers.
-                let mut sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-                sync_nodes.shuffle(&mut OsRng::default());
+                let sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
                 self.add_candidate_peers(&sync_nodes).await;
 
                 // Add the peer nodes to the list of candidate peers.
@@ -470,7 +469,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
 
         // Fetch the number of connected sync nodes.
         let num_connected_sync_nodes = connected_peers.intersection(&sync_nodes).count();
-      
+
         // Ensure the combined number of peers does not surpass the threshold.
         if candidate_peers.len() + peers.len() < E::MAXIMUM_CANDIDATE_PEERS {
             // Proceed to insert each new candidate peer IP.

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -472,8 +472,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
     /// as the peer providing this list could be subverting the protocol.
     ///
     async fn add_candidate_peers(&self, peers: &[SocketAddr]) {
+        // Acquire the candidate peers write lock.
         let mut candidate_peers = self.candidate_peers.write().await;
-
         // Ensure the combined number of peers does not surpass the threshold.
         if candidate_peers.len() + peers.len() < E::MAXIMUM_CANDIDATE_PEERS {
             // Proceed to insert each new candidate peer IP.
@@ -481,8 +481,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 // Ensure the peer is not self and is a new candidate peer.
                 let is_self = *peer_ip == self.local_ip
                     || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port();
-
-                if !is_self && !self.is_connected_to(*peer_ip).await && !candidate_peers.contains(peer_ip) {
+                if !is_self && !self.is_connected_to(*peer_ip).await {
                     candidate_peers.insert(*peer_ip);
                 }
             }

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -211,6 +211,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         let connected_peers = self.peers.connected_peers().await;
         let number_of_candidate_peers = candidate_peers.len();
         let number_of_connected_peers = connected_peers.len();
+        let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes().await;
 
         Ok(serde_json::json!({
             "candidate_peers": candidate_peers,
@@ -218,6 +219,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
             "latest_block_height": self.ledger.read().await.latest_block_height(),
             "number_of_candidate_peers": number_of_candidate_peers,
             "number_of_connected_peers": number_of_connected_peers,
+            "number_of_connected_sync_nodes": number_of_connected_sync_nodes,
             "status": self.status.to_string(),
             "type": E::NODE_TYPE,
             "version": E::MESSAGE_VERSION,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR fixes the `check_block_locators` call and introduces a limit to the number of sync nodes that a node can connect to.

- Add `number_of_connected_sync_nodes` to `getnodestate` RPC endpoint