### PR TITLE
Use atomic batch writes in the storage

### DIFF
--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -163,7 +163,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.ledger_router.clone()
     }
 
-    pub(super) async fn shut_down(&self) -> (Arc<Mutex<()>>, Arc<Mutex<()>>) {
+    pub(super) async fn shut_down(&self) {
         debug!("Ledger is shutting down...");
 
         // Set the terminator bit to `true` to ensure it stops mining.
@@ -180,13 +180,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.disconnect(peer_ip, DisconnectReason::ShuttingDown).await;
         }
         trace!("[ShuttingDown] Disconnect message has been sent to all connected peers");
-
-        // Return the lock for the canon chain and block requests.
-        let canon_lock = self.canon_lock.clone();
-        let block_requests_lock = self.block_requests_lock.clone();
-        trace!("[ShuttingDown] Block requests lock has been cloned");
-
-        (canon_lock, block_requests_lock)
     }
 
     ///

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -163,7 +163,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.ledger_router.clone()
     }
 
-    pub(super) async fn shut_down(&self) -> (Arc<Mutex<()>>, Arc<Mutex<()>>, Arc<parking_lot::RwLock<()>>) {
+    pub(super) async fn shut_down(&self) -> (Arc<Mutex<()>>, Arc<Mutex<()>>) {
         debug!("Ledger is shutting down...");
 
         // Set the terminator bit to `true` to ensure it stops mining.
@@ -184,10 +184,9 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         // Return the lock for the canon chain and block requests.
         let canon_lock = self.canon_lock.clone();
         let block_requests_lock = self.block_requests_lock.clone();
-        let storage_map_lock = self.canon.shut_down();
         trace!("[ShuttingDown] Block requests lock has been cloned");
 
-        (canon_lock, block_requests_lock, storage_map_lock)
+        (canon_lock, block_requests_lock)
     }
 
     ///

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -233,15 +233,10 @@ impl<N: Network, E: Environment> Server<N, E> {
 
         // Shut down the ledger.
         trace!("Proceeding to shut down the ledger...");
-        let (canon_lock, block_requests_lock) = self.ledger.shut_down().await;
-
-        // Acquire the locks for ledger.
-        trace!("Proceeding to lock the ledger...");
-        let _block_requests_lock = block_requests_lock.lock().await;
-        let _canon_lock = canon_lock.lock().await;
-        trace!("Ledger has shut down, proceeding to flush tasks...");
+        self.ledger.shut_down().await;
 
         // Flush the tasks.
+        trace!("Flushing tasks...");
         E::tasks().flush();
         trace!("Node has shut down.");
     }

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -233,13 +233,12 @@ impl<N: Network, E: Environment> Server<N, E> {
 
         // Shut down the ledger.
         trace!("Proceeding to shut down the ledger...");
-        let (canon_lock, block_requests_lock, storage_map_lock) = self.ledger.shut_down().await;
+        let (canon_lock, block_requests_lock) = self.ledger.shut_down().await;
 
         // Acquire the locks for ledger.
         trace!("Proceeding to lock the ledger...");
         let _block_requests_lock = block_requests_lock.lock().await;
         let _canon_lock = canon_lock.lock().await;
-        let _storage_map_lock = storage_map_lock.write();
         trace!("Ledger has shut down, proceeding to flush tasks...");
 
         // Flush the tasks.

--- a/storage/src/state/operator.rs
+++ b/storage/src/state/operator.rs
@@ -135,12 +135,12 @@ impl<N: Network> SharesState<N> {
         *entry = entry.saturating_add(1);
 
         // Insert the updated shares for the given block height.
-        self.shares.insert(&(block_height, coinbase_record), &shares)
+        self.shares.insert(&(block_height, coinbase_record), &shares, None)
     }
 
     /// Removes all of the shares for a given block height and coinbase record.
     fn remove_shares(&self, block_height: u32, coinbase_record: Record<N>) -> Result<()> {
-        self.shares.remove(&(block_height, coinbase_record))
+        self.shares.remove(&(block_height, coinbase_record), None)
     }
 
     fn get_provers(&self) -> Vec<Address<N>> {

--- a/storage/src/state/prover.rs
+++ b/storage/src/state/prover.rs
@@ -116,7 +116,7 @@ impl<N: Network> CoinbaseState<N> {
             Err(anyhow!("Record with commitment {} already exists in storage", commitment))
         } else {
             // Insert the record.
-            self.records.insert(&commitment, &(block_height, record))?;
+            self.records.insert(&commitment, &(block_height, record), None)?;
             Ok(())
         }
     }
@@ -124,7 +124,7 @@ impl<N: Network> CoinbaseState<N> {
     /// Removes the given record from storage.
     fn remove_record(&self, commitment: &N::Commitment) -> Result<()> {
         // Remove the record entry.
-        self.records.remove(commitment)?;
+        self.records.remove(commitment, None)?;
         Ok(())
     }
 }

--- a/storage/src/storage/rocksdb/mod.rs
+++ b/storage/src/storage/rocksdb/mod.rs
@@ -32,6 +32,7 @@ mod tests;
 use crate::storage::{Map, Storage};
 
 use anyhow::Result;
+use parking_lot::Mutex;
 use serde::{
     de::{self, DeserializeOwned},
     ser::SerializeSeq,
@@ -39,7 +40,7 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::{borrow::Borrow, fmt, marker::PhantomData, path::Path, sync::Arc};
+use std::{borrow::Borrow, collections::HashMap, fmt, marker::PhantomData, path::Path, sync::Arc};
 
 ///
 /// An instance of a RocksDB database.
@@ -48,6 +49,7 @@ use std::{borrow::Borrow, fmt, marker::PhantomData, path::Path, sync::Arc};
 pub struct RocksDB {
     rocksdb: Arc<rocksdb::DB>,
     context: Vec<u8>,
+    batches: Arc<Mutex<HashMap<usize, rocksdb::WriteBatch>>>,
     is_read_only: bool,
 }
 
@@ -82,6 +84,7 @@ impl Storage for RocksDB {
         Ok(RocksDB {
             rocksdb,
             context: context_bytes,
+            batches: Default::default(),
             is_read_only,
         })
     }

--- a/storage/src/storage/rocksdb/mod.rs
+++ b/storage/src/storage/rocksdb/mod.rs
@@ -99,9 +99,8 @@ impl Storage for RocksDB {
         context_bytes.extend_from_slice(new_context);
 
         Ok(DataMap {
-            rocksdb: self.rocksdb.clone(),
+            storage: self.clone(),
             context: context_bytes,
-            is_read_only: self.is_read_only,
             _phantom: PhantomData,
         })
     }

--- a/storage/src/storage/rocksdb/tests.rs
+++ b/storage/src/storage/rocksdb/tests.rs
@@ -36,7 +36,7 @@ fn test_insert_and_contains_key() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
-    map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+    map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
     assert!(map.contains_key(&123456789).expect("Failed to call contains key"));
     assert!(!map.contains_key(&000000000).expect("Failed to call contains key"));
 }
@@ -46,7 +46,7 @@ fn test_insert_and_get() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
-    map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+    map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
     assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get"));
     assert_eq!(None, map.get(&000000000).expect("Failed to get"));
 }
@@ -56,10 +56,10 @@ fn test_insert_and_remove() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
-    map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+    map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
     assert!(map.get(&123456789).expect("Failed to get").is_some());
 
-    map.remove(&123456789).expect("Failed to remove");
+    map.remove(&123456789, None).expect("Failed to remove");
     assert!(map.get(&123456789).expect("Failed to get").is_none());
 }
 
@@ -67,7 +67,7 @@ fn test_insert_and_remove() {
 fn test_insert_and_iter() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
-    map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+    map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
 
     let mut iter = map.iter();
     assert_eq!(Some((123456789, "123456789".to_string())), iter.next());
@@ -78,7 +78,7 @@ fn test_insert_and_iter() {
 fn test_insert_and_keys() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
-    map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+    map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
 
     let mut keys = map.keys();
     assert_eq!(Some(123456789), keys.next());
@@ -89,7 +89,7 @@ fn test_insert_and_keys() {
 fn test_insert_and_values() {
     let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
-    map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+    map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
 
     let mut values = map.values();
     assert_eq!(Some("123456789".to_string()), values.next());
@@ -102,7 +102,7 @@ fn test_reopen() {
     {
         let storage = RocksDB::open(directory.clone(), 0, false).expect("Failed to open storage");
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
-        map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
+        map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
         drop(storage);
     }
     {
@@ -110,4 +110,95 @@ fn test_reopen() {
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get"));
     }
+}
+
+#[test]
+fn test_batch_insert_and_remove() {
+    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
+
+    let batch = map.prepare_batch();
+
+    map.insert(&1, &"1".to_string(), Some(batch)).expect("Failed to insert");
+    assert!(map.get(&1).expect("Failed to get").is_none());
+
+    map.insert(&2, &"2".to_string(), Some(batch)).expect("Failed to insert");
+    assert!(map.get(&2).expect("Failed to get").is_none());
+
+    map.execute_batch(batch).expect("Failed to execute a batch");
+    assert!(map.get(&1).expect("Failed to get").is_some());
+    assert!(map.get(&2).expect("Failed to get").is_some());
+    assert!(map.execute_batch(batch).is_err());
+
+    let batch = map.prepare_batch();
+
+    map.remove(&1, Some(batch)).expect("Failed to remove");
+    assert!(map.get(&1).expect("Failed to get").is_some());
+    map.remove(&2, Some(batch)).expect("Failed to remove");
+    assert!(map.get(&2).expect("Failed to get").is_some());
+
+    map.execute_batch(batch).expect("Failed to execute a batch");
+    assert!(map.get(&1).expect("Failed to get").is_none());
+    assert!(map.get(&2).expect("Failed to get").is_none());
+    assert!(map.execute_batch(batch).is_err());
+}
+
+#[test]
+fn test_multiple_batches() {
+    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
+
+    let batch1 = map.prepare_batch();
+    let batch2 = map.prepare_batch();
+    let batch3 = map.prepare_batch();
+
+    map.insert(&1, &"1".to_string(), Some(batch1)).expect("Failed to insert");
+    map.insert(&2, &"2".to_string(), Some(batch1)).expect("Failed to insert");
+
+    map.insert(&3, &"3".to_string(), Some(batch2)).expect("Failed to insert");
+    map.insert(&4, &"4".to_string(), Some(batch2)).expect("Failed to insert");
+
+    map.insert(&5, &"5".to_string(), Some(batch3)).expect("Failed to insert");
+    map.insert(&6, &"6".to_string(), Some(batch3)).expect("Failed to insert");
+
+    for i in 1..=6 {
+        assert!(map.get(&i).expect("Failed to get").is_none());
+    }
+
+    map.execute_batch(batch3).expect("Failed to execute a batch");
+    assert!(map.get(&5).expect("Failed to get").is_some());
+    assert!(map.get(&6).expect("Failed to get").is_some());
+    assert!(map.execute_batch(batch3).is_err());
+
+    for i in 1..=4 {
+        assert!(map.get(&i).expect("Failed to get").is_none());
+    }
+
+    map.execute_batch(batch2).expect("Failed to execute a batch");
+    assert!(map.get(&3).expect("Failed to get").is_some());
+    assert!(map.get(&4).expect("Failed to get").is_some());
+    assert!(map.execute_batch(batch2).is_err());
+
+    assert!(map.get(&1).expect("Failed to get").is_none());
+    assert!(map.get(&2).expect("Failed to get").is_none());
+}
+
+#[test]
+fn test_discard_batch() {
+    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
+
+    let batch = map.prepare_batch();
+
+    map.insert(&1, &"1".to_string(), Some(batch)).expect("Failed to insert");
+    map.insert(&2, &"2".to_string(), Some(batch)).expect("Failed to insert");
+
+    assert!(map.get(&1).expect("Failed to get").is_none());
+    assert!(map.get(&2).expect("Failed to get").is_none());
+
+    assert!(map.discard_batch(batch).is_ok());
+    assert!(map.execute_batch(batch).is_err());
+
+    assert!(map.get(&1).expect("Failed to get").is_none());
+    assert!(map.get(&2).expect("Failed to get").is_none());
 }


### PR DESCRIPTION
This PR utilizes rockdb's atomic batch operations in order to address any remaining database inconsistency issues. This makes the use of locks during node shutdown obsolete. As a nice side effect, this should also make most database-related operations faster.

In order to limit the scope of API changes and to preserve the ergonomics of `DataMap` objects, batch operations are implemented in the existing `Map` trait:
- `Map::{insert, remove}` are extended with an optional batch id argument
- `Map::{prepare_batch, execute_batch, discard_batch}` are added

The following steps are required in order to execute a bundle of write operations atomically:
1. obtain a batch id using `Map::prepare_batch`
2. perform a number of `Map::{insert, remove}` operations using the id from point 1
3. call `Map::execute_batch` with the id from point 1 (or `Map::discard_batch` to cancel it)

notes:
- `Map::{prepare_batch, execute_batch, discard_batch}`, not unlike `Map::refresh`, can be performed on any implementer of `Map`; in other words, `execute_batch` can be called on a different object than `prepare_batch` just fine
- while it might make sense to **force** batching in more methods (i.e. by calling `prepare_batch` and later `execute_batch` within them even if they are called without a batch id) than just in `try_fixing_inconsistent_state`, it is the only method that was called both on its own and as part of another batch; all the others, like `BlockState::add_block`, are only called in the context of a "broader" batch, and they are not public, so I didn't consider it necessary
- `is_read_only` is removed from `DataMap`s, as it's a property of the actual storage shared by them all; instead, they now all contain a pointer to the whole `RocksDB` object
