### PR TITLE
Introduce a MapId object containing the DataMap prefix

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     helpers::BlockLocators,
-    storage::{DataMap, Map, Storage},
+    storage::{DataMap, Map, MapId, Storage},
 };
 use snarkvm::dpc::prelude::*;
 
@@ -117,7 +117,7 @@ impl<N: Network> LedgerState<N> {
             latest_block: RwLock::new(N::genesis_block().clone()),
             latest_block_hashes_and_headers: RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize)),
             latest_block_locators: Default::default(),
-            ledger_roots: storage.open_map("ledger_roots")?,
+            ledger_roots: storage.open_map(MapId::LedgerRoots)?,
             blocks: BlockState::open(storage)?,
             read_only: (is_read_only, Arc::new(AtomicU32::new(0)), RwLock::new(None)),
             map_lock: Default::default(),
@@ -246,7 +246,7 @@ impl<N: Network> LedgerState<N> {
             latest_block: RwLock::new(N::genesis_block().clone()),
             latest_block_hashes_and_headers: RwLock::new(CircularQueue::with_capacity(MAXIMUM_LINEAR_BLOCK_LOCATORS as usize)),
             latest_block_locators: Default::default(),
-            ledger_roots: storage.open_map("ledger_roots")?,
+            ledger_roots: storage.open_map(MapId::LedgerRoots)?,
             blocks: BlockState::open(storage)?,
             read_only: (is_read_only, Arc::new(AtomicU32::new(0)), RwLock::new(None)),
             map_lock: Default::default(),
@@ -1129,9 +1129,9 @@ impl<N: Network> BlockState<N> {
     /// Initializes a new instance of `BlockState`.
     fn open<S: Storage>(storage: S) -> Result<Self> {
         Ok(Self {
-            block_heights: storage.open_map("block_heights")?,
-            block_headers: storage.open_map("block_headers")?,
-            block_transactions: storage.open_map("block_transactions")?,
+            block_heights: storage.open_map(MapId::BlockHeights)?,
+            block_headers: storage.open_map(MapId::BlockHeaders)?,
+            block_transactions: storage.open_map(MapId::BlockTransactions)?,
             transactions: TransactionState::open(storage)?,
         })
     }
@@ -1397,10 +1397,10 @@ impl<N: Network> TransactionState<N> {
     /// Initializes a new instance of `TransactionState`.
     fn open<S: Storage>(storage: S) -> Result<Self> {
         Ok(Self {
-            transactions: storage.open_map("transactions")?,
-            transitions: storage.open_map("transitions")?,
-            serial_numbers: storage.open_map("serial_numbers")?,
-            commitments: storage.open_map("commitments")?,
+            transactions: storage.open_map(MapId::Transactions)?,
+            transitions: storage.open_map(MapId::Transitions)?,
+            serial_numbers: storage.open_map(MapId::SerialNumbers)?,
+            commitments: storage.open_map(MapId::Commitments)?,
         })
     }
 

--- a/storage/src/state/prover.rs
+++ b/storage/src/state/prover.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::storage::{DataMap, Map, Storage};
+use crate::storage::{DataMap, Map, MapId, Storage};
 use snarkvm::dpc::prelude::*;
 
 use anyhow::{anyhow, Result};
@@ -86,7 +86,7 @@ impl<N: Network> CoinbaseState<N> {
     /// Initializes a new instance of `CoinbaseState`.
     fn open<S: Storage>(storage: S) -> Result<Self> {
         Ok(Self {
-            records: storage.open_map("records")?,
+            records: storage.open_map(MapId::Records)?,
         })
     }
 

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -18,6 +18,8 @@
 pub mod rocksdb;
 #[cfg(feature = "rocks")]
 pub type DataMap<K, V> = crate::storage::rocksdb::DataMap<K, V>;
+#[cfg(feature = "rocks")]
+pub use crate::storage::rocksdb::MapId;
 
 pub mod traits;
 pub use traits::*;

--- a/storage/src/storage/rocksdb/map.rs
+++ b/storage/src/storage/rocksdb/map.rs
@@ -16,6 +16,39 @@
 
 use super::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MapId {
+    BlockHeaders,
+    BlockHeights,
+    BlockTransactions,
+    Commitments,
+    LedgerRoots,
+    Records,
+    SerialNumbers,
+    Transactions,
+    Transitions,
+    #[cfg(test)]
+    Test,
+}
+
+impl MapId {
+    pub fn as_bytes(&self) -> &'static [u8] {
+        match self {
+            Self::BlockHeaders => b"block_headers",
+            Self::BlockHeights => b"block_heights",
+            Self::BlockTransactions => b"block_transactions",
+            Self::Commitments => b"commitments",
+            Self::LedgerRoots => b"ledger_roots",
+            Self::Records => b"records",
+            Self::SerialNumbers => b"serial_numbers",
+            Self::Transactions => b"transactions",
+            Self::Transitions => b"transitions",
+            #[cfg(test)]
+            Self::Test => b"hello world",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct DataMap<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> {
     pub(super) rocksdb: Arc<rocksdb::DB>,

--- a/storage/src/storage/rocksdb/mod.rs
+++ b/storage/src/storage/rocksdb/mod.rs
@@ -21,7 +21,7 @@ mod keys;
 use keys::*;
 
 mod map;
-pub(crate) use map::*;
+pub use map::*;
 
 mod values;
 use values::*;
@@ -89,9 +89,9 @@ impl Storage for RocksDB {
     ///
     /// Opens a map with the given `context` from storage.
     ///
-    fn open_map<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned>(&self, context: &str) -> Result<DataMap<K, V>> {
+    fn open_map<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned>(&self, map_id: MapId) -> Result<DataMap<K, V>> {
         // Convert the new context into bytes.
-        let new_context = context.as_bytes();
+        let new_context = map_id.as_bytes();
 
         // Combine contexts to create a new scope.
         let mut context_bytes = self.context.clone();

--- a/storage/src/storage/rocksdb/tests.rs
+++ b/storage/src/storage/rocksdb/tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::storage::{rocksdb::RocksDB, Map, Storage};
+use crate::storage::{rocksdb::RocksDB, Map, MapId, Storage};
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir().expect("Failed to open temporary directory").into_path()
@@ -28,13 +28,13 @@ fn test_open() {
 #[test]
 fn test_open_map() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 }
 
 #[test]
 fn test_insert_and_contains_key() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
     assert!(map.contains_key(&123456789).expect("Failed to call contains key"));
@@ -44,7 +44,7 @@ fn test_insert_and_contains_key() {
 #[test]
 fn test_insert_and_get() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
     assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get"));
@@ -54,7 +54,7 @@ fn test_insert_and_get() {
 #[test]
 fn test_insert_and_remove() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
     assert!(map.get(&123456789).expect("Failed to get").is_some());
@@ -66,7 +66,7 @@ fn test_insert_and_remove() {
 #[test]
 fn test_insert_and_iter() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
     map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
 
     let mut iter = map.iter();
@@ -77,7 +77,7 @@ fn test_insert_and_iter() {
 #[test]
 fn test_insert_and_keys() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
     map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
 
     let mut keys = map.keys();
@@ -88,7 +88,7 @@ fn test_insert_and_keys() {
 #[test]
 fn test_insert_and_values() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
-    let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
     map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
 
     let mut values = map.values();
@@ -101,13 +101,13 @@ fn test_reopen() {
     let directory = temp_dir();
     {
         let storage = RocksDB::open(directory.clone(), 0, false).expect("Failed to open storage");
-        let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+        let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
         drop(storage);
     }
     {
         let storage = RocksDB::open(directory, 0, false).expect("Failed to open storage");
-        let map = storage.open_map::<u32, String>("hello world").expect("Failed to open data map");
+        let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get"));
     }
 }

--- a/storage/src/storage/traits.rs
+++ b/storage/src/storage/traits.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use super::DataMap;
+use super::{DataMap, MapId};
 
 use anyhow::Result;
 use serde::{de::DeserializeOwned, Deserializer, Serialize};
@@ -31,7 +31,7 @@ pub trait Storage: Serialize {
     ///
     /// Opens a map with the given `context` from storage.
     ///
-    fn open_map<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned>(&self, context: &str) -> Result<DataMap<K, V>>;
+    fn open_map<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned>(&self, map_id: MapId) -> Result<DataMap<K, V>>;
 
     ///
     /// Imports the given serialized bytes to reconstruct storage.


### PR DESCRIPTION
This PR facilitates further improvements to the `rocksdb` prefix setup. An immediate benefit is that it'll also be harder to make a typo when picking a context/prefix and to have their full list in a single spot.