### PR TITLE
Set default RPC address to 127.0.0.1:3032

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -52,7 +52,7 @@ pub struct Node {
     #[structopt(parse(try_from_str), default_value = "0.0.0.0:4132", long = "node")]
     pub node: SocketAddr,
     /// Specify the IP address and port for the RPC server.
-    #[structopt(parse(try_from_str), default_value = "0.0.0.0:3032", long = "rpc")]
+    #[structopt(parse(try_from_str), default_value = "127.0.0.1:3032", long = "rpc")]
     pub rpc: SocketAddr,
     /// Specify the username for the RPC server.
     #[structopt(default_value = "root", long = "username")]


### PR DESCRIPTION
0.0.0.0:3032 will be vulnerable to a hacker attack
