### PR TITLE
Shorten storage prefixes

### DIFF
--- a/storage/src/storage/rocksdb/keys.rs
+++ b/storage/src/storage/rocksdb/keys.rs
@@ -18,16 +18,14 @@ use super::*;
 
 /// An iterator over the keys of a prefix.
 pub struct Keys<'a, K> {
-    db_iter: rocksdb::DBRawIterator<'a>,
-    prefix: Vec<u8>,
+    db_iter: rocksdb::DBIterator<'a>,
     _phantom: PhantomData<K>,
 }
 
 impl<'a, K: DeserializeOwned> Keys<'a, K> {
-    pub(crate) fn new(db_iter: rocksdb::DBRawIterator<'a>, prefix: Vec<u8>) -> Self {
+    pub(crate) fn new(db_iter: rocksdb::DBIterator<'a>) -> Self {
         Self {
             db_iter,
-            prefix,
             _phantom: PhantomData,
         }
     }
@@ -37,21 +35,9 @@ impl<'a, K: DeserializeOwned> Iterator for Keys<'a, K> {
     type Item = K;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.db_iter.valid() {
-            let key = match self
-                .db_iter
-                .key()
-                .and_then(|k| if k.starts_with(&self.prefix) { Some(k) } else { None })
-                .map(|k| bincode::deserialize(&k[self.prefix.len()..]).ok())
-            {
-                Some(key) => key,
-                None => None,
-            };
+        let (key, _) = self.db_iter.next()?;
+        let key = bincode::deserialize(&key[PREFIX_LEN..]).ok()?;
 
-            self.db_iter.next();
-            key
-        } else {
-            None
-        }
+        Some(key)
     }
 }

--- a/storage/src/storage/rocksdb/map.rs
+++ b/storage/src/storage/rocksdb/map.rs
@@ -16,6 +16,8 @@
 
 use super::*;
 
+pub const PREFIX_LEN: usize = 4; // N::NETWORK_ID (u16) + MapId (u16)
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u16)]
 pub enum MapId {
@@ -125,30 +127,21 @@ impl<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> Map<'
     /// Returns an iterator visiting each key-value pair in the map.
     ///
     fn iter(&'a self) -> Self::Iterator {
-        let mut db_iter = self.rocksdb.raw_iterator();
-        db_iter.seek(&self.context);
-
-        Iter::new(db_iter, self.context.clone())
+        Iter::new(self.rocksdb.prefix_iterator(&self.context))
     }
 
     ///
     /// Returns an iterator over each key in the map.
     ///
     fn keys(&'a self) -> Self::Keys {
-        let mut db_iter = self.rocksdb.raw_iterator();
-        db_iter.seek(&self.context);
-
-        Keys::new(db_iter, self.context.clone())
+        Keys::new(self.rocksdb.prefix_iterator(&self.context))
     }
 
     ///
     /// Returns an iterator over each value in the map.
     ///
     fn values(&'a self) -> Self::Values {
-        let mut db_iter = self.rocksdb.raw_iterator();
-        db_iter.seek(&self.context);
-
-        Values::new(db_iter, self.context.clone())
+        Values::new(self.rocksdb.prefix_iterator(&self.context))
     }
 
     ///

--- a/storage/src/storage/rocksdb/map.rs
+++ b/storage/src/storage/rocksdb/map.rs
@@ -17,8 +17,9 @@
 use super::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u16)]
 pub enum MapId {
-    BlockHeaders,
+    BlockHeaders = 0,
     BlockHeights,
     BlockTransactions,
     Commitments,
@@ -30,25 +31,6 @@ pub enum MapId {
     Shares,
     #[cfg(test)]
     Test,
-}
-
-impl MapId {
-    pub fn as_bytes(&self) -> &'static [u8] {
-        match self {
-            Self::BlockHeaders => b"block_headers",
-            Self::BlockHeights => b"block_heights",
-            Self::BlockTransactions => b"block_transactions",
-            Self::Commitments => b"commitments",
-            Self::LedgerRoots => b"ledger_roots",
-            Self::Records => b"records",
-            Self::SerialNumbers => b"serial_numbers",
-            Self::Transactions => b"transactions",
-            Self::Transitions => b"transitions",
-            Self::Shares => b"shares",
-            #[cfg(test)]
-            Self::Test => b"hello world",
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/storage/src/storage/rocksdb/mod.rs
+++ b/storage/src/storage/rocksdb/mod.rs
@@ -63,6 +63,10 @@ impl Storage for RocksDB {
         // Customize database options.
         let mut options = rocksdb::Options::default();
 
+        // Register the prefix length.
+        let prefix_extractor = rocksdb::SliceTransform::create_fixed_prefix(PREFIX_LEN);
+        options.set_prefix_extractor(prefix_extractor);
+
         let primary = path.as_ref().to_path_buf();
         let rocksdb = match is_read_only {
             true => {

--- a/storage/src/storage/rocksdb/mod.rs
+++ b/storage/src/storage/rocksdb/mod.rs
@@ -39,7 +39,7 @@ use std::{
     fs::File,
     io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write},
     marker::PhantomData,
-    path::{Path, PathBuf},
+    path::Path,
     sync::Arc,
 };
 
@@ -83,17 +83,11 @@ impl Storage for RocksDB {
             }
         };
 
-        let mut storage = RocksDB {
+        Ok(RocksDB {
             rocksdb,
             context,
             is_read_only,
-        };
-
-        if !is_read_only {
-            storage.migrate(path)?;
-        }
-
-        Ok(storage)
+        })
     }
 
     ///
@@ -169,124 +163,6 @@ impl Storage for RocksDB {
                 writer.write_all(value)?;
             }
             iterator.next();
-        }
-
-        Ok(())
-    }
-
-    ///
-    /// Performs storage schema migration.
-    ///
-    fn migrate<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        // Check if migration is needed.
-        let needs_prefix_shortening = {
-            // This is the raw byte legacy format for the height of the genesis block.
-            // This check transcends all `DataMap`s, as it is performed directly on the rocksdb instance.
-            let key_with_long_prefix = vec![
-                2, 0, 0, 0, 2, 0, 13, 0, 0, 0, 98, 108, 111, 99, 107, 95, 104, 101, 105, 103, 104, 116, 115, 0, 0, 0, 0,
-            ];
-
-            self.rocksdb.get(&key_with_long_prefix)?.is_some()
-        };
-
-        // An early return in case the db is empty or the schema is up to date.
-        if !needs_prefix_shortening {
-            debug!("The storage schema format is up to date");
-            return Ok(());
-        }
-
-        debug!("The storage schema is out of date; performing migration");
-
-        // Perform a backup of the whole storage at a neighboring location.
-        let mut backup_path = path.as_ref().to_owned();
-        backup_path.pop();
-        backup_path = PathBuf::from(backup_path.to_string_lossy().into_owned());
-        backup_path.set_extension("bak");
-        debug!("Backing up storage at {}", backup_path.to_string_lossy());
-        self.export(&backup_path)?;
-
-        debug!("Migrating the storage to the new schema");
-        // This is basically `Storage::import` which shortens the keys by removing the records with the legacy
-        // format and inserting ones with the new one. It's not the fastest way to do it, but it's the safest.
-        {
-            let file = File::open(backup_path)?;
-            let mut reader = BufReader::new(file);
-
-            let len = reader.seek(SeekFrom::End(0))?;
-            reader.rewind()?;
-
-            let mut buf = vec![0u8; 16 * 1024];
-
-            while reader.stream_position()? < len {
-                reader.read_exact(&mut buf[..4])?;
-                let key_len = u32::from_le_bytes(buf[..4].try_into().unwrap()) as usize;
-
-                if key_len + 4 > buf.len() {
-                    buf.resize(key_len + 4, 0);
-                }
-
-                reader.read_exact(&mut buf[..key_len + 4])?;
-                let value_len = u32::from_le_bytes(buf[key_len..][..4].try_into().unwrap()) as usize;
-
-                if key_len + value_len > buf.len() {
-                    buf.resize(key_len + value_len, 0);
-                }
-
-                reader.read_exact(&mut buf[key_len..][..value_len])?;
-
-                // This part is where the code deviates from `Storage::import`.
-
-                let old_key = &buf[..key_len];
-                let value = &buf[key_len..][..value_len];
-
-                // Remember the N::NETWORK_ID for later.
-                let network_id = &old_key[4..][..2];
-
-                // Remove the N::NETWORK_ID bits and the label length.
-                if old_key.len() <= 10 {
-                    // The storage iterator can stumble across the updated records; ignore them.
-                    continue;
-                }
-                let mut old_key_shortened = &old_key[10..];
-
-                // Determine which map the record belongs to.
-                let mut new_map_id = None;
-
-                for (i, label) in [
-                    &b"block_headers"[..],
-                    &b"block_heights"[..],
-                    &b"block_transactions"[..],
-                    &b"commitments"[..],
-                    &b"ledger_roots"[..],
-                    &b"records"[..],
-                    &b"serial_numbers"[..],
-                    &b"transactions"[..],
-                    &b"transitions"[..],
-                    &b"shares"[..],
-                ]
-                .iter()
-                .enumerate()
-                {
-                    if old_key_shortened.starts_with(label) {
-                        new_map_id = Some(i as u16);
-                        old_key_shortened = &old_key_shortened[label.len()..];
-                    }
-                }
-
-                let new_map_id = if let Some(id) = new_map_id {
-                    id
-                } else {
-                    // The storage iterator can stumble across the updated records; ignore them.
-                    continue;
-                };
-
-                let mut new_key = network_id.to_vec();
-                new_key.extend_from_slice(&new_map_id.to_le_bytes());
-                new_key.extend_from_slice(old_key_shortened);
-
-                self.rocksdb.put(&new_key, value)?;
-                self.rocksdb.delete(old_key)?;
-            }
         }
 
         Ok(())

--- a/storage/src/storage/rocksdb/tests.rs
+++ b/storage/src/storage/rocksdb/tests.rs
@@ -20,6 +20,13 @@ fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir().expect("Failed to open temporary directory").into_path()
 }
 
+fn temp_file() -> std::path::PathBuf {
+    tempfile::NamedTempFile::new()
+        .expect("Failed to open temporary file")
+        .path()
+        .to_owned()
+}
+
 #[test]
 fn test_open() {
     let _storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
@@ -103,11 +110,35 @@ fn test_reopen() {
         let storage = RocksDB::open(directory.clone(), 0, false).expect("Failed to open storage");
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         map.insert(&123456789, &"123456789".to_string()).expect("Failed to insert");
-        drop(storage);
     }
     {
         let storage = RocksDB::open(directory, 0, false).expect("Failed to open storage");
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get"));
+    }
+}
+
+#[test]
+fn test_export_import() {
+    let file = temp_file();
+
+    {
+        let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+        let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
+
+        for i in 0..100 {
+            map.insert(&i, &i.to_string()).expect("Failed to insert");
+        }
+
+        storage.export(&file).expect("Failed to export storage");
+    }
+
+    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    storage.import(&file).expect("Failed to import storage");
+
+    let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
+
+    for i in 0..100 {
+        assert_eq!(map.get(&i).expect("Failed to insert"), Some(i.to_string()));
     }
 }

--- a/storage/src/storage/traits.rs
+++ b/storage/src/storage/traits.rs
@@ -17,10 +17,10 @@
 use super::{DataMap, MapId};
 
 use anyhow::Result;
-use serde::{de::DeserializeOwned, Deserializer, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use std::{borrow::Borrow, path::Path};
 
-pub trait Storage: Serialize {
+pub trait Storage {
     ///
     /// Opens storage at the given `path` and `context`.
     ///
@@ -34,14 +34,14 @@ pub trait Storage: Serialize {
     fn open_map<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned>(&self, map_id: MapId) -> Result<DataMap<K, V>>;
 
     ///
-    /// Imports the given serialized bytes to reconstruct storage.
+    /// Imports a file with the given path to reconstruct storage.
     ///
-    fn import<'de, D: Deserializer<'de>>(&self, deserializer: D) -> Result<(), D::Error>;
+    fn import<P: AsRef<Path>>(&self, path: P) -> Result<()>;
 
     ///
-    /// Exports the current state of storage into serialized bytes.
+    /// Exports the current state of storage to a single file at the specified location.
     ///
-    fn export(&self) -> Result<serde_json::Value>;
+    fn export<P: AsRef<Path>>(&self, path: P) -> Result<()>;
 }
 
 pub trait Map<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> {

--- a/storage/src/storage/traits.rs
+++ b/storage/src/storage/traits.rs
@@ -42,6 +42,11 @@ pub trait Storage {
     /// Exports the current state of storage to a single file at the specified location.
     ///
     fn export<P: AsRef<Path>>(&self, path: P) -> Result<()>;
+
+    ///
+    /// Performs storage schema migration.
+    ///
+    fn migrate<P: AsRef<Path>>(&mut self, path: P) -> Result<()>;
 }
 
 pub trait Map<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> {

--- a/storage/src/storage/traits.rs
+++ b/storage/src/storage/traits.rs
@@ -42,11 +42,6 @@ pub trait Storage {
     /// Exports the current state of storage to a single file at the specified location.
     ///
     fn export<P: AsRef<Path>>(&self, path: P) -> Result<()>;
-
-    ///
-    /// Performs storage schema migration.
-    ///
-    fn migrate<P: AsRef<Path>>(&mut self, path: P) -> Result<()>;
 }
 
 pub trait Map<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> {


### PR DESCRIPTION
This PR shortens all the storage prefixes in order to speed up lookups, pave way for internal rocksdb optimizations, and to reduce the storage size. This change is paired with automatic one-off migration, which is quite snappy. In order to achieve this, the following changes are introduced:
- `Storage::{import, export}` methods are changed to more tweakable and future-proof file-oriented implementations
- `Storage::migrate` is introduced and run automatically as part of `Storage::open`

For reference, below is a comparison between the current prefixes and this proposal:
```
current prefixes:

        | length prefix | N::NETWORK_ID | length prefix |      map id       |   key    |   value  |
|-------|---------------|---------------|---------------|-------------------|----------|----------|
| size  |  u32 (4B) LE  |  u16 (2B) LE  |  u32 (4B) LE  | <varies: 6 to 18> | <varies> | <varies> |
| bytes |  2, 0, 0, 0   |  2, 0 (now)   |    <varies>   |      <varies>     | <varies> | <varies> |

prefix length: 16B - 28B
```

```
this proposal:

        | N::NETWORK_ID |   map id    |   key    |   value  |
|-------|---------------|-------------|----------|----------|
| size  |  u16 (2B) LE  | u16 (2B) LE | <varies> | <varies> |
| bytes |  2, 0 (now)   |   <varies>  | <varies> | <varies> |

prefix length: 4B
```

As of today, this reduces the storage size by ~7%. Further optimizations facilitated by these changes will follow in future PRs.