### PR TITLE
Relax the block spam safeguard

### DIFF
--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -1172,7 +1172,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                 Message::UnconfirmedBlock(block_height, block_hash, block) => {
                                     // Drop the peer, if they have sent more than 5 unconfirmed blocks in the last 5 seconds.
                                     let frequency = peer.seen_inbound_blocks.values().filter(|t| t.elapsed().unwrap().as_secs() <= 5).count();
-                                    if frequency >= 5 {
+                                    if frequency >= 10 {
                                         warn!("Dropping {} for spamming unconfirmed blocks (frequency = {})", peer_ip, frequency);
                                         // Send a `PeerRestricted` message.
                                         if let Err(error) = peers_router.send(PeersRequest::PeerRestricted(peer_ip)).await {


### PR DESCRIPTION
This is a conservative change increasing the number of unconfirmed blocks received from a single peer considered to be spammy from `5` to `10`.

Cc https://github.com/AleoHQ/snarkOS/issues/1403; it might need to be relaxed further, especially if we increase peer counts.