### PR TITLE
Adds `latestcumulativeweight` RPC endpoint, adds `latest_cumulative_weight` to `getnodestate` RPC endpoint

### DIFF
--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -186,6 +186,10 @@ async fn handle_rpc<N: Network, E: Environment>(
             let result = rpc.latest_block_height().await.map_err(convert_crate_err);
             result_to_response(&req, result)
         }
+        "latestcumulativeweight" => {
+            let result = rpc.latest_cumulative_weight().await.map_err(convert_crate_err);
+            result_to_response(&req, result)
+        }
         "latestblockhash" => {
             let result = rpc.latest_block_hash().await.map_err(convert_crate_err);
             result_to_response(&req, result)

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -115,6 +115,11 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         Ok(self.ledger.latest_block_height())
     }
 
+    /// Returns the latest cumulative weight from the canonical chain.
+    async fn latest_cumulative_weight(&self) -> Result<u128, RpcError> {
+        Ok(self.ledger.latest_cumulative_weight())
+    }
+
     /// Returns the latest block hash from the canonical chain.
     async fn latest_block_hash(&self) -> Result<N::BlockHash, RpcError> {
         Ok(self.ledger.latest_block_hash())
@@ -217,6 +222,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
             "candidate_peers": candidate_peers,
             "connected_peers": connected_peers,
             "latest_block_height": self.ledger.latest_block_height(),
+            "latest_cumulative_weight": self.ledger.latest_cumulative_weight(),
             "number_of_candidate_peers": number_of_candidate_peers,
             "number_of_connected_peers": number_of_connected_peers,
             "number_of_connected_sync_nodes": number_of_connected_sync_nodes,

--- a/src/rpc/rpc_trait.rs
+++ b/src/rpc/rpc_trait.rs
@@ -30,6 +30,9 @@ pub trait RpcFunctions<N: Network> {
     #[doc = include_str!("./documentation/public_endpoints/latestblockheight.md")]
     async fn latest_block_height(&self) -> Result<u32, RpcError>;
 
+    // #[doc = include_str!("./documentation/public_endpoints/latestcumulativeweight.md")]
+    async fn latest_cumulative_weight(&self) -> Result<u128, RpcError>;
+
     #[doc = include_str!("./documentation/public_endpoints/latestblockhash.md")]
     async fn latest_block_hash(&self) -> Result<N::BlockHash, RpcError>;
 


### PR DESCRIPTION
## Motivation

- Adds `latestcumulativeweight` RPC endpoint
- Adds `latest_cumulative_weight` to `getnodestate` RPC endpoint
