### PR TITLE
Deferred serialisation/deserialisation of block header in `Ping` messages

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -92,7 +92,7 @@ pub enum Message<N: Network, E: Environment> {
     /// PeerResponse := (\[peer_ip\])
     PeerResponse(Vec<SocketAddr>),
     /// Ping := (version, node_type, status, block_hash, block_header)
-    Ping(u32, NodeType, State, N::BlockHash, BlockHeader<N>),
+    Ping(u32, NodeType, State, N::BlockHash, Data<BlockHeader<N>>),
     /// Pong := (is_fork, block_locators)
     Pong(Option<bool>, Data<BlockLocators<N>>),
     /// UnconfirmedBlock := (block_height, block_hash, block)
@@ -157,7 +157,8 @@ impl<N: Network, E: Environment> Message<N, E> {
             Self::PeerRequest => Ok(vec![]),
             Self::PeerResponse(peer_ips) => Ok(bincode::serialize(peer_ips)?),
             Self::Ping(version, node_type, status, block_hash, block_header) => {
-                Ok(bincode::serialize(&(version, node_type, status, block_hash, block_header))?)
+                let non_deferred = bincode::serialize(&(version, node_type, status, block_hash))?;
+                Ok([non_deferred, block_header.serialize_blocking()?].concat())
             }
             Self::Pong(is_fork, block_locators) => {
                 let serialized_is_fork: u8 = match is_fork {
@@ -217,7 +218,9 @@ impl<N: Network, E: Environment> Message<N, E> {
             },
             6 => Self::PeerResponse(bincode::deserialize(data)?),
             7 => {
-                let (version, node_type, status, block_hash, block_header) = bincode::deserialize(data)?;
+                let (version, node_type, status, block_hash) = bincode::deserialize(data)?;
+                let block_header = Data::Buffer(data[16..].to_vec());
+
                 Self::Ping(version, node_type, status, block_hash, block_header)
             }
             8 => {

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -218,8 +218,8 @@ impl<N: Network, E: Environment> Message<N, E> {
             },
             6 => Self::PeerResponse(bincode::deserialize(data)?),
             7 => {
-                let (version, node_type, status, block_hash) = bincode::deserialize(data)?;
-                let block_header = Data::Buffer(data[16..].to_vec());
+                let (version, node_type, status, block_hash) = bincode::deserialize(&data[0..44])?;
+                let block_header = Data::Buffer(data[44..].to_vec());
 
                 Self::Ping(version, node_type, status, block_hash, block_header)
             }

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -581,6 +581,19 @@ impl<N: Network, E: Environment> Peers<N, E> {
             Some((_, outbound)) => {
                 // Ensure sufficient time has passed before needing to send the message.
                 let is_ready_to_send = match message {
+                    Message::Ping(_, _, _, _, ref mut data) => {
+                        let block_header = if let Data::Object(block_header) = data {
+                            block_header
+                        } else {
+                            panic!("Logic error: the block header shouldn't have been serialized yet.");
+                        };
+
+                        // Perform non-blocking serialisation of the block header.
+                        let serialized_header = bincode::serialize(&block_header).expect("Block header serialization is bugged");
+                        let _ = std::mem::replace(data, Data::Buffer(serialized_header));
+
+                        true
+                    }
                     Message::UnconfirmedBlock(_, _, ref mut data) => {
                         let block = if let Data::Object(block) = data {
                             block
@@ -729,7 +742,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
             E::NODE_TYPE,
             local_status.get(),
             ledger_reader.latest_block_hash(),
-            ledger_reader.latest_block_header(),
+            Data::Object(ledger_reader.latest_block_header()),
         );
         trace!("Sending '{}' to {}", message.name(), peer_ip);
         outbound_socket.send(message).await?;
@@ -1043,8 +1056,14 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     peer.node_type = node_type;
                                     // Update the status of the peer.
                                     peer.status.update(status);
-                                    // Update the block header of the peer.
-                                    peer.block_header = block_header;
+
+                                    match block_header.deserialize().await {
+                                        Ok(block_header) => {
+                                            // Update the block header of the peer.
+                                            peer.block_header = block_header;
+                                        }
+                                        Err(error) => warn!("[Ping] {}", error),
+                                    }
 
                                     // Determine if the peer is on a fork (or unknown).
                                     let is_fork = match ledger_reader.get_block_hash(peer.block_header.height()) {
@@ -1083,7 +1102,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         let latest_block_header = ledger_reader.latest_block_header();
 
                                         // Send a `Ping` request to the peer.
-                                        let message = Message::Ping(E::MESSAGE_VERSION, E::NODE_TYPE, local_status.get(), latest_block_hash, latest_block_header);
+                                        let message = Message::Ping(E::MESSAGE_VERSION, E::NODE_TYPE, local_status.get(), latest_block_hash, Data::Object(latest_block_header));
                                         if let Err(error) = peers_router.send(PeersRequest::MessageSend(peer_ip, message)).await {
                                             warn!("[Ping] {}", error);
                                         }

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -1057,6 +1057,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     // Update the status of the peer.
                                     peer.status.update(status);
 
+                                    // Perform the deferred non-blocking deserialization of the block header.
                                     match block_header.deserialize().await {
                                         Ok(block_header) => {
                                             // Update the block header of the peer.

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -144,7 +144,7 @@ impl TestNode {
                 node.node_type(),
                 node.state(),
                 genesis.hash(),
-                genesis.header().clone(),
+                Data::Object(genesis.header().clone()),
             );
 
             loop {
@@ -307,6 +307,8 @@ impl Reading for TestNode {
             ClientMessage::PeerRequest => self.process_peer_request(source).await?,
             ClientMessage::PeerResponse(peer_ips) => self.process_peer_response(source, peer_ips).await?,
             ClientMessage::Ping(version, _peer_type, _peer_state, _block_hash, block_header) => {
+                // Deserialise the block header.
+                let block_header = block_header.deserialize().await.unwrap();
                 self.process_ping(source, version, block_header.height()).await?
             }
             ClientMessage::Pong(_is_fork, _block_locators) => {}


### PR DESCRIPTION
~~Drafted for now, pending some testing.~~
Edit: seems to work well on testnet 2, would be good to benchmark this as a follow-up.