### PR TITLE
Fast unconfirmed block cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui",
+ "twox-hash",
 ]
 
 [[package]]
@@ -2153,6 +2154,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"
@@ -2471,6 +2478,17 @@ dependencies = [
  "termion",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,9 @@ version = "0.1"
 version = "0.3"
 features = ["env-filter", "parking_lot"]
 
+[dependencies.twox-hash]
+version = "1"
+
 [dev-dependencies.rand_chacha]
 version = "0.3"
 

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -29,10 +29,13 @@ use crate::{
 use snarkvm::dpc::prelude::*;
 
 use anyhow::{anyhow, Result};
+use circular_queue::CircularQueue;
 use futures::SinkExt;
+use once_cell::sync::Lazy;
 use rand::{prelude::IteratorRandom, rngs::OsRng, thread_rng, Rng};
 use std::{
     collections::{HashMap, HashSet},
+    hash::{BuildHasher, Hash, Hasher},
     net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant, SystemTime},
@@ -46,6 +49,7 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
+use twox_hash::RandomXxHashBuilder64;
 
 /// Shorthand for the parent half of the `Peer` outbound message channel.
 pub(crate) type OutboundRouter<N, E> = mpsc::Sender<Message<N, E>>;
@@ -60,6 +64,9 @@ type PeersHandler<N, E> = mpsc::Receiver<PeersRequest<N, E>>;
 
 /// Shorthand for the parent half of the connection result channel.
 type ConnectionResult = oneshot::Sender<Result<()>>;
+
+/// A cache containing fast hashes of recent blocks.
+static BLOCK_CACHE: Lazy<RwLock<CircularQueue<u64>>> = Lazy::new(|| RwLock::new(CircularQueue::with_capacity(512)));
 
 ///
 /// An enum of requests that the `Peers` struct processes.
@@ -1165,6 +1172,19 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                             warn!("[PeerRestricted] {}", error);
                                         }
                                         break;
+                                    }
+
+                                    // Procure a fast, short hash of the block hash, and check if it's present in the cache.
+                                    let fast_hash = {
+                                        let mut hasher = RandomXxHashBuilder64::default().build_hasher();
+                                        block_hash.hash(&mut hasher);
+                                        hasher.finish()
+                                    };
+                                    if BLOCK_CACHE.read().await.iter().any(|&e| e == fast_hash) {
+                                        trace!("Skipping 'UnconfirmedBlock {}' from {}", block_height, peer_ip);
+                                        continue;
+                                    } else {
+                                        BLOCK_CACHE.write().await.push(fast_hash);
                                     }
 
                                     // Retrieve the last seen timestamp of the received block.


### PR DESCRIPTION
Split out from #1394; marking as a draft in order to address https://github.com/AleoHQ/snarkOS/pull/1394#discussion_r766332778 first.

This PR introduces a fast cache of recently seen unconfirmed blocks, so duplicates can be discarded as quickly as possible.