### PR TITLE
Move the block locator length check, deduplicate some logic in update_peer

### DIFF
--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -675,20 +675,9 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // If the given fork status is None, check if it can be updated.
             let is_fork = match is_fork {
                 Some(is_fork) => Some(is_fork),
-                None => match common_ancestor == latest_block_height_of_peer {
-                    // If the common ancestor matches the latest block height of the peer,
-                    // the peer is clearly on the same canonical chain as this node.
-                    true => Some(false),
-                    false => None,
-                },
-            };
-
-            // If the given fork status is None, check if it can be updated.
-            let is_fork = match is_fork {
-                Some(is_fork) => Some(is_fork),
-                None => match common_ancestor == self.canon.latest_block_height() {
-                    // If the common ancestor matches the latest block height of this node,
-                    // the peer is likely on the same canonical chain as this node.
+                None => match common_ancestor == latest_block_height_of_peer || common_ancestor == self.canon.latest_block_height() {
+                    // If the common ancestor matches the latest block height of the peer / this node,
+                    // the peer is clearly / likely on the same canonical chain as this node.
                     true => Some(false),
                     false => None,
                 },

--- a/storage/src/helpers/block_locators.rs
+++ b/storage/src/helpers/block_locators.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::MAXIMUM_BLOCK_LOCATORS;
 use snarkvm::{
     dpc::{BlockHeader, Network},
     utilities::{
@@ -29,7 +30,7 @@ use snarkvm::{
 
 use rayon::prelude::*;
 use serde::{de, ser, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
-use std::{collections::BTreeMap, ops::Deref};
+use std::{collections::BTreeMap, io::ErrorKind, ops::Deref};
 
 ///
 /// A helper struct to represent block locators from the ledger.
@@ -75,6 +76,12 @@ impl<N: Network> FromBytes for BlockLocators<N> {
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let num_locators: u32 = FromBytes::read_le(&mut reader)?;
+
+        // Check that the number of block_locators is less than the total MAXIMUM_BLOCK_LOCATORS.
+        if num_locators > MAXIMUM_BLOCK_LOCATORS {
+            error!("The list of block locators is too long");
+            return Err(ErrorKind::Other.into());
+        }
 
         let mut block_headers_bytes = Vec::with_capacity(num_locators as usize);
 

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -520,13 +520,6 @@ impl<N: Network> LedgerState<N> {
 
     /// Check that the block locators are well formed.
     pub fn check_block_locators(&self, block_locators: &BlockLocators<N>) -> Result<bool> {
-        // Check that the number of block_locators is less than the total MAXIMUM_BLOCK_LOCATORS.
-        if block_locators.len() > MAXIMUM_BLOCK_LOCATORS as usize {
-            return Ok(false);
-        }
-
-        let block_locators = &**block_locators;
-
         // Ensure the genesis block locator exists and is well-formed.
         let (expected_genesis_block_hash, expected_genesis_header) = match block_locators.get(&0) {
             Some((expected_genesis_block_hash, expected_genesis_header)) => (expected_genesis_block_hash, expected_genesis_header),


### PR DESCRIPTION
I was looking at `Pong` message handling, hoping to find potential performance improvements, and while bigger potential wins require more work, I've found two possible immediate improvements (the 2 commits in this PR).