### PR TITLE
Speed up network message serialization & propagation

### DIFF
--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -210,7 +210,7 @@ impl<N: Network, E: Environment> Message<N, E> {
     /// Serializes the given message into bytes.
     #[inline]
     pub fn serialize(&self) -> Result<Vec<u8>> {
-        Ok([self.id().to_le_bytes().to_vec(), self.data()?].concat())
+        Ok([&self.id().to_le_bytes()[..], &self.data()?].concat())
     }
 
     /// Deserializes the given buffer into a message.

--- a/testing/src/test_node.rs
+++ b/testing/src/test_node.rs
@@ -203,7 +203,8 @@ impl Handshake for TestNode {
             0,
         );
         trace!(parent: self.node().span(), "sending a challenge request to {}", peer_ip);
-        let msg = own_request.serialize().unwrap();
+        let mut msg = Vec::new();
+        own_request.serialize_into(&mut msg).unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
         connection.writer().write_all(&len).await?;
         connection.writer().write_all(&msg).await?;
@@ -252,7 +253,8 @@ impl Handshake for TestNode {
         // Respond with own challenge request.
         let own_response = ClientMessage::ChallengeResponse(Data::Object(genesis_block_header.clone()));
         trace!(parent: self.node().span(), "sending a challenge response to {}", peer_ip);
-        let msg = own_response.serialize().unwrap();
+        let mut msg = Vec::new();
+        own_response.serialize_into(&mut msg).unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
         connection.writer().write_all(&len).await?;
         connection.writer().write_all(&msg).await?;
@@ -343,11 +345,12 @@ impl Writing for TestNode {
     type Message = ClientMessage;
 
     fn write_message<W: io::Write>(&self, _target: SocketAddr, payload: &Self::Message, writer: &mut W) -> io::Result<()> {
-        let serialized = payload.serialize().unwrap();
-        let len = u32::to_le_bytes(serialized.len() as u32);
+        let mut msg = Vec::new();
+        payload.serialize_into(&mut msg).unwrap();
+        let len = u32::to_le_bytes(msg.len() as u32);
 
         writer.write_all(&len)?;
-        writer.write_all(&serialized)
+        writer.write_all(&msg)
     }
 }
 


### PR DESCRIPTION
This is achieved by:
- using `Bytes` instead of `Vec<u8>` inside `Data` (shallow copying for message propagation)
- writing directly into a `W: Write` instead of using intermediate vectors
- not using an intermediate vector to calculate the length of the outbound message

I've done some testing and it seems to work fine, but I welcome thorough reviews, as it's pretty low-level stuff.