### PR TITLE
Fix sync node hangs

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -124,7 +124,7 @@ impl<N: Network> Environment for SyncNode<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Sync;
     const MINIMUM_NUMBER_OF_PEERS: usize = 35;
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 2048;
+    const MAXIMUM_NUMBER_OF_PEERS: usize = 1024;
     const HEARTBEAT_IN_SECS: u64 = 5;
 }
 

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -900,6 +900,8 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // If the node is a sync node and the node is currently syncing,
             // reduce the number of connections down to the minimum threshold,
             // to improve the speed with which the node syncs back to tip.
+            // FIXME: causes sync nodes to hang when at maximum peers
+            /*
             if E::NODE_TYPE == NodeType::Sync && self.status.is_syncing() {
                 debug!("Temporarily reducing the number of connected peers to sync");
 
@@ -926,6 +928,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     self.disconnect_and_restrict(peer_ip, "disconnecting to sync").await;
                 }
             }
+            */
         }
     }
 


### PR DESCRIPTION
I'm still going to test it for a while, but it seems to fix the recent sync node hangs; the reduction in maximum peers is not related to the hang, but we shouldn't need that many (with the number of sync nodes we're running) and the sync nodes will be more responsive with a lower maximum.

Cc https://github.com/AleoHQ/snarkOS/issues/1358, https://github.com/AleoHQ/snarkOS/issues/1378