### PR TITLE
feat: disable ansi coloring when stdout being redirected into file

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -31,6 +31,7 @@ use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use anyhow::{anyhow, Result};
 use colored::*;
+use crossterm::tty::IsTty;
 use std::{io, net::SocketAddr, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 use tokio::{signal, sync::mpsc, task};
@@ -195,7 +196,7 @@ pub fn initialize_logger(verbosity: u8, log_sender: Option<mpsc::Sender<Vec<u8>>
     // Initialize tracing.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
-        .with_ansi(log_sender.is_none())
+        .with_ansi(log_sender.is_none() && io::stdout().is_tty())
         .with_writer(move || LogWriter::new(&log_sender))
         .with_target(verbosity == 3)
         .try_init();


### PR DESCRIPTION
## Motivation
avoid noises when collecting & analyzing log files from redirected stdout

## Test Plan
no test plan needed

## Related PRs
no related prs
