### PR TITLE
Don't allow to mine in future at all

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -48,8 +48,8 @@ pub const MAXIMUM_BLOCK_LOCATORS: u32 = MAXIMUM_LINEAR_BLOCK_LOCATORS.saturating
 /// TODO (howardwu): Reconcile this with the equivalent in `Environment`.
 const MAXIMUM_FORK_DEPTH: u32 = 4096;
 
-/// The maximum future block time - 2 minutes.
-const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 120;
+/// The maximum future block time - 19 seconds.
+const MAXIMUM_FUTURE_BLOCK_TIME: i64 = 19;
 
 ///
 /// A helper struct containing transaction metadata.


### PR DESCRIPTION
## Motivation

There is a group of guys who own a lot of power (aleo1gqa7nht8lv93ksgmfy8hnz028r776evnv5kllkcsx2ycek5ryq9suprafw) and they mine in advance and keeping blocks in private. After some time they send them to network and everyone is accepting this because of this condition:
```rust
        // Ensure the next block timestamp is within the declared time limit.
        let now = chrono::Utc::now().timestamp();
        if block.timestamp() > (now + MAXIMUM_FUTURE_BLOCK_TIME) {
            return Err(anyhow!("The given block timestamp exceeds the time limit"));
        }
```

To prevent this as soon as possible we can restrict future time as much as possible. I propose less then 20 seconds to not allow this guys to mine block on same high level of difficulty every time. Or they will always increase difficulty (that is not possible) or they will stay fair to mine in correct time (now)
