### PR TITLE
Stricter task accounting

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -83,7 +83,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         let terminator = Arc::new(AtomicBool::new(false));
 
         // Initialize a new instance for managing peers.
-        let peers = Peers::new(&mut tasks, local_ip, None, &status).await;
+        let peers = Peers::new(tasks.clone(), local_ip, None, &status).await;
         // Initialize a new instance for managing the ledger.
         let ledger = Ledger::<N, E>::open::<RocksDB, _>(&mut tasks, &ledger_storage_path, &status, &terminator, peers.router()).await?;
         // Initialize a new instance for managing the prover.

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -492,7 +492,7 @@ mod tests {
         let mut tasks = Tasks::new();
 
         // Initialize a new instance for managing peers.
-        let peers = Peers::new(&mut tasks, local_ip, None, &status).await;
+        let peers = Peers::new(tasks.clone(), local_ip, None, &status).await;
         // Initialize a new instance for managing the ledger.
         let ledger = Ledger::<N, E>::open::<S, _>(&mut tasks, &ledger_path, &status, &terminator, peers.router())
             .await


### PR DESCRIPTION
This PR extends `Peers` with the `Tasks` object, so that all pending connection requests and other peer-related tasks can be aborted upon shutdown.

This should improve the situation with issues like https://github.com/AleoHQ/snarkOS/issues/1380 by making the shutdown process more predictable.