### PR TITLE
feat: deferred de/serialisation for transactions

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -98,7 +98,7 @@ pub enum Message<N: Network, E: Environment> {
     /// UnconfirmedBlock := (block_height, block_hash, block)
     UnconfirmedBlock(u32, N::BlockHash, Data<Block<N>>),
     /// UnconfirmedTransaction := (transaction)
-    UnconfirmedTransaction(Transaction<N>),
+    UnconfirmedTransaction(Data<Transaction<N>>),
     /// Unused
     #[allow(unused)]
     Unused(PhantomData<E>),
@@ -177,7 +177,7 @@ impl<N: Network, E: Environment> Message<N, E> {
                 block.serialize_blocking()?,
             ]
             .concat()),
-            Self::UnconfirmedTransaction(transaction) => Ok(bincode::serialize(transaction)?),
+            Self::UnconfirmedTransaction(transaction) => Ok(transaction.serialize_blocking()?),
             Self::Unused(_) => Ok(vec![]),
         }
     }
@@ -238,7 +238,7 @@ impl<N: Network, E: Environment> Message<N, E> {
                 bincode::deserialize(&data[4..36])?,
                 Data::Buffer(data[36..].to_vec()),
             ),
-            10 => Self::UnconfirmedTransaction(bincode::deserialize(data)?),
+            10 => Self::UnconfirmedTransaction(Data::Buffer(data.to_vec())),
             _ => return Err(anyhow!("Invalid message ID {}", id)),
         };
 

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     helpers::{State, Status, Tasks},
+    Data,
     Environment,
     LedgerReader,
     LedgerRequest,
@@ -263,7 +264,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
             match self.memory_pool.write().await.add_transaction(&transaction) {
                 Ok(()) => {
                     // Upon success, propagate the unconfirmed transaction to the connected peers.
-                    let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedTransaction(transaction));
+                    let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedTransaction(Data::Object(transaction)));
                     if let Err(error) = self.peers_router.send(request).await {
                         warn!("[UnconfirmedTransaction] {}", error);
                     }


### PR DESCRIPTION
Follow up to #1356, introduces the deferred de/serialisation of unconfirmed transactions. 
