### PR TITLE
Perform clean shutdown upon Ctrl-C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,8 +2344,10 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ features = [
     "macros",
     "net",
     "rt-multi-thread",
+    "signal",
     "sync",
     "time"
 ]

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -1021,13 +1021,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     warn!("Peer {} is not following the protocol", peer_ip);
                                     break;
                                 },
-                                Message::Disconnect => {
-                                    // Route the `Disconnect` to the ledger.
-                                    if let Err(error) = ledger_router.send(LedgerRequest::Disconnect(peer_ip)).await {
-                                        warn!("[Disconnect] {}", error);
-                                    }
-                                    return;
-                                }
+                                Message::Disconnect => break,
                                 Message::PeerRequest => {
                                     // Send a `PeerResponse` message.
                                     if let Err(error) = peers_router.send(PeersRequest::SendPeerResponse(peer_ip)).await {
@@ -1194,7 +1188,10 @@ impl<N: Network, E: Environment> Peer<N, E> {
 
             // When this is reached, it means the peer has disconnected.
             // Route a `Disconnect` to the ledger.
-            if let Err(error) = ledger_router.send(LedgerRequest::Disconnect(peer_ip)).await {
+            if let Err(error) = ledger_router
+                .send(LedgerRequest::Disconnect(peer_ip, "peer has disconnected".to_string()))
+                .await
+            {
                 warn!("[Peer::Disconnect] {}", error);
             }
         });

--- a/src/node.rs
+++ b/src/node.rs
@@ -32,7 +32,7 @@ use anyhow::Result;
 use colored::*;
 use std::{net::SocketAddr, str::FromStr};
 use structopt::StructOpt;
-use tokio::task;
+use tokio::{signal, task};
 use tracing_subscriber::EnvFilter;
 
 #[derive(StructOpt, Debug)]
@@ -137,6 +137,11 @@ impl Node {
         // Initialize the node's server.
         let server = Server::<N, E>::initialize(self, miner, tasks.clone()).await?;
 
+        // Initialize signal handling; it also maintains ownership of the Server
+        // in order for it to not go out of scope.
+        let server_clone = server.clone();
+        handle_signals(server_clone);
+
         // Initialize the display, if enabled.
         if self.display {
             println!("\nThe snarkOS console is initializing...\n");
@@ -147,11 +152,6 @@ impl Node {
         if let Some(peer_ip) = &self.connect {
             let _ = server.connect_to(peer_ip.parse().unwrap()).await;
         }
-        // Spawn a task to handle the server.
-        tasks.append(task::spawn(async move {
-            let _server = server;
-            std::future::pending::<()>().await
-        }));
 
         Ok(())
     }
@@ -278,4 +278,19 @@ impl NewAccount {
 
         Ok(output)
     }
+}
+
+// This function is responsible for handling OS signals in order for the node to be able to intercept them
+// and perform a clean shutdown.
+// note: only Ctrl-C is currently supported, but it should work on both Unix-family systems and Windows.
+fn handle_signals<N: Network, E: Environment>(server: Server<N, E>) {
+    task::spawn(async move {
+        match signal::ctrl_c().await {
+            Ok(()) => {
+                server.shut_down();
+                std::process::exit(0);
+            }
+            Err(error) => error!("tokio::signal::ctrl_c encountered an error: {}", error),
+        }
+    });
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -325,7 +325,7 @@ fn handle_signals<N: Network, E: Environment>(server: Server<N, E>) {
     task::spawn(async move {
         match signal::ctrl_c().await {
             Ok(()) => {
-                server.shut_down();
+                server.shut_down().await;
                 std::process::exit(0);
             }
             Err(error) => error!("tokio::signal::ctrl_c encountered an error: {}", error),


### PR DESCRIPTION
Note: this PR only provides the means to automatically intercept `Ctrl-C` and perform `Server::shut_down`; further work might be required for that method to perform a fully clean shutdown.