### PR TITLE
Feat: basic connectivity metrics

### DIFF
--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -43,6 +43,10 @@ features = [ "test" ]
 path = "../environment"
 version = "2.0.2"
 
+[dependencies.snarkos-metrics]
+path = "../metrics"
+features = [ "test" ]
+
 [dependencies.snarkos-network]
 path = "../network"
 version = "2.0.2"

--- a/.integration/tests/metrics/mod.rs
+++ b/.integration/tests/metrics/mod.rs
@@ -16,8 +16,8 @@
 
 use crate::wait_until;
 
+use snarkos_integration::{ClientNode, TestNode};
 use snarkos_metrics as metrics;
-use snarkos_testing::{ClientNode, TestNode};
 
 use pea2pea::Pea2Pea;
 

--- a/.integration/tests/metrics/mod.rs
+++ b/.integration/tests/metrics/mod.rs
@@ -24,13 +24,13 @@ use pea2pea::Pea2Pea;
 #[tokio::test]
 async fn metrics_initialization() {
     // Start a test node.
-    let test_node = TestNode::default().await;
+    let _test_node = TestNode::default().await;
 
     // Initialise the metrics, we need to call this manually in tests.
     let snapshotter = metrics::initialize();
 
     // Start a snarkOS node.
-    let client_node = ClientNode::default().await;
+    let _client_node = ClientNode::default().await;
 
     // Verify the metrics have been properly initialised, expect the block height to be set.
     assert_eq!(

--- a/.integration/tests/metrics/mod.rs
+++ b/.integration/tests/metrics/mod.rs
@@ -1,0 +1,111 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::wait_until;
+
+use snarkos_metrics as metrics;
+use snarkos_testing::{ClientNode, TestNode};
+
+use pea2pea::Pea2Pea;
+
+#[tokio::test]
+async fn metrics_initialization() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Initialise the metrics, we need to call this manually in tests.
+    let snapshotter = metrics::initialize();
+
+    // Start a snarkOS node.
+    let client_node = ClientNode::default().await;
+
+    // Verify the metrics have been properly initialised, expect the block height to be set.
+    assert_eq!(
+        metrics::get_metric(&snapshotter, metrics::blocks::HEIGHT),
+        metrics::MetricVal::Gauge(0.0)
+    );
+    assert_eq!(
+        metrics::get_metric(&snapshotter, metrics::peers::CONNECTED),
+        metrics::MetricVal::Gauge(0.0)
+    );
+    assert_eq!(
+        metrics::get_metric(&snapshotter, metrics::peers::CANDIDATE),
+        metrics::MetricVal::Gauge(0.0)
+    );
+    assert_eq!(
+        metrics::get_metric(&snapshotter, metrics::peers::RESTRICTED),
+        metrics::MetricVal::Gauge(0.0)
+    );
+
+    // Clear the recorder to avoid the global state bleeding into other tests.
+    metrics::clear_recorder();
+}
+
+#[tokio::test]
+async fn connect_disconnect() {
+    // Start a test node.
+    let test_node = TestNode::default().await;
+
+    // Initialise the metrics, we need to call this manually in tests.
+    let snapshotter = metrics::initialize();
+
+    // Start a snarkOS node.
+    let client_node = ClientNode::default().await;
+
+    for _ in 0..3 {
+        // The test node should be able to connect to the snarkOS node.
+        test_node.node().connect(client_node.local_addr()).await.unwrap();
+
+        // Double-check with the snarkOS node.
+        wait_until!(1, client_node.connected_peers().await.len() == 1);
+
+        // Check the metrics.
+        assert_eq!(
+            metrics::get_metric(&snapshotter, metrics::peers::CONNECTED),
+            metrics::MetricVal::Gauge(1.0)
+        );
+        assert_eq!(
+            metrics::get_metric(&snapshotter, metrics::peers::CANDIDATE),
+            metrics::MetricVal::Gauge(0.0)
+        );
+        assert_eq!(
+            metrics::get_metric(&snapshotter, metrics::peers::RESTRICTED),
+            metrics::MetricVal::Gauge(0.0)
+        );
+
+        // Shut down the node, force a disconnect.
+        test_node.node().disconnect(client_node.local_addr()).await;
+
+        wait_until!(1, client_node.connected_peers().await.len() == 0);
+
+        // Check the metrics.
+        assert_eq!(
+            metrics::get_metric(&snapshotter, metrics::peers::CONNECTED),
+            metrics::MetricVal::Gauge(0.0)
+        );
+        assert_eq!(
+            metrics::get_metric(&snapshotter, metrics::peers::CANDIDATE),
+            metrics::MetricVal::Gauge(1.0)
+        );
+        assert_eq!(
+            metrics::get_metric(&snapshotter, metrics::peers::RESTRICTED),
+            metrics::MetricVal::Gauge(0.0)
+        );
+    }
+
+    // Clear the recorder to avoid the global state bleeding into other tests.
+    metrics::clear_recorder();
+}

--- a/.integration/tests/tests.rs
+++ b/.integration/tests/tests.rs
@@ -15,4 +15,5 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 mod common;
+mod metrics;
 mod network;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "envmnt"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,14 +1576,18 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0296c9cffd3d72c61d8fcd25efc381fd589f7b155a81f2fa5670010430f60c57"
 dependencies = [
+ "aho-corasick",
  "atomic-shim",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown",
+ "indexmap",
  "metrics",
  "num_cpus",
+ "ordered-float",
  "parking_lot 0.11.2",
  "quanta",
+ "radix_trie",
  "sketches-ddsketch",
 ]
 
@@ -1661,6 +1671,15 @@ name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nom"
@@ -1805,6 +1824,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2045,6 +2073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2 1.0.36",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -2642,6 +2680,7 @@ dependencies = [
  "rand",
  "snarkos",
  "snarkos-environment",
+ "snarkos-metrics",
  "snarkos-network",
  "snarkos-storage",
  "snarkvm",
@@ -2657,6 +2696,7 @@ version = "2.0.2"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
+ "metrics-util",
  "tokio",
 ]
 
@@ -2672,6 +2712,7 @@ dependencies = [
  "rand",
  "serde",
  "snarkos-environment",
+ "snarkos-metrics",
  "snarkos-storage",
  "snarkvm",
  "time 0.3.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ required-features = ["console"]
 default = [ "console", "rpc" ]
 console = [ "crossterm", "tui" ]
 cuda = [ "snarkvm/cuda" ]
-prometheus = [ "snarkos-metrics/prometheus" ]
+prometheus = [ "snarkos-metrics/prometheus", "snarkos-network/prometheus" ]
 rpc = [ "snarkos-rpc" ]
-test = [ "snarkos-metrics/test" ]
+test = [ "snarkos-metrics/test", "snarkos-network/test" ]
 
 [dependencies.aleo-std]
 version = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ required-features = ["console"]
 default = [ "console", "rpc" ]
 console = [ "crossterm", "tui" ]
 cuda = [ "snarkvm/cuda" ]
-prometheus = [ "snarkos-metrics" ]
+prometheus = [ "snarkos-metrics/prometheus" ]
 rpc = [ "snarkos-rpc" ]
-test = [ ]
+test = [ "snarkos-metrics/test" ]
 
 [dependencies.aleo-std]
 version = "0.1.6"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -16,11 +16,21 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2018"
 
+
+[features]
+prometheus = [ "metrics-exporter-prometheus" ]
+test = []
+
 [dependencies.metrics]
 version = "0.18"
 
+[dependencies.metrics-util]
+version = "0.11"
+
 [dependencies.metrics-exporter-prometheus]
 version = "0.8"
+optional = true
 
 [dependencies.tokio]
 version = "1"
+features = [ "rt" ]

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -1,0 +1,249 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_peers_connected_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "connected",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_peers_candidate_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "disconnected",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "snarkos_peers_restricted_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "connecting",
+          "refId": "F"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "states of current connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "delta"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "snarkos_blocks_height_total",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "block height",
+          "refId": "A"
+        }
+      ],
+      "title": "Block Height",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 31,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "snarkOS v2",
+  "uid": "f7OaOQB7z",
+  "version": 2
+}

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -14,15 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+// The `test` and `prometheus` features are mutually exclusive, fail compilation if this occurs.
+#[cfg(all(feature = "test", feature = "prometheus"))]
+compile_error!("feature \"test\" and feature \"prometheus\" cannot be enabled at the same time");
+
 mod names;
+
+#[cfg(feature = "test")]
+mod utils;
 
 // Re-export the metrics macros.
 pub use metrics::*;
 pub use names::*;
 
-use metrics_exporter_prometheus::PrometheusBuilder;
+// Re-export test utilities.
+#[cfg(feature = "test")]
+pub use utils::*;
 
+#[cfg(feature = "test")]
+use metrics_util::{DebuggingRecorder, Snapshotter};
+
+#[cfg(feature = "prometheus")]
 pub fn initialize() -> Option<tokio::task::JoinHandle<()>> {
+    use metrics_exporter_prometheus::PrometheusBuilder;
+
     let (recorder, exporter) = PrometheusBuilder::new().build().expect("can't build the prometheus exporter");
 
     metrics::set_boxed_recorder(Box::new(recorder)).expect("can't set the prometheus exporter");
@@ -31,5 +46,26 @@ pub fn initialize() -> Option<tokio::task::JoinHandle<()>> {
         exporter.await.expect("can't await the prometheus exporter");
     });
 
+    register_metrics();
+
     Some(metrics_exporter_task)
+}
+
+#[cfg(feature = "test")]
+pub fn initialize() -> Snapshotter {
+    // Let the errors through in case the recorder has already been set as is likely when running
+    // multiple metrics tests.
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    let _ = recorder.install();
+
+    register_metrics();
+
+    snapshotter
+}
+
+fn register_metrics() {
+    for name in GAUGE_NAMES {
+        register_gauge!(name);
+    }
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022 Aleo Systems Inc.
+// Copyright (C) 2019-2021 Aleo Systems Inc.
 // This file is part of the snarkOS library.
 
 // The snarkOS library is free software: you can redistribute it and/or modify
@@ -14,22 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-mod names;
-
-// Re-export the metrics macros.
-pub use metrics::*;
-pub use names::*;
-
-use metrics_exporter_prometheus::PrometheusBuilder;
-
-pub fn initialize() -> Option<tokio::task::JoinHandle<()>> {
-    let (recorder, exporter) = PrometheusBuilder::new().build().expect("can't build the prometheus exporter");
-
-    metrics::set_boxed_recorder(Box::new(recorder)).expect("can't set the prometheus exporter");
-
-    let metrics_exporter_task = tokio::task::spawn(async move {
-        exporter.await.expect("can't await the prometheus exporter");
-    });
-
-    Some(metrics_exporter_task)
+pub mod blocks {
+    pub const HEIGHT: &str = "snarkos_blocks_height_total";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 Aleo Systems Inc.
+// Copyright (C) 2019-2022 Aleo Systems Inc.
 // This file is part of the snarkOS library.
 
 // The snarkOS library is free software: you can redistribute it and/or modify
@@ -16,4 +16,10 @@
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
+}
+
+pub mod peers {
+    pub const CONNECTED: &str = "snarkos_peers_connected_total";
+    pub const CANDIDATE: &str = "snarkos_peers_candidate_total";
+    pub const RESTRICTED: &str = "snarkos_peers_restricted_total";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
+
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
 }

--- a/metrics/src/utils.rs
+++ b/metrics/src/utils.rs
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use metrics::Key;
+use metrics_util::{CompositeKey, DebugValue, MetricKind, Snapshotter};
+
+#[derive(Debug, PartialEq)]
+pub enum MetricVal {
+    Counter(u64),
+    Gauge(f64),
+    Histogram(Vec<f64>),
+}
+
+pub fn get_metric(snapshotter: &Snapshotter, metric: &'static str) -> MetricVal {
+    let key = CompositeKey::new(MetricKind::Gauge, Key::from_name(metric));
+
+    match &snapshotter.snapshot().into_hashmap().get(&key).unwrap().2 {
+        DebugValue::Gauge(val) => MetricVal::Gauge(val.into_inner()),
+        DebugValue::Counter(val) => MetricVal::Counter(*val),
+        DebugValue::Histogram(vals) => MetricVal::Histogram(vals.iter().map(|val| val.into_inner()).collect()),
+    }
+}

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -42,6 +42,11 @@ version = "1"
 path = "../environment"
 version = "2.0.2"
 
+[dependencies.snarkos-metrics]
+path = "../metrics"
+version = "2.0.2"
+optional = true
+
 [dependencies.snarkos-storage]
 path = "../storage"
 version = "2.0.2"
@@ -76,4 +81,5 @@ version = "0.1"
 
 [features]
 default = [ ]
-test = [ ]
+prometheus = [ "snarkos-metrics/prometheus" ]
+test = [ "snarkos-metrics/test" ]

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -513,7 +513,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 // Attempt to add the unconfirmed block as the next block in the canonical chain.
                 false => match self.canon.add_next_block(&unconfirmed_block) {
                     Ok(()) => {
-                        // Allocation necessary if prometheus is enabled.
                         let latest_block_height = self.canon.latest_block_height();
                         info!(
                             "Ledger successfully advanced to block {} ({})",
@@ -570,7 +569,6 @@ impl<N: Network, E: Environment> Ledger<N, E> {
 
         match self.canon.revert_to_block_height(block_height) {
             Ok(removed_blocks) => {
-                // Allocation necessary if prometheus is enabled.
                 let latest_block_height = self.canon.latest_block_height();
                 info!("Ledger successfully reverted to block {}", latest_block_height);
 

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -31,7 +31,7 @@ use snarkos_environment::{
 use snarkos_storage::{storage::Storage, BlockLocators, LedgerState, MAXIMUM_LINEAR_BLOCK_LOCATORS};
 use snarkvm::dpc::prelude::*;
 
-#[cfg(feature = "prometheus")]
+#[cfg(any(feature = "test", feature = "prometheus"))]
 use snarkos_metrics as metrics;
 
 use anyhow::Result;
@@ -521,7 +521,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                             self.canon.latest_block_hash()
                         );
 
-                        #[cfg(feature = "prometheus")]
+                        #[cfg(any(feature = "test", feature = "prometheus"))]
                         metrics::gauge!(metrics::blocks::HEIGHT, latest_block_height as f64);
 
                         // Update the timestamp of the last block increment.
@@ -574,7 +574,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 let latest_block_height = self.canon.latest_block_height();
                 info!("Ledger successfully reverted to block {}", latest_block_height);
 
-                #[cfg(feature = "prometheus")]
+                #[cfg(any(feature = "test", feature = "prometheus"))]
                 metrics::gauge!(metrics::blocks::HEIGHT, latest_block_height as f64);
 
                 // Update the last block update timestamp.

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -18,7 +18,7 @@ use crate::{Data, DisconnectReason, LedgerReader, LedgerRouter, Message, Operato
 use snarkos_environment::Environment;
 use snarkvm::dpc::prelude::*;
 
-#[cfg(feature = "prometheus")]
+#[cfg(any(feature = "test", feature = "prometheus"))]
 use snarkos_metrics as metrics;
 
 use anyhow::Result;
@@ -516,7 +516,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 // Remove an entry for this `Peer` in the candidate peers, if it exists.
                 self.candidate_peers.write().await.remove(&peer_ip);
 
-                #[cfg(feature = "prometheus")]
+                #[cfg(any(feature = "test", feature = "prometheus"))]
                 {
                     let number_of_connected_peers = self.number_of_connected_peers().await;
                     let number_of_candidate_peers = self.number_of_candidate_peers().await;
@@ -530,7 +530,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 // Add an entry for this `Peer` in the candidate peers.
                 self.candidate_peers.write().await.insert(peer_ip);
 
-                #[cfg(feature = "prometheus")]
+                #[cfg(any(feature = "test", feature = "prometheus"))]
                 {
                     let number_of_connected_peers = self.number_of_connected_peers().await;
                     let number_of_candidate_peers = self.number_of_candidate_peers().await;
@@ -544,7 +544,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 // Add an entry for this `Peer` in the restricted peers.
                 self.restricted_peers.write().await.insert(peer_ip, Instant::now());
 
-                #[cfg(feature = "prometheus")]
+                #[cfg(any(feature = "test", feature = "prometheus"))]
                 {
                     let number_of_connected_peers = self.number_of_connected_peers().await;
                     let number_of_restricted_peers = self.number_of_restricted_peers().await;
@@ -560,7 +560,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             PeersRequest::ReceivePeerResponse(peer_ips) => {
                 self.add_candidate_peers(peer_ips.iter()).await;
 
-                #[cfg(feature = "prometheus")]
+                #[cfg(any(feature = "test", feature = "prometheus"))]
                 {
                     let number_of_candidate_peers = self.number_of_candidate_peers().await;
                     metrics::gauge!(metrics::peers::CANDIDATE, number_of_candidate_peers as f64);
@@ -601,7 +601,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     trace!("Outbound channel failed: {}", error);
                     self.connected_peers.write().await.remove(&peer);
 
-                    #[cfg(feature = "prometheus")]
+                    #[cfg(any(feature = "test", feature = "prometheus"))]
                     {
                         let number_of_connected_peers = self.number_of_connected_peers().await;
                         metrics::gauge!(metrics::peers::CONNECTED, number_of_connected_peers as f64);

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -431,7 +431,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     fn initialize_metrics(ledger: LedgerReader<N>) {
         #[cfg(not(feature = "test"))]
         if let Some(handler) = snarkos_metrics::initialize() {
-            E::tasks().append(handler);
+            E::resources().register_task(handler);
         }
 
         // Set the block height as it could already be non-zero.


### PR DESCRIPTION
This PR adds some basic connectivity metrics. I've also added some tests that currently cover initialisation and connect/disconnect. These need to be run sequentially as the recorder used for tests stores state globally. Each test is responsible for clearing its recorder state.

Drafted as a Grafana dashboard still needs to be added and CI likely needs some adjusting.
