### PR TITLE
Version bump to `11`, update ledger logic, improve peer requests, update ping message

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -47,7 +47,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The specified type of node.
     const NODE_TYPE: NodeType;
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    const MESSAGE_VERSION: u32 = 10;
+    const MESSAGE_VERSION: u32 = 11;
     /// If `true`, a mining node will craft public coinbase transactions.
     const COINBASE_IS_PUBLIC: bool = false;
 
@@ -86,7 +86,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The maximum size of a message that can be transmitted in the network.
     const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
     /// The maximum number of blocks that may be fetched in one request.
-    const MAXIMUM_BLOCK_REQUEST: u32 = 100;
+    const MAXIMUM_BLOCK_REQUEST: u32 = 250;
     /// The maximum number of blocks that a fork can be.
     const MAXIMUM_FORK_DEPTH: u32 = 4096;
     /// The maximum number of failures tolerated before disconnecting from a peer.

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -65,9 +65,9 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const HEARTBEAT_IN_SECS: u64 = 9;
     /// The maximum duration in seconds permitted for establishing a connection with a node,
     /// before dropping the connection; it should be no greater than the `HEARTBEAT_IN_SECS`.
-    const CONNECTION_TIMEOUT_IN_SECS: u64 = 1;
+    const CONNECTION_TIMEOUT_IN_MILLIS: u64 = 500;
     /// The duration in seconds to sleep in between ping requests with a connected peer.
-    const PING_SLEEP_IN_SECS: u64 = 65;
+    const PING_SLEEP_IN_SECS: u64 = 60;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
     const RADIO_SILENCE_IN_SECS: u64 = 210; // 3.5 minutes

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -47,7 +47,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The specified type of node.
     const NODE_TYPE: NodeType;
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    const MESSAGE_VERSION: u32 = 11;
+    const MESSAGE_VERSION: u32 = 10;
     /// If `true`, a mining node will craft public coinbase transactions.
     const COINBASE_IS_PUBLIC: bool = false;
 
@@ -70,7 +70,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const PING_SLEEP_IN_SECS: u64 = 65;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
-    const RADIO_SILENCE_IN_SECS: u64 = 180; // 3 minutes
+    const RADIO_SILENCE_IN_SECS: u64 = 210; // 3.5 minutes
     /// The duration in seconds after which to expire a failure from a peer.
     const FAILURE_EXPIRY_TIME_IN_SECS: u64 = 7200; // 2 hours
 

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -47,7 +47,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The specified type of node.
     const NODE_TYPE: NodeType;
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    const MESSAGE_VERSION: u32 = 10;
+    const MESSAGE_VERSION: u32 = 11;
     /// If `true`, a mining node will craft public coinbase transactions.
     const COINBASE_IS_PUBLIC: bool = false;
 

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -81,7 +81,7 @@ pub enum Message<N: Network, E: Environment> {
     BlockRequest(u32, u32),
     /// BlockResponse := (block)
     BlockResponse(Data<Block<N>>),
-    /// ChallengeRequest := (version, fork_depth, node_type, status, listener_port, nonce, block_height)
+    /// ChallengeRequest := (version, fork_depth, node_type, status, listener_port, nonce, latest_block_height)
     ChallengeRequest(u32, u32, NodeType, State, u16, u64, u32),
     /// ChallengeResponse := (block_header)
     ChallengeResponse(Data<BlockHeader<N>>),

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -81,8 +81,8 @@ pub enum Message<N: Network, E: Environment> {
     BlockRequest(u32, u32),
     /// BlockResponse := (block)
     BlockResponse(Data<Block<N>>),
-    /// ChallengeRequest := (version, fork_depth, node_type, status, listener_port, nonce, latest_block_height)
-    ChallengeRequest(u32, u32, NodeType, State, u16, u64, u32),
+    /// ChallengeRequest := (version, fork_depth, node_type, status, listener_port, nonce, cumulative_weight)
+    ChallengeRequest(u32, u32, NodeType, State, u16, u64, u128),
     /// ChallengeResponse := (block_header)
     ChallengeResponse(Data<BlockHeader<N>>),
     /// Disconnect := ()
@@ -149,9 +149,9 @@ impl<N: Network, E: Environment> Message<N, E> {
         match self {
             Self::BlockRequest(start_block_height, end_block_height) => Ok(to_bytes_le![start_block_height, end_block_height]?),
             Self::BlockResponse(block) => Ok(block.serialize_blocking()?),
-            Self::ChallengeRequest(version, fork_depth, node_type, status, listener_port, nonce, block_height) => Ok(bincode::serialize(
-                &(version, fork_depth, node_type, status, listener_port, nonce, block_height),
-            )?),
+            Self::ChallengeRequest(version, fork_depth, node_type, status, listener_port, nonce, cumulative_weight) => Ok(
+                bincode::serialize(&(version, fork_depth, node_type, status, listener_port, nonce, cumulative_weight))?,
+            ),
             Self::ChallengeResponse(block_header) => Ok(block_header.serialize_blocking()?),
             Self::Disconnect => Ok(vec![]),
             Self::PeerRequest => Ok(vec![]),
@@ -204,8 +204,8 @@ impl<N: Network, E: Environment> Message<N, E> {
             0 => Self::BlockRequest(bincode::deserialize(&data[0..4])?, bincode::deserialize(&data[4..8])?),
             1 => Self::BlockResponse(Data::Buffer(data.to_vec())),
             2 => {
-                let (version, fork_depth, node_type, status, listener_port, nonce, block_height) = bincode::deserialize(data)?;
-                Self::ChallengeRequest(version, fork_depth, node_type, status, listener_port, nonce, block_height)
+                let (version, fork_depth, node_type, status, listener_port, nonce, cumulative_weight) = bincode::deserialize(data)?;
+                Self::ChallengeRequest(version, fork_depth, node_type, status, listener_port, nonce, cumulative_weight)
             }
             3 => Self::ChallengeResponse(Data::Buffer(data.to_vec())),
             4 => match data.is_empty() {

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -1131,11 +1131,11 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     peer.seen_inbound_blocks.insert(block_hash, SystemTime::now());
 
                                     // Ensure the unconfirmed block is at least within 2 blocks of the latest block height,
-                                    // and no more that 3 blocks ahead of the latest block height.
+                                    // and no more that 2 blocks ahead of the latest block height.
                                     // If it is stale, skip the routing of this unconfirmed block to the ledger.
                                     let latest_block_height = ledger_reader.latest_block_height();
                                     let lower_bound = latest_block_height.saturating_sub(2);
-                                    let upper_bound = latest_block_height.saturating_add(3);
+                                    let upper_bound = latest_block_height.saturating_add(2);
                                     let is_within_range = block_height >= lower_bound && block_height <= upper_bound;
 
                                     // Ensure the node is not peering.

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -395,12 +395,13 @@ impl<N: Network, E: Environment> Peers<N, E> {
 
                 // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
                 // Select the peers randomly from the list of candidate peers.
+                let midpoint_number_of_peers = E::MINIMUM_NUMBER_OF_PEERS.saturating_add(E::MAXIMUM_NUMBER_OF_PEERS) / 2;
                 for peer_ip in self
                     .candidate_peers()
                     .await
                     .iter()
                     .copied()
-                    .choose_multiple(&mut OsRng::default(), E::MINIMUM_NUMBER_OF_PEERS)
+                    .choose_multiple(&mut OsRng::default(), midpoint_number_of_peers)
                 {
                     // Ensure this node is not connected to more than the permitted number of sync nodes.
                     if sync_nodes.contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -105,7 +105,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
         // Initialize the prover pool.
         let pool = ThreadPoolBuilder::new()
             .stack_size(8 * 1024 * 1024)
-            .num_threads(num_cpus::get().max(1))
+            .num_threads((num_cpus::get() / 8 * 5).max(1))
             .build()?;
 
         // Initialize the prover.

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -105,7 +105,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
         // Initialize the prover pool.
         let pool = ThreadPoolBuilder::new()
             .stack_size(8 * 1024 * 1024)
-            .num_threads((num_cpus::get() / 8 * 5).max(1))
+            .num_threads((num_cpus::get() / 8 * 7).max(1))
             .build()?;
 
         // Initialize the prover.
@@ -149,8 +149,8 @@ impl<N: Network, E: Environment> Prover<N, E> {
                     // Notify the outer function that the task is ready.
                     let _ = router.send(());
                     loop {
-                        // If `terminator` is `false` and the status is not `Peering`, mine the next block.
-                        if !prover.terminator.load(Ordering::SeqCst) && !prover.status.is_peering() {
+                        // If `terminator` is `false` and the status is not `Peering` or `Mining` already, mine the next block.
+                        if !prover.terminator.load(Ordering::SeqCst) && !prover.status.is_peering() && !prover.status.is_mining() {
                             // Set the status to `Mining`.
                             prover.status.update(State::Mining);
 

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -149,8 +149,8 @@ impl<N: Network, E: Environment> Prover<N, E> {
                     // Notify the outer function that the task is ready.
                     let _ = router.send(());
                     loop {
-                        // If `terminator` is `false` and the status is `Ready`, mine the next block.
-                        if !prover.terminator.load(Ordering::SeqCst) && prover.status.is_ready() {
+                        // If `terminator` is `false` and the status is not `Peering`, mine the next block.
+                        if !prover.terminator.load(Ordering::SeqCst) && !prover.status.is_peering() {
                             // Set the status to `Mining`.
                             prover.status.update(State::Mining);
 

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -185,7 +185,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
 
                                 match result {
                                     Ok(Ok((block, coinbase_record))) => {
-                                        debug!("Miner has found an unconfirmed candidate for block {}", block.height());
+                                        debug!("Miner has found unconfirmed block {} ({})", block.height(), block.hash());
                                         // Store the coinbase record.
                                         if let Err(error) = state.add_coinbase_record(block.height(), coinbase_record) {
                                             warn!("[Miner] Failed to store coinbase record - {}", error);

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -340,7 +340,7 @@ impl<N: Network, E: Environment> Server<N, E> {
                                 // Ensure the record owner matches.
                                 if record.owner() == miner {
                                     // Add the block to the appropriate list.
-                                    match block_height + 1024 < latest_block_height {
+                                    match block_height + 2048 < latest_block_height {
                                         true => confirmed.push((block_height, record)),
                                         false => pending.push((block_height, record)),
                                     }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -186,14 +186,18 @@ impl<N: Network, E: Environment> Server<N, E> {
         self.status.update(State::ShuttingDown);
 
         // Shut down the ledger.
-        let ledger_lock = self.ledger.shut_down().await;
-        trace!("Ledger has shut down, proceeding to lock...");
+        trace!("Proceeding to shut down the ledger...");
+        let (canon_lock, block_requests_lock) = self.ledger.shut_down().await;
 
-        // Acquire the lock for ledger.
-        let _ledger_lock = ledger_lock.lock().await;
+        // Acquire the locks for ledger.
+        trace!("Proceeding to lock the ledger...");
+        let _canon_lock = canon_lock.lock().await;
+        let _block_requests_lock = block_requests_lock.lock().await;
+        trace!("Ledger has shut down, proceeding to flush tasks...");
 
         // Flush the tasks.
         self.tasks.flush();
+        trace!("Node has shut down.");
     }
 
     ///

--- a/src/node.rs
+++ b/src/node.rs
@@ -432,7 +432,7 @@ impl MinerStats {
                 // Ensure the record owner matches.
                 if record.owner() == miner {
                     // Add the block to the appropriate list.
-                    match block_height + 1024 < latest_block_height {
+                    match block_height + 2048 < latest_block_height {
                         true => confirmed.push((block_height, record)),
                         false => pending.push((block_height, record)),
                     }

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -42,7 +42,7 @@ use std::{
 const TWO_HOURS_UNIX: i64 = 7200;
 
 /// The maximum number of linear block locators.
-pub const MAXIMUM_LINEAR_BLOCK_LOCATORS: u32 = 128;
+pub const MAXIMUM_LINEAR_BLOCK_LOCATORS: u32 = 64;
 /// The maximum number of quadratic block locators.
 pub const MAXIMUM_QUADRATIC_BLOCK_LOCATORS: u32 = 32;
 /// The total maximum number of block locators.

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -54,6 +54,7 @@ const PING_INTERVAL_SECS: u64 = 5;
 const PEER_INTERVAL_SECS: u64 = 3;
 const DESIRED_CONNECTIONS: usize = <Client<Testnet2>>::MINIMUM_NUMBER_OF_PEERS * 3;
 const MESSAGE_VERSION: u32 = <Client<Testnet2>>::MESSAGE_VERSION;
+const MAXIMUM_FORK_DEPTH: u32 = <Client<Testnet2>>::MAXIMUM_FORK_DEPTH;
 
 pub const MAXIMUM_NUMBER_OF_PEERS: usize = <Client<Testnet2>>::MAXIMUM_NUMBER_OF_PEERS;
 
@@ -141,6 +142,7 @@ impl TestNode {
             let genesis = Testnet2::genesis_block();
             let ping_msg = ClientMessage::Ping(
                 MESSAGE_VERSION,
+                MAXIMUM_FORK_DEPTH,
                 node.node_type(),
                 node.state(),
                 genesis.hash(),
@@ -192,7 +194,7 @@ impl Handshake for TestNode {
         let genesis_block_header = Testnet2::genesis_block().header();
 
         // Send a challenge request to the peer.
-        let own_request = ClientMessage::ChallengeRequest(MESSAGE_VERSION, own_ip.port(), self.state.local_nonce, 0);
+        let own_request = ClientMessage::ChallengeRequest(MESSAGE_VERSION, MAXIMUM_FORK_DEPTH, own_ip.port(), self.state.local_nonce, 0);
         trace!(parent: self.node().span(), "sending a challenge request to {}", peer_ip);
         let msg = own_request.serialize().unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
@@ -209,7 +211,9 @@ impl Handshake for TestNode {
 
         // Register peer's nonce.
         let (peer_listening_addr, peer_nonce) =
-            if let Ok(Message::ChallengeRequest(peer_version, peer_listening_port, peer_nonce, _block_height)) = peer_request {
+            if let Ok(Message::ChallengeRequest(peer_version, _peer_fork_depth, peer_listening_port, peer_nonce, _block_height)) =
+                peer_request
+            {
                 if peer_version < MESSAGE_VERSION {
                     warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", peer_ip, peer_version);
                     return Err(io::ErrorKind::InvalidData.into());
@@ -306,7 +310,7 @@ impl Reading for TestNode {
             ClientMessage::Disconnect => {}
             ClientMessage::PeerRequest => self.process_peer_request(source).await?,
             ClientMessage::PeerResponse(peer_ips) => self.process_peer_response(source, peer_ips).await?,
-            ClientMessage::Ping(version, _peer_type, _peer_state, _block_hash, block_header) => {
+            ClientMessage::Ping(version, _fork_depth, _peer_type, _peer_state, _block_hash, block_header) => {
                 // Deserialise the block header.
                 let block_header = block_header.deserialize().await.unwrap();
                 self.process_ping(source, version, block_header.height()).await?

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -194,7 +194,15 @@ impl Handshake for TestNode {
         let genesis_block_header = Testnet2::genesis_block().header();
 
         // Send a challenge request to the peer.
-        let own_request = ClientMessage::ChallengeRequest(MESSAGE_VERSION, MAXIMUM_FORK_DEPTH, own_ip.port(), self.state.local_nonce, 0);
+        let own_request = ClientMessage::ChallengeRequest(
+            MESSAGE_VERSION,
+            MAXIMUM_FORK_DEPTH,
+            NodeType::Client,
+            State::Ready,
+            own_ip.port(),
+            self.state.local_nonce,
+            0,
+        );
         trace!(parent: self.node().span(), "sending a challenge request to {}", peer_ip);
         let msg = own_request.serialize().unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
@@ -210,31 +218,37 @@ impl Handshake for TestNode {
         let peer_request = ClientMessage::deserialize(&buf[..len]);
 
         // Register peer's nonce.
-        let (peer_listening_addr, peer_nonce) =
-            if let Ok(Message::ChallengeRequest(peer_version, _peer_fork_depth, peer_listening_port, peer_nonce, _block_height)) =
-                peer_request
-            {
-                if peer_version < MESSAGE_VERSION {
-                    warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", peer_ip, peer_version);
-                    return Err(io::ErrorKind::InvalidData.into());
-                }
-
-                let peer_listening_ip = SocketAddr::from((peer_ip.ip(), peer_listening_port));
-
-                if locked_peers
-                    .iter()
-                    .any(|peer| peer.nonce == peer_nonce || peer.listening_addr == peer_listening_ip)
-                {
-                    return Err(io::ErrorKind::AlreadyExists.into());
-                }
-
-                trace!(parent: self.node().span(), "received a challenge request from {}", peer_ip);
-
-                (peer_listening_ip, peer_nonce)
-            } else {
-                error!(parent: self.node().span(), "invalid challenge request from {}", peer_ip);
+        let (peer_listening_addr, peer_nonce) = if let Ok(Message::ChallengeRequest(
+            peer_version,
+            _peer_fork_depth,
+            _peer_node_type,
+            _peer_status,
+            peer_listening_port,
+            peer_nonce,
+            _block_height,
+        )) = peer_request
+        {
+            if peer_version < MESSAGE_VERSION {
+                warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", peer_ip, peer_version);
                 return Err(io::ErrorKind::InvalidData.into());
-            };
+            }
+
+            let peer_listening_ip = SocketAddr::from((peer_ip.ip(), peer_listening_port));
+
+            if locked_peers
+                .iter()
+                .any(|peer| peer.nonce == peer_nonce || peer.listening_addr == peer_listening_ip)
+            {
+                return Err(io::ErrorKind::AlreadyExists.into());
+            }
+
+            trace!(parent: self.node().span(), "received a challenge request from {}", peer_ip);
+
+            (peer_listening_ip, peer_nonce)
+        } else {
+            error!(parent: self.node().span(), "invalid challenge request from {}", peer_ip);
+            return Err(io::ErrorKind::InvalidData.into());
+        };
 
         // Respond with own challenge request.
         let own_response = ClientMessage::ChallengeResponse(Data::Object(genesis_block_header.clone()));

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -225,7 +225,7 @@ impl Handshake for TestNode {
             _peer_status,
             peer_listening_port,
             peer_nonce,
-            _block_height,
+            _cumulative_weight,
         )) = peer_request
         {
             if peer_version < MESSAGE_VERSION {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

- Version bump to `11`
- Updates `Ledger::add_block` to enforce fork-related block requests
- Updates the number of peer connection attempts from the minimum number of peers to the midpoint number of peers
- Updates `Ping` message to include the maximum fork depth, non-compliant peers will be dropped
- Updates the maximum block request to `250` (note this may be dialed back depending on performance)
- Reduces the number of linear block locators from `128` to `64`