### PR TITLE
A few storage-related tweaks

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -1274,8 +1274,8 @@ impl<N: Network> LedgerState<N> {
             let remove_ledger_root = self
                 .ledger_roots
                 .iter()
-                .filter(|(_, block_height)| current_block_height == *block_height)
-                .collect::<Vec<_>>();
+                .filter(|(_, block_height)| current_block_height == *block_height);
+
             for (ledger_root, _) in remove_ledger_root {
                 self.ledger_roots.remove(&ledger_root, Some(batch))?;
             }

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -231,11 +231,6 @@ impl<N: Network> LedgerState<N> {
         ledger.regenerate_ledger_tree()?;
         assert_eq!(ledger.ledger_tree.read().root(), latest_ledger_root);
 
-        // let value = storage.export()?;
-        // println!("{}", value);
-        // let storage_2 = S::open(".ledger_2", context)?;
-        // storage_2.import(value)?;
-
         info!("Ledger successfully loaded at block {}", ledger.latest_block_height());
         Ok(ledger)
     }

--- a/storage/src/state/prover.rs
+++ b/storage/src/state/prover.rs
@@ -41,11 +41,6 @@ impl<N: Network> ProverState<N> {
             coinbase: CoinbaseState::open(storage)?,
         };
 
-        // let value = storage.export()?;
-        // println!("{}", value);
-        // let storage_2 = S::open(".ledger_2", context)?;
-        // storage_2.import(value)?;
-
         info!("Prover successfully initialized");
         Ok(prover)
     }

--- a/storage/src/storage/rocksdb/tests.rs
+++ b/storage/src/storage/rocksdb/tests.rs
@@ -230,6 +230,6 @@ fn test_export_import() {
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     for i in 0..100 {
-        assert_eq!(map.get(&i).expect("Failed to insert"), Some(i.to_string()));
+        assert_eq!(map.get(&i).expect("Failed to get"), Some(i.to_string()));
     }
 }


### PR DESCRIPTION
This PR deduplicates some code and applies a few cleanups and performance tweaks in `snarkos-storage`. Each commit is a single self-contained change.