### PR TITLE
Tweak peer disconnect logic

### DIFF
--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -369,8 +369,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     {
                         info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
                         self.send(peer_ip, Message::Disconnect).await;
-                        // Add an entry for this `Peer` in the restricted peers.
-                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
                     }
                 }
 

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -352,8 +352,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     for peer_ip in peer_ips_to_disconnect {
                         info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
                         self.send(peer_ip, Message::Disconnect).await;
-                        // Add an entry for this `Peer` in the restricted peers.
-                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
                     }
                 }
 


### PR DESCRIPTION
When the node is above its max peers limit, it disconnects from randomly selected addresses and adds them to the restricted peers list. There is no reason to restrict these peers as they haven't misbehaved in any way. 

