### PR TITLE
Revert "Testnet2 run* scripts - no restart on push to non-testnet2 branch"

### DIFF
--- a/run-client.sh
+++ b/run-client.sh
@@ -22,7 +22,7 @@ while :
 do
   echo "Checking for updates..."
   git stash
-  STATUS=$(git pull origin testnet2)
+  STATUS=$(git pull)
 
   echo "Running the node..."
   

--- a/run-miner.sh
+++ b/run-miner.sh
@@ -30,7 +30,7 @@ while :
 do
   echo "Checking for updates..."
   git stash
-  STATUS=$(git pull origin testnet2)
+  STATUS=$(git pull)
 
   echo "Running the node..."
 


### PR DESCRIPTION
Reverts AleoHQ/snarkOS#1392

By adding `origin testnet2`, this change does not ensure the pulled changes are reflected on the current branch, if the current branch is no longer on testnet2. 