### PR TITLE
Ref: linearise logic in the `peers` module (1/..)

### DIFF
--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -280,10 +280,10 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     prover_router,
                     connection_result,
                 )
-                .await
+                .await;
             }
             PeersRequest::Heartbeat(ledger_reader, ledger_router, operator_router, prover_router) => {
-                self.heartbeat(ledger_reader, ledger_router, operator_router, prover_router).await
+                self.heartbeat(ledger_reader, ledger_router, operator_router, prover_router).await;
             }
             PeersRequest::MessagePropagate(sender, message) => {
                 self.propagate(sender, message).await;
@@ -292,82 +292,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 self.send(sender, message).await;
             }
             PeersRequest::PeerConnecting(stream, peer_ip, ledger_reader, ledger_router, operator_router, prover_router) => {
-                // Ensure the peer IP is not this node.
-                if peer_ip == self.local_ip
-                    || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
-                {
-                    debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
-                }
-                // Ensure the node does not surpass the maximum number of peer connections.
-                else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
-                    debug!("Dropping connection request from {} (maximum peers reached)", peer_ip);
-                }
-                // Ensure the node is not already connected to this peer.
-                else if self.is_connected_to(peer_ip).await {
-                    debug!("Dropping connection request from {} (already connected)", peer_ip);
-                }
-                // Ensure the peer is not restricted.
-                else if self.is_restricted(peer_ip).await {
-                    debug!("Dropping connection request from {} (restricted)", peer_ip);
-                }
-                // Spawn a handler to be run asynchronously.
-                else {
-                    // Sanitize the port from the peer, if it is a remote IP address.
-                    let (peer_lookup, peer_port) = match peer_ip.ip().is_loopback() {
-                        // Loopback case - Do not sanitize, merely pass through.
-                        true => (peer_ip, peer_ip.port()),
-                        // Remote case - Sanitize, storing u16::MAX for the peer IP address to dedup the peer next time.
-                        false => (SocketAddr::new(peer_ip.ip(), u16::MAX), peer_ip.port()),
-                    };
-
-                    // Lock seen_inbound_connections for further processing.
-                    let mut seen_inbound_connections = self.seen_inbound_connections.write().await;
-
-                    // Fetch the inbound tracker entry for this peer.
-                    let ((initial_port, num_attempts), last_seen) = seen_inbound_connections
-                        .entry(peer_lookup)
-                        .or_insert(((peer_port, 0), SystemTime::UNIX_EPOCH));
-                    let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
-
-                    // Reset the inbound tracker entry for this peer, if the predefined elapsed time has passed.
-                    if elapsed > E::RADIO_SILENCE_IN_SECS {
-                        // Reset the initial port for this peer.
-                        *initial_port = peer_port;
-                        // Reset the number of attempts for this peer.
-                        *num_attempts = 0;
-                        // Reset the last seen timestamp for this peer.
-                        *last_seen = SystemTime::now();
-                    }
-
-                    // Ensure the connecting peer has not surpassed the connection attempt limit.
-                    if *initial_port < peer_port && *num_attempts > E::MAXIMUM_CONNECTION_FAILURES {
-                        trace!("Dropping connection request from {} (tried {} secs ago)", peer_ip, elapsed);
-                        // Add an entry for this `Peer` in the restricted peers.
-                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-                    } else {
-                        debug!("Received a connection request from {}", peer_ip);
-                        // Update the number of attempts for this peer.
-                        *num_attempts += 1;
-
-                        // Release the lock over seen_inbound_connections.
-                        drop(seen_inbound_connections);
-
-                        // Initialize the peer handler.
-                        Peer::handler(
-                            stream,
-                            self.local_ip,
-                            self.local_nonce,
-                            &self.peers_router,
-                            ledger_reader,
-                            ledger_router,
-                            prover_router,
-                            operator_router,
-                            self.connected_nonces().await,
-                            None,
-                        )
-                        .await;
-                    }
-                }
+                self.peer_connecting(stream, peer_ip, ledger_reader, ledger_router, operator_router, prover_router)
+                    .await;
             }
             PeersRequest::PeerConnected(peer_ip, peer_nonce, outbound) => {
                 // Add an entry for this `Peer` in the connected peers.
@@ -662,6 +588,93 @@ impl<N: Network, E: Environment> Peers<N, E> {
                  );
              }
          }
+    }
+
+    async fn peer_connecting(
+        &self,
+        stream: TcpStream,
+        peer_ip: SocketAddr,
+        ledger_reader: LedgerReader<N>,
+        ledger_router: LedgerRouter<N>,
+        operator_router: OperatorRouter<N>,
+        prover_router: ProverRouter<N>,
+    ) {
+        // Ensure the peer IP is not this node.
+        if peer_ip == self.local_ip
+            || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
+        {
+            debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
+        }
+        // Ensure the node does not surpass the maximum number of peer connections.
+        else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
+            debug!("Dropping connection request from {} (maximum peers reached)", peer_ip);
+        }
+        // Ensure the node is not already connected to this peer.
+        else if self.is_connected_to(peer_ip).await {
+            debug!("Dropping connection request from {} (already connected)", peer_ip);
+        }
+        // Ensure the peer is not restricted.
+        else if self.is_restricted(peer_ip).await {
+            debug!("Dropping connection request from {} (restricted)", peer_ip);
+        }
+        // Spawn a handler to be run asynchronously.
+        else {
+            // Sanitize the port from the peer, if it is a remote IP address.
+            let (peer_lookup, peer_port) = match peer_ip.ip().is_loopback() {
+                // Loopback case - Do not sanitize, merely pass through.
+                true => (peer_ip, peer_ip.port()),
+                // Remote case - Sanitize, storing u16::MAX for the peer IP address to dedup the peer next time.
+                false => (SocketAddr::new(peer_ip.ip(), u16::MAX), peer_ip.port()),
+            };
+
+            // Lock seen_inbound_connections for further processing.
+            let mut seen_inbound_connections = self.seen_inbound_connections.write().await;
+
+            // Fetch the inbound tracker entry for this peer.
+            let ((initial_port, num_attempts), last_seen) = seen_inbound_connections
+                .entry(peer_lookup)
+                .or_insert(((peer_port, 0), SystemTime::UNIX_EPOCH));
+            let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
+
+            // Reset the inbound tracker entry for this peer, if the predefined elapsed time has passed.
+            if elapsed > E::RADIO_SILENCE_IN_SECS {
+                // Reset the initial port for this peer.
+                *initial_port = peer_port;
+                // Reset the number of attempts for this peer.
+                *num_attempts = 0;
+                // Reset the last seen timestamp for this peer.
+                *last_seen = SystemTime::now();
+            }
+
+            // Ensure the connecting peer has not surpassed the connection attempt limit.
+            if *initial_port < peer_port && *num_attempts > E::MAXIMUM_CONNECTION_FAILURES {
+                trace!("Dropping connection request from {} (tried {} secs ago)", peer_ip, elapsed);
+                // Add an entry for this `Peer` in the restricted peers.
+                self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+            } else {
+                debug!("Received a connection request from {}", peer_ip);
+                // Update the number of attempts for this peer.
+                *num_attempts += 1;
+
+                // Release the lock over seen_inbound_connections.
+                drop(seen_inbound_connections);
+
+                // Initialize the peer handler.
+                Peer::handler(
+                    stream,
+                    self.local_ip,
+                    self.local_nonce,
+                    &self.peers_router,
+                    ledger_reader,
+                    ledger_router,
+                    prover_router,
+                    operator_router,
+                    self.connected_nonces().await,
+                    None,
+                )
+                .await;
+            }
+        }
     }
 
     ///

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -354,6 +354,35 @@ impl<N: Network, E: Environment> Peers<N, E> {
         }
     }
 
+    async fn can_connect(&self, peer_ip: SocketAddr) -> bool {
+        if peer_ip == self.local_ip
+            || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
+        {
+            debug!("Dropping connection request to {} (attempted to self-connect)", peer_ip);
+            return false;
+        }
+
+        // Ensure the node does not surpass the maximum number of peer connections.
+        if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
+            debug!("Dropping connection request to {} (maximum peers reached)", peer_ip);
+            return false;
+        }
+
+        // Ensure the peer is a new connection.
+        if self.is_connected_to(peer_ip).await {
+            debug!("Dropping connection request to {} (already connected)", peer_ip);
+            return false;
+        }
+
+        // Ensure the peer is not restricted.
+        if self.is_restricted(peer_ip).await {
+            debug!("Dropping connection request to {} (restricted)", peer_ip);
+            return false;
+        }
+
+        true
+    }
+
     async fn connect(
         &self,
         peer_ip: SocketAddr,
@@ -363,72 +392,58 @@ impl<N: Network, E: Environment> Peers<N, E> {
         prover_router: ProverRouter<N>,
         connection_result: ConnectionResult,
     ) {
-        // Ensure the peer IP is not this node.
-        if peer_ip == self.local_ip
-            || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
-        {
-            debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
+        if !self.can_connect(peer_ip).await {
+            return;
         }
-        // Ensure the node does not surpass the maximum number of peer connections.
-        else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
-            debug!("Skipping connection request to {} (maximum peers reached)", peer_ip);
+
+        // Lock seen_outbound_connections for further processing.
+        let mut seen_outbound_connections = self.seen_outbound_connections.write().await;
+
+        // Ensure the node respects the connection frequency limit.
+        let last_seen = seen_outbound_connections.entry(peer_ip).or_insert(SystemTime::UNIX_EPOCH);
+        let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
+
+        if elapsed < E::RADIO_SILENCE_IN_SECS {
+            trace!("Skipping connection request to {} (tried {} secs ago)", peer_ip, elapsed);
+            return;
         }
-        // Ensure the peer is a new connection.
-        else if self.is_connected_to(peer_ip).await {
-            debug!("Skipping connection request to {} (already connected)", peer_ip);
-        }
-        // Ensure the peer is not restricted.
-        else if self.is_restricted(peer_ip).await {
-            debug!("Skipping connection request to {} (restricted)", peer_ip);
-        }
+
         // Attempt to open a TCP stream.
-        else {
-            // Lock seen_outbound_connections for further processing.
-            let mut seen_outbound_connections = self.seen_outbound_connections.write().await;
+        debug!("Connecting to {}...", peer_ip);
+        // Update the last seen timestamp for this peer.
+        seen_outbound_connections.insert(peer_ip, SystemTime::now());
 
-            // Ensure the node respects the connection frequency limit.
-            let last_seen = seen_outbound_connections.entry(peer_ip).or_insert(SystemTime::UNIX_EPOCH);
-            let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
-            if elapsed < E::RADIO_SILENCE_IN_SECS {
-                trace!("Skipping connection request to {} (tried {} secs ago)", peer_ip, elapsed);
-            } else {
-                debug!("Connecting to {}...", peer_ip);
-                // Update the last seen timestamp for this peer.
-                seen_outbound_connections.insert(peer_ip, SystemTime::now());
+        // Release the lock over seen_outbound_connections.
+        drop(seen_outbound_connections);
 
-                // Release the lock over seen_outbound_connections.
-                drop(seen_outbound_connections);
-
-                // Initialize the peer handler.
-                match timeout(Duration::from_millis(E::CONNECTION_TIMEOUT_IN_MILLIS), TcpStream::connect(peer_ip)).await {
-                    Ok(stream) => match stream {
-                        Ok(stream) => {
-                            Peer::handler(
-                                stream,
-                                self.local_ip,
-                                self.local_nonce,
-                                &self.peers_router,
-                                ledger_reader,
-                                ledger_router,
-                                prover_router,
-                                operator_router,
-                                self.connected_nonces().await,
-                                Some(connection_result),
-                            )
-                            .await
-                        }
-                        Err(error) => {
-                            trace!("Failed to connect to '{}': '{:?}'", peer_ip, error);
-                            self.candidate_peers.write().await.remove(&peer_ip);
-                        }
-                    },
-                    Err(error) => {
-                        error!("Unable to reach '{}': '{:?}'", peer_ip, error);
-                        self.candidate_peers.write().await.remove(&peer_ip);
-                    }
-                };
+        // Initialize the peer handler.
+        match timeout(Duration::from_millis(E::CONNECTION_TIMEOUT_IN_MILLIS), TcpStream::connect(peer_ip)).await {
+            Ok(stream) => match stream {
+                Ok(stream) => {
+                    Peer::handler(
+                        stream,
+                        self.local_ip,
+                        self.local_nonce,
+                        &self.peers_router,
+                        ledger_reader,
+                        ledger_router,
+                        prover_router,
+                        operator_router,
+                        self.connected_nonces().await,
+                        Some(connection_result),
+                    )
+                    .await
+                }
+                Err(error) => {
+                    trace!("Failed to connect to '{}': '{:?}'", peer_ip, error);
+                    self.candidate_peers.write().await.remove(&peer_ip);
+                }
+            },
+            Err(error) => {
+                error!("Unable to reach '{}': '{:?}'", peer_ip, error);
+                self.candidate_peers.write().await.remove(&peer_ip);
             }
-        }
+        };
     }
 
     async fn heartbeat(
@@ -599,81 +614,65 @@ impl<N: Network, E: Environment> Peers<N, E> {
         operator_router: OperatorRouter<N>,
         prover_router: ProverRouter<N>,
     ) {
-        // Ensure the peer IP is not this node.
-        if peer_ip == self.local_ip
-            || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
-        {
-            debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
+        if !self.can_connect(peer_ip).await {
+            return;
         }
-        // Ensure the node does not surpass the maximum number of peer connections.
-        else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
-            debug!("Dropping connection request from {} (maximum peers reached)", peer_ip);
-        }
-        // Ensure the node is not already connected to this peer.
-        else if self.is_connected_to(peer_ip).await {
-            debug!("Dropping connection request from {} (already connected)", peer_ip);
-        }
-        // Ensure the peer is not restricted.
-        else if self.is_restricted(peer_ip).await {
-            debug!("Dropping connection request from {} (restricted)", peer_ip);
-        }
+
         // Spawn a handler to be run asynchronously.
-        else {
-            // Sanitize the port from the peer, if it is a remote IP address.
-            let (peer_lookup, peer_port) = match peer_ip.ip().is_loopback() {
-                // Loopback case - Do not sanitize, merely pass through.
-                true => (peer_ip, peer_ip.port()),
-                // Remote case - Sanitize, storing u16::MAX for the peer IP address to dedup the peer next time.
-                false => (SocketAddr::new(peer_ip.ip(), u16::MAX), peer_ip.port()),
-            };
+        // Sanitize the port from the peer, if it is a remote IP address.
+        let (peer_lookup, peer_port) = match peer_ip.ip().is_loopback() {
+            // Loopback case - Do not sanitize, merely pass through.
+            true => (peer_ip, peer_ip.port()),
+            // Remote case - Sanitize, storing u16::MAX for the peer IP address to dedup the peer next time.
+            false => (SocketAddr::new(peer_ip.ip(), u16::MAX), peer_ip.port()),
+        };
 
-            // Lock seen_inbound_connections for further processing.
-            let mut seen_inbound_connections = self.seen_inbound_connections.write().await;
+        // Lock seen_inbound_connections for further processing.
+        let mut seen_inbound_connections = self.seen_inbound_connections.write().await;
 
-            // Fetch the inbound tracker entry for this peer.
-            let ((initial_port, num_attempts), last_seen) = seen_inbound_connections
-                .entry(peer_lookup)
-                .or_insert(((peer_port, 0), SystemTime::UNIX_EPOCH));
-            let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
+        // Fetch the inbound tracker entry for this peer.
+        let ((initial_port, num_attempts), last_seen) = seen_inbound_connections
+            .entry(peer_lookup)
+            .or_insert(((peer_port, 0), SystemTime::UNIX_EPOCH));
+        let elapsed = last_seen.elapsed().unwrap_or(Duration::MAX).as_secs();
 
-            // Reset the inbound tracker entry for this peer, if the predefined elapsed time has passed.
-            if elapsed > E::RADIO_SILENCE_IN_SECS {
-                // Reset the initial port for this peer.
-                *initial_port = peer_port;
-                // Reset the number of attempts for this peer.
-                *num_attempts = 0;
-                // Reset the last seen timestamp for this peer.
-                *last_seen = SystemTime::now();
-            }
+        // Reset the inbound tracker entry for this peer, if the predefined elapsed time has passed.
+        if elapsed > E::RADIO_SILENCE_IN_SECS {
+            // Reset the initial port for this peer.
+            *initial_port = peer_port;
+            // Reset the number of attempts for this peer.
+            *num_attempts = 0;
+            // Reset the last seen timestamp for this peer.
+            *last_seen = SystemTime::now();
+        }
 
-            // Ensure the connecting peer has not surpassed the connection attempt limit.
-            if *initial_port < peer_port && *num_attempts > E::MAXIMUM_CONNECTION_FAILURES {
-                trace!("Dropping connection request from {} (tried {} secs ago)", peer_ip, elapsed);
-                // Add an entry for this `Peer` in the restricted peers.
-                self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-            } else {
-                debug!("Received a connection request from {}", peer_ip);
-                // Update the number of attempts for this peer.
-                *num_attempts += 1;
+        // Ensure the connecting peer has not surpassed the connection attempt limit.
+        if *initial_port < peer_port && *num_attempts > E::MAXIMUM_CONNECTION_FAILURES {
+            trace!("Dropping connection request from {} (tried {} secs ago)", peer_ip, elapsed);
+            // Add an entry for this `Peer` in the restricted peers.
+            self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+        } else {
+            debug!("Received a connection request from {}", peer_ip);
+            // Update the number of attempts for this peer.
+            *num_attempts += 1;
 
-                // Release the lock over seen_inbound_connections.
-                drop(seen_inbound_connections);
+            // Release the lock over seen_inbound_connections.
+            drop(seen_inbound_connections);
 
-                // Initialize the peer handler.
-                Peer::handler(
-                    stream,
-                    self.local_ip,
-                    self.local_nonce,
-                    &self.peers_router,
-                    ledger_reader,
-                    ledger_router,
-                    prover_router,
-                    operator_router,
-                    self.connected_nonces().await,
-                    None,
-                )
-                .await;
-            }
+            // Initialize the peer handler.
+            Peer::handler(
+                stream,
+                self.local_ip,
+                self.local_nonce,
+                &self.peers_router,
+                ledger_reader,
+                ledger_router,
+                prover_router,
+                operator_router,
+                self.connected_nonces().await,
+                None,
+            )
+            .await;
         }
     }
 

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -618,7 +618,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
             return;
         }
 
-        // Spawn a handler to be run asynchronously.
         // Sanitize the port from the peer, if it is a remote IP address.
         let (peer_lookup, peer_port) = match peer_ip.ip().is_loopback() {
             // Loopback case - Do not sanitize, merely pass through.

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -283,156 +283,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 .await
             }
             PeersRequest::Heartbeat(ledger_reader, ledger_router, operator_router, prover_router) => {
-                // Obtain the number of connected peers.
-                let number_of_connected_peers = self.number_of_connected_peers().await;
-                // Ensure the number of connected peers is below the maximum threshold.
-                if number_of_connected_peers > E::MAXIMUM_NUMBER_OF_PEERS {
-                    debug!("Exceeded maximum number of connected peers");
-
-                    // Determine the peers to disconnect from.
-                    let num_excess_peers = number_of_connected_peers.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
-                    let peer_ips_to_disconnect = self
-                        .connected_peers
-                        .read()
-                        .await
-                        .iter()
-                        .filter(|(peer_ip, _)| {
-                            !E::sync_nodes().contains(peer_ip)
-                                && !E::beacon_nodes().contains(peer_ip)
-                                && !E::trusted_nodes().contains(peer_ip)
-                        })
-                        .take(num_excess_peers)
-                        .map(|(&peer_ip, _)| peer_ip)
-                        .collect::<Vec<SocketAddr>>();
-
-                    // Proceed to send disconnect requests to these peers.
-                    for peer_ip in peer_ips_to_disconnect {
-                        info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
-                        self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
-                        // Add an entry for this `Peer` in the restricted peers.
-                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-                    }
-                }
-
-                // TODO (howardwu): This logic can be optimized and unified with the context around it.
-                // Determine if the node is connected to more sync nodes than expected.
-                let connected_sync_nodes = self.connected_sync_nodes().await;
-                let number_of_connected_sync_nodes = connected_sync_nodes.len();
-                let num_excess_sync_nodes = number_of_connected_sync_nodes.saturating_sub(1);
-                if num_excess_sync_nodes > 0 {
-                    debug!("Exceeded maximum number of sync nodes");
-
-                    // Proceed to send disconnect requests to these peers.
-                    for peer_ip in connected_sync_nodes
-                        .iter()
-                        .copied()
-                        .choose_multiple(&mut OsRng::default(), num_excess_sync_nodes)
-                    {
-                        info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
-                        self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
-                        // Add an entry for this `Peer` in the restricted peers.
-                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-                    }
-                }
-
-                // Ensure that the trusted nodes are connected.
-                if !E::trusted_nodes().is_empty() {
-                    let connected_peers = self.connected_peers().await.into_iter().collect::<HashSet<_>>();
-                    let trusted_nodes = E::trusted_nodes();
-                    let disconnected_trusted_nodes = trusted_nodes.difference(&connected_peers).copied();
-                    for peer_ip in disconnected_trusted_nodes {
-                        // Initialize the connection process.
-                        let (router, handler) = oneshot::channel();
-                        let request = PeersRequest::Connect(
-                            peer_ip,
-                            ledger_reader.clone(),
-                            ledger_router.clone(),
-                            operator_router.clone(),
-                            prover_router.clone(),
-                            router,
-                        );
-                        if let Err(error) = self.peers_router.send(request).await {
-                            warn!("Failed to transmit the request: '{}'", error);
-                        }
-
-                        // Do not wait for the result of each connection.
-                        // Procure a resource id to register the task with, as it might be terminated at any point in time.
-                        let resource_id = E::resources().procure_id();
-                        E::resources().register_task(
-                            Some(resource_id),
-                            task::spawn(async move {
-                                let _ = handler.await;
-
-                                E::resources().deregister(resource_id);
-                            }),
-                        );
-                    }
-                }
-
-                // Skip if the number of connected peers is above the minimum threshold.
-                match number_of_connected_peers < E::MINIMUM_NUMBER_OF_PEERS {
-                    true => {
-                        trace!("Sending request for more peer connections");
-                        // Request more peers if the number of connected peers is below the threshold.
-                        for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 3) {
-                            self.send(*peer_ip, Message::PeerRequest).await;
-                        }
-                    }
-                    false => return,
-                };
-
-                // Add the sync nodes to the list of candidate peers.
-                if number_of_connected_sync_nodes == 0 {
-                    self.add_candidate_peers(E::sync_nodes().iter()).await;
-                }
-
-                // Add the beacon nodes to the list of candidate peers.
-                self.add_candidate_peers(E::beacon_nodes().iter()).await;
-
-                // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
-                // Select the peers randomly from the list of candidate peers.
-                let midpoint_number_of_peers = E::MINIMUM_NUMBER_OF_PEERS.saturating_add(E::MAXIMUM_NUMBER_OF_PEERS) / 2;
-                for peer_ip in self
-                    .candidate_peers()
-                    .await
-                    .iter()
-                    .copied()
-                    .choose_multiple(&mut OsRng::default(), midpoint_number_of_peers)
-                {
-                    // Ensure this node is not connected to more than the permitted number of sync nodes.
-                    if E::sync_nodes().contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {
-                        continue;
-                    }
-
-                    if !self.is_connected_to(peer_ip).await {
-                        trace!("Attempting connection to {}...", peer_ip);
-
-                        // Initialize the connection process.
-                        let (router, handler) = oneshot::channel();
-                        let request = PeersRequest::Connect(
-                            peer_ip,
-                            ledger_reader.clone(),
-                            ledger_router.clone(),
-                            operator_router.clone(),
-                            prover_router.clone(),
-                            router,
-                        );
-                        if let Err(error) = self.peers_router.send(request).await {
-                            warn!("Failed to transmit the request: '{}'", error);
-                        }
-                        // Do not wait for the result of each connection.
-                        // Procure a resource id to register the task with, as it might be terminated at any point in time.
-                        let resource_id = E::resources().procure_id();
-                        E::resources().register_task(
-                            Some(resource_id),
-                            task::spawn(async move {
-                                let _ = handler.await;
-
-                                E::resources().deregister(resource_id);
-                            }),
-                        );
-                    }
-                }
+                self.heartbeat(ledger_reader, ledger_router, operator_router, prover_router).await
             }
             PeersRequest::MessagePropagate(sender, message) => {
                 self.propagate(sender, message).await;
@@ -652,6 +503,165 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 };
             }
         }
+    }
+
+    async fn heartbeat(
+        &self,
+        ledger_reader: LedgerReader<N>,
+        ledger_router: LedgerRouter<N>,
+        operator_router: OperatorRouter<N>,
+        prover_router: ProverRouter<N>,
+    ) {
+         // Obtain the number of connected peers.
+         let number_of_connected_peers = self.number_of_connected_peers().await;
+         // Ensure the number of connected peers is below the maximum threshold.
+         if number_of_connected_peers > E::MAXIMUM_NUMBER_OF_PEERS {
+             debug!("Exceeded maximum number of connected peers");
+
+             // Determine the peers to disconnect from.
+             let num_excess_peers = number_of_connected_peers.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
+             let peer_ips_to_disconnect = self
+                 .connected_peers
+                 .read()
+                 .await
+                 .iter()
+                 .filter(|(peer_ip, _)| {
+                     !E::sync_nodes().contains(peer_ip)
+                         && !E::beacon_nodes().contains(peer_ip)
+                         && !E::trusted_nodes().contains(peer_ip)
+                 })
+                 .take(num_excess_peers)
+                 .map(|(&peer_ip, _)| peer_ip)
+                 .collect::<Vec<SocketAddr>>();
+
+             // Proceed to send disconnect requests to these peers.
+             for peer_ip in peer_ips_to_disconnect {
+                 info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
+                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
+                 // Add an entry for this `Peer` in the restricted peers.
+                 self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+             }
+         }
+
+         // TODO (howardwu): This logic can be optimized and unified with the context around it.
+         // Determine if the node is connected to more sync nodes than expected.
+         let connected_sync_nodes = self.connected_sync_nodes().await;
+         let number_of_connected_sync_nodes = connected_sync_nodes.len();
+         let num_excess_sync_nodes = number_of_connected_sync_nodes.saturating_sub(1);
+         if num_excess_sync_nodes > 0 {
+             debug!("Exceeded maximum number of sync nodes");
+
+             // Proceed to send disconnect requests to these peers.
+             for peer_ip in connected_sync_nodes
+                 .iter()
+                 .copied()
+                 .choose_multiple(&mut OsRng::default(), num_excess_sync_nodes)
+             {
+                 info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
+                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
+                 // Add an entry for this `Peer` in the restricted peers.
+                 self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+             }
+         }
+
+         // Ensure that the trusted nodes are connected.
+         if !E::trusted_nodes().is_empty() {
+             let connected_peers = self.connected_peers().await.into_iter().collect::<HashSet<_>>();
+             let trusted_nodes = E::trusted_nodes();
+             let disconnected_trusted_nodes = trusted_nodes.difference(&connected_peers).copied();
+             for peer_ip in disconnected_trusted_nodes {
+                 // Initialize the connection process.
+                 let (router, handler) = oneshot::channel();
+                 let request = PeersRequest::Connect(
+                     peer_ip,
+                     ledger_reader.clone(),
+                     ledger_router.clone(),
+                     operator_router.clone(),
+                     prover_router.clone(),
+                     router,
+                 );
+                 if let Err(error) = self.peers_router.send(request).await {
+                     warn!("Failed to transmit the request: '{}'", error);
+                 }
+
+                 // Do not wait for the result of each connection.
+                 // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                 let resource_id = E::resources().procure_id();
+                 E::resources().register_task(
+                     Some(resource_id),
+                     task::spawn(async move {
+                         let _ = handler.await;
+
+                         E::resources().deregister(resource_id);
+                     }),
+                 );
+             }
+         }
+
+         // Skip if the number of connected peers is above the minimum threshold.
+         match number_of_connected_peers < E::MINIMUM_NUMBER_OF_PEERS {
+             true => {
+                 trace!("Sending request for more peer connections");
+                 // Request more peers if the number of connected peers is below the threshold.
+                 for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 3) {
+                     self.send(*peer_ip, Message::PeerRequest).await;
+                 }
+             }
+             false => return,
+         };
+
+         // Add the sync nodes to the list of candidate peers.
+         if number_of_connected_sync_nodes == 0 {
+             self.add_candidate_peers(E::sync_nodes().iter()).await;
+         }
+
+         // Add the beacon nodes to the list of candidate peers.
+         self.add_candidate_peers(E::beacon_nodes().iter()).await;
+
+         // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
+         // Select the peers randomly from the list of candidate peers.
+         let midpoint_number_of_peers = E::MINIMUM_NUMBER_OF_PEERS.saturating_add(E::MAXIMUM_NUMBER_OF_PEERS) / 2;
+         for peer_ip in self
+             .candidate_peers()
+             .await
+             .iter()
+             .copied()
+             .choose_multiple(&mut OsRng::default(), midpoint_number_of_peers)
+         {
+             // Ensure this node is not connected to more than the permitted number of sync nodes.
+             if E::sync_nodes().contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {
+                 continue;
+             }
+
+             if !self.is_connected_to(peer_ip).await {
+                 trace!("Attempting connection to {}...", peer_ip);
+
+                 // Initialize the connection process.
+                 let (router, handler) = oneshot::channel();
+                 let request = PeersRequest::Connect(
+                     peer_ip,
+                     ledger_reader.clone(),
+                     ledger_router.clone(),
+                     operator_router.clone(),
+                     prover_router.clone(),
+                     router,
+                 );
+                 if let Err(error) = self.peers_router.send(request).await {
+                     warn!("Failed to transmit the request: '{}'", error);
+                 }
+                 // Do not wait for the result of each connection.
+                 // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                 let resource_id = E::resources().procure_id();
+                 E::resources().register_task(
+                     Some(resource_id),
+                     task::spawn(async move {
+                         let _ = handler.await;
+
+                         E::resources().deregister(resource_id);
+                     }),
+                 );
+             }
+         }
     }
 
     ///


### PR DESCRIPTION
This begins the process of refactoring the code in the `peers` module, in an attempt reduce the control flow complexity and identify deduplication/modularisation opportunities. I'll be favouring smaller PRs in this process to keep conflicts with other changesets to a minimum. 

Commits for this PR are self-contained refactors. 
