### PR TITLE
Introduce an mining duration to ensure fresh block templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "snarkvm-dpc",
  "snarkvm-utilities",
@@ -1992,7 +1992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "derivative",
  "rand",
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-dpc"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "anyhow",
  "base58",
@@ -2079,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "anyhow",
  "derivative",
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-gadgets"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "anyhow",
  "derivative",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-marlin"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "bincode",
  "blake2",
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-polycommit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2173,12 +2173,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-profiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee545ab#ee545ab9357d3b0f8224c5e3fb84ca6e75d4d8fd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=02c814c#02c814c34c8f9f8b46401e447b6799e01b19ede1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 test = []
 
 [dependencies]
-snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ee545ab" }
+snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "02c814c" }
 #snarkvm = { path = "../snarkVM" }
 
 bytes = "1.0.0"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,7 +17,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ee545ab" }
+snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "02c814c" }
 #snarkvm = { path = "../../snarkVM" }
 
 [dependencies.anyhow]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -25,7 +25,7 @@ path = "../storage"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "ee545ab"
+rev = "02c814c"
 #path = "../../snarkVM"
 
 [dependencies.anyhow]


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the snarkVM rev to the version that constrains the amount of time the miner is allowed to attempt to the next block. After this duration has expired without finding the next block, the miner will retry with an updated block template.

https://github.com/AleoHQ/snarkVM/pull/557


