### PR TITLE
Bump dependencies

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.1"
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.33"
+version = "0.34"
 
 [dependencies.rand]
 version = "0.8"

--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -26,7 +26,7 @@ version = "0.1"
 version = "1"
 
 [dependencies.pea2pea]
-version = "0.33"
+version = "0.34"
 
 [dependencies.peak_alloc]
 version = "0.1"

--- a/.synthetic_node/Cargo.toml
+++ b/.synthetic_node/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2021"
 version = "0.1"
 
 [dependencies.pea2pea]
-version = "0.33.0"
+version = "0.34"
 
 [dependencies.rand]
 version = "0.8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayref"
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "itertools"
@@ -1471,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
 dependencies = [
  "cc",
  "libc",
@@ -1898,9 +1898,9 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pea2pea"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348fe4a211a16afef08c2c2004e903c72fa5684b8faa9934559e8058c178bd11"
+checksum = "0d90feae3311b6204e24def79e34e663816bed86264bf3788de3a1c20a391f7e"
 dependencies = [
  "async-trait",
  "once_cell",
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
Updates a few dependencies:

```
aleo-std v0.1.8 -> v0.1.12
anyhow v1.0.53 -> v1.0.55
cc v1.0.72 -> v1.0.73
crypto-common v0.1.2 -> v0.1.3
digest v0.10.2 -> v0.10.3
getrandom v0.2.4 -> v0.2.5
ipnet v2.3.1 -> v2.4.0
libc v0.2.117 -> v0.2.119
libz-sys v1.1.3 -> v1.1.4
metrics-util v0.11.0 -> v0.11.1
once_cell v1.9.0 -> v1.10.0
rand v0.8.4 -> v0.8.5
redox_syscall v0.2.10 -> v0.2.11
rustls v0.20.2 -> v0.20.4
semver v1.0.5 -> v1.0.6
sha2 v0.10.1 -> v0.10.2
tokio v1.16.1 -> v1.17.0
tracing v0.1.30 -> v0.1.31
tracing-subscriber v0.3.8 -> v0.3.9
```
