### PR TITLE
Add `getblocktemplate` and `getmemorypool` RPC endpoints

### DIFF
--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -74,7 +74,7 @@ pub struct Prover<N: Network, E: Environment> {
     /// The prover router of the node.
     prover_router: ProverRouter<N>,
     /// The pool of unconfirmed transactions.
-    memory_pool: RwLock<MemoryPool<N>>,
+    memory_pool: Arc<RwLock<MemoryPool<N>>>,
     /// The status of the node.
     status: Status,
     /// A terminator bit for the prover.
@@ -113,7 +113,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
             state: Arc::new(ProverState::open_writer::<S, P>(path)?),
             miner: Arc::new(pool),
             prover_router,
-            memory_pool: RwLock::new(MemoryPool::new()),
+            memory_pool: Arc::new(RwLock::new(MemoryPool::new())),
             status: status.clone(),
             terminator: terminator.clone(),
             peers_router,

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -220,6 +220,11 @@ impl<N: Network, E: Environment> Prover<N, E> {
         self.prover_router.clone()
     }
 
+    /// Returns an instance of the memory pool.
+    pub(crate) fn memory_pool(&self) -> Arc<RwLock<MemoryPool<N>>> {
+        self.memory_pool.clone()
+    }
+
     /// Returns all coinbase records in storage.
     pub fn to_coinbase_records(&self) -> Vec<(u32, Record<N>)> {
         self.state.to_coinbase_records()

--- a/src/rpc/documentation/public_endpoints/getblocks.md
+++ b/src/rpc/documentation/public_endpoints/getblocks.md
@@ -17,12 +17,12 @@ Returns up to `MAX_RESPONSE_BLOCKS` blocks from the given `start_block_height` t
 
 #### Block
 
-|        Parameter            |  Type  | Description |
-|:---------------------------:|:------:|:-----------:|
-| `block_hash`                | string | The hash of the block. |
+|        Parameter            |  Type  |                            Description                            |
+|:---------------------------:|:------:|:-----------------------------------------------------------------:|
+| `block_hash`                | string | The hash of the block.                                            |
 | `header`                    | object | The block header containing the state of the ledger at the block. |
-| `previous_block_hash`       | string | The hash of the previous block. |
-| `transactions`              | object | The list of transactions included in the block. |
+| `previous_block_hash`       | string | The hash of the previous block.                                   |
+| `transactions`              | object | The list of transactions included in the block.                   |
 
 
 ### Example Request

--- a/src/rpc/documentation/public_endpoints/getmemorypool.md
+++ b/src/rpc/documentation/public_endpoints/getmemorypool.md
@@ -1,0 +1,70 @@
+# Get Memory Pool
+Returns the transactions in the node's current transaction memory pool.
+
+### Arguments
+
+None
+
+### Response
+
+|     Parameter         |  Type  |                Description               |
+|:---------------------:|:------:|:----------------------------------------:|
+| `result`              |  array | The array of transactions                |
+
+
+#### Transaction
+
+|      Parameter      |  Type  | Description |
+|:-------------------:|:------:|:-----------:|
+| `events`            | array  | The events emitted from the transaction |
+| `inner_circuit_id`  | string | The ID of the inner circuit used to execute each transition. |
+| `ledger_root`       | string | The ledger root used to prove inclusion of ledger-consumed records. |
+| `transaction_id`    | string | The ID of this transaction. |
+| `transitions`       | array  | The state transitions. |
+
+### Example Request
+```ignore
+curl --data-binary '{"jsonrpc": "2.0", "id":"documentation", "method": "getmemorypool", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:3030/
+```
+
+### Example Response
+
+```json
+{
+   "jsonrpc":"2.0",
+   "result":[
+     {
+       "events":[
+
+       ],
+       "inner_circuit_id":"ic14z3rtzc25jgjxs6tzat3wtsrf5gees5zel8tggsslzrfyzhxw4xsgdfe4qk6997427zsfl9tqqesq5fzw5q",
+       "ledger_root":"al1enk2kwh9nuzcj2q9kdutekavlf8ayjqcuszgezsfax8qxn9k0yxqfr9fr2",
+       "transaction_id":"at1pazplqjlhvyvex64xrykr4egpt77z05n74u5vlnkyv05r3ctgyxs0cgj6w",
+       "transitions":[
+         {
+           "ciphertext_ids":[
+             "ar18gr9hxzr40ve9238eddus8vq7ka8a07wk63666hmdqk7ess5mqqsh5xazm",
+             "ar1qd0aga9fs724frhws2hp6dsfr5k7fmmtdllm7dupkp9ez85xlcpqnh4kcs"
+           ],
+           "ciphertexts":[
+             "580a3b830d17818b866c8f4f7bc4f518dcd775adce1274e902d07edc49e3e9005418da88939bac4437a271cb34cf792e3bad3385fe05ec086b5e5c485b291209a7ced29b1f6f169dd13504a71ce57c3348fe8778c7a102e26791fb298a7a0a0edfae8e065599cd3869d08a91ffa06fb6e41f68033d9b8d9269fa6f948f167f07c7d57ab6f3198c3d568a60525cb4959df7655dc8de9751d3cd8ec6b5aa834c0b0b081c6734fb62670b80cc885210392e6f56cd2b4aec22c53257a3422fe474041540a950c102b00c36cb6e889a7cefe2822a003e9332f3536a18fd3bc1690e11094593d25543c3df7e2fc4a24754eafdf4e0002ed4673c1a84c49ddcc510870efef1b4f95f0cf7d1a2e0e754eaa188a22cefb4938e616506154135091874c10ed4abe8bf94915a782e545acc07663237c2c826fd2c516fd14a2f9d2c570afe0d",
+             "3bba8e8ac95b43c3bc4be5792cf73f05458113641d7b15946e169188a7534f0ff6b7328b7549d042dfaeea13b81f8ea6eac72d68ea68681874a823fd08fa44043f074b48823758688ab1114ab0b5f2143ceaf1d8ef448ab21fd874a4e3ffb30919b8cddae76870d0e766fb43e847cb6f02fc18041e709695f9b03ffea5d7f206977a06b37c5a0f8b1a576b351233446bfaf6f8cc310bfcc1fa1138c310a3810d98f6cba62e95230e7966b59d3e383ab87a9f61760922b538e81004e6ab7efb02d811a7198af891db3eaa2d4e589643cf1d0f3c2b87c39d5d2cf163a59728b001d3e23485afe77843d2e3ab8554face8e7a8b3b68f3f87c164f58ad3da18c22073143de79f68e127a2eca9e51b60806502cd73d9aa9d728411edabc5d09e1160324358a0a5d7d307ba6b915c3c79942401f469c4cb0b0adcd25177c939768f110"
+           ],
+           "commitments":[
+             "cm1uc8hl5umr8u7dgxxsrhp8e7rkwj8ue5qcjsuunfkt8s5dfld3grqwjnyvh",
+             "cm1u0exutsg529akllpatxnmnsuzcjcyu5q7j9nfxe30d9dj5ntjgpsyvempu"
+           ],
+           "proof":"ozkp10wlufvmlyze6wk6zg8m5sghzl75zzuswa3yp4l5zs3k8ngsfhxqdkcg2x4l0f7eunqd2309hemc4u0lveqmgv38xemqsheu5xh8qvcxyuj4z5600k9dm6uxndcww40s3phecn4c3zs7hjakd7mlua23rqze7cpul8qjd2p3jf7g4yhy97ph5cmqp3vj8naa90zxpl678hentktuh6gc000kctmdl0k9xgmt39lstaf0kkew7aw0khvvyxfk8l46z8sqn79y26s834j4v9rsk2gdgw3pgy39gfl8jc7563wn2p76007qw8wzvsfahshktyeul2838qvhepfq7l3gg8kz97stekzy8unwvyausznnkpc88ms8nv9cyvxsm4ew5hg94e7xs5zgsfn047v8fl2jzs80jhf8g5c49u774rvuq7l2elcj7j0f2s58a9yqp6mlmwlm8emrsqqgcnmsq8",
+           "serial_numbers":[
+             "sn19my835fmg0yqte5pycgm9h3j7quvc2s6s8dmngvce0ew8xvvpvfqgqpsej",
+             "sn17w9vn0n4hf0a038e8jhm4qjdcq2r2wp63sdu98cjmwxn3xl4kcpqa0jcvz"
+           ],
+           "transition_id":"as15d8a5nrc86xn5cqmfd208wmn3xa9ul3y9l7w8eys4gj6637awvqskxa3ef",
+           "value_balance":-500000000000
+         }
+       ]
+     }
+   ],
+   "id":"1"
+}
+```

--- a/src/rpc/documentation/public_endpoints/getmemorypool.md
+++ b/src/rpc/documentation/public_endpoints/getmemorypool.md
@@ -14,13 +14,13 @@ None
 
 #### Transaction
 
-|      Parameter      |  Type  | Description |
-|:-------------------:|:------:|:-----------:|
-| `events`            | array  | The events emitted from the transaction |
-| `inner_circuit_id`  | string | The ID of the inner circuit used to execute each transition. |
-| `ledger_root`       | string | The ledger root used to prove inclusion of ledger-consumed records. |
-| `transaction_id`    | string | The ID of this transaction. |
-| `transitions`       | array  | The state transitions. |
+|      Parameter     |  Type  |                             Description                             |
+|:------------------:|:------:|:-------------------------------------------------------------------:|
+| `events`           | array  | The events emitted from the transaction                             |
+| `inner_circuit_id` | string | The ID of the inner circuit used to execute each transition.        |
+| `ledger_root`      | string | The ledger root used to prove inclusion of ledger-consumed records. |
+| `transaction_id`   | string | The ID of this transaction.                                         |
+| `transitions`      | array  | The state transitions.                                              |
 
 ### Example Request
 ```ignore

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -290,6 +290,10 @@ async fn handle_rpc<N: Network, E: Environment>(
             let result = rpc.get_ledger_proof(params.remove(0)).await.map_err(convert_crate_err);
             result_to_response(&req, result)
         }
+        "getmemorypool" => {
+            let result = rpc.get_memory_pool().await.map_err(convert_crate_err);
+            result_to_response(&req, result)
+        }
         "gettransaction" => {
             let result = rpc.get_transaction(params.remove(0)).await.map_err(convert_crate_err);
             result_to_response(&req, result)

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -422,7 +422,7 @@ fn result_to_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Client;
+    use crate::{helpers::State, ledger::Ledger, Client, Prover};
 
     use crate::helpers::Tasks;
     use snarkos_storage::{
@@ -442,7 +442,6 @@ mod tests {
         path::{Path, PathBuf},
         sync::atomic::AtomicBool,
     };
-    use tokio::sync::mpsc;
 
     fn temp_dir() -> std::path::PathBuf {
         tempfile::tempdir().expect("Failed to open temporary directory").into_path()
@@ -451,11 +450,6 @@ mod tests {
     /// Returns a dummy caller IP address.
     fn caller() -> SocketAddr {
         "0.0.0.0:3030".to_string().parse().unwrap()
-    }
-
-    /// Initializes a new instance of the `Peers` struct.
-    async fn peers<N: Network, E: Environment>() -> Arc<Peers<N, E>> {
-        Peers::new(&mut Tasks::new(), "0.0.0.0:4130".parse().unwrap(), None, &Status::new()).await
     }
 
     /// Initializes a new instance of the ledger state.
@@ -472,21 +466,57 @@ mod tests {
             username: "root".to_string(),
             password: "pass".to_string(),
         };
-        let ledger = Arc::new(new_ledger_state::<N, S, P>(path));
 
-        // Create a dummy mpsc channel for Prover requests. todo (@collinc97): only get requests will work until this is changed
-        let (prover_router, _prover_handler) = mpsc::channel(1024);
+        // Derive the storage paths.
+        let (ledger_path, prover_path) = match &path {
+            Some(p) => {
+                let path = p.as_ref().to_path_buf();
 
-        let memory_pool = Arc::new(RwLock::new(MemoryPool::new()));
+                let mut ledger_path = path.clone();
+                ledger_path.push("/snarkos-test-ledger");
+                let mut prover_path = path;
+                prover_path.push("/snarkos-test-prover");
 
-        RpcImpl::<N, E>::new(
-            credentials,
-            Status::new(),
-            peers::<N, E>().await,
-            ledger,
-            prover_router,
-            memory_pool,
+                (ledger_path, prover_path)
+            }
+            None => (temp_dir(), temp_dir()),
+        };
+
+        // Initialize the node.
+        let local_ip: SocketAddr = "0.0.0.0:8888".parse().expect("Failed to parse ip");
+
+        // Initialize the status indicator.
+        let status = Status::new();
+        status.update(State::Ready);
+
+        // Initialize the terminator bit.
+        let terminator = Arc::new(AtomicBool::new(false));
+        // Initialize the tasks handler.
+        let mut tasks = Tasks::new();
+
+        // Initialize a new instance for managing peers.
+        let peers = Peers::new(&mut tasks, local_ip, None, &status).await;
+        // Initialize a new instance for managing the ledger.
+        let ledger = Ledger::<N, E>::open::<S, _>(&mut tasks, &ledger_path, &status, &terminator, peers.router())
+            .await
+            .expect("Failed to initialize ledger");
+
+        // Initialize a new instance for managing the prover.
+        let prover = Prover::open::<S, _>(
+            &mut tasks,
+            &prover_path,
+            None,
+            local_ip,
+            &status,
+            &terminator,
+            peers.router(),
+            ledger.reader(),
+            ledger.router(),
         )
+        .await
+        .expect("Failed to initialize prover");
+
+        RpcImpl::<N, E>::new(credentials, status, peers, ledger.reader(), prover.router(), prover.memory_pool())
     }
 
     /// Deserializes a rpc response into the given type.
@@ -1211,8 +1241,43 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_memory_pool() {
+        let mut rng = ChaChaRng::seed_from_u64(123456789);
+
         // Initialize a new RPC.
         let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+
+        // Send a transaction to the node.
+
+        // Initialize a new account.
+        let account = Account::<Testnet2>::new(&mut rng);
+        let address = account.address();
+
+        // Initialize a new transaction.
+        let (transaction, _) =
+            Transaction::<Testnet2>::new_coinbase(address, AleoAmount(0), true, &mut rng).expect("Failed to create a coinbase transaction");
+
+        // Initialize a new request that calls the `sendtransaction` endpoint.
+        let request = Request::new(Body::from(format!(
+            "{{
+	\"jsonrpc\": \"2.0\",
+	\"id\": \"1\",
+	\"method\": \"sendtransaction\",
+	\"params\": [
+        \"{}\"
+    ]
+}}",
+            hex::encode(transaction.to_bytes_le().unwrap())
+        )));
+
+        // Send the request to the RPC.
+        let _response = handle_rpc(caller(), rpc.clone(), request)
+            .await
+            .expect("Test RPC failed to process request");
+
+        // Give the node some time to process the transaction.
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        // Fetch the transaction from the memory_pool.
 
         // Initialize a new request that calls the `getmemorypool` endpoint.
         let request = Request::new(Body::from(
@@ -1232,7 +1297,7 @@ mod tests {
         let actual: Vec<Transaction<Testnet2>> = process_response(response).await;
 
         // Check the transactions.
-        let expected = Vec::<Transaction<Testnet2>>::new();
+        let expected = vec![transaction];
         assert_eq!(*expected, actual);
     }
 }

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -469,16 +469,7 @@ mod tests {
 
         // Derive the storage paths.
         let (ledger_path, prover_path) = match &path {
-            Some(p) => {
-                let path = p.as_ref().to_path_buf();
-
-                let mut ledger_path = path.clone();
-                ledger_path.push("/snarkos-test-ledger");
-                let mut prover_path = path;
-                prover_path.push("/snarkos-test-prover");
-
-                (ledger_path, prover_path)
-            }
+            Some(p) => (p.as_ref().to_path_buf(), temp_dir()),
             None => (temp_dir(), temp_dir()),
         };
 

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -29,13 +29,14 @@ use crate::{
 };
 use snarkos_storage::Metadata;
 use snarkvm::{
-    dpc::{Block, BlockHeader, Network, Transaction, Transactions, Transition},
+    dpc::{Block, BlockHeader, MemoryPool, Network, Transaction, Transactions, Transition},
     utilities::FromBytes,
 };
 
 use jsonrpc_core::Value;
 use snarkvm::utilities::ToBytes;
 use std::{cmp::max, net::SocketAddr, ops::Deref, sync::Arc};
+use tokio::sync::RwLock;
 
 #[derive(Debug, Error)]
 pub enum RpcError {
@@ -184,6 +185,11 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         let record_commitment: N::Commitment = serde_json::from_value(record_commitment)?;
         let ledger_proof = self.ledger.get_ledger_inclusion_proof(record_commitment)?;
         Ok(hex::encode(ledger_proof.to_bytes_le().expect("Failed to serialize ledger proof")))
+    }
+
+    /// Returns transactions in the node's memory pool.
+    async fn get_memory_pool(&self) -> Result<Vec<Transaction<N>>, RpcError> {
+        Ok(vec![])
     }
 
     /// Returns a transaction with metadata given the transaction ID.

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -68,6 +68,7 @@ pub struct RpcInner<N: Network, E: Environment> {
     peers: Arc<Peers<N, E>>,
     ledger: LedgerReader<N>,
     prover_router: ProverRouter<N>,
+    memory_pool: Arc<RwLock<MemoryPool<N>>>,
     /// RPC credentials for accessing guarded endpoints
     #[allow(unused)]
     pub(crate) credentials: RpcCredentials,
@@ -93,12 +94,14 @@ impl<N: Network, E: Environment> RpcImpl<N, E> {
         peers: Arc<Peers<N, E>>,
         ledger: LedgerReader<N>,
         prover_router: ProverRouter<N>,
+        memory_pool: Arc<RwLock<MemoryPool<N>>>,
     ) -> Self {
         Self(Arc::new(RpcInner {
             status,
             peers,
             ledger,
             prover_router,
+            memory_pool,
             credentials,
         }))
     }
@@ -189,7 +192,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
 
     /// Returns transactions in the node's memory pool.
     async fn get_memory_pool(&self) -> Result<Vec<Transaction<N>>, RpcError> {
-        Ok(vec![])
+        Ok(self.memory_pool.read().await.transactions())
     }
 
     /// Returns a transaction with metadata given the transaction ID.

--- a/src/rpc/rpc_trait.rs
+++ b/src/rpc/rpc_trait.rs
@@ -17,7 +17,7 @@
 //! Definition of the public and private RPC endpoints.
 
 use crate::rpc::rpc_impl::RpcError;
-use snarkvm::dpc::{Block, BlockHeader, Network, Transactions, Transition};
+use snarkvm::dpc::{Block, BlockHeader, Network, Transaction, Transactions, Transition};
 
 use std::net::SocketAddr;
 
@@ -71,6 +71,9 @@ pub trait RpcFunctions<N: Network> {
 
     #[doc = include_str!("./documentation/public_endpoints/getledgerproof.md")]
     async fn get_ledger_proof(&self, record_commitment: serde_json::Value) -> Result<String, RpcError>;
+
+    #[doc = include_str!("./documentation/public_endpoints/getmemorypool.md")]
+    async fn get_memory_pool(&self) -> Result<Vec<Transaction<N>>, RpcError>;
 
     #[doc = include_str!("./documentation/public_endpoints/gettransaction.md")]
     async fn get_transaction(&self, transaction_id: serde_json::Value) -> Result<serde_json::Value, RpcError>;

--- a/src/rpc/rpc_trait.rs
+++ b/src/rpc/rpc_trait.rs
@@ -63,6 +63,9 @@ pub trait RpcFunctions<N: Network> {
     #[doc = include_str!("./documentation/public_endpoints/getblockheader.md")]
     async fn get_block_header(&self, block_height: u32) -> Result<BlockHeader<N>, RpcError>;
 
+    // #[doc = include_str!("./documentation/public_endpoints/getblocktemplate.md")]
+    async fn get_block_template(&self) -> Result<serde_json::Value, RpcError>;
+
     #[doc = include_str!("./documentation/public_endpoints/getblocktransactions.md")]
     async fn get_block_transactions(&self, block_height: u32) -> Result<Transactions<N>, RpcError>;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds 2 RPC endpoints. 
1. `getmemorypool` - fetches the node's memory pool transactions.
2. `getblocktemplate` - Fetches the node's memory pool transactions and relevant data required to mine the next block.

Additionally, the RPC testing framework now runs a real client that will process local/testing state changes.

## Test Plan

 A  `test_get_memory_pool` and a `test_get_block_template` test have been added to verify the endpoints are working as intended.
