### PR TITLE
Ignore duplicate blocks, increase desired peer counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui",
+ "twox-hash",
 ]
 
 [[package]]
@@ -2153,6 +2154,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"
@@ -2471,6 +2478,17 @@ dependencies = [
  "termion",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,9 @@ version = "0.1"
 version = "0.3"
 features = ["env-filter", "parking_lot"]
 
+[dependencies.twox-hash]
+version = "1"
+
 [dev-dependencies.rand_chacha]
 version = "0.3"
 

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -140,8 +140,8 @@ impl<N: Network> Environment for ClientTrial<N> {
         "159.223.124.150:4132", "137.184.192.155:4132", "147.182.213.228:4132", "137.184.202.162:4132", "159.223.118.35:4132",
         "161.35.106.91:4132", "157.245.133.62:4132", "143.198.166.150:4132",
     ];
-    const MINIMUM_NUMBER_OF_PEERS: usize = 11;
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 31;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 41;
+    const MAXIMUM_NUMBER_OF_PEERS: usize = 71;
 }
 
 #[derive(Clone, Debug, Default)]
@@ -156,7 +156,7 @@ impl<N: Network> Environment for MinerTrial<N> {
         "159.223.124.150:4132", "137.184.192.155:4132", "147.182.213.228:4132", "137.184.202.162:4132", "159.223.118.35:4132",
         "161.35.106.91:4132", "157.245.133.62:4132", "143.198.166.150:4132",
     ];
-    const MINIMUM_NUMBER_OF_PEERS: usize = 11;
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 21;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 21;
+    const MAXIMUM_NUMBER_OF_PEERS: usize = 31;
     const COINBASE_IS_PUBLIC: bool = true;
 }

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -602,29 +602,23 @@ impl<N: Network, E: Environment> Peers<N, E> {
 
                         true
                     }
-                    Message::UnconfirmedBlock(_, _, ref mut data) => {
-                        let block = if let Data::Object(block) = data {
-                            block
-                        } else {
-                            panic!("Logic error: the block shouldn't have been serialized yet.");
-                        };
-
+                    Message::UnconfirmedBlock(block_height, block_hash, ref mut data) => {
                         // Lock seen_outbound_blocks for further processing.
                         let mut seen_outbound_blocks = self.seen_outbound_blocks.write().await;
 
                         // Retrieve the last seen timestamp of this block for this peer.
                         let seen_blocks = seen_outbound_blocks.entry(peer).or_insert_with(Default::default);
-                        let last_seen = seen_blocks.entry(block.hash()).or_insert(SystemTime::UNIX_EPOCH);
+                        let last_seen = seen_blocks.entry(block_hash).or_insert(SystemTime::UNIX_EPOCH);
                         let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
 
                         // Update the timestamp for the peer and sent block.
-                        seen_blocks.insert(block.hash(), SystemTime::now());
+                        seen_blocks.insert(block_hash, SystemTime::now());
                         // Report the unconfirmed block height.
                         if is_ready_to_send {
-                            trace!("Preparing to send 'UnconfirmedBlock {}' to {}", block.height(), peer);
+                            trace!("Preparing to send 'UnconfirmedBlock {}' to {}", block_height, peer);
                         }
 
-                        // Perform non-blocking serialization of the block.
+                        // Perform non-blocking serialization of the block (if it hasn't been serialized yet).
                         let serialized_block = Data::serialize(data.clone()).await.expect("Block serialization is bugged");
                         let _ = std::mem::replace(data, Data::Buffer(serialized_block));
 
@@ -671,7 +665,13 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Sends the given message to every connected peer, excluding the sender.
     ///
-    async fn propagate(&self, sender: SocketAddr, message: Message<N, E>) {
+    async fn propagate(&self, sender: SocketAddr, mut message: Message<N, E>) {
+        // Perform ahead-of-time, non-blocking serialization just once for applicable objects.
+        if let Message::UnconfirmedBlock(_, _, ref mut data) = message {
+            let serialized_block = Data::serialize(data.clone()).await.expect("Block serialization is bugged");
+            let _ = std::mem::replace(data, Data::Buffer(serialized_block));
+        }
+
         // Iterate through all peers that are not the sender, sync node, or beacon node.
         for peer in self
             .connected_peers()


### PR DESCRIPTION
This PR aims to allow the nodes to handle more connections by ensuring that any duplicate inbound blocks are quickly identified and discarded.

The default numbers for client peers is greatly increased, while the number for miners is increased to a smaller extent.