### PR TITLE
Move most of the sending logic from Peers to Peer

### DIFF
--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -108,12 +108,8 @@ pub struct Peers<N: Network, E: Environment> {
     restricted_peers: RwLock<HashMap<SocketAddr, Instant>>,
     /// The map of peers to their first-seen port number, number of attempts, and timestamp of the last inbound connection request.
     seen_inbound_connections: RwLock<HashMap<SocketAddr, ((u16, u32), SystemTime)>>,
-    /// The map of peers to a map of block hashes to their last seen timestamp.
-    seen_outbound_blocks: RwLock<HashMap<SocketAddr, HashMap<N::BlockHash, SystemTime>>>,
     /// The map of peers to the timestamp of their last outbound connection request.
     seen_outbound_connections: RwLock<HashMap<SocketAddr, SystemTime>>,
-    /// The map of peers to a map of transaction IDs to their last seen timestamp.
-    seen_outbound_transactions: RwLock<HashMap<SocketAddr, HashMap<N::TransactionID, SystemTime>>>,
 }
 
 impl<N: Network, E: Environment> Peers<N, E> {
@@ -144,10 +140,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
             connected_peers: Default::default(),
             candidate_peers: Default::default(),
             restricted_peers: Default::default(),
-            seen_outbound_blocks: Default::default(),
             seen_inbound_connections: Default::default(),
             seen_outbound_connections: Default::default(),
-            seen_outbound_transactions: Default::default(),
         });
 
         // Initialize the peers router process.
@@ -531,22 +525,12 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 self.connected_peers.write().await.remove(&peer_ip);
                 // Add an entry for this `Peer` in the candidate peers.
                 self.candidate_peers.write().await.insert(peer_ip);
-
-                // Remove an entry for this `Peer` from the seen blocks.
-                self.seen_outbound_blocks.write().await.remove(&peer_ip);
-                // Remove an entry for this `Peer` from the seen transactions.
-                self.seen_outbound_transactions.write().await.remove(&peer_ip);
             }
             PeersRequest::PeerRestricted(peer_ip) => {
                 // Remove an entry for this `Peer` in the connected peers, if it exists.
                 self.connected_peers.write().await.remove(&peer_ip);
                 // Add an entry for this `Peer` in the restricted peers.
                 self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-
-                // Remove an entry for this `Peer` from the seen blocks.
-                self.seen_outbound_blocks.write().await.remove(&peer_ip);
-                // Remove an entry for this `Peer` from the seen transactions.
-                self.seen_outbound_transactions.write().await.remove(&peer_ip);
             }
             PeersRequest::SendPeerResponse(recipient) => {
                 // Send a `PeerResponse` message.
@@ -585,79 +569,13 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Sends the given message to specified peer.
     ///
-    async fn send(&self, peer: SocketAddr, mut message: Message<N, E>) {
+    async fn send(&self, peer: SocketAddr, message: Message<N, E>) {
         let target_peer = self.connected_peers.read().await.get(&peer).cloned();
         match target_peer {
             Some((_, outbound)) => {
-                // Ensure sufficient time has passed before needing to send the message.
-                let is_ready_to_send = match message {
-                    Message::Ping(_, _, _, _, _, ref mut data) => {
-                        // Perform non-blocking serialisation of the block header.
-                        let serialized_header = Data::serialize(data.clone()).await.expect("Block header serialization is bugged");
-                        let _ = std::mem::replace(data, Data::Buffer(serialized_header));
-
-                        true
-                    }
-                    Message::UnconfirmedBlock(_, _, ref mut data) => {
-                        let block = if let Data::Object(block) = data {
-                            block
-                        } else {
-                            panic!("Logic error: the block shouldn't have been serialized yet.");
-                        };
-
-                        // Lock seen_outbound_blocks for further processing.
-                        let mut seen_outbound_blocks = self.seen_outbound_blocks.write().await;
-
-                        // Retrieve the last seen timestamp of this block for this peer.
-                        let seen_blocks = seen_outbound_blocks.entry(peer).or_insert_with(Default::default);
-                        let last_seen = seen_blocks.entry(block.hash()).or_insert(SystemTime::UNIX_EPOCH);
-                        let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
-
-                        // Update the timestamp for the peer and sent block.
-                        seen_blocks.insert(block.hash(), SystemTime::now());
-                        // Report the unconfirmed block height.
-                        if is_ready_to_send {
-                            trace!("Preparing to send 'UnconfirmedBlock {}' to {}", block.height(), peer);
-                        }
-
-                        // Perform non-blocking serialization of the block.
-                        let serialized_block = Data::serialize(data.clone()).await.expect("Block serialization is bugged");
-                        let _ = std::mem::replace(data, Data::Buffer(serialized_block));
-
-                        is_ready_to_send
-                    }
-                    Message::UnconfirmedTransaction(ref transaction) => {
-                        // Lock seen_outbound_transactions for further processing.
-                        let mut seen_outbound_transactions = self.seen_outbound_transactions.write().await;
-
-                        // Retrieve the last seen timestamp of this transaction for this peer.
-                        let seen_transactions = seen_outbound_transactions.entry(peer).or_insert_with(Default::default);
-                        let last_seen = seen_transactions
-                            .entry(transaction.transaction_id())
-                            .or_insert(SystemTime::UNIX_EPOCH);
-                        let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
-
-                        // Update the timestamp for the peer and sent transaction.
-                        seen_transactions.insert(transaction.transaction_id(), SystemTime::now());
-                        // Report the unconfirmed block height.
-                        if is_ready_to_send {
-                            trace!(
-                                "Preparing to send '{} {}' to {}",
-                                message.name(),
-                                transaction.transaction_id(),
-                                peer
-                            );
-                        }
-                        is_ready_to_send
-                    }
-                    _ => true,
-                };
-                // Send the message if it is ready.
-                if is_ready_to_send {
-                    if let Err(error) = outbound.send(message.clone()).await {
-                        trace!("Outbound channel failed: {}", error);
-                        self.connected_peers.write().await.remove(&peer);
-                    }
+                if let Err(error) = outbound.send(message).await {
+                    trace!("Outbound channel failed: {}", error);
+                    self.connected_peers.write().await.remove(&peer);
                 }
             }
             None => warn!("Attempted to send to a non-connected peer {}", peer),
@@ -721,6 +639,10 @@ struct Peer<N: Network, E: Environment> {
     seen_inbound_blocks: HashMap<N::BlockHash, SystemTime>,
     /// The map of transaction IDs to their last seen timestamp.
     seen_inbound_transactions: HashMap<N::TransactionID, SystemTime>,
+    /// The map of peers to a map of block hashes to their last seen timestamp.
+    seen_outbound_blocks: HashMap<N::BlockHash, SystemTime>,
+    /// The map of peers to a map of transaction IDs to their last seen timestamp.
+    seen_outbound_transactions: HashMap<N::TransactionID, SystemTime>,
 }
 
 impl<N: Network, E: Environment> Peer<N, E> {
@@ -779,6 +701,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
             outbound_handler,
             seen_inbound_blocks: Default::default(),
             seen_inbound_transactions: Default::default(),
+            seen_outbound_blocks: Default::default(),
+            seen_outbound_transactions: Default::default(),
         })
     }
 
@@ -1001,15 +925,74 @@ impl<N: Network, E: Environment> Peer<N, E> {
             loop {
                 tokio::select! {
                     // Message channel is routing a message outbound to the peer.
-                    Some(message) = peer.outbound_handler.recv() => {
+                    Some(mut message) = peer.outbound_handler.recv() => {
                         // Disconnect if the peer has not communicated back within the predefined time.
                         if peer.last_seen.elapsed() > Duration::from_secs(E::RADIO_SILENCE_IN_SECS) {
                             warn!("Peer {} has not communicated in {} seconds", peer_ip, peer.last_seen.elapsed().as_secs());
                             break;
                         } else {
-                            // Route a message to the peer.
-                            if let Err(error) = peer.send(message).await {
-                                warn!("[OutboundRouter] {}", error);
+                            // Ensure sufficient time has passed before needing to send the message.
+                            let is_ready_to_send = match message {
+                                Message::Ping(_, _, _, _, _, ref mut data) => {
+                                    // Perform non-blocking serialisation of the block header.
+                                    let serialized_header = Data::serialize(data.clone()).await.expect("Block header serialization is bugged");
+                                    let _ = std::mem::replace(data, Data::Buffer(serialized_header));
+
+                                    true
+                                }
+                                Message::UnconfirmedBlock(_, _, ref mut data) => {
+                                    let block = if let Data::Object(block) = data {
+                                        block
+                                    } else {
+                                        panic!("Logic error: the block shouldn't have been serialized yet.");
+                                    };
+
+                                    // Retrieve the last seen timestamp of this block for this peer.
+                                    let last_seen = peer.seen_outbound_blocks.entry(block.hash()).or_insert(SystemTime::UNIX_EPOCH);
+                                    let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
+
+                                    // Update the timestamp for the peer and sent block.
+                                    peer.seen_outbound_blocks.insert(block.hash(), SystemTime::now());
+                                    // Report the unconfirmed block height.
+                                    if is_ready_to_send {
+                                        trace!("Preparing to send 'UnconfirmedBlock {}' to {}", block.height(), peer_ip);
+                                    }
+
+                                    // Perform non-blocking serialization of the block.
+                                    let serialized_block = Data::serialize(data.clone()).await.expect("Block serialization is bugged");
+                                    let _ = std::mem::replace(data, Data::Buffer(serialized_block));
+
+                                    is_ready_to_send
+                                }
+                                Message::UnconfirmedTransaction(ref transaction) => {
+                                    // Retrieve the last seen timestamp of this transaction for this peer.
+                                    let last_seen = peer
+                                        .seen_outbound_transactions
+                                        .entry(transaction.transaction_id())
+                                        .or_insert(SystemTime::UNIX_EPOCH);
+                                    let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
+
+                                    // Update the timestamp for the peer and sent transaction.
+                                    peer.seen_outbound_transactions.insert(transaction.transaction_id(), SystemTime::now());
+                                    // Report the unconfirmed block height.
+                                    if is_ready_to_send {
+                                        trace!(
+                                            "Preparing to send '{} {}' to {}",
+                                            message.name(),
+                                            transaction.transaction_id(),
+                                            peer_ip
+                                        );
+                                    }
+                                    is_ready_to_send
+                                }
+                                _ => true,
+                            };
+                            // Send the message if it is ready.
+                            if is_ready_to_send {
+                                // Route a message to the peer.
+                                if let Err(error) = peer.send(message).await {
+                                    warn!("[OutboundRouter] {}", error);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This PR moves most of the sending logic from `Peers` to `Peer`, making propagation more concurrent and reducing locking.

Marking it as a draft, as I haven't had the chance to test it thoroughly yet.

Cc https://github.com/AleoHQ/snarkOS/issues/1419.