### PR TITLE
Add `latest_block_hash` to `getnodestate` RPC endpoint

### DIFF
--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -1124,6 +1124,7 @@ mod tests {
         let expected = serde_json::json!({
             "candidate_peers": Vec::<SocketAddr>::new(),
             "connected_peers": Vec::<SocketAddr>::new(),
+            "latest_block_hash": Testnet2::genesis_block().hash(),
             "latest_block_height": 0,
             "latest_cumulative_weight": 0,
             "number_of_candidate_peers": 0,

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -291,12 +291,14 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         let number_of_connected_peers = connected_peers.len();
         let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes().await;
 
+        let latest_block_hash = self.ledger.latest_block_hash();
         let latest_block_height = self.ledger.latest_block_height();
         let latest_cumulative_weight = self.ledger.latest_cumulative_weight();
 
         Ok(serde_json::json!({
             "candidate_peers": candidate_peers,
             "connected_peers": connected_peers,
+            "latest_block_hash": latest_block_hash,
             "latest_block_height": latest_block_height,
             "latest_cumulative_weight": latest_cumulative_weight,
             "number_of_candidate_peers": number_of_candidate_peers,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds an additional `latest_block_hash` field to the `getnodestate` RPC response.

## Test Plan

The `test_get_node_state` has been updated to reflect the above change
