### PR TITLE
Fix edge case handling of legder case 2cba

### DIFF
--- a/src/helpers/block_requests.rs
+++ b/src/helpers/block_requests.rs
@@ -209,7 +209,7 @@ pub(crate) fn handle_block_requests<N: Network, E: Environment>(
             else if let Some(first_deviating_locator) = first_deviating_locator {
                 // Case 2(c)(b)(a) - Check if the real common ancestor is NOT within `ALEO_MAXIMUM_FORK_DEPTH`.
                 // If this peer is outside of the fork range of this ledger, proceed to disconnect from the peer.
-                if latest_block_height.saturating_sub(first_deviating_locator) >= N::ALEO_MAXIMUM_FORK_DEPTH {
+                if latest_block_height.saturating_sub(first_deviating_locator) > N::ALEO_MAXIMUM_FORK_DEPTH {
                     debug!("Peer {} exceeded the permitted fork range, disconnecting", maximal_peer);
                     return BlockRequestHandler::AbortAndDisconnect(Case::TwoCBA, DisconnectReason::ExceededForkRange);
                 }


### PR DESCRIPTION
The ledger was refusing to switch fork if the first deviating locator is just on the maximum fork depth limitation.

Fixed #1634.

*Turns out this is why tests are useful.*

<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

(Write your motivation here)

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

(Link your related PRs here)
