### PR TITLE
Updates `PoolResponse` from block header to PoSW proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "fe438c9d2f2b0fb88a112154ed81e30b0a491c29322afe1db3b6eec5811f5ba0"
 
 [[package]]
 name = "byteorder"
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "snarkvm-dpc",
  "snarkvm-utilities",
@@ -1992,7 +1992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "derivative",
  "rand",
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-dpc"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "anyhow",
  "base58",
@@ -2079,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "anyhow",
  "derivative",
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-gadgets"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "anyhow",
  "derivative",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-marlin"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "bincode",
  "blake2",
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-polycommit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2173,12 +2173,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-profiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ff10c20#ff10c20512bb7f7853bf8c3f308d951e78a02290"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=459ea96#459ea966476e73b3c5296bf34ef508e0e7bcf547"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 test = []
 
 [dependencies]
-snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ff10c20" }
+snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "459ea96" }
 #snarkvm = { path = "../snarkVM" }
 
 bytes = "1.0.0"

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -75,6 +75,12 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The maximum number of failures tolerated before disconnecting from a peer.
     const MAXIMUM_NUMBER_OF_FAILURES: usize = 1024;
 
+    /// Returns the beacon nodes preset for the node.
+    fn beacon_nodes() -> &'static HashSet<SocketAddr> {
+        static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
+        NODES.get_or_init(|| Self::BEACON_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
+    }
+
     /// Returns the sync nodes preset for the node.
     fn sync_nodes() -> &'static HashSet<SocketAddr> {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -42,9 +42,9 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const DEFAULT_RPC_PORT: u16 = 3030 + Self::Network::NETWORK_ID;
 
     /// The list of beacon nodes to bootstrap the node server with.
-    const BEACON_NODES: [&'static str; 0] = [];
+    const BEACON_NODES: &'static [&'static str] = &[];
     /// The list of sync nodes to bootstrap the node server with.
-    const SYNC_NODES: [&'static str; 13] = ["127.0.0.1:4131", "127.0.0.1:4133", "127.0.0.1:4134", "127.0.0.1:4135", "127.0.0.1:4136", "127.0.0.1:4137", "127.0.0.1:4138", "127.0.0.1:4139", "127.0.0.1:4140", "127.0.0.1:4141", "127.0.0.1:4142", "127.0.0.1:4143", "127.0.0.1:4144"];
+    const SYNC_NODES: &'static [&'static str] = &["127.0.0.1:4135"];
 
     /// The duration in seconds to sleep in between heartbeat executions.
     const HEARTBEAT_IN_SECS: u64 = 9;
@@ -75,13 +75,13 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The maximum number of failures tolerated before disconnecting from a peer.
     const MAXIMUM_NUMBER_OF_FAILURES: usize = 1024;
 
-    /// Returns the beacon nodes preset for the node.
+    /// Returns the list of beacon nodes to bootstrap the node server with.
     fn beacon_nodes() -> &'static HashSet<SocketAddr> {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
         NODES.get_or_init(|| Self::BEACON_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
     }
 
-    /// Returns the sync nodes preset for the node.
+    /// Returns the list of sync nodes to bootstrap the node server with.
     fn sync_nodes() -> &'static HashSet<SocketAddr> {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
         NODES.get_or_init(|| Self::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
@@ -172,7 +172,7 @@ pub struct ClientTrial<N: Network>(PhantomData<N>);
 impl<N: Network> Environment for ClientTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Client;
-    const SYNC_NODES: [&'static str; 13] = [
+    const SYNC_NODES: &'static [&'static str] = &[
         "144.126.219.193:4132", "165.232.145.194:4132", "143.198.164.241:4132", "188.166.7.13:4132", "167.99.40.226:4132",
         "159.223.124.150:4132", "137.184.192.155:4132", "147.182.213.228:4132", "137.184.202.162:4132", "159.223.118.35:4132",
         "161.35.106.91:4132", "157.245.133.62:4132", "143.198.166.150:4132",
@@ -188,7 +188,7 @@ pub struct MinerTrial<N: Network>(PhantomData<N>);
 impl<N: Network> Environment for MinerTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Miner;
-    const SYNC_NODES: [&'static str; 13] = [
+    const SYNC_NODES: &'static [&'static str] = &[
         "144.126.219.193:4132", "165.232.145.194:4132", "143.198.164.241:4132", "188.166.7.13:4132", "167.99.40.226:4132",
         "159.223.124.150:4132", "137.184.192.155:4132", "147.182.213.228:4132", "137.184.202.162:4132", "159.223.118.35:4132",
         "161.35.106.91:4132", "157.245.133.62:4132", "143.198.166.150:4132",
@@ -205,7 +205,7 @@ pub struct OperatorTrial<N: Network>(PhantomData<N>);
 impl<N: Network> Environment for OperatorTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Operator;
-    const SYNC_NODES: [&'static str; 13] = [
+    const SYNC_NODES: &'static [&'static str] = &[
         "144.126.219.193:4132", "165.232.145.194:4132", "143.198.164.241:4132", "188.166.7.13:4132", "167.99.40.226:4132",
         "159.223.124.150:4132", "137.184.192.155:4132", "147.182.213.228:4132", "137.184.202.162:4132", "159.223.118.35:4132",
         "161.35.106.91:4132", "157.245.133.62:4132", "143.198.166.150:4132",
@@ -222,7 +222,7 @@ pub struct ProverTrial<N: Network>(PhantomData<N>);
 impl<N: Network> Environment for ProverTrial<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Prover;
-    const SYNC_NODES: [&'static str; 13] = [
+    const SYNC_NODES: &'static [&'static str] = &[
         "144.126.219.193:4132", "165.232.145.194:4132", "143.198.164.241:4132", "188.166.7.13:4132", "167.99.40.226:4132",
         "159.223.124.150:4132", "137.184.192.155:4132", "147.182.213.228:4132", "137.184.202.162:4132", "159.223.118.35:4132",
         "161.35.106.91:4132", "157.245.133.62:4132", "143.198.166.150:4132",

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -19,8 +19,10 @@ use snarkvm::dpc::Network;
 
 use once_cell::sync::OnceCell;
 use std::{
+    collections::HashSet,
     fmt::Debug,
     marker::PhantomData,
+    net::SocketAddr,
     sync::{atomic::AtomicBool, Arc},
 };
 
@@ -73,6 +75,12 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     /// The maximum number of failures tolerated before disconnecting from a peer.
     const MAXIMUM_NUMBER_OF_FAILURES: usize = 1024;
 
+    /// Returns the sync nodes preset for the node.
+    fn sync_nodes() -> &'static HashSet<SocketAddr> {
+        static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
+        NODES.get_or_init(|| Self::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
+    }
+    
     /// Returns the tasks handler for the node.
     fn tasks() -> &'static Tasks<tokio::task::JoinHandle<()>> {
         static TASKS: OnceCell<Tasks<tokio::task::JoinHandle<()>>> = OnceCell::new();

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -149,7 +149,7 @@ impl<N: Network> Environment for Prover<N> {
     type Network = N;
     const NODE_TYPE: NodeType = NodeType::Prover;
     const COINBASE_IS_PUBLIC: bool = true;
-    const MINIMUM_NUMBER_OF_PEERS: usize = 1;
+    const MINIMUM_NUMBER_OF_PEERS: usize = 2;
     const MAXIMUM_NUMBER_OF_PEERS: usize = 21;
 }
 

--- a/src/helpers/block_requests.rs
+++ b/src/helpers/block_requests.rs
@@ -18,7 +18,7 @@ use crate::{network::ledger::PeersState, Environment};
 use snarkos_storage::{BlockLocators, LedgerState};
 use snarkvm::dpc::prelude::*;
 
-use std::{collections::HashSet, net::SocketAddr};
+use std::net::SocketAddr;
 
 /// Checks if any of the peers are ahead and have a larger block height, if they are on a fork, and their block locators.
 /// The maximum known block height and cumulative weight are tracked for the purposes of further operations.
@@ -27,8 +27,6 @@ pub fn find_maximal_peer<N: Network, E: Environment>(
     maximum_block_height: &mut u32,
     maximum_cumulative_weight: &mut u128,
 ) -> Option<(SocketAddr, bool, BlockLocators<N>)> {
-    let sync_nodes: HashSet<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-
     // Determine if the peers state has any sync nodes.
     // TODO: have nodes sync up to tip - 4096 with only sync nodes, then switch to syncing with the longest chain.
     let peers_contains_sync_node = false;
@@ -40,7 +38,7 @@ pub fn find_maximal_peer<N: Network, E: Environment>(
 
     for (peer_ip, peer_state) in peers_state.iter() {
         // Only update the maximal peer if there are no sync nodes or the peer is a sync node.
-        if !peers_contains_sync_node || sync_nodes.contains(peer_ip) {
+        if !peers_contains_sync_node || E::sync_nodes().contains(peer_ip) {
             // Update the maximal peer state if the peer is ahead and the peer knows if you are a fork or not.
             // This accounts for (Case 1 and Case 2(a))
             if let Some((_, _, is_on_fork, block_height, block_locators)) = peer_state {

--- a/src/network/operator.rs
+++ b/src/network/operator.rs
@@ -27,7 +27,7 @@ use crate::{
     ProverRouter,
 };
 use snarkos_storage::{storage::Storage, OperatorState};
-use snarkvm::dpc::prelude::*;
+use snarkvm::dpc::{prelude::*, PoSWProof};
 
 use anyhow::Result;
 use rand::thread_rng;
@@ -55,10 +55,10 @@ type OperatorHandler<N> = mpsc::Receiver<OperatorRequest<N>>;
 ///
 #[derive(Debug)]
 pub enum OperatorRequest<N: Network> {
-    /// PoolRegister := (peer_ip, worker_address)
+    /// PoolRegister := (peer_ip, prover_address)
     PoolRegister(SocketAddr, Address<N>),
-    /// PoolResponse := (peer_ip, proposed_block_header, worker_address)
-    PoolResponse(SocketAddr, BlockHeader<N>, Address<N>),
+    /// PoolResponse := (peer_ip, prover_address, nonce, proof)
+    PoolResponse(SocketAddr, Address<N>, N::PoSWNonce, PoSWProof<N>),
 }
 
 /// The predefined base share difficulty.
@@ -263,42 +263,17 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     warn!("[PoolRegister] No current block template exists");
                 }
             }
-            OperatorRequest::PoolResponse(peer_ip, block_header, prover) => {
+            OperatorRequest::PoolResponse(peer_ip, prover, nonce, proof) => {
                 if let Some(block_template) = self.block_template.read().await.clone() {
-                    // Ensure the given block header corresponds to the correct block height.
-                    if block_template.block_height() != block_header.height() {
-                        warn!("[PoolResponse] Peer {} sent a stale block.", peer_ip);
-                        return;
-                    }
-                    // Ensure the timestamp in the block template matches in the block header.
-                    if block_template.block_timestamp() != block_header.timestamp() {
-                        warn!("[PoolResponse] Peer {} sent a block with an incorrect timestamp.", peer_ip);
-                        return;
-                    }
-                    // Ensure the difficulty target in the block template matches in the block header.
-                    if block_template.difficulty_target() != block_header.difficulty_target() {
-                        warn!("[PoolResponse] Peer {} sent a block with an incorrect difficulty target.", peer_ip);
-                        return;
-                    }
-                    // Ensure the previous ledger root in the block template matches in the block header.
-                    if block_template.previous_ledger_root() != block_header.previous_ledger_root() {
-                        warn!("[PoolResponse] Peer {} sent a block with an incorrect ledger root.", peer_ip);
-                        return;
-                    }
-                    // Ensure the transactions root in the block header matches the one from the block template.
-                    if block_template.transactions().transactions_root() != block_header.transactions_root() {
-                        warn!("[PoolResponse] Peer {} has changed the list of block transactions.", peer_ip);
-                        return;
-                    }
                     // Ensure the given nonce from the prover is new.
-                    if self.known_nonces.read().await.contains(&block_header.nonce()) {
+                    if self.known_nonces.read().await.contains(&nonce) {
                         warn!("[PoolResponse] Peer {} sent a duplicate share", peer_ip);
                         // TODO (julesdesmit): punish?
                         return;
                     }
 
                     // Update known nonces.
-                    self.known_nonces.write().await.insert(block_header.nonce());
+                    self.known_nonces.write().await.insert(nonce);
 
                     // Retrieve the share difficulty for the given prover.
                     let share_difficulty = {
@@ -313,12 +288,12 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     };
 
                     // Ensure the share difficulty target is met, and the PoSW proof is valid.
-                    let block_height = block_header.height();
+                    let block_height = block_template.block_height();
                     if !N::posw().verify(
                         block_height,
                         share_difficulty,
-                        &[*block_header.to_header_root().unwrap(), *block_header.nonce()],
-                        block_header.proof(),
+                        &[*block_template.to_header_root().unwrap(), *nonce],
+                        &proof,
                     ) {
                         warn!("[PoolResponse] PoSW proof verification failed");
                         return;
@@ -345,11 +320,19 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     // If the block has satisfactory difficulty and is valid, proceed to broadcast it.
                     let previous_block_hash = block_template.previous_block_hash();
                     let transactions = block_template.transactions().clone();
-                    if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
-                        info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
-                        let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block, self.prover_router.clone());
-                        if let Err(error) = self.ledger_router.send(request).await {
-                            warn!("Failed to broadcast mined block - {}", error);
+                    if let Ok(block_header) = BlockHeader::<N>::from(
+                        block_template.previous_ledger_root(),
+                        block_template.transactions().transactions_root(),
+                        BlockHeaderMetadata::new(&block_template),
+                        nonce,
+                        proof,
+                    ) {
+                        if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
+                            info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
+                            let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block, self.prover_router.clone());
+                            if let Err(error) = self.ledger_router.send(request).await {
+                                warn!("Failed to broadcast mined block - {}", error);
+                            }
                         }
                     }
                 } else {

--- a/src/network/operator.rs
+++ b/src/network/operator.rs
@@ -311,8 +311,8 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     let coinbase_record = block_template.coinbase_record().clone();
                     match self.state.increment_share(block_height, coinbase_record, &prover) {
                         Ok(..) => info!(
-                            "Operator received a valid share from {} ({}) for block {}",
-                            peer_ip, prover, block_height,
+                            "Operator has received a valid share from {} ({}) for block {}",
+                            prover, peer_ip, block_height,
                         ),
                         Err(error) => error!("{}", error),
                     }

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -706,15 +706,15 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         warn!("[PoolRequest] could not deserialize block template");
                                     }
                                 }
-                                Message::PoolResponse(address, block_header) => {
+                                Message::PoolResponse(address, nonce, proof) => {
                                     if E::NODE_TYPE != NodeType::Operator {
                                         trace!("Skipping 'PoolResponse' from {}", peer_ip);
-                                    } else if let Ok(block_header) = block_header.deserialize().await {
-                                        if let Err(error) = operator_router.send(OperatorRequest::PoolResponse(peer_ip, block_header, address)).await {
+                                    } else if let Ok(proof) = proof.deserialize().await {
+                                        if let Err(error) = operator_router.send(OperatorRequest::PoolResponse(peer_ip, address, nonce, proof)).await {
                                             warn!("[PoolResponse] {}", error);
                                         }
                                     } else {
-                                        warn!("[PoolResponse] could not deserialize block");
+                                        warn!("[PoolResponse] could not deserialize proof");
                                     }
                                 }
                                 Message::Unused(_) => break, // Peer is not following the protocol.

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -196,8 +196,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     pub async fn connected_sync_nodes(&self) -> HashSet<SocketAddr> {
         let connected_peers: HashSet<SocketAddr> = self.connected_peers.read().await.keys().into_iter().copied().collect();
-        let sync_nodes: HashSet<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-        connected_peers.intersection(&sync_nodes).copied().collect()
+        connected_peers.intersection(E::sync_nodes()).copied().collect()
     }
 
     ///
@@ -206,8 +205,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     pub async fn number_of_connected_sync_nodes(&self) -> usize {
         let connected_peers: HashSet<SocketAddr> = self.connected_peers.read().await.keys().into_iter().copied().collect();
-        let sync_nodes: HashSet<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-        connected_peers.intersection(&sync_nodes).count()
+        connected_peers.intersection(E::sync_nodes()).count()
     }
 
     ///
@@ -326,7 +324,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         .iter()
                         .filter(|(&peer_ip, _)| {
                             let peer_str = peer_ip.to_string();
-                            !E::SYNC_NODES.contains(&peer_str.as_str()) && !E::BEACON_NODES.contains(&peer_str.as_str())
+                            !E::sync_nodes().contains(&peer_ip) && !E::BEACON_NODES.contains(&peer_str.as_str())
                         })
                         .take(num_excess_peers)
                         .map(|(&peer_ip, _)| peer_ip)
@@ -347,6 +345,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 let number_of_connected_sync_nodes = connected_sync_nodes.len();
                 let num_excess_sync_nodes = number_of_connected_sync_nodes.saturating_sub(1);
                 if num_excess_sync_nodes > 0 {
+                    debug!("Exceeded maximum number of sync nodes");
+
                     // Proceed to send disconnect requests to these peers.
                     for peer_ip in connected_sync_nodes
                         .iter()
@@ -373,14 +373,13 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 };
 
                 // Add the sync nodes to the list of candidate peers.
-                let sync_nodes: Vec<SocketAddr> = E::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
                 if number_of_connected_sync_nodes == 0 {
-                    self.add_candidate_peers(&sync_nodes).await;
+                    self.add_candidate_peers(E::sync_nodes().iter()).await;
                 }
 
                 // Add the beacon nodes to the list of candidate peers.
                 let beacon_nodes: Vec<SocketAddr> = E::BEACON_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-                self.add_candidate_peers(&beacon_nodes).await;
+                self.add_candidate_peers(beacon_nodes.iter()).await;
 
                 // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
                 // Select the peers randomly from the list of candidate peers.
@@ -393,7 +392,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     .choose_multiple(&mut OsRng::default(), midpoint_number_of_peers)
                 {
                     // Ensure this node is not connected to more than the permitted number of sync nodes.
-                    if sync_nodes.contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {
+                    if E::sync_nodes().contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {
                         continue;
                     }
 
@@ -528,7 +527,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 self.send(recipient, Message::PeerResponse(connected_peers)).await;
             }
             PeersRequest::ReceivePeerResponse(peer_ips) => {
-                self.add_candidate_peers(&peer_ips).await;
+                self.add_candidate_peers(peer_ips.iter()).await;
             }
         }
     }
@@ -539,19 +538,17 @@ impl<N: Network, E: Environment> Peers<N, E> {
     /// This method skips adding any given peers if the combined size exceeds the threshold,
     /// as the peer providing this list could be subverting the protocol.
     ///
-    async fn add_candidate_peers(&self, peers: &[SocketAddr]) {
+    async fn add_candidate_peers<'a, T: ExactSizeIterator<Item = &'a SocketAddr> + IntoIterator>(&self, peers: T) {
         // Acquire the candidate peers write lock.
         let mut candidate_peers = self.candidate_peers.write().await;
         // Ensure the combined number of peers does not surpass the threshold.
-        if candidate_peers.len() + peers.len() < E::MAXIMUM_CANDIDATE_PEERS {
-            // Proceed to insert each new candidate peer IP.
-            for peer_ip in peers.iter().take(E::MAXIMUM_CANDIDATE_PEERS) {
-                // Ensure the peer is not self and is a new candidate peer.
-                let is_self = *peer_ip == self.local_ip
-                    || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port();
-                if !is_self && !self.is_connected_to(*peer_ip).await {
-                    candidate_peers.insert(*peer_ip);
-                }
+        for peer_ip in peers.take(E::MAXIMUM_CANDIDATE_PEERS.saturating_sub(candidate_peers.len())) {
+            // Ensure the peer is not self and is a new candidate peer.
+            let is_self = *peer_ip == self.local_ip
+                || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port();
+            if !is_self && !self.is_connected_to(*peer_ip).await {
+                // Proceed to insert each new candidate peer IP.
+                candidate_peers.insert(*peer_ip);
             }
         }
     }
@@ -589,7 +586,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             .iter()
             .filter(|peer_ip| {
                 let peer_str = peer_ip.to_string();
-                *peer_ip != &sender && !E::SYNC_NODES.contains(&peer_str.as_str()) && !E::BEACON_NODES.contains(&peer_str.as_str())
+                *peer_ip != &sender && !E::sync_nodes().contains(peer_ip) && !E::BEACON_NODES.contains(&peer_str.as_str())
             })
             .copied()
             .collect::<Vec<_>>()

--- a/src/network/peers.rs
+++ b/src/network/peers.rs
@@ -322,10 +322,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         .read()
                         .await
                         .iter()
-                        .filter(|(&peer_ip, _)| {
-                            let peer_str = peer_ip.to_string();
-                            !E::sync_nodes().contains(&peer_ip) && !E::BEACON_NODES.contains(&peer_str.as_str())
-                        })
+                        .filter(|(peer_ip, _)| !E::sync_nodes().contains(peer_ip) && !E::beacon_nodes().contains(peer_ip))
                         .take(num_excess_peers)
                         .map(|(&peer_ip, _)| peer_ip)
                         .collect::<Vec<SocketAddr>>();
@@ -378,8 +375,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 }
 
                 // Add the beacon nodes to the list of candidate peers.
-                let beacon_nodes: Vec<SocketAddr> = E::BEACON_NODES.iter().map(|ip| ip.parse().unwrap()).collect();
-                self.add_candidate_peers(beacon_nodes.iter()).await;
+                self.add_candidate_peers(E::beacon_nodes().iter()).await;
 
                 // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
                 // Select the peers randomly from the list of candidate peers.
@@ -584,10 +580,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             .connected_peers()
             .await
             .iter()
-            .filter(|peer_ip| {
-                let peer_str = peer_ip.to_string();
-                *peer_ip != &sender && !E::sync_nodes().contains(peer_ip) && !E::BEACON_NODES.contains(&peer_str.as_str())
-            })
+            .filter(|peer_ip| *peer_ip != &sender && !E::sync_nodes().contains(peer_ip) && !E::beacon_nodes().contains(peer_ip))
             .copied()
             .collect::<Vec<_>>()
         {

--- a/src/network/prover.rs
+++ b/src/network/prover.rs
@@ -26,7 +26,7 @@ use crate::{
     PeersRouter,
 };
 use snarkos_storage::{storage::Storage, ProverState};
-use snarkvm::dpc::prelude::*;
+use snarkvm::dpc::{posw::PoSWProof, prelude::*};
 
 use anyhow::{anyhow, Result};
 use rand::thread_rng;
@@ -245,6 +245,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
                             E::status().update(State::Mining);
 
                             let thread_pool = self.thread_pool.clone();
+                            let block_height = block_template.block_height();
                             let block_template = block_template.clone();
 
                             let result = task::spawn_blocking(move || {
@@ -260,8 +261,11 @@ impl<N: Network, E: Environment> Prover<N, E> {
                                             &[*block_header.to_header_root().unwrap(), *block_header.nonce()],
                                             block_header.proof(),
                                         ) {
-                                            let proof_difficulty = block_header.proof().to_proof_difficulty()?;
-                                            return Ok::<(BlockHeader<N>, u64), anyhow::Error>((block_header, proof_difficulty));
+                                            return Ok::<(N::PoSWNonce, PoSWProof<N>, u64), anyhow::Error>((
+                                                block_header.nonce(),
+                                                block_header.proof().clone(),
+                                                block_header.proof().to_proof_difficulty()?,
+                                            ));
                                         }
                                     }
                                 })
@@ -271,21 +275,20 @@ impl<N: Network, E: Environment> Prover<N, E> {
                             E::status().update(State::Ready);
 
                             match result {
-                                Ok(Ok((block_header, proof_difficulty))) => {
+                                Ok(Ok((nonce, proof, proof_difficulty))) => {
                                     info!(
                                         "Prover successfully mined a share for unconfirmed block {} with proof difficulty of {}",
-                                        block_header.height(),
-                                        proof_difficulty
+                                        block_height, proof_difficulty
                                     );
 
                                     // Send a `PoolResponse` to the operator.
-                                    let message = Message::PoolResponse(recipient, Data::Object(block_header));
+                                    let message = Message::PoolResponse(recipient, nonce, Data::Object(proof));
                                     if let Err(error) = self.peers_router.send(PeersRequest::MessageSend(operator_ip, message)).await {
                                         warn!("[PoolResponse] {}", error);
                                     }
                                 }
                                 Ok(Err(error)) => trace!("{}", error),
-                                Err(error) => trace!("{}", anyhow!("Could not mine next block {}", error)),
+                                Err(error) => trace!("{}", anyhow!("Failed to mine the next block {}", error)),
                             }
                         }
                     }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,7 +17,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies]
-snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "ff10c20" }
+snarkvm = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "459ea96" }
 #snarkvm = { path = "../../snarkVM" }
 
 [dependencies.anyhow]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -25,7 +25,7 @@ path = "../storage"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "ff10c20"
+rev = "459ea96"
 #path = "../../snarkVM"
 
 [dependencies.anyhow]


### PR DESCRIPTION
## Motivation

- Updates PoolResponse from block header to PoSW proof
- Updates sync and beacon node access to fix the dropping issue when running multiple provers locally
- Bumps snarkVM rev to `459ea96`

## Remarks

Closes #1518 
Closes #1522