### PR TITLE
Fix/rpc request serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "2b85aed1b7ca965b6613d14ab243c746316180401cbb9ba3b2cb22bff16fc08f"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -115,7 +115,7 @@ checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c9d2f2b0fb88a112154ed81e30b0a491c29322afe1db3b6eec5811f5ba0"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+checksum = "7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939"
 dependencies = [
  "curl-sys",
  "libc",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.52+curl-7.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+checksum = "14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971"
 dependencies = [
  "cc",
  "libc",
@@ -559,7 +559,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -631,6 +631,15 @@ checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
 dependencies = [
  "fsio",
  "indexmap",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -739,7 +748,7 @@ checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -819,9 +828,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
 dependencies = [
  "bytes",
  "fnv",
@@ -953,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1029,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "json-rpc-types"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbbae830dd9982663675265535efd2db328489088a05983da93b006ed6a7efd"
+checksum = "f3890d4363efba3cd8a2fa2871ea3cd975cbaab25fca51344645950f950c4d7b"
 dependencies = [
  "serde",
  "str-buf",
@@ -1447,7 +1456,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
  "version_check",
 ]
 
@@ -1804,7 +1813,7 @@ checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -1832,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2041,7 +2050,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -2251,7 +2260,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -2273,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
@@ -2284,13 +2293,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2332,7 +2341,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -2396,7 +2405,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -2469,7 +2478,7 @@ checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -2648,7 +2657,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -2682,7 +2691,7 @@ checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.14",
- "syn 1.0.84",
+ "syn 1.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,7 @@ version = "0.14"
 features = [ "http1", "runtime", "server", "tcp" ]
 
 [dependencies.json-rpc-types]
-git = "https://github.com/whalelephant/json-rpc-types"
-branch = "deserialize-version-with-str"
-version = "1.0"
+version = "1.0.2"
 
 [dependencies.jsonrpc-core]
 version = "18"
@@ -107,7 +105,7 @@ version = "1"
 
 [dependencies.serde_json]
 version = "1"
-features = [ "arbitrary_precision", "raw_value" ]
+features = [ "arbitrary_precision" ]
 
 [dependencies.structopt]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ version = "0.14"
 features = [ "http1", "runtime", "server", "tcp" ]
 
 [dependencies.json-rpc-types]
+git = "https://github.com/whalelephant/json-rpc-types"
+branch = "deserialise-id-with-map"
 version = "1.0"
 
 [dependencies.jsonrpc-core]
@@ -105,7 +107,7 @@ version = "1"
 
 [dependencies.serde_json]
 version = "1"
-features = [ "arbitrary_precision" ]
+features = [ "arbitrary_precision", "raw_value" ]
 
 [dependencies.structopt]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ features = [ "http1", "runtime", "server", "tcp" ]
 
 [dependencies.json-rpc-types]
 git = "https://github.com/whalelephant/json-rpc-types"
-branch = "deserialise-id-with-map"
+branch = "deserialize-version-with-str"
 version = "1.0"
 
 [dependencies.jsonrpc-core]

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -141,8 +141,6 @@ async fn handle_rpc<N: Network, E: Environment>(
     };
 
     // Deserialize the JSON-RPC request.
-    // First deserialize into serde_json::Value - a workaround https://github.com/serde-rs/json/issues/505 
-    // for https://github.com/AleoHQ/snarkOS/issues/1369
     let req = if let Ok(req_data) = serde_json::from_slice::<serde_json::Value>(&data) {
         match serde_json::from_value::<jrt::Request<Params>>(req_data) {
             Ok(req) => req,

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -141,18 +141,32 @@ async fn handle_rpc<N: Network, E: Environment>(
     };
 
     // Deserialize the JSON-RPC request.
-    let req: jrt::Request<Params> = match serde_json::from_slice(&data) {
-        Ok(req) => req,
-        Err(_) => {
-            let resp = jrt::Response::<(), ()>::error(
-                jrt::Version::V2,
-                jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Couldn't parse the RPC body"),
-                None,
-            );
-            let body = serde_json::to_vec(&resp).unwrap_or_default();
+    // First deserialize into serde_json::Value - a workaround https://github.com/serde-rs/json/issues/505 
+    // for https://github.com/AleoHQ/snarkOS/issues/1369
+    let req = if let Ok(req_data) = serde_json::from_slice::<serde_json::Value>(&data) {
+        match serde_json::from_value::<jrt::Request<Params>>(req_data) {
+            Ok(req) => req,
+            Err(e) => {
+                debug!("Request Parsing Error: {:?}", e);
+                let resp = jrt::Response::<(), ()>::error(
+                    jrt::Version::V2,
+                    jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Couldn't parse the RPC body"),
+                    None,
+                );
+                let body = serde_json::to_vec(&resp).unwrap_or_default();
 
-            return Ok(hyper::Response::new(body.into()));
+                return Ok(hyper::Response::new(body.into()));
+            }
         }
+    } else {
+        let resp = jrt::Response::<(), ()>::error(
+            jrt::Version::V2,
+            jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Couldn't parse the RPC body into Value"),
+            None,
+        );
+        let body = serde_json::to_vec(&resp).unwrap_or_default();
+
+        return Ok(hyper::Response::new(body.into()));
     };
 
     debug!("Received '{}' RPC request from {}: {:?}", &*req.method, caller, headers);

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -159,7 +159,7 @@ async fn handle_rpc<N: Network, E: Environment>(
     } else {
         let resp = jrt::Response::<(), ()>::error(
             jrt::Version::V2,
-            jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Couldn't parse the RPC body into Value"),
+            jrt::Error::with_custom_msg(jrt::ErrorCode::ParseError, "Deserialize to Value failed"),
             None,
         );
         let body = serde_json::to_vec(&resp).unwrap_or_default();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Closes #1369 without introducing new dependencies with jsonrpc-* crates.

There is an issue with parsing numerical value with json rpc id field. The work around implemented is to first parse into `serde_json::Value` as suggested [here](https://github.com/serde-rs/serde/issues/1413).

Another [PR](https://github.com/DoumanAsh/json-rpc-types/pull/2) to the temp dependency json-rpc-type fixes the issue of how `serde_json::Value` string deserialization requires escaping and cannot therefore be cast to a borrowed str type. 

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

```
 curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"latestblockheight","params":[],"id":"1"}' localhost:3032
 
 curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"latestblockheight","params":[],"id":1}' localhost:3032
```

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->
 #1496 
#1537 
