### PR TITLE
Ensure that storage map operations are not interrupted by a shutdown

### DIFF
--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -221,7 +221,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.ledger_router.clone()
     }
 
-    pub(super) async fn shut_down(&self) -> (Arc<Mutex<()>>, Arc<Mutex<()>>) {
+    pub(super) async fn shut_down(&self) -> (Arc<Mutex<()>>, Arc<Mutex<()>>, Arc<parking_lot::RwLock<()>>) {
         debug!("Ledger is shutting down...");
 
         // Set the terminator bit to `true` to ensure it stops mining.
@@ -242,9 +242,10 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Return the lock for the canon chain and block requests.
         let canon_lock = self.canon_lock.clone();
         let block_requests_lock = self.block_requests_lock.clone();
+        let storage_map_lock = self.canon.shut_down();
         trace!("[ShuttingDown] Block requests lock has been cloned");
 
-        (canon_lock, block_requests_lock)
+        (canon_lock, block_requests_lock, storage_map_lock)
     }
 
     ///

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -187,12 +187,13 @@ impl<N: Network, E: Environment> Server<N, E> {
 
         // Shut down the ledger.
         trace!("Proceeding to shut down the ledger...");
-        let (canon_lock, block_requests_lock) = self.ledger.shut_down().await;
+        let (canon_lock, block_requests_lock, storage_map_lock) = self.ledger.shut_down().await;
 
         // Acquire the locks for ledger.
         trace!("Proceeding to lock the ledger...");
         let _canon_lock = canon_lock.lock().await;
         let _block_requests_lock = block_requests_lock.lock().await;
+        let _storage_map_lock = storage_map_lock.write();
         trace!("Ledger has shut down, proceeding to flush tasks...");
 
         // Flush the tasks.


### PR DESCRIPTION
This PR is a quick potential fix for https://github.com/AleoHQ/snarkOS/issues/1375. It ensures that some non-atomic storage operations can't be interrupted when the node is shutting down.

The proper solution - which will be a larger undertaking - is recorded as a `FIXME`.