### PR TITLE
Perf: use `parking_lot::RwLock` where possible 

### DIFF
--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -264,7 +264,7 @@ impl<N: Network, E: Environment> Server<N, E> {
             info!("Listening for peers at {}", local_ip);
             loop {
                 // Don't accept connections if the node is breaching the configured peer limit.
-                if peers.number_of_connected_peers().await < E::MAXIMUM_NUMBER_OF_PEERS {
+                if peers.number_of_connected_peers() < E::MAXIMUM_NUMBER_OF_PEERS {
                     // Asynchronously wait for an inbound TcpStream.
                     match listener.accept().await {
                         // Process the inbound connection request.

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -304,11 +304,11 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
 
     /// Returns the current state of this node.
     async fn get_node_state(&self) -> Result<Value, RpcError> {
-        let candidate_peers = self.peers.candidate_peers().await;
+        let candidate_peers = self.peers.candidate_peers();
         let connected_peers = self.peers.connected_peers();
         let number_of_candidate_peers = candidate_peers.len();
         let number_of_connected_peers = connected_peers.len();
-        let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes().await;
+        let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes();
 
         let latest_block_hash = self.ledger.latest_block_hash();
         let latest_block_height = self.ledger.latest_block_height();

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -299,13 +299,13 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
 
     /// Returns the peers currently connected to this node.
     async fn get_connected_peers(&self) -> Result<Vec<SocketAddr>, RpcError> {
-        Ok(self.peers.connected_peers().await)
+        Ok(self.peers.connected_peers())
     }
 
     /// Returns the current state of this node.
     async fn get_node_state(&self) -> Result<Value, RpcError> {
         let candidate_peers = self.peers.candidate_peers().await;
-        let connected_peers = self.peers.connected_peers().await;
+        let connected_peers = self.peers.connected_peers();
         let number_of_candidate_peers = candidate_peers.len();
         let number_of_connected_peers = connected_peers.len();
         let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes().await;

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -32,8 +32,8 @@ impl ClientNode {
     }
 
     /// Returns the list of connected peers of the node.
-    pub async fn connected_peers(&self) -> Vec<SocketAddr> {
-        self.server.peers().connected_peers().await
+    pub fn connected_peers(&self) -> Vec<SocketAddr> {
+        self.server.peers().connected_peers()
     }
 
     /// Resets the node's known peers. This is practical, as it makes the node not reconnect

--- a/testing/tests/network/basic_connectivity.rs
+++ b/testing/tests/network/basic_connectivity.rs
@@ -81,7 +81,7 @@ async fn handshake_as_responder_works() {
     test_node.node().connect(client_node.local_addr()).await.unwrap();
 
     // Double-check with the snarkOS node.
-    assert!(client_node.connected_peers().await.len() == 1)
+    assert!(client_node.connected_peers().len() == 1)
 }
 
 #[tokio::test]
@@ -181,7 +181,7 @@ async fn peer_accounting_works() {
     let test_node_addr = test_node.node().listening_addr().unwrap();
 
     // Double-check that the initial list of peers is empty.
-    assert!(client_node.connected_peers().await.is_empty());
+    assert!(client_node.connected_peers().is_empty());
 
     // Perform the connect+disconnect routine a few fimes.
     for _ in 0..3 {
@@ -189,7 +189,7 @@ async fn peer_accounting_works() {
         client_node.connect(test_node_addr).await.unwrap();
 
         // Verify that the list of peers is not empty anymore.
-        assert!(client_node.connected_peers().await.len() == 1);
+        assert!(client_node.connected_peers().len() == 1);
 
         // The test node disconnects from the snarkOS node.
         wait_until!(1, test_node.node().num_connected() == 1);
@@ -197,7 +197,7 @@ async fn peer_accounting_works() {
         assert!(test_node.node().disconnect(client_node_addr).await);
 
         // The list of snarkOS peers should be empty again.
-        wait_until!(1, client_node.connected_peers().await.is_empty());
+        wait_until!(1, client_node.connected_peers().is_empty());
 
         // The snarkOS node should not attempt to connect on its own.
         client_node.reset_known_peers().await;

--- a/testing/tests/network/cleanups.rs
+++ b/testing/tests/network/cleanups.rs
@@ -60,7 +60,7 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
 
         // Disconnect the test node from the snarkOS node.
         assert!(test_node.node().disconnect(client_node.local_addr()).await);
-        wait_until!(1, client_node.connected_peers().await.is_empty());
+        wait_until!(1, client_node.connected_peers().is_empty());
         client_node.reset_known_peers().await;
 
         if i == 0 {
@@ -104,7 +104,7 @@ async fn outbound_connect_and_disconnect_doesnt_leak() {
         wait_until!(1, test_node.node().num_connected() == 1);
         let client_node_addr = test_node.node().connected_addrs()[0];
         assert!(test_node.node().disconnect(client_node_addr).await);
-        wait_until!(1, client_node.connected_peers().await.is_empty());
+        wait_until!(1, client_node.connected_peers().is_empty());
         client_node.reset_known_peers().await;
 
         if i == 0 {


### PR DESCRIPTION
These collections never held the lock over an `await` point making it possible to switch to more performant `parking_lot` variants. 

I'm currently testing this change, hence the draft. 