### PR TITLE
Simplify storage map iterators, pave way for perf improvements

### DIFF
--- a/storage/src/storage/rocksdb/iterator.rs
+++ b/storage/src/storage/rocksdb/iterator.rs
@@ -18,16 +18,16 @@ use super::*;
 
 /// An iterator over all key-value pairs in a data map.
 pub struct Iter<'a, K, V> {
-    db_iter: rocksdb::DBRawIterator<'a>,
-    prefix: Vec<u8>,
+    db_iter: rocksdb::DBIterator<'a>,
+    prefix_len: usize,
     _phantom: PhantomData<(K, V)>,
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iter<'a, K, V> {
-    pub(super) fn new(db_iter: rocksdb::DBRawIterator<'a>, prefix: Vec<u8>) -> Self {
+    pub(super) fn new(db_iter: rocksdb::DBIterator<'a>, prefix_len: usize) -> Self {
         Self {
             db_iter,
-            prefix,
+            prefix_len,
             _phantom: PhantomData,
         }
     }
@@ -37,31 +37,10 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.db_iter.valid() {
-            let key = match self
-                .db_iter
-                .key()
-                .and_then(|k| {
-                    if k[0..self.prefix.len()] == self.prefix[..] {
-                        Some(k)
-                    } else {
-                        None
-                    }
-                })
-                .map(|k| bincode::deserialize(&k[self.prefix.len()..]).ok())
-            {
-                Some(key) => key,
-                None => None,
-            };
-            let value = match self.db_iter.value().map(|v| bincode::deserialize(v).ok()) {
-                Some(value) => value,
-                None => None,
-            };
+        let (key, value) = self.db_iter.next()?;
+        let key = bincode::deserialize(&key[self.prefix_len..]).ok()?;
+        let value = bincode::deserialize(&value).ok()?;
 
-            self.db_iter.next();
-            key.and_then(|k| value.map(|v| (k, v)))
-        } else {
-            None
-        }
+        Some((key, value))
     }
 }

--- a/storage/src/storage/rocksdb/map.rs
+++ b/storage/src/storage/rocksdb/map.rs
@@ -94,30 +94,21 @@ impl<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> Map<'
     /// Returns an iterator visiting each key-value pair in the map.
     ///
     fn iter(&'a self) -> Self::Iterator {
-        let mut db_iter = self.rocksdb.raw_iterator();
-        db_iter.seek(&self.context);
-
-        Iter::new(db_iter, self.context.clone())
+        Iter::new(self.rocksdb.prefix_iterator(&self.context), self.context.len())
     }
 
     ///
     /// Returns an iterator over each key in the map.
     ///
     fn keys(&'a self) -> Self::Keys {
-        let mut db_iter = self.rocksdb.raw_iterator();
-        db_iter.seek(&self.context);
-
-        Keys::new(db_iter, self.context.clone())
+        Keys::new(self.rocksdb.prefix_iterator(&self.context), self.context.len())
     }
 
     ///
     /// Returns an iterator over each value in the map.
     ///
     fn values(&'a self) -> Self::Values {
-        let mut db_iter = self.rocksdb.raw_iterator();
-        db_iter.seek(&self.context);
-
-        Values::new(db_iter, self.context.clone())
+        Values::new(self.rocksdb.prefix_iterator(&self.context))
     }
 
     ///

--- a/storage/src/storage/rocksdb/mod.rs
+++ b/storage/src/storage/rocksdb/mod.rs
@@ -63,6 +63,11 @@ impl Storage for RocksDB {
         // Customize database options.
         let mut options = rocksdb::Options::default();
 
+        // FIXME: shorten the prefixes and make them the same length
+        let prefix_extractor = rocksdb::SliceTransform::create_fixed_prefix(16);
+        options.set_prefix_extractor(prefix_extractor);
+        options.set_memtable_prefix_bloom_ratio(0.05);
+
         let primary = path.as_ref().to_path_buf();
         let rocksdb = match is_read_only {
             true => {

--- a/storage/src/storage/rocksdb/values.rs
+++ b/storage/src/storage/rocksdb/values.rs
@@ -18,16 +18,14 @@ use super::*;
 
 /// An iterator over the values of a prefix.
 pub struct Values<'a, V> {
-    db_iter: rocksdb::DBRawIterator<'a>,
-    prefix: Vec<u8>,
+    db_iter: rocksdb::DBIterator<'a>,
     _phantom: PhantomData<V>,
 }
 
 impl<'a, V: DeserializeOwned> Values<'a, V> {
-    pub(crate) fn new(db_iter: rocksdb::DBRawIterator<'a>, prefix: Vec<u8>) -> Self {
+    pub(crate) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
         Self {
             db_iter,
-            prefix,
             _phantom: PhantomData,
         }
     }
@@ -37,26 +35,9 @@ impl<'a, V: DeserializeOwned> Iterator for Values<'a, V> {
     type Item = V;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.db_iter.valid() {
-            let value = self
-                .db_iter
-                .key()
-                .and_then(|k| {
-                    if k[0..self.prefix.len()] == self.prefix[..] {
-                        Some(k)
-                    } else {
-                        None
-                    }
-                })
-                .and_then(|_| match self.db_iter.value().map(|v| bincode::deserialize(v).ok()) {
-                    Some(value) => value,
-                    None => None,
-                });
+        let (_, value) = self.db_iter.next()?;
+        let value = bincode::deserialize(&value).ok()?;
 
-            self.db_iter.next();
-            value
-        } else {
-            None
-        }
+        Some(value)
     }
 }


### PR DESCRIPTION
The purpose of this draft PR is to simplify the use of RocksDB's [prefix seek feature](https://github.com/facebook/rocksdb/wiki/Prefix-Seek), which makes the code easier to reason about and paves way for related performance improvements.

In order to maximize the performance potential of these changes, we might want to shorten the existing prefixes and to align their lengths. IMO 4B prefixes (a `u16` for the `NETWORK_ID` plus a `u16` for the object prefix that should be `enum`-ified) would suffice.