### PR TITLE
Enable more blocking threads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
         .enable_all()
         .thread_stack_size(8 * 1024 * 1024)
         .worker_threads((num_cpus::get() / 8 * 2).max(1))
-        .max_blocking_threads((num_cpus::get() / 8 * 2).max(1))
+        .max_blocking_threads(num_cpus::get())
         .build()?;
 
     // Initialize the parallelization parameters.


### PR DESCRIPTION
Most of the work that's being done in the blocking threads is offloaded to `rayon` threadpools, so increasing their number will lead to greater average CPU utilization, with `rayon` being able to utilize its threadpools more aggressively.

The default value is `512`, so setting it to the number of available cores is still pretty conservative.