### PR TITLE
Fix lints from the updated nightly

### DIFF
--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -236,14 +236,17 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 // Update the block requests.
                 self.update_block_requests().await;
 
+                let block_requests = self.number_of_block_requests().await;
+                let connected_peers = self.peers_state.read().await.len();
+
                 debug!(
                     "Status Report (type = {}, status = {}, block_height = {}, cumulative_weight = {}, block_requests = {}, connected_peers = {})",
                     E::NODE_TYPE,
                     E::status(),
                     self.canon.latest_block_height(),
                     self.canon.latest_cumulative_weight(),
-                    self.number_of_block_requests().await,
-                    self.peers_state.read().await.len()
+                    block_requests,
+                    connected_peers,
                 );
             }
             LedgerRequest::Pong(peer_ip, node_type, status, is_fork, block_locators) => {

--- a/src/rpc/rpc.rs
+++ b/src/rpc/rpc.rs
@@ -1137,7 +1137,7 @@ mod tests {
         \"{}\"
     ]
 }}",
-            record_commitment.to_string()
+            record_commitment
         )));
 
         // Send the request to the RPC.
@@ -1228,7 +1228,7 @@ mod tests {
         \"{}\"
     ]
 }}",
-            transaction_id.to_string()
+            transaction_id
         )));
 
         // Send the request to the RPC.

--- a/storage/benches/lookups.rs
+++ b/storage/benches/lookups.rs
@@ -32,8 +32,8 @@ fn lookups(c: &mut Criterion) {
 
     // Read the test blocks.
     // note: the `blocks_100` and `blocks_1000` files were generated on a testnet2 storage using `LedgerState::dump_blocks`.
-    let mut test_blocks = fs::read(format!("benches/blocks_{}", NUM_BLOCKS)).expect(&format!("Missing the test blocks file"));
-    let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&mut test_blocks).expect("Failed to deserialize a block dump");
+    let test_blocks = fs::read(format!("benches/blocks_{}", NUM_BLOCKS)).unwrap_or_else(|_| panic!("Missing the test blocks file"));
+    let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&test_blocks).expect("Failed to deserialize a block dump");
     assert_eq!(blocks.len(), NUM_BLOCKS - 1);
 
     // Prepare the collections for block component ids.
@@ -77,7 +77,7 @@ fn lookups(c: &mut Criterion) {
     c.bench_function("blocks_lookup_by_hash", |b| {
         b.iter(|| {
             let hash = block_hashes.choose(&mut rng).unwrap();
-            ledger.contains_block_hash(&hash).expect("Lookup by block hash failed");
+            ledger.contains_block_hash(hash).expect("Lookup by block hash failed");
         })
     });
 

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -297,9 +297,9 @@ fn test_transaction_fees() {
     // Craft the transaction variables.
     let coinbase_transaction = &block.transactions()[0];
 
-    let available_balance = AleoAmount::from_i64(-1 * coinbase_transaction.value_balance().0);
+    let available_balance = AleoAmount::from_i64(-coinbase_transaction.value_balance().0);
     let fee = AleoAmount::from_i64(rng.gen_range(1..available_balance.0));
-    let amount = available_balance.sub(fee.clone());
+    let amount = available_balance.sub(fee);
     let coinbase_record = coinbase_transaction.to_decrypted_records(&view_key.into()).collect::<Vec<_>>();
 
     let ledger_proof = ledger.get_ledger_inclusion_proof(coinbase_record[0].commitment()).unwrap();
@@ -313,10 +313,10 @@ fn test_transaction_fees() {
     let transfer_request = Request::new_transfer(
         private_key,
         coinbase_record,
-        vec![ledger_proof.clone(), LedgerProof::default()],
+        vec![ledger_proof, LedgerProof::default()],
         recipient,
         amount,
-        fee.clone(),
+        fee,
         true,
         rng,
     )


### PR DESCRIPTION
It seems that the nightly image was updated, causing the pending PRs to fail the `clippy` job. This PR takes care of the current clippy lints.