### PR TITLE
Unifies the thread pool for the node

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -18,6 +18,7 @@ use crate::helpers::{NodeType, Status, Tasks};
 use snarkvm::dpc::Network;
 
 use once_cell::sync::OnceCell;
+use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::{
     collections::HashSet,
     fmt::Debug,
@@ -74,7 +75,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const MAXIMUM_BLOCK_REQUEST: u32 = 250;
     /// The maximum number of failures tolerated before disconnecting from a peer.
     const MAXIMUM_NUMBER_OF_FAILURES: usize = 1024;
-
+    
     /// Returns the list of beacon nodes to bootstrap the node server with.
     fn beacon_nodes() -> &'static HashSet<SocketAddr> {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
@@ -103,6 +104,18 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     fn terminator() -> &'static Arc<AtomicBool> {
         static TERMINATOR: OnceCell<Arc<AtomicBool>> = OnceCell::new();
         TERMINATOR.get_or_init(|| Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Returns a thread pool for the node to perform intensive operations.
+    fn thread_pool() -> &'static Arc<ThreadPool> {
+        static POOL: OnceCell<Arc<ThreadPool>> = OnceCell::new();
+        POOL.get_or_init(|| {
+            Arc::new(ThreadPoolBuilder::new()
+                .stack_size(8 * 1024 * 1024)
+                .num_threads((num_cpus::get() * 7 / 8).max(2))
+                .build()
+                .expect("Failed to initialize a thread pool for the node"))
+        })
     }
 }
 

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -75,7 +75,7 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const MAXIMUM_BLOCK_REQUEST: u32 = 250;
     /// The maximum number of failures tolerated before disconnecting from a peer.
     const MAXIMUM_NUMBER_OF_FAILURES: usize = 1024;
-    
+
     /// Returns the list of beacon nodes to bootstrap the node server with.
     fn beacon_nodes() -> &'static HashSet<SocketAddr> {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Unifies the thread pool for the node.

As more node types appear, unifying the thread pool will ensure we don't overutilize resources, and makes it easier to track and debug potential utilization issues.

This PR should be merged after #1529.
