### PR TITLE
Decrypt transactions with record view key in gettransaction RPC

### DIFF
--- a/src/rpc/documentation/public_endpoints/gettransaction.md
+++ b/src/rpc/documentation/public_endpoints/gettransaction.md
@@ -9,10 +9,11 @@ Returns a transaction with metadata given the transaction ID.
 
 ### Response
 
-|   Parameter   |  Type  |                Description                |
-|:-------------:|:------:|:-----------------------------------------:|
-|  `metadata`   | object | The metadata of the requested transaction |
-| `transaction` | object |          The transaction object           |
+|      Parameter      |  Type  |                            Description                             |
+|:-------------------:|:------:|:------------------------------------------------------------------:|
+| `decrypted_records` | array  | The decrypted records using record view key events, if they exist. |
+|     `metadata`      | object |             The metadata of the requested transaction              |
+|    `transaction`    | object |                       The transaction object                       |
 
 #### Transaction Metadata
 
@@ -31,6 +32,18 @@ Returns a transaction with metadata given the transaction ID.
 |   `ledger_root`    | string | The ledger root used to prove inclusion of ledger-consumed records. |
 |  `transaction_id`  | string |                     The ID of this transaction.                     |
 |   `transitions`    | array  |                       The state transitions.                        |
+
+#### Record
+
+|     Parameter     |  Type  |               Description               |
+|:-----------------:|:------:|:---------------------------------------:|
+|   `commitment`    | string |     The commitment of this record.      |
+|      `owner`      | string |            The record owner.            |
+|     `payload`     | string |           The record payload.           |
+|   `program_id`    | string |     The program id of this record.      |
+|   `randomizer`    | string | The randomizer used for the ciphertext. |
+| `record_view_key` | string |      The view key of this record.       |
+|      `value`      | number |            The record value.            |
 
 ### Example Request
 ```ignore
@@ -83,7 +96,18 @@ curl --data-binary '{"jsonrpc": "2.0", "id":"1", "method": "gettransaction", "pa
           "value_balance": -1000000000000000
         }
       ]
-    }
+    },
+    "decrypted_records": [
+      {
+        "commitment":"cm1xck4eyf3a3qnz69yyrr3jf698mqzwpjgkqu0j359p0sdr5wyjyqsn0604p",
+        "owner":"aleo1h35g4ld7wqahxw3puelmntaeddzr2rukmhty5a8cw5vqe65s2cpsrd4ghl",
+        "payload":"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "program_id":"ap1lhj3g5uzervu3km7rl0rsd0u5j6pj9ujum6yxrvms4mx8r2qhew88ga849hnjypghswxceh02frszs45qmd",
+        "randomizer":"rr1v76mftwzagt9k9nsjjpdqgytv4ddk24e9q7f240daar7avcv3q9qku3vtg",
+        "record_view_key":"rcvk1mujt98tc2r04l58haxjv48s5a7vnhx8ws24fxpdruuk3z37vscqsjtvlg5",
+        "value":1000000000000000
+      }
+    ]
   },
   "id": "1"
 }

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -444,6 +444,7 @@ mod tests {
     use hyper::Request;
     use rand::{thread_rng, SeedableRng};
     use rand_chacha::ChaChaRng;
+    use snarkvm::dpc::Record;
     use std::{
         path::{Path, PathBuf},
         sync::atomic::AtomicBool,
@@ -1166,6 +1167,7 @@ mod tests {
         pub struct GetTransactionResponse {
             pub transaction: Transaction<Testnet2>,
             pub metadata: snarkos_storage::Metadata<Testnet2>,
+            pub decrypted_records: Vec<Record<Testnet2>>,
         }
 
         // Initialize a new ledger.
@@ -1199,11 +1201,16 @@ mod tests {
         let actual: GetTransactionResponse = process_response(response).await;
 
         // Check the transaction.
-        assert_eq!(*Testnet2::genesis_block().transactions().first().unwrap(), actual.transaction);
+        let expected_transaction = Testnet2::genesis_block().transactions().first().unwrap();
+        assert_eq!(*expected_transaction, actual.transaction);
 
         // Check the metadata.
         let expected_transaction_metadata = ledger.get_transaction_metadata(&transaction_id).unwrap();
         assert_eq!(expected_transaction_metadata, actual.metadata);
+
+        // Check the records.
+        let expected_decrypted_records: Vec<Record<Testnet2>> = expected_transaction.to_records().collect();
+        assert_eq!(expected_decrypted_records, actual.decrypted_records)
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1470

## Overview

The `gettransaction` JSON response now has a `decrypted_records` field with the array of records.

[Documentation](https://github.com/AleoHQ/snarkOS/blob/feature/rpc-gettransaction/src/rpc/documentation/public_endpoints/gettransaction.md)

## Testing

[Updated Test](https://github.com/AleoHQ/snarkOS/blob/8eabbc3c992d78cdbcd5a72f18c2473a91802bb0/src/rpc/rpc.rs#L1213) - Calling the `gettransaction` endpoint on the genesis transition id correctly returns the decrypted records.