### PR TITLE
strict future block time

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -49,7 +49,7 @@ pub const MAXIMUM_BLOCK_LOCATORS: u32 = MAXIMUM_LINEAR_BLOCK_LOCATORS.saturating
 const MAXIMUM_FORK_DEPTH: u32 = 4096;
 
 /// The maximum future block time - 2 minutes.
-const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 120;
+const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 2;
 
 ///
 /// A helper struct containing transaction metadata.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Attackers can take advantage of the loose time limit to attack the network. e.g
1. miner a mined a block， weight(24000) ，block time diff（2s），ignore the propagation time
2. attacker set the block timestamp_a(time.now()) + MAXIMUM_FUTURE_BLOCK_TIME，weight(~4000)，win the block with block time diff 122s（2s）
3. the next block weight will be 8w （assume block time is "timestamp_a + 10s"）
4. the sencond block weight will be 160w (assume block time is "timestamp_a + 10 + 100s")
5. the third block weight will be 3200w
6. then the network will freeze

I have observed similar things happening on the network.
Miners should be responsible for their local time（ntp）
## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

(Link your related PRs here)
