### PR TITLE
Testnet2 run* scripts - no restart on push to non-testnet2 branch

### DIFF
--- a/run-client.sh
+++ b/run-client.sh
@@ -22,7 +22,7 @@ while :
 do
   echo "Checking for updates..."
   git stash
-  STATUS=$(git pull)
+  STATUS=$(git pull origin testnet2)
 
   echo "Running the node..."
   

--- a/run-miner.sh
+++ b/run-miner.sh
@@ -30,7 +30,7 @@ while :
 do
   echo "Checking for updates..."
   git stash
-  STATUS=$(git pull)
+  STATUS=$(git pull origin testnet2)
 
   echo "Running the node..."
 


### PR DESCRIPTION
## Motivation
For now scripts `run-miner.sh` and `run-client.sh` restarts on change in any branch in repo. This shouldn't happen, because this scripts runs only testnet2 codebase.

## Test Plan
I've checked that status response doesn't change 
```
test@test ~/snarkOS # STATUS=$(git pull origin testnet2)
From github.com:AleoHQ/snarkOS
 * branch              testnet2   -> FETCH_HEAD
test@test ~/snarkOS # echo $STATUS
Already up to date.
```

## Related PRs
(Link your related PRs here)
