### PR TITLE
Validate locators searching by their height

### DIFF
--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -696,16 +696,16 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Verify the integrity of the block hashes sent by the peer.
             for (block_height, (block_hash, _)) in block_locators.iter() {
                 // Ensure the block hash corresponds with the block height, if the block hash exists in this ledger.
-                if let Ok(expected_block_height) = self.canon.get_block_height(block_hash) {
-                    if expected_block_height != *block_height {
-                        let error = format!("Invalid block height {} for block hash {}", expected_block_height, block_hash);
+                if let Ok(expected_block_hash) = self.canon.get_block_hash(*block_height) {
+                    if expected_block_hash != *block_hash {
+                        let error = format!("Invalid block height {} for block hash {}", block_height, block_hash);
                         trace!("{}", error);
                         self.add_failure(peer_ip, error).await;
                         return;
                     } else {
                         // Update the common ancestor, as this block hash exists in this ledger.
-                        if expected_block_height > common_ancestor {
-                            common_ancestor = expected_block_height
+                        if *block_height > common_ancestor {
+                            common_ancestor = *block_height
                         }
                     }
                 }


### PR DESCRIPTION
`get_block_height` is super slow compared to `get_block_hash`; using the latter to validate the block locators reduces the duration of the associated loop from hundreds of ms to **zero** ms.