### PR TITLE
Replace `chrono` with `time` (RUSTSEC-2020-0159)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,7 +2340,6 @@ dependencies = [
  "bincode",
  "bytes",
  "cfg-if 1.0.0",
- "chrono",
  "circular-queue",
  "colored",
  "crossterm",
@@ -2357,6 +2365,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "thiserror",
+ "time 0.3.7",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2380,7 +2389,6 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "bincode",
- "chrono",
  "circular-queue",
  "criterion",
  "itertools",
@@ -2393,6 +2401,7 @@ dependencies = [
  "serde_json",
  "snarkvm",
  "tempfile",
+ "time 0.3.7",
  "tracing",
 ]
 
@@ -2807,6 +2816,16 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -3230,5 +3249,5 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time",
+ "time 0.1.43",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,6 @@ version = "0.1"
 [dependencies.bincode]
 version = "1.0"
 
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-features = [ "clock", "serde" ]
-
 [dependencies.cfg-if]
 version = "1.0"
 
@@ -119,6 +114,9 @@ version = "0.3"
 
 [dependencies.thiserror]
 version = "1.0"
+
+[dependencies.time]
+version = "0.3.7"
 
 [dependencies.tokio]
 version = "1"

--- a/src/network/ledger.rs
+++ b/src/network/ledger.rs
@@ -29,7 +29,6 @@ use snarkos_storage::{storage::Storage, BlockLocators, LedgerState, MAXIMUM_LINE
 use snarkvm::dpc::prelude::*;
 
 use anyhow::Result;
-use chrono::Utc;
 use std::{
     collections::HashMap,
     net::SocketAddr,
@@ -37,6 +36,7 @@ use std::{
     sync::{atomic::Ordering, Arc},
     time::{Duration, Instant},
 };
+use time::OffsetDateTime;
 use tokio::{
     sync::{mpsc, oneshot, Mutex, RwLock},
     task,
@@ -847,7 +847,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         block_hash: Option<N::BlockHash>,
         locked_block_requests: &mut HashMap<BlockRequest<N>, i64>,
     ) {
-        match locked_block_requests.insert((block_height, block_hash).into(), Utc::now().timestamp()) {
+        match locked_block_requests.insert((block_height, block_hash).into(), OffsetDateTime::now_utc().unix_timestamp()) {
             None => debug!("Requesting block {} from {}", block_height, peer_ip),
             Some(_old_request) => self.add_failure(peer_ip, format!("Duplicate block request for {}", peer_ip)).await,
         }
@@ -892,7 +892,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     async fn remove_expired_block_requests(&self) {
         // Clear all block requests that have lived longer than `E::RADIO_SILENCE_IN_SECS`.
-        let now = Utc::now().timestamp();
+        let now = OffsetDateTime::now_utc().unix_timestamp();
         self.block_requests.write().await.iter_mut().for_each(|(_peer, block_requests)| {
             block_requests.retain(|_, time_of_request| now.saturating_sub(*time_of_request) < E::RADIO_SILENCE_IN_SECS as i64)
         });
@@ -904,7 +904,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     async fn add_failure(&self, peer_ip: SocketAddr, failure: String) {
         trace!("Adding failure for {}: {}", peer_ip, failure);
         match self.failures.write().await.get_mut(&peer_ip) {
-            Some(failures) => failures.push((failure, Utc::now().timestamp())),
+            Some(failures) => failures.push((failure, OffsetDateTime::now_utc().unix_timestamp())),
             None => error!("Missing failure entry for {}", peer_ip),
         };
     }
@@ -914,7 +914,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     async fn remove_expired_failures(&self) {
         // Clear all failures that have lived longer than `E::FAILURE_EXPIRY_TIME_IN_SECS`.
-        let now = Utc::now().timestamp();
+        let now = OffsetDateTime::now_utc().unix_timestamp();
         self.failures.write().await.iter_mut().for_each(|(_, failures)| {
             failures.retain(|(_, time_of_fail)| now.saturating_sub(*time_of_fail) < E::FAILURE_EXPIRY_TIME_IN_SECS as i64)
         });

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -36,6 +36,7 @@ use snarkvm::{
 use jsonrpc_core::Value;
 use snarkvm::{dpc::Record, utilities::ToBytes};
 use std::{cmp::max, net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
+use time::OffsetDateTime;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Error)]
@@ -191,7 +192,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcImpl<N, E> {
         // Prepare the new block.
         let previous_block_hash = latest_block.hash();
         let block_height = self.ledger.latest_block_height() + 1;
-        let block_timestamp = chrono::Utc::now().timestamp();
+        let block_timestamp = OffsetDateTime::now_utc().unix_timestamp();
 
         // Compute the block difficulty target.
         let difficulty_target = if N::NETWORK_ID == 2 && block_height <= snarkvm::dpc::testnet2::V12_UPGRADE_BLOCK_HEIGHT {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -39,11 +39,6 @@ version = "1"
 version = "1.0"
 optional = true
 
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-features = [ "clock", "serde" ]
-
 [dependencies.circular-queue]
 version = "0.2"
 
@@ -70,6 +65,9 @@ version = "1"
 
 [dependencies.serde_json]
 version = "1"
+
+[dependencies.time]
+version = "0.3.7"
 
 [dependencies.tracing]
 version = "0.1"

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -37,6 +37,7 @@ use std::{
     thread,
     thread::JoinHandle,
 };
+use time::OffsetDateTime;
 
 /// The maximum number of linear block locators.
 pub const MAXIMUM_LINEAR_BLOCK_LOCATORS: u32 = 64;
@@ -599,7 +600,10 @@ impl<N: Network> LedgerState<N> {
         let previous_block_hash = latest_block.hash();
         let block_height = latest_block.height().saturating_add(1);
         // Ensure that the new timestamp is ahead of the previous timestamp.
-        let block_timestamp = std::cmp::max(chrono::Utc::now().timestamp(), latest_block.timestamp().saturating_add(1));
+        let block_timestamp = std::cmp::max(
+            OffsetDateTime::now_utc().unix_timestamp(),
+            latest_block.timestamp().saturating_add(1),
+        );
 
         // Compute the block difficulty target.
         let difficulty_target = if N::NETWORK_ID == 2 && block_height <= snarkvm::dpc::testnet2::V12_UPGRADE_BLOCK_HEIGHT {
@@ -732,7 +736,7 @@ impl<N: Network> LedgerState<N> {
         }
 
         // Ensure the next block timestamp is within the declared time limit.
-        let now = chrono::Utc::now().timestamp();
+        let now = OffsetDateTime::now_utc().unix_timestamp();
         if block.timestamp() > (now + N::ALEO_FUTURE_TIME_LIMIT_IN_SECS) {
             return Err(anyhow!("The given block timestamp exceeds the time limit"));
         }


### PR DESCRIPTION
Unfortunately, `chrono` still hasn't seen the release of a new version dealing with its outdated `time` dependency and isn't currently well-maintained. Note that we still have the troublesome `time` version in our dependency tree and it will only be entirely removed once snarkVM is updated following the merge of https://github.com/AleoHQ/snarkVM/pull/635 and once `zip` and `self_update` get new releases.

```
$ cargo tree -i time:0.1.43
time v0.1.43
└── zip v0.5.13
    └── self_update v0.28.0
        └── snarkos v2.0.0
```