### PR TITLE
Use an alias for the current network

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -27,6 +27,8 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
+pub type CurrentNetwork = snarkvm::dpc::testnet2::Testnet2;
+
 #[rustfmt::skip]
 pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     type Network: Network;
@@ -87,19 +89,19 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
         NODES.get_or_init(|| Self::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
     }
-    
+
     /// Returns the tasks handler for the node.
     fn tasks() -> &'static Tasks<tokio::task::JoinHandle<()>> {
         static TASKS: OnceCell<Tasks<tokio::task::JoinHandle<()>>> = OnceCell::new();
         TASKS.get_or_init(Tasks::new)
     }
-    
+
     /// Returns the status of the node.
     fn status() -> &'static Status {
         static STATUS: OnceCell<Status> = OnceCell::new();
         STATUS.get_or_init(Status::new)
     }
-    
+
     /// Returns the terminator bit for the prover.
     fn terminator() -> &'static Arc<AtomicBool> {
         static TERMINATOR: OnceCell<Arc<AtomicBool>> = OnceCell::new();

--- a/src/helpers/block_request.rs
+++ b/src/helpers/block_request.rs
@@ -76,7 +76,8 @@ impl<N: Network> Hash for BlockRequest<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::{dpc::testnet2::Testnet2, prelude::UniformRand};
+    use crate::CurrentNetwork;
+    use snarkvm::prelude::UniformRand;
 
     use rand::{thread_rng, Rng};
 
@@ -86,17 +87,17 @@ mod tests {
 
         for _ in 0..5 {
             let block_height: u32 = rng.gen();
-            let block_hash = <Testnet2 as Network>::BlockHash::rand(rng);
+            let block_hash = <CurrentNetwork as Network>::BlockHash::rand(rng);
 
-            let request = BlockRequest::<Testnet2>::from(block_height);
+            let request = BlockRequest::<CurrentNetwork>::from(block_height);
             assert_eq!(block_height, request.block_height());
             assert_eq!(None, request.block_hash());
 
-            let request = BlockRequest::<Testnet2>::from((block_height, None));
+            let request = BlockRequest::<CurrentNetwork>::from((block_height, None));
             assert_eq!(block_height, request.block_height());
             assert_eq!(None, request.block_hash());
 
-            let request = BlockRequest::<Testnet2>::from((block_height, Some(block_hash)));
+            let request = BlockRequest::<CurrentNetwork>::from((block_height, Some(block_hash)));
             assert_eq!(block_height, request.block_height());
             assert_eq!(Some(block_hash), request.block_hash());
         }
@@ -108,14 +109,14 @@ mod tests {
 
         for _ in 0..5 {
             let block_height: u32 = rng.gen();
-            let block_hash = <Testnet2 as Network>::BlockHash::rand(rng);
+            let block_hash = <CurrentNetwork as Network>::BlockHash::rand(rng);
 
-            let a = BlockRequest::<Testnet2>::from(block_height);
-            let b = BlockRequest::<Testnet2>::from((block_height, None));
+            let a = BlockRequest::<CurrentNetwork>::from(block_height);
+            let b = BlockRequest::<CurrentNetwork>::from((block_height, None));
             assert_eq!(a, b);
 
-            let a = BlockRequest::<Testnet2>::from(block_height);
-            let b = BlockRequest::<Testnet2>::from((block_height, Some(block_hash)));
+            let a = BlockRequest::<CurrentNetwork>::from(block_height);
+            let b = BlockRequest::<CurrentNetwork>::from((block_height, Some(block_hash)));
             assert_eq!(a, b);
         }
     }

--- a/src/helpers/block_requests.rs
+++ b/src/helpers/block_requests.rs
@@ -243,8 +243,7 @@ pub(crate) fn handle_block_requests<N: Network, E: Environment>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Client;
-    use snarkvm::dpc::testnet2::Testnet2;
+    use crate::{Client, CurrentNetwork};
 
     use rand::{thread_rng, Rng};
 
@@ -272,7 +271,7 @@ mod tests {
             let maximum_common_ancestor = peer_maximum_block_height;
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -310,7 +309,7 @@ mod tests {
             let maximum_common_ancestor = peer_maximum_block_height;
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -349,7 +348,7 @@ mod tests {
             let peer_first_deviating_locator = Some(maximum_common_ancestor + 1);
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -388,7 +387,7 @@ mod tests {
             let peer_first_deviating_locator = Some(maximum_common_ancestor + 1);
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -401,7 +400,7 @@ mod tests {
 
             let expected_number_of_block_requests = std::cmp::min(
                 peer_maximum_block_height - latest_block_height,
-                Client::<Testnet2>::MAXIMUM_BLOCK_REQUEST,
+                Client::<CurrentNetwork>::MAXIMUM_BLOCK_REQUEST,
             );
             let expected_start_block_height = latest_block_height + 1;
             let expected_end_block_height = expected_start_block_height + expected_number_of_block_requests - 1;
@@ -428,7 +427,7 @@ mod tests {
         for _ in 0..ITERATIONS {
             // Declare internal state.
             let latest_block_height: u32 =
-                rng.gen_range(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 1..(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 1) * 2);
+                rng.gen_range(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 1..(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 1) * 2);
             let latest_cumulative_weight: u128 = latest_block_height as u128;
 
             // Declare peer state.
@@ -441,11 +440,11 @@ mod tests {
 
             // Declare locator state.
             let maximum_common_ancestor =
-                rng.gen_range(latest_block_height.saturating_sub(Testnet2::ALEO_MAXIMUM_FORK_DEPTH)..latest_block_height);
+                rng.gen_range(latest_block_height.saturating_sub(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH)..latest_block_height);
             let peer_first_deviating_locator = Some(rng.gen_range(maximum_common_ancestor + 1..latest_block_height));
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -458,7 +457,7 @@ mod tests {
 
             let expected_number_of_block_requests = std::cmp::min(
                 peer_maximum_block_height - maximum_common_ancestor,
-                Client::<Testnet2>::MAXIMUM_BLOCK_REQUEST,
+                Client::<CurrentNetwork>::MAXIMUM_BLOCK_REQUEST,
             );
             let expected_start_block_height = maximum_common_ancestor + 1;
             let expected_end_block_height = expected_start_block_height + expected_number_of_block_requests - 1;
@@ -486,7 +485,7 @@ mod tests {
         for _ in 0..ITERATIONS {
             // Declare internal state.
             let latest_block_height: u32 =
-                rng.gen_range(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 2..(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 2) * 2);
+                rng.gen_range(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 2..(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 2) * 2);
             let latest_cumulative_weight: u128 = latest_block_height as u128;
 
             // Declare peer state.
@@ -498,12 +497,13 @@ mod tests {
             let peer_maximum_cumulative_weight: u128 = peer_maximum_block_height as u128;
 
             // Declare locator state.
-            let maximum_common_ancestor = rng.gen_range(0..latest_block_height.saturating_sub(Testnet2::ALEO_MAXIMUM_FORK_DEPTH) / 2);
-            let peer_first_deviating_locator =
-                Some(rng.gen_range(maximum_common_ancestor + 1..latest_block_height.saturating_sub(Testnet2::ALEO_MAXIMUM_FORK_DEPTH)));
+            let maximum_common_ancestor = rng.gen_range(0..latest_block_height.saturating_sub(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH) / 2);
+            let peer_first_deviating_locator = Some(
+                rng.gen_range(maximum_common_ancestor + 1..latest_block_height.saturating_sub(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH)),
+            );
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -533,7 +533,7 @@ mod tests {
         for _ in 0..ITERATIONS {
             // Declare internal state.
             let latest_block_height: u32 =
-                rng.gen_range(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 1..(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 1) * 2);
+                rng.gen_range(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 1..(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 1) * 2);
             let latest_cumulative_weight: u128 = latest_block_height as u128;
 
             // Declare peer state.
@@ -545,12 +545,12 @@ mod tests {
             let peer_maximum_cumulative_weight: u128 = peer_maximum_block_height as u128;
 
             // Declare locator state.
-            let maximum_common_ancestor = rng.gen_range(0..latest_block_height.saturating_sub(Testnet2::ALEO_MAXIMUM_FORK_DEPTH));
+            let maximum_common_ancestor = rng.gen_range(0..latest_block_height.saturating_sub(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH));
             let peer_first_deviating_locator =
-                Some(rng.gen_range(latest_block_height.saturating_sub(Testnet2::ALEO_MAXIMUM_FORK_DEPTH)..latest_block_height));
+                Some(rng.gen_range(latest_block_height.saturating_sub(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH)..latest_block_height));
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,
@@ -563,7 +563,7 @@ mod tests {
 
             let expected_number_of_block_requests = std::cmp::min(
                 peer_maximum_block_height - maximum_common_ancestor,
-                Client::<Testnet2>::MAXIMUM_BLOCK_REQUEST,
+                Client::<CurrentNetwork>::MAXIMUM_BLOCK_REQUEST,
             );
             let expected_start_block_height = maximum_common_ancestor + 1;
             let expected_end_block_height = expected_start_block_height + expected_number_of_block_requests - 1;
@@ -591,7 +591,7 @@ mod tests {
         for _ in 0..ITERATIONS {
             // Declare internal state.
             let latest_block_height: u32 =
-                rng.gen_range(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 1..(Testnet2::ALEO_MAXIMUM_FORK_DEPTH + 1) * 2);
+                rng.gen_range(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 1..(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH + 1) * 2);
             let latest_cumulative_weight: u128 = latest_block_height as u128;
 
             // Declare peer state.
@@ -603,11 +603,11 @@ mod tests {
             let peer_maximum_cumulative_weight: u128 = peer_maximum_block_height as u128;
 
             // Declare locator state.
-            let maximum_common_ancestor = rng.gen_range(0..latest_block_height.saturating_sub(Testnet2::ALEO_MAXIMUM_FORK_DEPTH));
+            let maximum_common_ancestor = rng.gen_range(0..latest_block_height.saturating_sub(CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH));
             let peer_first_deviating_locator = None;
 
             // Determine if block requests or forking is required.
-            let result = handle_block_requests::<Testnet2, Client<Testnet2>>(
+            let result = handle_block_requests::<CurrentNetwork, Client<CurrentNetwork>>(
                 latest_block_height,
                 latest_cumulative_weight,
                 peer_ip,

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -421,13 +421,13 @@ fn result_to_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{environment::Client, helpers::State, ledger::Ledger, network::Prover};
+    use crate::{environment::Client, helpers::State, ledger::Ledger, network::Prover, CurrentNetwork};
     use snarkos_storage::{
         storage::{rocksdb::RocksDB, Storage},
         LedgerState,
     };
     use snarkvm::{
-        dpc::{testnet2::Testnet2, AccountScheme, AleoAmount, Transaction, Transactions, Transition},
+        dpc::{AccountScheme, AleoAmount, Transaction, Transactions, Transition},
         prelude::{Account, Block, BlockHeader},
         utilities::ToBytes,
     };
@@ -562,7 +562,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_rpc() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request with an empty body.
         let request = Request::new(Body::empty());
@@ -578,7 +578,7 @@ mod tests {
     #[tokio::test]
     async fn test_latest_block() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `latestblock` endpoint.
         let request = Request::new(Body::from(
@@ -595,17 +595,17 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a block.
-        let actual: Block<Testnet2> = process_response(response).await;
+        let actual: Block<CurrentNetwork> = process_response(response).await;
 
         // Check the block.
-        let expected = Testnet2::genesis_block();
+        let expected = CurrentNetwork::genesis_block();
         assert_eq!(*expected, actual);
     }
 
     #[tokio::test]
     async fn test_latest_block_height() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `latestblockheight` endpoint.
         let request = Request::new(Body::from(
@@ -625,14 +625,14 @@ mod tests {
         let actual: u32 = process_response(response).await;
 
         // Check the block height.
-        let expected = Testnet2::genesis_block().height();
+        let expected = CurrentNetwork::genesis_block().height();
         assert_eq!(expected, actual);
     }
 
     #[tokio::test]
     async fn test_latest_block_hash() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `latestblockhash` endpoint.
         let request = Request::new(Body::from(
@@ -649,17 +649,17 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a block hash.
-        let actual: <Testnet2 as Network>::BlockHash = process_response(response).await;
+        let actual: <CurrentNetwork as Network>::BlockHash = process_response(response).await;
 
         // Check the block hash.
-        let expected = Testnet2::genesis_block().hash();
+        let expected = CurrentNetwork::genesis_block().hash();
         assert_eq!(expected, actual);
     }
 
     #[tokio::test]
     async fn test_latest_block_header() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `latestblockheader` endpoint.
         let request = Request::new(Body::from(
@@ -676,17 +676,17 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a block header.
-        let actual: BlockHeader<Testnet2> = process_response(response).await;
+        let actual: BlockHeader<CurrentNetwork> = process_response(response).await;
 
         // Check the block header.
-        let expected = Testnet2::genesis_block().header();
+        let expected = CurrentNetwork::genesis_block().header();
         assert_eq!(*expected, actual);
     }
 
     #[tokio::test]
     async fn test_latest_block_transactions() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `latestblocktransactions` endpoint.
         let request = Request::new(Body::from(
@@ -703,17 +703,17 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into transactions.
-        let actual: Transactions<Testnet2> = process_response(response).await;
+        let actual: Transactions<CurrentNetwork> = process_response(response).await;
 
         // Check the transactions.
-        let expected = Testnet2::genesis_block().transactions();
+        let expected = CurrentNetwork::genesis_block().transactions();
         assert_eq!(*expected, actual);
     }
 
     #[tokio::test]
     async fn test_latest_ledger_root() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         let expected = rpc.latest_ledger_root().await.unwrap();
 
@@ -732,7 +732,7 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a ledger root.
-        let actual: <Testnet2 as Network>::LedgerRoot = process_response(response).await;
+        let actual: <CurrentNetwork as Network>::LedgerRoot = process_response(response).await;
 
         // Check the ledger root.
         assert_eq!(expected, actual);
@@ -741,7 +741,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_block() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `getblock` endpoint.
         let request = Request::new(Body::from(
@@ -761,10 +761,10 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a block.
-        let actual: Block<Testnet2> = process_response(response).await;
+        let actual: Block<CurrentNetwork> = process_response(response).await;
 
         // Check the block.
-        let expected = Testnet2::genesis_block();
+        let expected = CurrentNetwork::genesis_block();
         assert_eq!(*expected, actual);
     }
 
@@ -777,11 +777,11 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
+        let ledger_state = new_ledger_state::<CurrentNetwork, RocksDB, PathBuf>(Some(directory.clone()));
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
-        let account = Account::<Testnet2>::new(&mut thread_rng());
+        let account = Account::<CurrentNetwork>::new(&mut thread_rng());
         let address = account.address();
 
         // Mine the next block.
@@ -795,7 +795,7 @@ mod tests {
         drop(ledger_state);
 
         // Initialize a new RPC with the ledger state containing the genesis block and block_1.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(Some(directory.clone())).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(Some(directory.clone())).await;
 
         // Initialize a new request that calls the `getblocks` endpoint.
         let request = Request::new(Body::from(
@@ -815,10 +815,10 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into blocks.
-        let actual: Vec<Block<Testnet2>> = process_response(response).await;
+        let actual: Vec<Block<CurrentNetwork>> = process_response(response).await;
 
         // Check the blocks.
-        let expected = vec![Testnet2::genesis_block(), &block_1];
+        let expected = vec![CurrentNetwork::genesis_block(), &block_1];
         expected.into_iter().zip(actual.into_iter()).for_each(|(expected, actual)| {
             assert_eq!(*expected, actual);
         });
@@ -827,10 +827,10 @@ mod tests {
     #[tokio::test]
     async fn test_get_block_height() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Get the genesis block hash.
-        let block_hash = Testnet2::genesis_block().hash().to_string();
+        let block_hash = CurrentNetwork::genesis_block().hash().to_string();
 
         // Initialize a new request that calls the `getblockheight` endpoint.
         let request = Request::new(Body::from(format!(
@@ -854,14 +854,14 @@ mod tests {
         let actual: u32 = process_response(response).await;
 
         // Check the block height.
-        let expected = Testnet2::genesis_block().height();
+        let expected = CurrentNetwork::genesis_block().height();
         assert_eq!(expected, actual);
     }
 
     #[tokio::test]
     async fn test_get_block_hash() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `getblockhash` endpoint.
         let request = Request::new(Body::from(
@@ -881,10 +881,10 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a block hash.
-        let actual: <Testnet2 as Network>::BlockHash = process_response(response).await;
+        let actual: <CurrentNetwork as Network>::BlockHash = process_response(response).await;
 
         // Check the block hash.
-        let expected = Testnet2::genesis_block().hash();
+        let expected = CurrentNetwork::genesis_block().hash();
         assert_eq!(expected, actual);
     }
 
@@ -897,11 +897,11 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
+        let ledger_state = new_ledger_state::<CurrentNetwork, RocksDB, PathBuf>(Some(directory.clone()));
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
-        let account = Account::<Testnet2>::new(&mut thread_rng());
+        let account = Account::<CurrentNetwork>::new(&mut thread_rng());
         let address = account.address();
 
         // Mine the next block.
@@ -915,7 +915,7 @@ mod tests {
         drop(ledger_state);
 
         // Initialize a new RPC with the ledger state containing the genesis block and block_1.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(Some(directory.clone())).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(Some(directory.clone())).await;
 
         // Initialize a new request that calls the `getblockhashes` endpoint.
         let request = Request::new(Body::from(
@@ -935,10 +935,10 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into block hashes.
-        let actual: Vec<<Testnet2 as Network>::BlockHash> = process_response(response).await;
+        let actual: Vec<<CurrentNetwork as Network>::BlockHash> = process_response(response).await;
 
         // Check the block hashes.
-        let expected = vec![Testnet2::genesis_block().hash(), block_1.hash()];
+        let expected = vec![CurrentNetwork::genesis_block().hash(), block_1.hash()];
         expected.into_iter().zip(actual.into_iter()).for_each(|(expected, actual)| {
             assert_eq!(expected, actual);
         });
@@ -947,7 +947,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_block_header() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `getblockheader` endpoint.
         let request = Request::new(Body::from(
@@ -967,24 +967,24 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a block header.
-        let actual: BlockHeader<Testnet2> = process_response(response).await;
+        let actual: BlockHeader<CurrentNetwork> = process_response(response).await;
 
         // Check the block header.
-        let expected = Testnet2::genesis_block().header();
+        let expected = CurrentNetwork::genesis_block().header();
         assert_eq!(*expected, actual);
     }
 
     #[tokio::test]
     async fn test_get_block_template() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize the expected block template values.
-        let expected_previous_block_hash = Testnet2::genesis_block().hash().to_string();
+        let expected_previous_block_hash = CurrentNetwork::genesis_block().hash().to_string();
         let expected_block_height = 1;
         let expected_ledger_root = rpc.latest_ledger_root().await.unwrap().to_string();
         let expected_transactions = Vec::<serde_json::Value>::new();
-        let expected_block_reward = Block::<Testnet2>::block_reward(1).0;
+        let expected_block_reward = Block::<CurrentNetwork>::block_reward(1).0;
 
         // Initialize a new request that calls the `getblocktemplate` endpoint.
         let request = Request::new(Body::from(
@@ -1014,7 +1014,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_block_transactions() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `getblocktransactions` endpoint.
         let request = Request::new(Body::from(
@@ -1034,20 +1034,20 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into transactions.
-        let actual: Transactions<Testnet2> = process_response(response).await;
+        let actual: Transactions<CurrentNetwork> = process_response(response).await;
 
         // Check the transactions.
-        let expected = Testnet2::genesis_block().transactions();
+        let expected = CurrentNetwork::genesis_block().transactions();
         assert_eq!(*expected, actual);
     }
 
     #[tokio::test]
     async fn test_get_ciphertext() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Get the commitment from the genesis coinbase transaction.
-        let commitment = Testnet2::genesis_block().to_coinbase_transaction().unwrap().transitions()[0]
+        let commitment = CurrentNetwork::genesis_block().to_coinbase_transaction().unwrap().transitions()[0]
             .commitments()
             .next()
             .unwrap()
@@ -1072,11 +1072,11 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a ciphertext.
-        let actual: <Testnet2 as Network>::RecordCiphertext = process_response(response).await;
+        let actual: <CurrentNetwork as Network>::RecordCiphertext = process_response(response).await;
 
         // Check the ciphertext.
         assert!(
-            Testnet2::genesis_block()
+            CurrentNetwork::genesis_block()
                 .transactions()
                 .first()
                 .unwrap()
@@ -1094,11 +1094,11 @@ mod tests {
         let directory = temp_dir();
 
         // Initialize a new ledger state at the temporary directory.
-        let ledger_state = new_ledger_state::<Testnet2, RocksDB, PathBuf>(Some(directory.clone()));
+        let ledger_state = new_ledger_state::<CurrentNetwork, RocksDB, PathBuf>(Some(directory.clone()));
         assert_eq!(0, ledger_state.latest_block_height());
 
         // Initialize a new account.
-        let account = Account::<Testnet2>::new(&mut rng);
+        let account = Account::<CurrentNetwork>::new(&mut rng);
         let address = account.address();
 
         // Mine the next block.
@@ -1120,7 +1120,7 @@ mod tests {
         drop(ledger_state);
 
         // Initialize a new RPC with the ledger state containing the genesis block and block_1.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(Some(directory.clone())).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(Some(directory.clone())).await;
 
         // Initialize a new request that calls the `getledgerproof` endpoint.
         let request = Request::new(Body::from(format!(
@@ -1151,14 +1151,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_node_state() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Declare the expected node state.
         let expected = serde_json::json!({
-            "address": Option::<Address<Testnet2>>::None,
+            "address": Option::<Address<CurrentNetwork>>::None,
             "candidate_peers": Vec::<SocketAddr>::new(),
             "connected_peers": Vec::<SocketAddr>::new(),
-            "latest_block_hash": Testnet2::genesis_block().hash(),
+            "latest_block_hash": CurrentNetwork::genesis_block().hash(),
             "latest_block_height": 0,
             "latest_cumulative_weight": 0,
             "launched": format!("{} minutes ago", 0),
@@ -1166,9 +1166,9 @@ mod tests {
             "number_of_connected_peers": 0,
             "number_of_connected_sync_nodes": 0,
             "software": format!("snarkOS {}", env!("CARGO_PKG_VERSION")),
-            "status": Client::<Testnet2>::status().to_string(),
-            "type": Client::<Testnet2>::NODE_TYPE,
-            "version": Client::<Testnet2>::MESSAGE_VERSION,
+            "status": Client::<CurrentNetwork>::status().to_string(),
+            "type": Client::<CurrentNetwork>::NODE_TYPE,
+            "version": Client::<CurrentNetwork>::MESSAGE_VERSION,
         });
 
         // Initialize a new request that calls the `getnodestate` endpoint.
@@ -1199,19 +1199,19 @@ mod tests {
         /// Additional metadata included with a transaction response
         #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
         pub struct GetTransactionResponse {
-            pub transaction: Transaction<Testnet2>,
-            pub metadata: snarkos_storage::Metadata<Testnet2>,
-            pub decrypted_records: Vec<Record<Testnet2>>,
+            pub transaction: Transaction<CurrentNetwork>,
+            pub metadata: snarkos_storage::Metadata<CurrentNetwork>,
+            pub decrypted_records: Vec<Record<CurrentNetwork>>,
         }
 
         // Initialize a new ledger.
-        let ledger = new_ledger_state::<Testnet2, RocksDB, PathBuf>(None);
+        let ledger = new_ledger_state::<CurrentNetwork, RocksDB, PathBuf>(None);
 
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Get the genesis coinbase transaction ID.
-        let transaction_id = Testnet2::genesis_block().to_coinbase_transaction().unwrap().transaction_id();
+        let transaction_id = CurrentNetwork::genesis_block().to_coinbase_transaction().unwrap().transaction_id();
 
         // Initialize a new request that calls the `gettransaction` endpoint.
         let request = Request::new(Body::from(format!(
@@ -1235,7 +1235,7 @@ mod tests {
         let actual: GetTransactionResponse = process_response(response).await;
 
         // Check the transaction.
-        let expected_transaction = Testnet2::genesis_block().transactions().first().unwrap();
+        let expected_transaction = CurrentNetwork::genesis_block().transactions().first().unwrap();
         assert_eq!(*expected_transaction, actual.transaction);
 
         // Check the metadata.
@@ -1243,17 +1243,17 @@ mod tests {
         assert_eq!(expected_transaction_metadata, actual.metadata);
 
         // Check the records.
-        let expected_decrypted_records: Vec<Record<Testnet2>> = expected_transaction.to_records().collect();
+        let expected_decrypted_records: Vec<Record<CurrentNetwork>> = expected_transaction.to_records().collect();
         assert_eq!(expected_decrypted_records, actual.decrypted_records)
     }
 
     #[tokio::test]
     async fn test_get_transition() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Get a transition ID from the genesis coinbase transaction.
-        let transition_id = Testnet2::genesis_block().to_coinbase_transaction().unwrap().transitions()[0]
+        let transition_id = CurrentNetwork::genesis_block().to_coinbase_transaction().unwrap().transitions()[0]
             .transition_id()
             .to_string();
 
@@ -1276,11 +1276,11 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a transition.
-        let actual: Transition<Testnet2> = process_response(response).await;
+        let actual: Transition<CurrentNetwork> = process_response(response).await;
 
         // Check the transition.
         assert!(
-            Testnet2::genesis_block()
+            CurrentNetwork::genesis_block()
                 .transactions()
                 .first()
                 .unwrap()
@@ -1293,7 +1293,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_connected_peers() {
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `gettransition` endpoint.
         let request = Request::new(Body::from(
@@ -1322,15 +1322,15 @@ mod tests {
         let mut rng = ChaChaRng::seed_from_u64(123456789);
 
         // Initialize a new account.
-        let account = Account::<Testnet2>::new(&mut rng);
+        let account = Account::<CurrentNetwork>::new(&mut rng);
         let address = account.address();
 
         // Initialize a new transaction.
-        let (transaction, _) = Transaction::<Testnet2>::new_coinbase(address, AleoAmount(1234), true, &mut rng)
+        let (transaction, _) = Transaction::<CurrentNetwork>::new_coinbase(address, AleoAmount(1234), true, &mut rng)
             .expect("Failed to create a coinbase transaction");
 
         // Initialize a new rpc.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Initialize a new request that calls the `sendtransaction` endpoint.
         let request = Request::new(Body::from(format!(
@@ -1351,7 +1351,7 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into a ciphertext.
-        let actual: <Testnet2 as Network>::TransactionID = process_response(response).await;
+        let actual: <CurrentNetwork as Network>::TransactionID = process_response(response).await;
 
         // Check the transaction id.
         let expected = transaction.transaction_id();
@@ -1361,7 +1361,7 @@ mod tests {
     #[tokio::test]
     async fn test_send_transaction_large() {
         // Initialize a new RPC.
-        new_rpc_server::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        new_rpc_server::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         ///
         /// Sends a `sendtransaction` RPC request to the given node address.
@@ -1393,7 +1393,7 @@ mod tests {
         let response = result.expect("Test RPC failed to process request");
 
         // Process the response into a transaction ID.
-        let actual: <Testnet2 as Network>::TransactionID =
+        let actual: <CurrentNetwork as Network>::TransactionID =
             serde_json::from_value(response["result"].clone()).expect("Failed to deserialize response from send_transaction");
 
         // Check the transaction id.
@@ -1405,17 +1405,17 @@ mod tests {
         let mut rng = ChaChaRng::seed_from_u64(123456789);
 
         // Initialize a new RPC.
-        let rpc = new_rpc::<Testnet2, Client<Testnet2>, RocksDB, PathBuf>(None).await;
+        let rpc = new_rpc::<CurrentNetwork, Client<CurrentNetwork>, RocksDB, PathBuf>(None).await;
 
         // Send a transaction to the node.
 
         // Initialize a new account.
-        let account = Account::<Testnet2>::new(&mut rng);
+        let account = Account::<CurrentNetwork>::new(&mut rng);
         let address = account.address();
 
         // Initialize a new transaction.
-        let (transaction, _) =
-            Transaction::<Testnet2>::new_coinbase(address, AleoAmount(0), true, &mut rng).expect("Failed to create a coinbase transaction");
+        let (transaction, _) = Transaction::<CurrentNetwork>::new_coinbase(address, AleoAmount(0), true, &mut rng)
+            .expect("Failed to create a coinbase transaction");
 
         // Initialize a new request that calls the `sendtransaction` endpoint.
         let request = Request::new(Body::from(format!(
@@ -1455,7 +1455,7 @@ mod tests {
             .expect("Test RPC failed to process request");
 
         // Process the response into transactions.
-        let actual: Vec<Transaction<Testnet2>> = process_response(response).await;
+        let actual: Vec<Transaction<CurrentNetwork>> = process_response(response).await;
 
         // Check the transactions.
         let expected = vec![transaction];

--- a/storage/benches/lookups.rs
+++ b/storage/benches/lookups.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_storage::{storage::rocksdb::RocksDB, LedgerState};
-use snarkvm::{dpc::testnet2::Testnet2, prelude::Block, traits::Network};
+use snarkos_storage::{storage::rocksdb::RocksDB, CurrentNetwork, LedgerState};
+use snarkvm::{prelude::Block, traits::Network};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::{prelude::SliceRandom, thread_rng, Rng, SeedableRng};
@@ -33,26 +33,26 @@ fn lookups(c: &mut Criterion) {
     // Read the test blocks.
     // note: the `blocks_100` and `blocks_1000` files were generated on a testnet2 storage using `LedgerState::dump_blocks`.
     let mut test_blocks = fs::read(format!("benches/blocks_{}", NUM_BLOCKS)).expect(&format!("Missing the test blocks file"));
-    let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&mut test_blocks).expect("Failed to deserialize a block dump");
+    let blocks: Vec<Block<CurrentNetwork>> = bincode::deserialize(&mut test_blocks).expect("Failed to deserialize a block dump");
     assert_eq!(blocks.len(), NUM_BLOCKS - 1);
 
     // Prepare the collections for block component ids.
 
     let mut block_hashes = Vec::with_capacity(NUM_BLOCKS);
-    block_hashes.push(Testnet2::genesis_block().hash());
+    block_hashes.push(CurrentNetwork::genesis_block().hash());
 
     let mut tx_ids = Vec::with_capacity(NUM_BLOCKS);
-    for tx_id in Testnet2::genesis_block().transactions().transaction_ids() {
+    for tx_id in CurrentNetwork::genesis_block().transactions().transaction_ids() {
         tx_ids.push(tx_id);
     }
 
     let mut tx_commitments = Vec::with_capacity(NUM_BLOCKS);
-    for tx_commitment in Testnet2::genesis_block().transactions().commitments() {
+    for tx_commitment in CurrentNetwork::genesis_block().transactions().commitments() {
         tx_commitments.push(tx_commitment);
     }
 
     let mut tx_serial_numbers = Vec::with_capacity(NUM_BLOCKS);
-    for tx_serial_number in Testnet2::genesis_block().transactions().serial_numbers() {
+    for tx_serial_number in CurrentNetwork::genesis_block().transactions().serial_numbers() {
         tx_serial_numbers.push(tx_serial_number);
     }
 

--- a/storage/src/helpers/block_locators.rs
+++ b/storage/src/helpers/block_locators.rs
@@ -212,15 +212,16 @@ impl<N: Network> Deref for BlockLocators<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::dpc::testnet2::Testnet2;
+    use crate::CurrentNetwork;
 
     #[test]
     fn test_block_locators_serde_json() {
-        let expected_block_height = Testnet2::genesis_block().height();
-        let expected_block_hash = Testnet2::genesis_block().hash();
-        let expected_block_header = Testnet2::genesis_block().header().clone();
+        let expected_block_height = CurrentNetwork::genesis_block().height();
+        let expected_block_hash = CurrentNetwork::genesis_block().hash();
+        let expected_block_header = CurrentNetwork::genesis_block().header().clone();
         let expected_block_locators =
-            BlockLocators::<Testnet2>::from([(expected_block_height, (expected_block_hash, Some(expected_block_header)))].into()).unwrap();
+            BlockLocators::<CurrentNetwork>::from([(expected_block_height, (expected_block_hash, Some(expected_block_header)))].into())
+                .unwrap();
 
         // Serialize
         let expected_string = expected_block_locators.to_string();
@@ -235,11 +236,12 @@ mod tests {
 
     #[test]
     fn test_block_locators_bincode() {
-        let expected_block_height = Testnet2::genesis_block().height();
-        let expected_block_hash = Testnet2::genesis_block().hash();
-        let expected_block_header = Testnet2::genesis_block().header().clone();
+        let expected_block_height = CurrentNetwork::genesis_block().height();
+        let expected_block_hash = CurrentNetwork::genesis_block().hash();
+        let expected_block_header = CurrentNetwork::genesis_block().header().clone();
         let expected_block_locators =
-            BlockLocators::<Testnet2>::from([(expected_block_height, (expected_block_hash, Some(expected_block_header)))].into()).unwrap();
+            BlockLocators::<CurrentNetwork>::from([(expected_block_height, (expected_block_hash, Some(expected_block_header)))].into())
+                .unwrap();
 
         // Serialize
         let expected_bytes = expected_block_locators.to_bytes_le().unwrap();

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -35,3 +35,5 @@ pub use state::{
 };
 
 pub mod storage;
+
+pub type CurrentNetwork = snarkvm::dpc::testnet2::Testnet2;

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -16,9 +16,10 @@
 
 use crate::{
     storage::{rocksdb::RocksDB, Storage},
+    CurrentNetwork,
     LedgerState,
 };
-use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
+use snarkvm::dpc::prelude::*;
 
 use rand::{thread_rng, Rng};
 use std::sync::atomic::AtomicBool;
@@ -35,13 +36,13 @@ fn create_new_ledger<N: Network, S: Storage>() -> LedgerState<N> {
 #[test]
 fn test_genesis() {
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
 
     // Retrieve the genesis block.
-    let genesis = Testnet2::genesis_block();
+    let genesis = CurrentNetwork::genesis_block();
 
     // Initialize a new ledger tree.
-    let mut ledger_tree = LedgerTree::<Testnet2>::new().expect("Failed to initialize ledger tree");
+    let mut ledger_tree = LedgerTree::<CurrentNetwork>::new().expect("Failed to initialize ledger tree");
     ledger_tree.add(&genesis.hash()).expect("Failed to add to ledger tree");
 
     // Ensure the ledger is at the genesis block.
@@ -61,17 +62,17 @@ fn test_add_next_block() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
-    let mut ledger_tree = LedgerTree::<Testnet2>::new().expect("Failed to initialize ledger tree");
+    let mut ledger_tree = LedgerTree::<CurrentNetwork>::new().expect("Failed to initialize ledger tree");
     ledger_tree
-        .add(&Testnet2::genesis_block().hash())
+        .add(&CurrentNetwork::genesis_block().hash())
         .expect("Failed to add to ledger tree");
 
     // Initialize a new account.
-    let account = Account::<Testnet2>::new(&mut thread_rng());
+    let account = Account::<CurrentNetwork>::new(&mut thread_rng());
     let address = account.address();
 
     // Mine the next block.
@@ -91,7 +92,7 @@ fn test_add_next_block() {
     assert_eq!(ledger_tree.root(), ledger.latest_ledger_root());
 
     // Retrieve the genesis block.
-    let genesis = Testnet2::genesis_block();
+    let genesis = CurrentNetwork::genesis_block();
 
     // Ensure the block locators are correct.
     let block_locators = ledger.latest_block_locators();
@@ -109,17 +110,17 @@ fn test_remove_last_block() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
-    let mut ledger_tree = LedgerTree::<Testnet2>::new().expect("Failed to initialize ledger tree");
+    let mut ledger_tree = LedgerTree::<CurrentNetwork>::new().expect("Failed to initialize ledger tree");
     ledger_tree
-        .add(&Testnet2::genesis_block().hash())
+        .add(&CurrentNetwork::genesis_block().hash())
         .expect("Failed to add to ledger tree");
 
     // Initialize a new account.
-    let account = Account::<Testnet2>::new(&mut thread_rng());
+    let account = Account::<CurrentNetwork>::new(&mut thread_rng());
     let address = account.address();
 
     // Mine the next block.
@@ -136,7 +137,7 @@ fn test_remove_last_block() {
     assert_eq!(vec![block], blocks);
 
     // Retrieve the genesis block.
-    let genesis = Testnet2::genesis_block();
+    let genesis = CurrentNetwork::genesis_block();
 
     // Ensure the ledger is back at the genesis block.
     assert_eq!(0, ledger.latest_block_height());
@@ -155,17 +156,17 @@ fn test_remove_last_2_blocks() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
-    let mut ledger_tree = LedgerTree::<Testnet2>::new().expect("Failed to initialize ledger tree");
+    let mut ledger_tree = LedgerTree::<CurrentNetwork>::new().expect("Failed to initialize ledger tree");
     ledger_tree
-        .add(&Testnet2::genesis_block().hash())
+        .add(&CurrentNetwork::genesis_block().hash())
         .expect("Failed to add to ledger tree");
 
     // Initialize a new account.
-    let account = Account::<Testnet2>::new(&mut thread_rng());
+    let account = Account::<CurrentNetwork>::new(&mut thread_rng());
     let address = account.address();
 
     // Mine the next block.
@@ -189,7 +190,7 @@ fn test_remove_last_2_blocks() {
     assert_eq!(vec![block_1, block_2], blocks);
 
     // Retrieve the genesis block.
-    let genesis = Testnet2::genesis_block();
+    let genesis = CurrentNetwork::genesis_block();
 
     // Ensure the ledger is back at the genesis block.
     assert_eq!(0, ledger.latest_block_height());
@@ -208,17 +209,17 @@ fn test_get_block_locators() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new ledger tree.
-    let mut ledger_tree = LedgerTree::<Testnet2>::new().expect("Failed to initialize ledger tree");
+    let mut ledger_tree = LedgerTree::<CurrentNetwork>::new().expect("Failed to initialize ledger tree");
     ledger_tree
-        .add(&Testnet2::genesis_block().hash())
+        .add(&CurrentNetwork::genesis_block().hash())
         .expect("Failed to add to ledger tree");
 
     // Initialize a new account.
-    let account = Account::<Testnet2>::new(&mut thread_rng());
+    let account = Account::<CurrentNetwork>::new(&mut thread_rng());
     let address = account.address();
 
     // Mine the next block.
@@ -279,11 +280,11 @@ fn test_transaction_fees() {
     let terminator = AtomicBool::new(false);
 
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
     assert_eq!(0, ledger.latest_block_height());
 
     // Initialize a new account.
-    let account = Account::<Testnet2>::new(&mut thread_rng());
+    let account = Account::<CurrentNetwork>::new(&mut thread_rng());
     let private_key = account.private_key();
     let view_key = account.view_key();
     let address = account.address();
@@ -305,7 +306,7 @@ fn test_transaction_fees() {
     let ledger_proof = ledger.get_ledger_inclusion_proof(coinbase_record[0].commitment()).unwrap();
 
     // Initialize a recipient account.
-    let recipient_account = Account::<Testnet2>::new(rng);
+    let recipient_account = Account::<CurrentNetwork>::new(rng);
     let recipient_view_key = recipient_account.view_key();
     let recipient = recipient_account.address();
 
@@ -336,7 +337,7 @@ fn test_transaction_fees() {
     ledger.add_next_block(&block_2).expect("Failed to add next block to ledger");
     assert_eq!(2, ledger.latest_block_height());
 
-    let expected_block_reward = Block::<Testnet2>::block_reward(2).add(fee);
+    let expected_block_reward = Block::<CurrentNetwork>::block_reward(2).add(fee);
     let output_record = &block_2.transactions()[0].to_decrypted_records(recipient_view_key)[0];
     let new_coinbase_record = &block_2.transactions()[1].to_decrypted_records(view_key)[0];
 

--- a/testing/src/client_node.rs
+++ b/testing/src/client_node.rs
@@ -14,15 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos::{Client, Server};
-use snarkvm::dpc::testnet2::Testnet2;
+use snarkos::{Client, CurrentNetwork, Server};
 
 use std::{fs, net::SocketAddr};
 use structopt::StructOpt;
 
 /// A facade for a snarkOS client node.
 pub struct ClientNode {
-    pub server: Server<Testnet2, Client<Testnet2>>,
+    pub server: Server<CurrentNetwork, Client<CurrentNetwork>>,
 }
 
 impl ClientNode {
@@ -58,7 +57,9 @@ impl ClientNode {
         let permanent_args = &["snarkos", "--norpc"];
         let combined_args = permanent_args.iter().chain(extra_args.iter());
         let config = snarkos::Node::from_iter(combined_args);
-        let server = Server::<Testnet2, Client<Testnet2>>::initialize(&config, None, None).await.unwrap();
+        let server = Server::<CurrentNetwork, Client<CurrentNetwork>>::initialize(&config, None, None)
+            .await
+            .unwrap();
 
         ClientNode { server }
     }


### PR DESCRIPTION
It's something that has been on my mind for a while now - in order for future default network changes to be simpler, we can have a global type alias for the current `N::Network`.

Note: it's currently set separately in both `snarkos` and `snarkos-storage`, but the one in `snarkos` could technically be based on the `snarkos-storage` one. In any case, it's still 2 places to adjust as opposed to dozens.