### PR TITLE
Reduce blocking when (de)serializing messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Build and run tests
           no_output_timeout: 35m
-          command: RUST_MIN_STACK=8388608 cargo test --workspace
+          command: RUST_MIN_STACK=8388608 cargo test --workspace --release
       - clear_environment:
           cache_key: snarkos-stable-cache
 
@@ -175,7 +175,7 @@ jobs:
           root: my_workspace
           paths:
             - docker_tag_amd
-  
+
   publish_snarkos_manifest:
     machine:
       image: ubuntu-2004:202101-01
@@ -197,7 +197,7 @@ jobs:
           command: |
             AMD_TAG=$(cat my_workspace/docker_tag_amd)
             echo $AMD_TAG
-            docker pull $DOCKER_REPO:$AMD_TAG  
+            docker pull $DOCKER_REPO:$AMD_TAG
       - run:
           name: "Create and push docker multi arch manifest"
           command: |

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,8 @@ fn main() -> Result<()> {
     let runtime = runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(8 * 1024 * 1024)
-        .worker_threads(num_cpus::get().saturating_sub(1).max(1)) // Don't use 100% of the cores
-        .max_blocking_threads(num_cpus::get().saturating_sub(1).max(1)) // Don't use 100% of the cores
+        .worker_threads((num_cpus::get() / 4).max(1))
+        .max_blocking_threads((num_cpus::get() / 4).max(1))
         .build()?;
 
     // Initialize the parallelization parameters.

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -17,6 +17,7 @@
 use crate::{
     helpers::{CircularMap, State, Status},
     Environment,
+    MaybeSerialized,
     Message,
     NodeType,
     PeersRequest,
@@ -202,6 +203,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     // Process the unconfirmed block.
                     self.add_block(block.clone()).await;
                     // Propagate the unconfirmed block to the connected peers.
+                    let block = MaybeSerialized::Deserialized(block);
                     let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedBlock(block));
                     if let Err(error) = peers_router.send(request).await {
                         warn!("[UnconfirmedBlock] {}", error);

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -16,8 +16,8 @@
 
 use crate::{
     helpers::{CircularMap, State, Status},
+    Data,
     Environment,
-    MaybeSerialized,
     Message,
     NodeType,
     PeersRequest,
@@ -203,8 +203,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     // Process the unconfirmed block.
                     self.add_block(block.clone()).await;
                     // Propagate the unconfirmed block to the connected peers.
-                    let block = MaybeSerialized::Deserialized(block);
-                    let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedBlock(block));
+                    let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedBlock(Data::Object(block)));
                     if let Err(error) = peers_router.send(request).await {
                         warn!("[UnconfirmedBlock] {}", error);
                     }

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -17,8 +17,8 @@
 use snarkos::{
     helpers::{State, Status},
     Client,
+    Data,
     Environment,
-    MaybeSerialized,
     Message,
     NodeType,
 };
@@ -227,7 +227,7 @@ impl Handshake for TestNode {
             };
 
         // Respond with own challenge request.
-        let own_response = ClientMessage::ChallengeResponse(MaybeSerialized::Deserialized(genesis_block_header.clone()));
+        let own_response = ClientMessage::ChallengeResponse(Data::Object(genesis_block_header.clone()));
         trace!(parent: self.node().span(), "sending a challenge response to {}", peer_ip);
         let msg = own_response.serialize().unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
@@ -385,7 +385,7 @@ impl TestNode {
         let genesis = Testnet2::genesis_block();
         let msg = ClientMessage::Pong(
             None,
-            MaybeSerialized::Deserialized(BlockLocators::<Testnet2>::from(
+            Data::Object(BlockLocators::<Testnet2>::from(
                 vec![(genesis.height(), (genesis.hash(), None))].into_iter().collect(),
             )),
         );

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -18,6 +18,7 @@ use snarkos::{
     helpers::{State, Status},
     Client,
     Environment,
+    MaybeSerialized,
     Message,
     NodeType,
 };
@@ -226,7 +227,7 @@ impl Handshake for TestNode {
             };
 
         // Respond with own challenge request.
-        let own_response = ClientMessage::ChallengeResponse(genesis_block_header.clone());
+        let own_response = ClientMessage::ChallengeResponse(MaybeSerialized::Deserialized(genesis_block_header.clone()));
         trace!(parent: self.node().span(), "sending a challenge response to {}", peer_ip);
         let msg = own_response.serialize().unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
@@ -240,6 +241,8 @@ impl Handshake for TestNode {
         let peer_response = ClientMessage::deserialize(&buf[..len]);
 
         if let Ok(Message::ChallengeResponse(block_header)) = peer_response {
+            let block_header = block_header.deserialize().await.unwrap();
+
             trace!(parent: self.node().span(), "received a challenge response from {}", peer_ip);
             if block_header.height() == CHALLENGE_HEIGHT && &block_header == genesis_block_header && block_header.is_valid() {
                 // Register the newly connected snarkOS peer.
@@ -382,7 +385,9 @@ impl TestNode {
         let genesis = Testnet2::genesis_block();
         let msg = ClientMessage::Pong(
             None,
-            BlockLocators::<Testnet2>::from(vec![(genesis.height(), (genesis.hash(), None))].into_iter().collect()),
+            MaybeSerialized::Deserialized(BlockLocators::<Testnet2>::from(
+                vec![(genesis.height(), (genesis.hash(), None))].into_iter().collect(),
+            )),
         );
 
         info!(parent: self.node().span(), "sending a Pong to {}", source);

--- a/testing/tests/common/mod.rs
+++ b/testing/tests/common/mod.rs
@@ -24,8 +24,21 @@ use tracing_subscriber::filter::EnvFilter;
 // note: snarkOS node currently starts it by default, so it's not needed
 pub fn start_logger() {
     let filter = match EnvFilter::try_from_default_env() {
-        Ok(filter) => filter.add_directive("mio=off".parse().unwrap()),
-        _ => EnvFilter::default().add_directive("mio=off".parse().unwrap()),
+        Ok(filter) => filter
+            .add_directive("mio=off".parse().unwrap())
+            .add_directive("tokio_util=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::conn=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::decode=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::io=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::role=off".parse().unwrap()),
+        _ => EnvFilter::default()
+            .add_directive("mio=off".parse().unwrap())
+            .add_directive("mio=off".parse().unwrap())
+            .add_directive("tokio_util=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::conn=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::decode=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::io=off".parse().unwrap())
+            .add_directive("hyper::proto::h1::role=off".parse().unwrap()),
     };
     tracing_subscriber::fmt().with_env_filter(filter).with_target(false).init();
 }


### PR DESCRIPTION
This PR introduces deferred non-blocking deserialization for messages that take a long time to parse. This should improve the responsiveness of nodes, especially ones with many active connections.

The object that enables this, `MaybeSerialized`, is intended to be used within `Message`, ~and while it is currently only used for non-blocking deserialization, it could technically easily enable non-blocking serialization as well if need be~ and already applies to the slow bits in both serialization and deserialization.