### PR TITLE
Don't accept connections when at max peers

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -106,6 +106,7 @@ impl<N: Network, E: Environment> Server<N, E> {
             local_ip,
             listener,
             peers.router(),
+            peers.clone(),
             ledger.reader(),
             ledger.router(),
             prover.router(),
@@ -210,6 +211,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         local_ip: SocketAddr,
         listener: TcpListener,
         peers_router: PeersRouter<N, E>,
+        peers: Arc<Peers<N, E>>,
         ledger_reader: LedgerReader<N>,
         ledger_router: LedgerRouter<N>,
         prover_router: ProverRouter<N>,
@@ -221,23 +223,27 @@ impl<N: Network, E: Environment> Server<N, E> {
             let _ = router.send(());
             info!("Listening for peers at {}", local_ip);
             loop {
-                // Asynchronously wait for an inbound TcpStream.
-                match listener.accept().await {
-                    // Process the inbound connection request.
-                    Ok((stream, peer_ip)) => {
-                        let request = PeersRequest::PeerConnecting(
-                            stream,
-                            peer_ip,
-                            ledger_reader.clone(),
-                            ledger_router.clone(),
-                            prover_router.clone(),
-                        );
-                        if let Err(error) = peers_router.send(request).await {
-                            error!("Failed to send request to peers: {}", error)
+                // Don't accept connections if the node is breaching the configured peer limit.
+                if peers.number_of_connected_peers().await < E::MAXIMUM_NUMBER_OF_PEERS {
+                    // Asynchronously wait for an inbound TcpStream.
+                    match listener.accept().await {
+                        // Process the inbound connection request.
+                        Ok((stream, peer_ip)) => {
+                            let request = PeersRequest::PeerConnecting(
+                                stream,
+                                peer_ip,
+                                ledger_reader.clone(),
+                                ledger_router.clone(),
+                                prover_router.clone(),
+                            );
+                            if let Err(error) = peers_router.send(request).await {
+                                error!("Failed to send request to peers: {}", error)
+                            }
                         }
+                        Err(error) => error!("Failed to accept a connection: {}", error),
                     }
-                    Err(error) => error!("Failed to accept a connection: {}", error),
                 }
+
                 // Add a small delay to prevent overloading the network from handshakes.
                 tokio::time::sleep(Duration::from_millis(150)).await;
             }


### PR DESCRIPTION
This should improve the performance of sync nodes and any other nodes that are the target of many inbound connections.