### PR TITLE
Update serialization of `getnodestate`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,10 @@ version = "1"
 version = "0.27"
 
 [dependencies.serde]
-version = "1.0.130"
+version = "1"
 
 [dependencies.serde_json]
-version = "1.0.72"
+version = "1"
 features = [ "arbitrary_precision" ]
 
 [dependencies.structopt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,11 @@ version = "1"
 version = "0.27"
 
 [dependencies.serde]
-version = "1"
+version = "1.0.130"
 
 [dependencies.serde_json]
-version = "1"
+version = "1.0.72"
+features = [ "arbitrary_precision" ]
 
 [dependencies.structopt]
 version = "0.3"

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -1042,6 +1042,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_node_state() {
+        // Initialize a new RPC.
+        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+
+        // Declare the expected node state.
+        let expected = serde_json::json!({
+            "candidate_peers": Vec::<SocketAddr>::new(),
+            "connected_peers": Vec::<SocketAddr>::new(),
+            "latest_block_height": 0,
+            "latest_cumulative_weight": 0,
+            "number_of_candidate_peers": 0,
+            "number_of_connected_peers": 0,
+            "number_of_connected_sync_nodes": 0,
+            "software": format!("snarkOS {}", env!("CARGO_PKG_VERSION")),
+            "status": rpc.status.to_string(),
+            "type": Client::<Testnet2>::NODE_TYPE,
+            "version": Client::<Testnet2>::MESSAGE_VERSION,
+        });
+
+        // Initialize a new request that calls the `getnodestate` endpoint.
+        let request = Request::new(Body::from(
+            r#"{
+	"jsonrpc":"2.0",
+	"id": "1",
+	"method": "getnodestate"
+}"#,
+        ));
+
+        // Send the request to the RPC.
+        let response = handle_rpc(caller(), rpc, request)
+            .await
+            .expect("Test RPC failed to process request");
+
+        // Process the response into a ledger root.
+        let actual: serde_json::Value = process_response(response).await;
+
+        println!("get_node_state: {:?}", actual);
+
+        // Check the ledger root.
+        assert_eq!(expected, actual);
+    }
+
+    #[tokio::test]
     async fn test_get_transaction() {
         /// Additional metadata included with a transaction response
         #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -19,7 +19,10 @@
 use crate::{
     helpers::Status,
     rpc::{rpc_impl::RpcImpl, rpc_trait::RpcFunctions},
-    Environment, LedgerReader, Peers, ProverRouter,
+    Environment,
+    LedgerReader,
+    Peers,
+    ProverRouter,
 };
 use snarkvm::dpc::Network;
 
@@ -964,12 +967,14 @@ mod tests {
         let actual: <Testnet2 as Network>::RecordCiphertext = process_response(response).await;
 
         // Check the ciphertext.
-        assert!(Testnet2::genesis_block()
-            .transactions()
-            .first()
-            .unwrap()
-            .ciphertexts()
-            .any(|expected| *expected == actual));
+        assert!(
+            Testnet2::genesis_block()
+                .transactions()
+                .first()
+                .unwrap()
+                .ciphertexts()
+                .any(|expected| *expected == actual)
+        );
     }
 
     #[tokio::test]
@@ -1157,13 +1162,15 @@ mod tests {
         let actual: Transition<Testnet2> = process_response(response).await;
 
         // Check the transition.
-        assert!(Testnet2::genesis_block()
-            .transactions()
-            .first()
-            .unwrap()
-            .transitions()
-            .iter()
-            .any(|expected| *expected == actual));
+        assert!(
+            Testnet2::genesis_block()
+                .transactions()
+                .first()
+                .unwrap()
+                .transitions()
+                .iter()
+                .any(|expected| *expected == actual)
+        );
     }
 
     #[tokio::test]

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -19,10 +19,7 @@
 use crate::{
     helpers::Status,
     rpc::{rpc_impl::RpcImpl, rpc_trait::RpcFunctions},
-    Environment,
-    LedgerReader,
-    Peers,
-    ProverRouter,
+    Environment, LedgerReader, Peers, ProverRouter,
 };
 use snarkvm::dpc::Network;
 
@@ -35,7 +32,7 @@ use hyper::{
 use json_rpc_types as jrt;
 use jsonrpc_core::{Metadata, Params};
 use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 use tokio::sync::oneshot;
 
 /// Defines the authentication format for accessing private endpoints on the RPC server.
@@ -409,8 +406,7 @@ fn result_to_response<T: Serialize>(
 ) -> jrt::Response<serde_json::Value, String> {
     match result {
         Ok(res) => {
-            let candidate_string = serde_json::to_string(&res).unwrap_or_default();
-            let result = serde_json::Value::from_str(&candidate_string).unwrap_or_default();
+            let result = serde_json::to_value(&res).unwrap_or_default();
 
             jrt::Response::result(jrt::Version::V2, result, request.id.clone())
         }
@@ -968,14 +964,12 @@ mod tests {
         let actual: <Testnet2 as Network>::RecordCiphertext = process_response(response).await;
 
         // Check the ciphertext.
-        assert!(
-            Testnet2::genesis_block()
-                .transactions()
-                .first()
-                .unwrap()
-                .ciphertexts()
-                .any(|expected| *expected == actual)
-        );
+        assert!(Testnet2::genesis_block()
+            .transactions()
+            .first()
+            .unwrap()
+            .ciphertexts()
+            .any(|expected| *expected == actual));
     }
 
     #[tokio::test]
@@ -1163,15 +1157,13 @@ mod tests {
         let actual: Transition<Testnet2> = process_response(response).await;
 
         // Check the transition.
-        assert!(
-            Testnet2::genesis_block()
-                .transactions()
-                .first()
-                .unwrap()
-                .transitions()
-                .iter()
-                .any(|expected| *expected == actual)
-        );
+        assert!(Testnet2::genesis_block()
+            .transactions()
+            .first()
+            .unwrap()
+            .transitions()
+            .iter()
+            .any(|expected| *expected == actual));
     }
 
     #[tokio::test]

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -63,7 +63,7 @@ impl From<RpcError> for std::io::Error {
 
 #[doc(hidden)]
 pub struct RpcInner<N: Network, E: Environment> {
-    status: Status,
+    pub(crate) status: Status,
     peers: Arc<Peers<N, E>>,
     ledger: LedgerReader<N>,
     prover_router: ProverRouter<N>,
@@ -219,7 +219,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes().await;
 
         let latest_block_height = self.ledger.latest_block_height();
-        let latest_cumulative_weight = self.ledger.latest_cumulative_weight().to_string();
+        let latest_cumulative_weight = self.ledger.latest_cumulative_weight();
 
         Ok(serde_json::json!({
             "candidate_peers": candidate_peers,

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -52,10 +52,10 @@ version = "0.17"
 optional = true
 
 [dependencies.serde]
-version = "1"
+version = "1.0.130"
 
 [dependencies.serde_json]
-version = "1"
+version = "1.0.72"
 
 [dependencies.tracing]
 version = "0.1"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -52,10 +52,10 @@ version = "0.17"
 optional = true
 
 [dependencies.serde]
-version = "1.0.130"
+version = "1"
 
 [dependencies.serde_json]
-version = "1.0.72"
+version = "1"
 
 [dependencies.tracing]
 version = "0.1"


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the serialization of the `getnodestate` rpc output to reflect a u128 for `latest_cumulative_weight` (instead of using a String).

## Test Plan

A `getnodestate` RPC test has been added.

