### PR TITLE
Add CI for `storage` and `testing` modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     docker:
       - image: cimg/rust:1.56.1
     resource_class: 2xlarge
-    parallelism: 20
+    parallelism: 10
     steps:
       - checkout
       - setup_environment:
@@ -70,6 +70,51 @@ jobs:
       - clear_environment:
           cache_key: snarkos-stable-cache
 
+  storage:
+    docker:
+      - image: cimg/rust:1.56.1
+    resource_class: 2xlarge
+    parallelism: 5
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: snarkos-storage-cache
+      - run:
+          name: Build and run tests
+          no_output_timeout: 35m
+          command: |
+            cd storage
+            cargo test -- --list --format terse | sed 's/: test//' > test_names.txt
+            TEST_NAMES=$(circleci tests split test_names.txt)
+            for i in $(echo $TEST_NAMES | sed "s/ / /g")
+            do
+                RUST_MIN_STACK=8388608 cargo test --workspace $i 
+            done
+      - clear_environment:
+          cache_key: snarkos-storage-cache
+
+  testing:
+    docker:
+      - image: cimg/rust:1.56.1
+    resource_class: 2xlarge
+    parallelism: 5
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: snarkos-testing-cache
+      - run:
+          name: Build and run tests
+          no_output_timeout: 35m
+          command: |
+            cd testing
+            cargo test -- --list --format terse | sed 's/: test//' > test_names.txt
+            TEST_NAMES=$(circleci tests split test_names.txt)
+            for i in $(echo $TEST_NAMES | sed "s/ / /g")
+            do
+                RUST_MIN_STACK=8388608 cargo test --workspace $i 
+            done
+      - clear_environment:
+          cache_key: snarkos-testing-cache
 
   # codecov:
   #   machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,8 @@ workflows:
   main-workflow:
     jobs:
       - tests
+      - storage
+      - testing
       # - codecov:
       #     requires:
       #       - rust-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
 jobs:
   tests:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.57.1
     resource_class: 2xlarge
     parallelism: 10
     steps:
@@ -72,7 +72,7 @@ jobs:
 
   storage:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.57.1
     resource_class: 2xlarge
     parallelism: 5
     steps:
@@ -95,7 +95,7 @@ jobs:
 
   testing:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.57.1
     resource_class: 2xlarge
     parallelism: 5
     steps:
@@ -134,7 +134,7 @@ jobs:
 
   fmt:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.57.1
     resource_class: 2xlarge
     steps:
       - checkout
@@ -150,7 +150,7 @@ jobs:
 
   clippy:
     docker:
-      - image: cimg/rust:1.56.1
+      - image: cimg/rust:1.57.1
     resource_class: 2xlarge
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
 jobs:
   tests:
     docker:
-      - image: cimg/rust:1.57.1
+      - image: cimg/rust:1.57.0
     resource_class: 2xlarge
     parallelism: 10
     steps:
@@ -72,7 +72,7 @@ jobs:
 
   storage:
     docker:
-      - image: cimg/rust:1.57.1
+      - image: cimg/rust:1.57.0
     resource_class: 2xlarge
     parallelism: 5
     steps:
@@ -95,7 +95,7 @@ jobs:
 
   testing:
     docker:
-      - image: cimg/rust:1.57.1
+      - image: cimg/rust:1.57.0
     resource_class: 2xlarge
     parallelism: 5
     steps:
@@ -134,7 +134,7 @@ jobs:
 
   fmt:
     docker:
-      - image: cimg/rust:1.57.1
+      - image: cimg/rust:1.57.0
     resource_class: 2xlarge
     steps:
       - checkout
@@ -150,7 +150,7 @@ jobs:
 
   clippy:
     docker:
-      - image: cimg/rust:1.57.1
+      - image: cimg/rust:1.57.0
     resource_class: 2xlarge
     steps:
       - checkout

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -842,7 +842,6 @@ impl<N: Network> LedgerState<N> {
             .write()
             .push((block.hash(), block.header().clone()));
         *self.latest_block_locators.write() = self.get_block_locators(block.height())?;
-
         *self.latest_block.write() = block.clone();
 
         // The map lock goes out of scope on its own.

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -476,7 +476,7 @@ impl<N: Network> LedgerState<N> {
             .latest_block_hashes_and_headers
             .read()
             .asc_iter()
-            .skip_while(|(_, header)| header.height() == 0) // Skip the genesis block.
+            .filter(|(_, header)| header.height() != 0) // Skip the genesis block.
             .take(num_block_headers as usize)
             .cloned()
             .map(|(hash, header)| (header.height(), (hash, Some(header))))
@@ -841,9 +841,7 @@ impl<N: Network> LedgerState<N> {
         self.latest_block_hashes_and_headers
             .write()
             .push((block.hash(), block.header().clone()));
-        println!("got to here");
         *self.latest_block_locators.write() = self.get_block_locators(block.height())?;
-        println!("got to here after");
 
         *self.latest_block.write() = block.clone();
 

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -476,6 +476,7 @@ impl<N: Network> LedgerState<N> {
             .latest_block_hashes_and_headers
             .read()
             .asc_iter()
+            .skip_while(|(_, header)| header.height() == 0) // Skip the genesis block.
             .take(num_block_headers as usize)
             .cloned()
             .map(|(hash, header)| (header.height(), (hash, Some(header))))
@@ -840,7 +841,10 @@ impl<N: Network> LedgerState<N> {
         self.latest_block_hashes_and_headers
             .write()
             .push((block.hash(), block.header().clone()));
+        println!("got to here");
         *self.latest_block_locators.write() = self.get_block_locators(block.height())?;
+        println!("got to here after");
+
         *self.latest_block.write() = block.clone();
 
         // The map lock goes out of scope on its own.

--- a/testing/tests/network/basic_connectivity.rs
+++ b/testing/tests/network/basic_connectivity.rs
@@ -24,7 +24,6 @@ use std::sync::{
 };
 use tokio::task;
 
-#[ignore]
 #[tokio::test]
 async fn client_nodes_can_connect_to_each_other() {
     // Start 2 snarkOS nodes.
@@ -35,7 +34,6 @@ async fn client_nodes_can_connect_to_each_other() {
     client_node1.connect(client_node2.local_addr()).await.unwrap();
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_nodes_can_connect_to_each_other() {
     // Start 2 test nodes.
@@ -53,7 +51,6 @@ async fn test_nodes_can_connect_to_each_other() {
     assert!(test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
 }
 
-#[ignore]
 #[tokio::test]
 async fn handshake_as_initiator_works() {
     // Start a test node.
@@ -72,7 +69,6 @@ async fn handshake_as_initiator_works() {
     wait_until!(1, test_node.node().num_connected() == 1);
 }
 
-#[ignore]
 #[tokio::test]
 async fn handshake_as_responder_works() {
     // Start a test node.
@@ -88,7 +84,6 @@ async fn handshake_as_responder_works() {
     assert!(client_node.connected_peers().await.len() == 1)
 }
 
-#[ignore]
 #[tokio::test]
 async fn node_cant_connect_to_itself() {
     // Start a snarkOS node.
@@ -98,7 +93,6 @@ async fn node_cant_connect_to_itself() {
     assert!(client_node.connect(client_node.local_addr()).await.is_err());
 }
 
-#[ignore]
 #[tokio::test]
 async fn node_cant_connect_to_another_twice() {
     // Start a test node.
@@ -115,7 +109,6 @@ async fn node_cant_connect_to_another_twice() {
     assert!(client_node.connect(test_node_addr).await.is_err());
 }
 
-#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_duplicate_connection_attempts_fail() {
     // The number of concurrent connection attempts.
@@ -151,7 +144,6 @@ async fn concurrent_duplicate_connection_attempts_fail() {
     wait_until!(5, error_count.load(Relaxed) == NUM_CONCURRENT_ATTEMPTS - 1);
 }
 
-#[ignore]
 #[tokio::test]
 async fn connection_limits_are_obeyed() {
     // Start a snarkOS node.
@@ -179,7 +171,6 @@ async fn connection_limits_are_obeyed() {
     assert!(extra_test_node.node().connect(client_node.local_addr()).await.is_err());
 }
 
-#[ignore]
 #[tokio::test]
 async fn peer_accounting_works() {
     // Start a snarkOS node.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds CI for the `storage` and `testing` modules. 

Additionally, it fixes a `get_block_locators` off-by-one issue by skipping the genesis block in the initial collection of block locator headers.
