### PR TITLE
Greatly speed up block height lookups and contains_key calls

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -18,7 +18,7 @@ use crate::{
     helpers::BlockLocators,
     storage::{DataMap, Map, MapId, Storage},
 };
-use snarkvm::dpc::prelude::*;
+use snarkvm::{dpc::prelude::*, prelude::FromBytes};
 
 use anyhow::{anyhow, Result};
 use circular_queue::CircularQueue;
@@ -29,6 +29,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
+    io::{self, Read},
     path::Path,
     sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
@@ -1303,8 +1304,23 @@ impl<N: Network> BlockState<N> {
 
     /// Returns the block height for the given block hash.
     fn get_block_height(&self, block_hash: &N::BlockHash) -> Result<u32> {
-        match self.block_headers.get(block_hash)? {
-            Some(block_header) => Ok(block_header.height()),
+        // Performance note: this method is using `Storage::get_raw` in order to avoid costly
+        // (and duplicate) proof verification, which happens automatically upon full deserialization.
+        match self.block_headers.get_raw(block_hash)? {
+            Some(raw_block_header) => {
+                // Ensure that any changes to the header's format don't go unnoticed.
+                debug_assert_eq!(N::NETWORK_ID, 2);
+                // Wrap the raw bytes in a reader.
+                let mut block_header_reader = io::Cursor::new(raw_block_header);
+                // Deserialize the bytes before the heights, skipping their values.
+                let _: N::LedgerRoot = FromBytes::read_le(&mut block_header_reader)?;
+                let _: N::TransactionsRoot = FromBytes::read_le(&mut block_header_reader)?;
+                // Obtain the block height.
+                let mut raw_block_height = [0u8; 4];
+                block_header_reader.read_exact(&mut raw_block_height)?;
+                let block_height = u32::from_le_bytes(raw_block_height);
+                Ok(block_height)
+            }
             None => return Err(anyhow!("Block {} missing from block headers map", block_hash)),
         }
     }

--- a/storage/src/storage/rocksdb/map.rs
+++ b/storage/src/storage/rocksdb/map.rs
@@ -72,7 +72,7 @@ impl<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> Map<'
         K: Borrow<Q>,
         Q: Serialize + ?Sized,
     {
-        self.get(key).map(|v| v.is_some())
+        self.get_raw(key).map(|v| v.is_some())
     }
 
     ///

--- a/storage/src/storage/rocksdb/map.rs
+++ b/storage/src/storage/rocksdb/map.rs
@@ -83,12 +83,10 @@ impl<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> Map<'
         K: Borrow<Q>,
         Q: Serialize + ?Sized,
     {
-        let mut key_buf = self.context.clone();
-        key_buf.reserve(bincode::serialized_size(&key)? as usize);
-        bincode::serialize_into(&mut key_buf, &key)?;
-        match self.rocksdb.get(&key_buf)? {
-            Some(data) => Ok(Some(bincode::deserialize(&data)?)),
-            None => Ok(None),
+        match self.get_raw(key) {
+            Ok(Some(bytes)) => Ok(Some(bincode::deserialize(&bytes)?)),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
         }
     }
 

--- a/storage/src/storage/traits.rs
+++ b/storage/src/storage/traits.rs
@@ -66,6 +66,14 @@ pub trait Map<'a, K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwn
         Q: Serialize + ?Sized;
 
     ///
+    /// Returns the raw value for the given key from the map, if it exists.
+    ///
+    fn get_raw<Q>(&self, key: &Q) -> Result<Option<Vec<u8>>>
+    where
+        K: Borrow<Q>,
+        Q: Serialize + ?Sized;
+
+    ///
     /// Inserts the given key-value pair into the map.
     ///
     fn insert<Q>(&self, key: &Q, value: &V) -> Result<()>


### PR DESCRIPTION
Supersedes https://github.com/AleoHQ/snarkOS/pull/1538.

This reduces the time needed to validate inbound block locators from hundreds of ms to **zero** ms. It will also boost any other operation which calls `get_block_height`.