### PR TITLE
Display tracing logs when running with --display

### DIFF
--- a/src/display/logs.rs
+++ b/src/display/logs.rs
@@ -32,7 +32,7 @@ pub(super) struct Logs {
 
 impl Logs {
     pub(super) fn new(log_receiver: mpsc::Receiver<Vec<u8>>) -> Self {
-        let log_limit = 57; // an arbitrary number fitting the testing terminal room
+        let log_limit = 128; // an arbitrary number fitting the testing terminal room
 
         Self {
             log_receiver,
@@ -50,11 +50,13 @@ impl Logs {
 
         let mut new_logs = Vec::new();
         while let Ok(log) = self.log_receiver.try_recv() {
-            new_logs.push(String::from_utf8(log).unwrap());
+            new_logs.push(match String::from_utf8(log) {
+                Ok(log) => log,
+                _ => String::new(),
+            });
         }
 
         let all_logs = self.log_cache.len() + new_logs.len();
-
         if all_logs > self.log_limit {
             let remaining_room = self.log_limit - self.log_cache.len();
             let overflow = all_logs - self.log_cache.len();

--- a/src/display/logs.rs
+++ b/src/display/logs.rs
@@ -14,28 +14,66 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use tokio::sync::mpsc;
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
-    widgets::{canvas::Canvas, Block, Borders},
+    widgets::{Block, Borders, Paragraph},
     Frame,
 };
 
-pub(super) struct Logs;
+use std::collections::VecDeque;
+
+pub(super) struct Logs {
+    log_receiver: mpsc::Receiver<Vec<u8>>,
+    log_cache: VecDeque<String>,
+    log_limit: usize,
+}
 
 impl Logs {
-    pub(super) fn draw<B: Backend>(&self, f: &mut Frame<B>, area: Rect) {
+    pub(super) fn new(log_receiver: mpsc::Receiver<Vec<u8>>) -> Self {
+        let log_limit = 57; // an arbitrary number fitting the testing terminal room
+
+        Self {
+            log_receiver,
+            log_cache: VecDeque::with_capacity(log_limit),
+            log_limit,
+        }
+    }
+
+    pub(super) fn draw<B: Backend>(&mut self, f: &mut Frame<B>, area: Rect) {
         // Initialize the layout of the page.
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Percentage(100)].as_ref())
             .split(area);
 
-        let canvas = Canvas::default()
-            .block(Block::default().borders(Borders::ALL).title("Logs"))
-            .paint(|_ctx| {
-                // ctx.draw(&ball);
-            });
-        f.render_widget(canvas, chunks[0]);
+        let mut new_logs = Vec::new();
+        while let Ok(log) = self.log_receiver.try_recv() {
+            new_logs.push(String::from_utf8(log).unwrap());
+        }
+
+        let all_logs = self.log_cache.len() + new_logs.len();
+
+        if all_logs > self.log_limit {
+            let remaining_room = self.log_limit - self.log_cache.len();
+            let overflow = all_logs - self.log_cache.len();
+
+            if overflow > self.log_limit {
+                self.log_cache.clear();
+            } else {
+                let missing_room = all_logs - remaining_room;
+                for _ in 0..missing_room {
+                    self.log_cache.pop_front();
+                }
+            }
+        };
+
+        self.log_cache.extend(new_logs.into_iter().take(self.log_limit));
+
+        let combined_logs = self.log_cache.iter().map(|s| s.as_str()).collect::<String>();
+
+        let combined_logs = Paragraph::new(combined_logs).block(Block::default().borders(Borders::ALL).title("Logs"));
+        f.render_widget(combined_logs, chunks[0]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ fn main() -> Result<()> {
 
     runtime.block_on(async move {
         node.start().await.expect("Failed to start the node");
-        std::future::pending::<()>().await;
     });
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos::Node;
+use snarkos::{initialize_logger, Node};
 
 use anyhow::Result;
 use structopt::StructOpt;
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
 
     // Start logging, if enabled.
     if !node.display {
-        node.initialize_logger();
+        initialize_logger(node.verbosity, None);
     }
 
     // Initialize the runtime configuration.

--- a/src/node.rs
+++ b/src/node.rs
@@ -150,8 +150,12 @@ impl Node {
         // Spawn a task to handle the server.
         tasks.append(task::spawn(async move {
             let _server = server;
-            std::future::pending::<()>().await
+            std::future::pending::<()>().await;
         }));
+
+        // Note: Do not move this. The pending await must be here otherwise
+        // other snarkOS commands will not exit.
+        std::future::pending::<()>().await;
 
         Ok(())
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -30,9 +30,9 @@ use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use anyhow::Result;
 use colored::*;
-use std::{net::SocketAddr, str::FromStr};
+use std::{io, net::SocketAddr, str::FromStr};
 use structopt::StructOpt;
-use tokio::task;
+use tokio::{sync::mpsc, task};
 use tracing_subscriber::EnvFilter;
 
 #[derive(StructOpt, Debug)]
@@ -140,7 +140,7 @@ impl Node {
         // Initialize the display, if enabled.
         if self.display {
             println!("\nThe snarkOS console is initializing...\n");
-            let _display = Display::<N, E>::start(server.clone())?;
+            let _display = Display::<N, E>::start(server.clone(), self.verbosity)?;
         };
 
         // Connect to a peer if one was given as an argument.
@@ -155,30 +155,32 @@ impl Node {
 
         Ok(())
     }
+}
 
-    pub fn initialize_logger(&self) {
-        match self.verbosity {
-            0 => std::env::set_var("RUST_LOG", "info"),
-            1 => std::env::set_var("RUST_LOG", "debug"),
-            2 | 3 => std::env::set_var("RUST_LOG", "trace"),
-            _ => std::env::set_var("RUST_LOG", "info"),
-        };
+pub fn initialize_logger(verbosity: u8, log_sender: Option<mpsc::Sender<Vec<u8>>>) {
+    match verbosity {
+        0 => std::env::set_var("RUST_LOG", "info"),
+        1 => std::env::set_var("RUST_LOG", "debug"),
+        2 | 3 => std::env::set_var("RUST_LOG", "trace"),
+        _ => std::env::set_var("RUST_LOG", "info"),
+    };
 
-        // Filter out undesirable logs.
-        let filter = EnvFilter::from_default_env()
-            .add_directive("mio=off".parse().unwrap())
-            .add_directive("tokio_util=off".parse().unwrap())
-            .add_directive("hyper::proto::h1::conn=off".parse().unwrap())
-            .add_directive("hyper::proto::h1::decode=off".parse().unwrap())
-            .add_directive("hyper::proto::h1::io=off".parse().unwrap())
-            .add_directive("hyper::proto::h1::role=off".parse().unwrap());
+    // Filter out undesirable logs.
+    let filter = EnvFilter::from_default_env()
+        .add_directive("mio=off".parse().unwrap())
+        .add_directive("tokio_util=off".parse().unwrap())
+        .add_directive("hyper::proto::h1::conn=off".parse().unwrap())
+        .add_directive("hyper::proto::h1::decode=off".parse().unwrap())
+        .add_directive("hyper::proto::h1::io=off".parse().unwrap())
+        .add_directive("hyper::proto::h1::role=off".parse().unwrap());
 
-        // Initialize tracing.
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(filter)
-            .with_target(self.verbosity == 3)
-            .try_init();
-    }
+    // Initialize tracing.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(log_sender.is_none())
+        .with_writer(move || LogWriter::new(&log_sender))
+        .with_target(verbosity == 3)
+        .try_init();
 }
 
 #[derive(StructOpt, Debug)]
@@ -195,6 +197,38 @@ impl Command {
             Self::Update(command) => command.parse(),
             Self::Experimental(command) => command.parse(),
         }
+    }
+}
+
+enum LogWriter {
+    Stdout(io::Stdout),
+    Sender(mpsc::Sender<Vec<u8>>),
+}
+
+impl LogWriter {
+    fn new(log_sender: &Option<mpsc::Sender<Vec<u8>>>) -> Self {
+        if let Some(sender) = log_sender {
+            Self::Sender(sender.clone())
+        } else {
+            Self::Stdout(io::stdout())
+        }
+    }
+}
+
+impl io::Write for LogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Stdout(stdout) => stdout.write(buf),
+            Self::Sender(sender) => {
+                let log = buf.to_vec();
+                let _ = sender.try_send(log);
+                Ok(buf.len())
+            }
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR is a very simple, quick implementation for redirecting `tracing` logs to `tui`; it can surely be made faster and better-looking, and the log caching logic is not airtight in case of a large volume of pending logs.

It already does work, but I'm filing it as a draft so it can be improved upon.