### PR TITLE
add a command line argument to set config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +235,28 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+dependencies = [
+ "cargo-platform",
+ "semver 0.11.0",
+ "semver-parser",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cassowary"
@@ -575,6 +603,15 @@ checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
 dependencies = [
  "fsio",
  "indexmap",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -1426,6 +1463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
+ "serde",
 ]
 
 [[package]]
@@ -1840,6 +1898,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "skeptic"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188b810342d98f23f0bb875045299f34187b559370b041eb11520c905370a888"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1956,7 @@ dependencies = [
  "snarkos-storage",
  "snarkvm",
  "structopt",
+ "structopt-toml",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2206,6 +2280,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "structopt-toml"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27d68c57e6cc3fb03041c49534e50a6ccef677c511effc1c5bf12a4bc865a62"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_derive",
+ "skeptic",
+ "structopt",
+ "structopt-toml-derive",
+ "toml",
+]
+
+[[package]]
+name = "structopt-toml-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316302a563af68baf93e5e77b8355a8bfe168c67c4424623365ca5bf521d013e"
+dependencies = [
+ "proc-macro2 1.0.34",
+ "quote 1.0.10",
+ "syn 1.0.82",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,6 +2598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2674,17 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2672,6 +2793,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ features = [ "arbitrary_precision" ]
 [dependencies.structopt]
 version = "0.3"
 
+[dependencies.structopt-toml]
+version = "0.5"
+
 [dependencies.thiserror]
 version = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
+        --config <config-file>       Specify the config file path
         --connect <connect>          Specify the IP address and port of a peer to connect to
         --dev <dev>                  Enables development mode, specify a unique ID for the local node
         --miner <miner>              Specify this as a mining node, with the given miner address

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,35 @@
+# If true, the node will render a read-only display
+display = false
+
+# If  true, the node will not initialize the RPC server
+norpc = false
+
+# Specify the IP address and port of a peer to connect to
+# connect = 
+
+# Enables development mode, specify a unique ID for the local node
+# dev = 132
+
+# Specify this as a mining node, with the given miner address
+# miner =  
+
+# Specify the network of this node [default: 2]
+network = 2
+
+# Specify the IP address and port for the node server [default: 0.0.0.0:4132]
+node = "0.0.0.0:4144"
+
+# Specify the IP address and port for the RPC server [default: 0.0.0.0:3032]
+rpc = "0.0.0.0:3044"
+
+# Specify the password for the RPC server [default: pass]
+rpc_password = "passss"
+
+# Specify the username for the RPC server [default: root]
+rpc_username = "roottt"
+
+# Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
+verbosity = 2
+
+trial = true
+sync = true

--- a/config.toml
+++ b/config.toml
@@ -17,19 +17,22 @@ norpc = false
 network = 2
 
 # Specify the IP address and port for the node server [default: 0.0.0.0:4132]
-node = "0.0.0.0:4144"
+node = "0.0.0.0:4132"
 
 # Specify the IP address and port for the RPC server [default: 0.0.0.0:3032]
-rpc = "0.0.0.0:3044"
+rpc = "0.0.0.0:3032"
 
 # Specify the password for the RPC server [default: pass]
-rpc_password = "passss"
+rpc_password = "pass"
 
 # Specify the username for the RPC server [default: root]
-rpc_username = "roottt"
+rpc_username = "root"
 
 # Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
 verbosity = 2
 
-trial = true
-sync = true
+# Specify whether connect to offical nodes
+trial = false
+
+# Specify if this node is a sync node
+sync = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::fs;
+
 use snarkos::{initialize_logger, Node};
 
 use anyhow::Result;
 use structopt::StructOpt;
+use structopt_toml::StructOptToml;
 use tokio::runtime;
 
 fn main() -> Result<()> {
@@ -26,7 +29,14 @@ fn main() -> Result<()> {
     }
 
     // Parse the provided arguments.
-    let node = Node::from_args();
+    let mut node = Node::from_args();
+    match node.config {
+        Some(file) => {
+            let content = fs::read_to_string(file).expect("failed to read config file");
+            node = Node::from_args_with_toml(&content).expect("failed to parse config file")
+        }
+        None => (),
+    }
 
     // Start logging, if enabled.
     if !node.display {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
 
     // Parse the provided arguments.
     let mut node = Node::from_args();
-    match node.config {
+    match node.config_file {
         Some(file) => {
             let content = fs::read_to_string(file).expect("failed to read config file");
             node = Node::from_args_with_toml(&content).expect("failed to parse config file")

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,6 +26,7 @@ use crate::{
     NodeType,
     SyncNode,
 };
+use serde::Deserialize;
 use snarkos_storage::storage::rocksdb::RocksDB;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
@@ -34,12 +35,16 @@ use colored::*;
 use crossterm::tty::IsTty;
 use std::{io, net::SocketAddr, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
+use structopt_toml::StructOptToml;
 use tokio::{signal, sync::mpsc, task};
 use tracing_subscriber::EnvFilter;
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize, StructOptToml)]
 #[structopt(name = "snarkos", author = "The Aleo Team <hello@aleo.org>", setting = structopt::clap::AppSettings::ColoredHelp)]
 pub struct Node {
+    /// Specify config.
+    #[structopt(long = "config")]
+    pub config: Option<String>,
     /// Specify the IP address and port of a peer to connect to.
     #[structopt(long = "connect")]
     pub connect: Option<String>,
@@ -202,7 +207,7 @@ pub fn initialize_logger(verbosity: u8, log_sender: Option<mpsc::Sender<Vec<u8>>
         .try_init();
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub enum Command {
     #[structopt(name = "clean", about = "Removes the ledger files from storage")]
     Clean(Clean),
@@ -257,7 +262,7 @@ impl io::Write for LogWriter {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub struct Clean {
     /// Specify the network of the ledger to remove from storage.
     #[structopt(default_value = "2", long = "network")]
@@ -294,7 +299,7 @@ impl Clean {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub struct Update {
     /// Lists all available versions of snarkOS
     #[structopt(short = "l", long)]
@@ -334,7 +339,7 @@ impl Update {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub struct Experimental {
     #[structopt(subcommand)]
     commands: ExperimentalCommands,
@@ -348,13 +353,13 @@ impl Experimental {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub enum ExperimentalCommands {
     #[structopt(name = "new_account", about = "Generate a new Aleo Account.")]
     NewAccount(NewAccount),
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub struct NewAccount {}
 
 impl NewAccount {
@@ -375,7 +380,7 @@ impl NewAccount {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub struct MinerSubcommand {
     #[structopt(subcommand)]
     commands: MinerCommands,
@@ -389,13 +394,13 @@ impl MinerSubcommand {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub enum MinerCommands {
     #[structopt(name = "stats", about = "Prints statistics for the miner.")]
     Stats(MinerStats),
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Deserialize)]
 pub struct MinerStats {
     #[structopt()]
     address: String,

--- a/src/node.rs
+++ b/src/node.rs
@@ -42,9 +42,9 @@ use tracing_subscriber::EnvFilter;
 #[derive(StructOpt, Debug, Deserialize, StructOptToml)]
 #[structopt(name = "snarkos", author = "The Aleo Team <hello@aleo.org>", setting = structopt::clap::AppSettings::ColoredHelp)]
 pub struct Node {
-    /// Specify config.
+    /// Specify the config file path.
     #[structopt(long = "config")]
-    pub config: Option<String>,
+    pub config_file: Option<String>,
     /// Specify the IP address and port of a peer to connect to.
     #[structopt(long = "connect")]
     pub connect: Option<String>,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

add config file to easily manage node

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->


```
cargo run -- -h

...
OPTIONS:
        --config <config-file>       Specify the config file path
...

cargo run -- --config config.toml
```

config file example: 

``` toml
# If true, the node will render a read-only display
display = false

# If  true, the node will not initialize the RPC server
norpc = false

# Specify the IP address and port of a peer to connect to
# connect = 

# Enables development mode, specify a unique ID for the local node
# dev = 132

# Specify this as a mining node, with the given miner address
# miner =  

# Specify the network of this node [default: 2]
network = 2

# Specify the IP address and port for the node server [default: 0.0.0.0:4132]
node = "0.0.0.0:4144"

# Specify the IP address and port for the RPC server [default: 0.0.0.0:3032]
rpc = "0.0.0.0:3044"

# Specify the password for the RPC server [default: pass]
rpc_password = "passss"

# Specify the username for the RPC server [default: root]
rpc_username = "roottt"

# Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
verbosity = 2

trial = true
sync = true
```

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

(Link your related PRs here)