### PR TITLE
Don't disconnect from sync nodes too soon

### DIFF
--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -332,12 +332,15 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 }
             }
             PeersRequest::Heartbeat(ledger_reader, ledger_router, prover_router) => {
+                // Obtain the number of connected peers.
+                let number_of_connected_peers = self.number_of_connected_peers().await;
+
                 // Ensure the number of connected peers is below the maximum threshold.
-                if self.number_of_connected_peers().await > E::MAXIMUM_NUMBER_OF_PEERS {
+                if number_of_connected_peers > E::MAXIMUM_NUMBER_OF_PEERS {
                     debug!("Exceeded maximum number of connected peers");
 
                     // Determine the peers to disconnect from.
-                    let num_excess_peers = self.number_of_connected_peers().await.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
+                    let num_excess_peers = number_of_connected_peers.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
                     let peer_ips_to_disconnect = self
                         .connected_peers
                         .read()
@@ -365,7 +368,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 let connected_sync_nodes = self.connected_sync_nodes().await;
                 let number_of_connected_sync_nodes = connected_sync_nodes.len();
                 let num_excess_sync_nodes = number_of_connected_sync_nodes.saturating_sub(1);
-                if num_excess_sync_nodes > 0 {
+                if number_of_connected_peers >= E::MINIMUM_NUMBER_OF_PEERS && num_excess_sync_nodes > 0 {
                     // Proceed to send disconnect requests to these peers.
                     for peer_ip in connected_sync_nodes
                         .iter()
@@ -380,7 +383,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 }
 
                 // Skip if the number of connected peers is above the minimum threshold.
-                match self.number_of_connected_peers().await < E::MINIMUM_NUMBER_OF_PEERS {
+                match number_of_connected_peers < E::MINIMUM_NUMBER_OF_PEERS {
                     true => {
                         trace!("Sending request for more peer connections");
                         // Request more peers if the number of connected peers is below the threshold.


### PR DESCRIPTION
I noticed this while starting a node with high desired peer counts; it would start disconnecting from peers stating it's over the limit, while it was far from it. It appears that it was the condition checking if too many sync nodes are connected - I relaxed it so that it only goes into force when the node has at least the minimum number of peers.

In addition, since it's highly unlikely that this value will change in that context, the number of currently connected peers is now obtained just once, at the beginning, for improved performance

This PR has the potential to improve issues like https://github.com/AleoHQ/snarkOS/issues/1358.