### PR TITLE
Introduce a notion of trusted peers

### DIFF
--- a/environment/src/lib.rs
+++ b/environment/src/lib.rs
@@ -56,6 +56,8 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     const BEACON_NODES: &'static [&'static str] = &[];
     /// The list of sync nodes to bootstrap the node server with.
     const SYNC_NODES: &'static [&'static str] = &["127.0.0.1:4135"];
+    /// The list of nodes to attempt to maintain connections with.
+    const TRUSTED_NODES: &'static [&'static str] = &[];
 
     /// The duration in seconds to sleep in between heartbeat executions.
     const HEARTBEAT_IN_SECS: u64 = 9;
@@ -96,6 +98,12 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     fn sync_nodes() -> &'static HashSet<SocketAddr> {
         static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
         NODES.get_or_init(|| Self::SYNC_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
+    }
+
+    /// Returns the list of trusted nodes.
+    fn trusted_nodes() -> &'static HashSet<SocketAddr> {
+        static NODES: OnceCell<HashSet<SocketAddr>> = OnceCell::new();
+        NODES.get_or_init(|| Self::TRUSTED_NODES.iter().map(|ip| ip.parse().unwrap()).collect())
     }
 
     /// Returns the resource handler for the node.


### PR DESCRIPTION
This PR introduces the concept of trusted peers, which the node will attempt to maintain a connection to at all times. It should be useful for mining pools. Having any trusted node addresses in place means that:
- the node will keep attempting to connect to them whenever it notices that a connection is missing
- the node will not disconnect from them due to it having too many peers (it will instead disconnect from other peers); note: all other disconnect reasons (e.g. invalid message) are still grounds for disconnecting, in order to not miss any issues

By default, the list of trusted peers is empty.

Cc @zosorock 