### PR TITLE
Test transaction fees in coinbase transactions

### DIFF
--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -234,6 +234,11 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
             .map(|tx| tx.to_string())
             .collect();
 
+        // Enforce that the transaction fee is positive or zero.
+        if transaction_fees.is_negative() {
+            return Err(RpcError::Message("Invalid transaction fees".to_string()));
+        }
+
         // Calculate the final coinbase reward (including the transaction fees).
         coinbase_reward = coinbase_reward.add(transaction_fees);
 

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -662,6 +662,11 @@ impl<N: Network> LedgerState<N> {
             .cloned()
             .collect();
 
+        // Enforce that the transaction fee is positive or zero.
+        if transaction_fees.is_negative() {
+            return Err(anyhow!("Invalid transaction fees"));
+        }
+
         // Calculate the final coinbase reward (including the transaction fees).
         coinbase_reward = coinbase_reward.add(transaction_fees);
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR simply adds a check that transaction fees used to craft a coinbase transaction can't be negative and adds a test to ensure the coinbase reward is calculated correctly.

## Test Plan

A `test_transaction_fees` test has been added to verify that the coinbase reward includes the fees from the transactions in the block.
