### PR TITLE
Revert "Speed up storage validation for block headers"

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -28,7 +28,7 @@ use rand::{CryptoRng, Rng};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::BTreeMap,
     path::Path,
     sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
@@ -152,16 +152,18 @@ impl<N: Network> LedgerState<N> {
             // The map lock goes out of scope on its own.
         }
 
-        // Check that all canonical block headers exist in storage.
-        let count = ledger.get_block_header_count()?;
-        assert_eq!(count, latest_block_height.saturating_add(1));
-
         // Iterate and append each block hash from genesis to tip to validate ledger state.
         const INCREMENT: u32 = 500;
         let mut start_block_height = 0u32;
         while start_block_height <= latest_block_height {
             // Compute the end block height (inclusive) for this iteration.
             let end_block_height = std::cmp::min(start_block_height.saturating_add(INCREMENT), latest_block_height);
+
+            // Perform a spot check that the block headers for this iteration exists in storage.
+            if start_block_height % 2 == 0 {
+                let block_headers = ledger.get_block_headers(start_block_height, end_block_height)?;
+                assert_eq!(end_block_height - start_block_height + 1, block_headers.len() as u32);
+            }
 
             // Retrieve the block hashes.
             let block_hashes = ledger.get_block_hashes(start_block_height, end_block_height)?;
@@ -433,11 +435,6 @@ impl<N: Network> LedgerState<N> {
     /// Returns the block headers from the given `start_block_height` to `end_block_height` (inclusive).
     pub fn get_block_headers(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<BlockHeader<N>>> {
         self.blocks.get_block_headers(start_block_height, end_block_height)
-    }
-
-    /// Returns the number of all block headers belonging to canonical blocks.
-    pub fn get_block_header_count(&self) -> Result<u32> {
-        self.blocks.get_block_header_count()
     }
 
     /// Returns the transactions from the block of the given block height.
@@ -1253,15 +1250,6 @@ impl<N: Network> BlockState<N> {
             .into_par_iter()
             .map(|height| self.get_block_header(height))
             .collect()
-    }
-
-    /// Returns the number of all block headers belonging to canonical blocks.
-    pub fn get_block_header_count(&self) -> Result<u32> {
-        let block_hashes = self.block_heights.values().collect::<HashSet<_>>();
-
-        let count = self.block_headers.keys().filter(|hash| block_hashes.contains(hash)).count();
-
-        Ok(count as u32)
     }
 
     /// Returns the transactions from the block of the given block height.


### PR DESCRIPTION
Reverts AleoHQ/snarkOS#1431

This PR is the right idea, but requires some touch ups to adhere our desired design goals. Notably:
- the `get_block_header_count` method should have **private** visibility in the `BlockState` struct
- we should remove exposing the `get_block_header_count` as it could be confused for "latest_block_height"
    - Remark: while in most cases, the two should be equivalent (off-by-one), corrupted state would imply a mismatch.
- **Most importantly**, this PR makes validation **less restrictive**/"**less safe**" as we no longer synthesize the block header and implicitly verify that the block header SNARK proof is valid