### PR TITLE
Allow the node to auto-forward its listnening port using UPnP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
+dependencies = [
+ "http",
+ "log",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1277,19 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "igd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4e7ee8b51e541486d7040883fe1f00e2a9954bcc24fd155b7e4f03ed4b93dd"
+dependencies = [
+ "attohttpc",
+ "log",
+ "rand",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -2803,6 +2828,7 @@ dependencies = [
  "clap 3.1.15",
  "colored",
  "crossterm",
+ "igd",
  "num_cpus",
  "rand",
  "rayon",
@@ -3868,6 +3894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,6 +3980,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ version = "2.0"
 version = "0.23"
 optional = true
 
+[dependencies.igd]
+version = "0.12"
+
 [dependencies.num_cpus]
 version = "1"
 

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -64,6 +64,9 @@ pub struct Node {
     /// Specify the IP address and port for the node server.
     #[clap(parse(try_from_str), default_value = "0.0.0.0:4132", long = "node")]
     pub node: SocketAddr,
+    /// If the flag is set, the node will attempt to use UPnP to open its listening port.
+    #[structopt(long = "upnp")]
+    pub upnp: bool,
     /// Specify the IP address and port for the RPC server.
     #[clap(parse(try_from_str), default_value = "0.0.0.0:3032", long = "rpc")]
     pub rpc: SocketAddr,


### PR DESCRIPTION
The testnet2 equivalent of https://github.com/AleoHQ/snarkOS/pull/1218; the only difference is that the external address is not registered, but it can be extended with that functionality if need be.

Supersedes https://github.com/AleoHQ/snarkOS/pull/1218.
Closes https://github.com/AleoHQ/snarkOS/issues/423.