### PR TITLE
Introduce feature-gated task metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "serde",
  "snarkvm",
  "tokio",
+ "tokio-metrics",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3299,6 +3300,17 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
  "syn 1.0.86",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb585a0069b53171684e22d5255984ec30d1c7304fd0a4a9a603ffd8c765cdd"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ console = [ "crossterm", "tui" ]
 cuda = [ "snarkvm/cuda" ]
 prometheus = [ "snarkos-metrics/prometheus", "snarkos-network/prometheus" ]
 rpc = [ "snarkos-rpc" ]
+task-metrics = [ "snarkos-environment/task-metrics" ]
 test = [ "snarkos-metrics/test", "snarkos-network/test" ]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -35,6 +35,10 @@ version = "0.8.0"
 version = "1"
 features = ["sync", "rt", "time"]
 
+[dependencies.tokio-metrics]
+version = "0.1"
+optional = true
+
 [dependencies.tracing]
 version = "0.1"
 
@@ -44,3 +48,6 @@ version = "0.3"
 [dev-dependencies.tokio]
 version = "1"
 features = ["macros", "rt-multi-thread", "time"]
+
+[features]
+task-metrics = [ "tokio-metrics" ]


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/1652, only the last 2 commits are new ([relevant diff](https://github.com/AleoHQ/snarkOS/pull/1653/files/78d02b4df3b6738187cef4a375faee07dbd8e011..98d6ed09b781ae88b262228e8925482929bd15ea)).

This PR introduces a non-default `task-metrics` feature which allows any task to be instrumented using `tokio-metrics`. Such tasks need to be registered using the new `Resources::register_instrumented_task` method.

While this PR currently only allows the instrumentation of individual tasks, in the future it will also be extended to instrument the whole runtime as well - this feature of `tokio-metrics` is just unstable at the moment.