### PR TITLE
More comprehensive resource management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "snarkvm",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.8.0"
 
 [dependencies.tokio]
 version = "1"
-features = ["sync", "rt"]
+features = ["sync", "rt", "time"]
 
 [dependencies.tracing]
 version = "0.1"

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -37,3 +37,10 @@ features = ["sync", "rt"]
 
 [dependencies.tracing]
 version = "0.1"
+
+[dev-dependencies.tracing-subscriber]
+version = "0.3"
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["macros", "rt-multi-thread", "time"]

--- a/environment/src/helpers/resources.rs
+++ b/environment/src/helpers/resources.rs
@@ -159,14 +159,14 @@ impl Resources {
 
     /// Register the given task with the resource handler and optionally
     /// with an associated resource id.
-    pub fn register_task(&self, handle: tokio::task::JoinHandle<()>, id: Option<ResourceId>) {
+    pub fn register_task(&self, id: Option<ResourceId>, handle: tokio::task::JoinHandle<()>) {
         let task = Resource::Task(handle);
         self.register(task, id);
     }
 
     /// Register the given thread with the resource handler and optionally
     /// with an associated resource id.
-    pub fn register_thread(&self, handle: std::thread::JoinHandle<()>, abort_sender: AbortSignal, id: Option<ResourceId>) {
+    pub fn register_thread(&self, id: Option<ResourceId>, handle: std::thread::JoinHandle<()>, abort_sender: AbortSignal) {
         let thread = Resource::Thread(handle, abort_sender);
         self.register(thread, id);
     }
@@ -221,7 +221,7 @@ mod tests {
                 time::sleep(Duration::from_millis(10)).await;
             }
         });
-        resources.register_task(task, Some(task_id));
+        resources.register_task(Some(task_id), task);
 
         resources.log_summary();
 
@@ -236,7 +236,7 @@ mod tests {
                 thread::sleep(Duration::from_millis(10));
             }
         });
-        resources.register_thread(thread, tx, Some(thread_id));
+        resources.register_thread(Some(thread_id), thread, tx);
 
         resources.log_summary();
         resources.deregister(task_id);

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -355,6 +355,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
                             warn!("Failed to report a failed connection");
                         }
                     }
+                    E::resources().deregister(peer_resource_id);
+
                     return;
                 }
             };

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -484,6 +484,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
                             Some(resource_id),
                             task::spawn(async move {
                                 let _ = handler.await;
+
+                                E::resources().deregister(resource_id);
                             }),
                         );
                     }

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -138,26 +138,29 @@ impl<N: Network, E: Environment> Peers<N, E> {
         {
             let peers = peers.clone();
             let (router, handler) = oneshot::channel();
-            let peers_task = task::spawn(async move {
-                // Notify the outer function that the task is ready.
-                let _ = router.send(());
-                // Asynchronously wait for a peers request.
-                while let Some(request) = peers_handler.recv().await {
-                    let peers = peers.clone();
-                    // Procure a resource id to register the task with, as it might be terminated at any point in time.
-                    let resource_id = E::resources().procure_id();
-                    // Asynchronously process a peers request.
-                    let update_task = task::spawn(async move {
-                        // Update the state of the peers.
-                        peers.update(request).await;
+            E::resources().register_task(
+                None, // No need to provide an id, as the task will run indefinitely.
+                task::spawn(async move {
+                    // Notify the outer function that the task is ready.
+                    let _ = router.send(());
+                    // Asynchronously wait for a peers request.
+                    while let Some(request) = peers_handler.recv().await {
+                        let peers = peers.clone();
+                        // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                        let resource_id = E::resources().procure_id();
+                        // Asynchronously process a peers request.
+                        E::resources().register_task(
+                            Some(resource_id),
+                            task::spawn(async move {
+                                // Update the state of the peers.
+                                peers.update(request).await;
 
-                        E::resources().deregister(resource_id);
-                    });
-                    E::resources().register_task(update_task, Some(resource_id));
-                }
-            });
-            // Register the task; no need to provide an id, as it will run indefinitely.
-            E::resources().register_task(peers_task, None);
+                                E::resources().deregister(resource_id);
+                            }),
+                        );
+                    }
+                }),
+            );
 
             // Wait until the peers router task is ready.
             let _ = handler.await;
@@ -410,9 +413,16 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         }
 
                         // Do not wait for the result of each connection.
-                        E::resources().register_task(task::spawn(async move {
-                            let _ = handler.await;
-                        }));
+                        // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                        let resource_id = E::resources().procure_id();
+                        E::resources().register_task(
+                            Some(resource_id),
+                            task::spawn(async move {
+                                let _ = handler.await;
+
+                                E::resources().deregister(resource_id);
+                            }),
+                        );
                     }
                 }
 
@@ -470,10 +480,12 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         // Do not wait for the result of each connection.
                         // Procure a resource id to register the task with, as it might be terminated at any point in time.
                         let resource_id = E::resources().procure_id();
-                        let task = task::spawn(async move {
-                            let _ = handler.await;
-                        });
-                        E::resources().register_task(task, Some(resource_id));
+                        E::resources().register_task(
+                            Some(resource_id),
+                            task::spawn(async move {
+                                let _ = handler.await;
+                            }),
+                        );
                     }
                 }
             }

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -109,17 +109,18 @@ impl<N: Network, E: Environment> Prover<N, E> {
         {
             let prover = prover.clone();
             let (router, handler) = oneshot::channel();
-            let task = task::spawn(async move {
-                // Notify the outer function that the task is ready.
-                let _ = router.send(());
-                // Asynchronously wait for a prover request.
-                while let Some(request) = prover_handler.recv().await {
-                    // Update the state of the prover.
-                    prover.update(request).await;
-                }
-            });
-            // Register the task; no need to provide an id, as it will run indefinitely.
-            E::resources().register_task(task, None);
+            E::resources().register_task(
+                None, // No need to provide an id, as the task will run indefinitely.
+                task::spawn(async move {
+                    // Notify the outer function that the task is ready.
+                    let _ = router.send(());
+                    // Asynchronously wait for a prover request.
+                    while let Some(request) = prover_handler.recv().await {
+                        // Update the state of the prover.
+                        prover.update(request).await;
+                    }
+                }),
+            );
 
             // Wait until the prover handler is ready.
             let _ = handler.await;
@@ -134,22 +135,23 @@ impl<N: Network, E: Environment> Prover<N, E> {
         if E::NODE_TYPE == NodeType::Prover && prover.pool.is_some() {
             let prover = prover.clone();
             let (router, handler) = oneshot::channel();
-            let task = task::spawn(async move {
-                // Notify the outer function that the task is ready.
-                let _ = router.send(());
-                loop {
-                    // Sleep for `1` second.
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            E::resources().register_task(
+                None, // No need to provide an id, as the task will run indefinitely.
+                task::spawn(async move {
+                    // Notify the outer function that the task is ready.
+                    let _ = router.send(());
+                    loop {
+                        // Sleep for `1` second.
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-                    // TODO (howardwu): Check that the prover is connected to the pool before proceeding.
-                    //  Currently we use a sleep function to probabilistically ensure the peer is connected.
-                    if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
-                        prover.send_pool_register().await;
+                        // TODO (howardwu): Check that the prover is connected to the pool before proceeding.
+                        //  Currently we use a sleep function to probabilistically ensure the peer is connected.
+                        if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
+                            prover.send_pool_register().await;
+                        }
                     }
-                }
-            });
-            // Register the task; no need to provide an id, as it will run indefinitely.
-            E::resources().register_task(task, None);
+                }),
+            );
 
             // Wait until the operator handler is ready.
             let _ = handler.await;
@@ -322,70 +324,73 @@ impl<N: Network, E: Environment> Prover<N, E> {
                 // Initialize the prover process.
                 let prover = prover.clone();
                 let (router, handler) = oneshot::channel();
-                let mining_loop_task = task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    loop {
-                        // If `terminator` is `false` and the status is not `Peering` or `Mining` already, mine the next block.
-                        if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
-                            // Set the status to `Mining`.
-                            E::status().update(State::Mining);
+                E::resources().register_task(
+                    None, // No need to provide an id, as the task will run indefinitely.
+                    task::spawn(async move {
+                        // Notify the outer function that the task is ready.
+                        let _ = router.send(());
+                        loop {
+                            // If `terminator` is `false` and the status is not `Peering` or `Mining` already, mine the next block.
+                            if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
+                                // Set the status to `Mining`.
+                                E::status().update(State::Mining);
 
-                            // Prepare the unconfirmed transactions and dependent objects.
-                            let state = prover.state.clone();
-                            let canon = prover.ledger_reader.clone(); // This is *safe* as the ledger only reads.
-                            let unconfirmed_transactions = prover.memory_pool.read().await.transactions();
-                            let ledger_router = prover.ledger_router.clone();
-                            let prover_router = prover.prover_router.clone();
+                                // Prepare the unconfirmed transactions and dependent objects.
+                                let state = prover.state.clone();
+                                let canon = prover.ledger_reader.clone(); // This is *safe* as the ledger only reads.
+                                let unconfirmed_transactions = prover.memory_pool.read().await.transactions();
+                                let ledger_router = prover.ledger_router.clone();
+                                let prover_router = prover.prover_router.clone();
 
-                            // Procure a resource id to register the task with, as it might be terminated at any point in time.
-                            let mining_task_id = E::resources().procure_id();
-                            let mining_task = task::spawn(async move {
-                                // Mine the next block.
-                                let result = task::spawn_blocking(move || {
-                                    E::thread_pool().install(move || {
-                                        canon.mine_next_block(
-                                            recipient,
-                                            E::COINBASE_IS_PUBLIC,
-                                            &unconfirmed_transactions,
-                                            E::terminator(),
-                                            &mut thread_rng(),
-                                        )
-                                    })
-                                })
-                                .await
-                                .map_err(|e| e.into());
+                                // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                                let mining_task_id = E::resources().procure_id();
+                                E::resources().register_task(
+                                    Some(mining_task_id),
+                                    task::spawn(async move {
+                                        // Mine the next block.
+                                        let result = task::spawn_blocking(move || {
+                                            E::thread_pool().install(move || {
+                                                canon.mine_next_block(
+                                                    recipient,
+                                                    E::COINBASE_IS_PUBLIC,
+                                                    &unconfirmed_transactions,
+                                                    E::terminator(),
+                                                    &mut thread_rng(),
+                                                )
+                                            })
+                                        })
+                                        .await
+                                        .map_err(|e| e.into());
 
-                                // Set the status to `Ready`.
-                                E::status().update(State::Ready);
+                                        // Set the status to `Ready`.
+                                        E::status().update(State::Ready);
 
-                                match result {
-                                    Ok(Ok((block, coinbase_record))) => {
-                                        debug!("Miner has found unconfirmed block {} ({})", block.height(), block.hash());
-                                        // Store the coinbase record.
-                                        if let Err(error) = state.add_coinbase_record(block.height(), coinbase_record) {
-                                            warn!("[Miner] Failed to store coinbase record - {}", error);
+                                        match result {
+                                            Ok(Ok((block, coinbase_record))) => {
+                                                debug!("Miner has found unconfirmed block {} ({})", block.height(), block.hash());
+                                                // Store the coinbase record.
+                                                if let Err(error) = state.add_coinbase_record(block.height(), coinbase_record) {
+                                                    warn!("[Miner] Failed to store coinbase record - {}", error);
+                                                }
+
+                                                // Broadcast the next block.
+                                                let request = LedgerRequest::UnconfirmedBlock(local_ip, block, prover_router.clone());
+                                                if let Err(error) = ledger_router.send(request).await {
+                                                    warn!("Failed to broadcast mined block - {}", error);
+                                                }
+                                            }
+                                            Ok(Err(error)) | Err(error) => trace!("{}", error),
                                         }
 
-                                        // Broadcast the next block.
-                                        let request = LedgerRequest::UnconfirmedBlock(local_ip, block, prover_router.clone());
-                                        if let Err(error) = ledger_router.send(request).await {
-                                            warn!("Failed to broadcast mined block - {}", error);
-                                        }
-                                    }
-                                    Ok(Err(error)) | Err(error) => trace!("{}", error),
-                                }
-
-                                E::resources().deregister(mining_task_id);
-                            });
-                            E::resources().register_task(mining_task, Some(mining_task_id));
+                                        E::resources().deregister(mining_task_id);
+                                    }),
+                                );
+                            }
+                            // Proceed to sleep for a preset amount of time.
+                            tokio::time::sleep(MINER_HEARTBEAT_IN_SECONDS).await;
                         }
-                        // Proceed to sleep for a preset amount of time.
-                        tokio::time::sleep(MINER_HEARTBEAT_IN_SECONDS).await;
-                    }
-                });
-                // Register the task; no need to provide an id, as it will run indefinitely.
-                E::resources().register_task(mining_loop_task, None);
+                    }),
+                );
 
                 // Wait until the miner task is ready.
                 let _ = handler.await;

--- a/rpc/src/tests.rs
+++ b/rpc/src/tests.rs
@@ -127,7 +127,7 @@ async fn new_rpc_server<N: Network, E: Environment, S: Storage>(existing_rpc_con
     // Initialize the RPC server.
     let (rpc_server_addr, rpc_server_handle) = initialize_rpc_server("127.0.0.1:0".parse().unwrap(), rpc_context).await;
 
-    E::resources().register_task(rpc_server_handle, None);
+    E::resources().register_task(None, rpc_server_handle);
 
     rpc_server_addr
 }

--- a/rpc/src/tests.rs
+++ b/rpc/src/tests.rs
@@ -127,7 +127,7 @@ async fn new_rpc_server<N: Network, E: Environment, S: Storage>(existing_rpc_con
     // Initialize the RPC server.
     let (rpc_server_addr, rpc_server_handle) = initialize_rpc_server("127.0.0.1:0".parse().unwrap(), rpc_context).await;
 
-    E::resources().register_task(rpc_server_handle);
+    E::resources().register_task(rpc_server_handle, None);
 
     rpc_server_addr
 }

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -494,7 +494,7 @@ impl MinerStats {
 // for the node to be able to intercept them and perform a clean shutdown.
 // Note: Only Ctrl-C is supported; it should work on both Unix-family systems and Windows.
 pub fn handle_signals<N: Network, E: Environment>(server: Server<N, E>) {
-    tokio::task::spawn(async move {
+    let task = tokio::task::spawn(async move {
         match tokio::signal::ctrl_c().await {
             Ok(()) => {
                 server.shut_down().await;
@@ -503,4 +503,6 @@ pub fn handle_signals<N: Network, E: Environment>(server: Server<N, E>) {
             Err(error) => error!("tokio::signal::ctrl_c encountered an error: {}", error),
         }
     });
+    // Register the task; no need to provide an id, as it will run indefinitely.
+    E::resources().register_task(task, None);
 }

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -115,7 +115,7 @@ impl<N: Network, E: Environment> Server<N, E> {
             let prover_router = prover.router();
 
             let (router, handler) = oneshot::channel();
-            E::resources().register_task(task::spawn(async move {
+            let task = task::spawn(async move {
                 // Notify the outer function that the task is ready.
                 let _ = router.send(());
                 loop {
@@ -141,7 +141,10 @@ impl<N: Network, E: Environment> Server<N, E> {
                     // Sleep for `30` seconds.
                     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
                 }
-            }));
+            });
+            // Register the task; no need to provide an id, as it will run indefinitely.
+            E::resources().register_task(task, None);
+
             // Wait until the prover handler is ready.
             let _ = handler.await;
         }
@@ -263,7 +266,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     ) {
         // Initialize the listener process.
         let (router, handler) = oneshot::channel();
-        E::resources().register_task(task::spawn(async move {
+        let task = task::spawn(async move {
             // Notify the outer function that the task is ready.
             let _ = router.send(());
             info!("Listening for peers at {}", local_ip);
@@ -295,7 +298,10 @@ impl<N: Network, E: Environment> Server<N, E> {
                     tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
-        }));
+        });
+        // Register the task; no need to provide an id, as it will run indefinitely.
+        E::resources().register_task(task, None);
+
         // Wait until the listener task is ready.
         let _ = handler.await;
     }
@@ -313,7 +319,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     ) {
         // Initialize the heartbeat process.
         let (router, handler) = oneshot::channel();
-        E::resources().register_task(task::spawn(async move {
+        let task = task::spawn(async move {
             // Notify the outer function that the task is ready.
             let _ = router.send(());
             loop {
@@ -334,7 +340,10 @@ impl<N: Network, E: Environment> Server<N, E> {
                 // Sleep for `E::HEARTBEAT_IN_SECS` seconds.
                 tokio::time::sleep(Duration::from_secs(E::HEARTBEAT_IN_SECS)).await;
             }
-        }));
+        });
+        // Register the task; no need to provide an id, as it will run indefinitely.
+        E::resources().register_task(task, None);
+
         // Wait until the heartbeat task is ready.
         let _ = handler.await;
     }
@@ -369,7 +378,8 @@ impl<N: Network, E: Environment> Server<N, E> {
 
             debug!("JSON-RPC server listening on {}", rpc_server_addr);
 
-            E::resources().register_task(rpc_server_handle);
+            // Register the task; no need to provide an id, as it will run indefinitely.
+            E::resources().register_task(rpc_server_handle, None);
         }
     }
 
@@ -380,7 +390,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     async fn initialize_notification(ledger: LedgerReader<N>, prover: Arc<Prover<N, E>>, address: Option<Address<N>>) {
         // Initialize the heartbeat process.
         let (router, handler) = oneshot::channel();
-        E::resources().register_task(task::spawn(async move {
+        let task = task::spawn(async move {
             // Notify the outer function that the task is ready.
             let _ = router.send(());
             loop {
@@ -422,7 +432,10 @@ impl<N: Network, E: Environment> Server<N, E> {
                 // Sleep for `120` seconds.
                 tokio::time::sleep(Duration::from_secs(120)).await;
             }
-        }));
+        });
+        // Register the task; no need to provide an id, as it will run indefinitely.
+        E::resources().register_task(task, None);
+
         // Wait until the heartbeat task is ready.
         let _ = handler.await;
     }

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -244,7 +244,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         self.ledger.shut_down().await;
 
         // Flush the tasks.
-        E::resources().abort();
+        E::resources().shut_down();
         trace!("Node has shut down.");
     }
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/AleoHQ/snarkOS/pull/1615; it extends the current resource management setup with the possibility of deregistering individual resources based on an identifier that needs to be procured in advance. Why in advance? Two reasons:

1. While task accounting could be done in the following fashion:
```
pub fn register_task<T>(&self, future: T)
where
    T: Future + Send + 'static,
    T::Output: Send + 'static,
{
    let resource_id = self.procure_id();
    let resources = self.clone();

    let task_handle = tokio::task::spawn(async move {
        let _ = future.await;
        resources.deregister(resource_id);
    });
    let resource = Resource::Task(task_handle);

    self.register(resource, Some(resource_id));
}
```
this would only allow their automatic "self-destruction", but not ad-hoc/on-demand individual termination, e.g. if it needs to be triggered elsewhere. In other words, this design provides greater utility.

2. This is not feasible for threads, because those can't be aborted from "the outside" (hence the need for an `abort_sender` when they are registered, which is then incorporated inside the body of their inner function. Working around this is technically possible, but would be quite ugly and restrictive.

I also decided to be explicit and always require an optional resource id argument instead of introducing a method like `Resources::register_anonymous_task` that would internally call `::register_task` and pass `None` as the resource id; this was done in order to always be aware what the implications of not providing an id are, and all callsites have appropriate comments.

Another design consideration is the `ResourceId`; in order to maintain the current lockless structure, the resource ids are only ever increasing, so it's possible for a resource to get an id going into thousands (and beyond) with only a handful of resources actually registered. It is possible to reuse expired ids, but it would increase the complexity of implementation and likely have a slight performance impact. Since `usize` is typically 64 bits in size these days, we are VERY unlikely to ever run out of available ids, even if the node is running non-stop for years.