### PR TITLE
Further improvements to the network crawler

### DIFF
--- a/.crawler/src/constants.rs
+++ b/.crawler/src/constants.rs
@@ -14,24 +14,38 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_environment::{Client, ClientTrial, CurrentNetwork, Environment};
+use snarkos_environment::{ClientTrial, CurrentNetwork, Environment};
 
+/// The IDs of messages that are accepted by the crawler.
+// note: ChallengeRequest and ChallengeResponse are only expected during the handshake.
 pub const ACCEPTED_MESSAGE_IDS: &'static [u16] = &[
-    2, // ChallengeRequest
-    3, // ChallengeResponse
     4, // Disconnect
     5, // PeerRequest
     6, // PeerResponse
     7, // Ping
 ];
-// The interval for revisiting connections.
-pub const CRAWL_INTERVAL_MINS: i64 = 3;
-pub const LOG_INTERVAL_SECS: u64 = 12;
+/// The interval for revisiting successfully crawled nodes.
+pub const CRAWL_INTERVAL_MINS: i64 = 10;
+/// The amount of time (in seconds) between crawling logs.
+pub const LOG_INTERVAL_SECS: u64 = 10;
+/// The maximum number of peers the crawler can have at a time.
 pub const MAXIMUM_NUMBER_OF_PEERS: usize = 1000;
-pub const MESSAGE_VERSION: u32 = <Client<CurrentNetwork>>::MESSAGE_VERSION;
-pub const PEER_INTERVAL_SECS: u64 = 10;
+/// The amount of time (in seconds) between peer updates.
+pub const PEER_UPDATE_INTERVAL_SECS: u64 = 10;
+/// The list of sync nodes to begin crawling with.
 pub const SYNC_NODES: &'static [&'static str] = <ClientTrial<CurrentNetwork>>::SYNC_NODES;
-// Purges connections that haven't been seen within this time (in hours).
+/// Connections that haven't been seen within this time (in hours) are forgotten.
 pub const STALE_CONNECTION_CUTOFF_TIME_HRS: i64 = 4;
+/// The number of lists of peers that a single peer needs to provide before it's disconnected from.
 pub const DESIRED_PEER_SET_COUNT: u8 = 3;
+/// The maximum number of connections to attempt to initiate when updating peers.
 pub const NUM_CONCURRENT_CONNECTION_ATTEMPTS: u8 = 20;
+/// The maximum time (in milliseconds) a handshake can take; doesn't have to match the one in the snarkOS node.
+pub const MAX_HANDSHAKE_TIME_MS: u64 = 10_000;
+/// The size of the per-connection read buffer.
+// TODO: double-check maximum message length
+pub const READ_BUFFER_SIZE: usize = 16 * 1024;
+/// The number of peers shared with the crawled nodes when requested.
+pub const SHARED_PEER_COUNT: usize = 15;
+/// The number of connection failures after which a node is removed from the list of known nodes.
+pub const MAX_CONNECTION_FAILURE_COUNT: u8 = 10;

--- a/.crawler/src/main.rs
+++ b/.crawler/src/main.rs
@@ -32,11 +32,13 @@ async fn main() {
     // Enable tracing for the crawler.
     snarkos_synthetic_node::enable_tracing();
 
+    // Register the addresses of the sync nodes.
     for addr in SYNC_NODES {
         let addr = addr.parse().unwrap();
         crawler.known_network.add_node(addr);
     }
 
+    // Start crawling.
     crawler.run_periodic_tasks();
 
     std::future::pending::<()>().await;

--- a/.crawler/tests/peering.rs
+++ b/.crawler/tests/peering.rs
@@ -42,6 +42,9 @@ async fn basics() {
         node.node().connect(*prev_node_addr).await.unwrap();
     }
 
+    // A small delay to make sure all connections are ready.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
     // Double-check the topology.
     for (i, node) in test_nodes.iter().enumerate() {
         if i == 0 || i == NUM_NODES - 1 {

--- a/.integration/tests/network/basic_connectivity.rs
+++ b/.integration/tests/network/basic_connectivity.rs
@@ -48,7 +48,7 @@ async fn test_nodes_can_connect_to_each_other() {
     test_node1.node().connect(test_node0_addr).await.unwrap();
 
     // Ensure that both nodes have an active connection now.
-    assert!(test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
+    wait_until!(1, test_node0.node().num_connected() == 1 && test_node1.node().num_connected() == 1);
 }
 
 #[tokio::test]
@@ -81,7 +81,7 @@ async fn handshake_as_responder_works() {
     test_node.node().connect(client_node.local_addr()).await.unwrap();
 
     // Double-check with the snarkOS node.
-    assert!(client_node.connected_peers().await.len() == 1)
+    wait_until!(1, client_node.connected_peers().await.len() == 1);
 }
 
 #[tokio::test]

--- a/.synthetic_node/Cargo.toml
+++ b/.synthetic_node/Cargo.toml
@@ -21,6 +21,9 @@ edition = "2021"
 [dependencies.async-trait]
 version = "0.1"
 
+[dependencies.parking_lot]
+version = "0.12"
+
 [dependencies.pea2pea]
 version = "0.34"
 

--- a/.synthetic_node/src/lib.rs
+++ b/.synthetic_node/src/lib.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkos_environment::{
-    helpers::{NodeType, State, Status},
+    helpers::{NodeType, State},
     Client,
     CurrentNetwork,
     Environment,
@@ -23,6 +23,7 @@ use snarkos_environment::{
 use snarkos_network::{Data, Message};
 use snarkvm::traits::Network;
 
+use parking_lot::RwLock;
 use pea2pea::{
     protocols::{Disconnect, Handshake, Writing},
     Connection,
@@ -30,26 +31,23 @@ use pea2pea::{
     Pea2Pea,
 };
 use rand::{thread_rng, Rng};
-use std::{collections::HashSet, convert::TryInto, io, net::SocketAddr, sync::Arc};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::Mutex,
-};
+use std::{collections::HashMap, convert::TryInto, io, net::SocketAddr, sync::Arc};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::*;
 use tracing_subscriber::filter::LevelFilter;
 
-// Consts & aliases.
+/// The number of bytes indicating the length of network messages.
 pub const MESSAGE_LENGTH_PREFIX_SIZE: usize = 4;
-pub const CHALLENGE_HEIGHT: u32 = 0;
+
+/// These 3 values are checked during the handshake.
 pub const MESSAGE_VERSION: u32 = <Client<CurrentNetwork>>::MESSAGE_VERSION;
 pub const MAXIMUM_FORK_DEPTH: u32 = CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH;
 
-pub const MAXIMUM_NUMBER_OF_PEERS: usize = <Client<CurrentNetwork>>::MAXIMUM_NUMBER_OF_PEERS;
-
+// Type aliases.
 pub type ClientMessage = Message<CurrentNetwork, Client<CurrentNetwork>>;
 pub type ClientNonce = u64;
 
-/// The test node; it consists of a `Node` that handles networking and `State`
+/// The test node; it consists of a `Pea2PeaNode` that handles networking and `State`
 /// that can be extended freely based on test requirements.
 #[derive(Clone)]
 pub struct SynthNode {
@@ -60,19 +58,24 @@ pub struct SynthNode {
 /// Represents a connected snarkOS client peer.
 pub struct ClientPeer {
     pub connected_addr: SocketAddr,
-    pub listening_addr: SocketAddr,
-    nonce: ClientNonce,
+    pub nonce: ClientNonce,
+    pub node_type: NodeType,
+    pub cumulative_weight: u128,
+    pub peer_version: u32,
 }
 
 /// snarkOS client state required for test purposes.
 #[derive(Clone)]
 pub struct ClientState {
+    /// The random nonce used during the handshake.
     pub local_nonce: ClientNonce,
-    /// The list of known peers; `Pea2Pea` includes its own internal peer handling,
-    /// but snarkOS nodes must discover the listening address and unique nonce of each peer;
-    /// this collection facilitates the snarkOS peering experience to align with snarkOS logic.
-    pub peers: Arc<Mutex<Vec<ClientPeer>>>,
-    pub status: Status,
+    /// The map of listening addresses to the corresponding peers.
+    /// `Pea2Pea` includes its own internal peer handling, but snarkOS nodes
+    /// must discover the listening address and unique nonce of each peer; this
+    /// collection facilitates the snarkOS peering experience to align with snarkOS logic.
+    pub peers: Arc<RwLock<HashMap<SocketAddr, ClientPeer>>>,
+    /// A map from connected addresses to listening addresses.
+    pub address_map: Arc<RwLock<HashMap<SocketAddr, SocketAddr>>>,
 }
 
 impl Default for ClientState {
@@ -80,7 +83,7 @@ impl Default for ClientState {
         Self {
             local_nonce: thread_rng().gen(),
             peers: Default::default(),
-            status: Status::new(),
+            address_map: Default::default(),
         }
     }
 }
@@ -92,37 +95,19 @@ impl Pea2Pea for SynthNode {
 }
 
 impl SynthNode {
-    /// Creates a test node using the given `Pea2Pea` node.
+    /// Creates a test node using the given `Pea2Pea` node and with the given `State`.
     pub fn new(node: Pea2PeaNode, state: ClientState) -> Self {
         Self { node, state }
     }
 
-    pub fn node_type(&self) -> NodeType {
-        NodeType::Client
+    /// Returns the peer's connected address when provided with the listening address.
+    pub fn get_peer_connected_addr(&self, addr: SocketAddr) -> Option<SocketAddr> {
+        self.state.peers.read().get(&addr).map(|peer| peer.connected_addr)
     }
 
-    pub fn state(&self) -> State {
-        self.state.status.get()
-    }
-
-    pub async fn get_peer_connected_addr(&self, addr: SocketAddr) -> Option<SocketAddr> {
-        self.state
-            .peers
-            .lock()
-            .await
-            .iter()
-            .find(|peer| peer.listening_addr == addr || peer.connected_addr == addr)
-            .map(|peer| peer.connected_addr)
-    }
-
-    pub async fn get_peer_listening_addr(&self, addr: SocketAddr) -> Option<SocketAddr> {
-        self.state
-            .peers
-            .lock()
-            .await
-            .iter()
-            .find(|peer| peer.connected_addr == addr || peer.listening_addr == addr)
-            .map(|peer| peer.listening_addr)
+    /// Returns the peer's listening address when provided with the connected address.
+    pub fn get_peer_listening_addr(&self, addr: SocketAddr) -> Option<SocketAddr> {
+        self.state.address_map.read().get(&addr).copied()
     }
 }
 
@@ -130,19 +115,15 @@ impl SynthNode {
 #[async_trait::async_trait]
 impl Handshake for SynthNode {
     async fn perform_handshake(&self, mut connection: Connection) -> io::Result<Connection> {
-        // Guard against double (two-sided) connections.
-        let mut locked_peers = self.state.peers.lock().await;
-
         let own_ip = self.node().listening_addr()?;
-        let peer_ip = connection.addr;
+        let peer_addr = connection.addr;
 
-        if locked_peers
-            .iter()
-            .any(|peer| peer.listening_addr == peer_ip || peer.connected_addr == peer_ip)
-        {
+        // An immediate duplicate connection check.
+        if self.state.address_map.read().contains_key(&peer_addr) {
             return Err(io::ErrorKind::AlreadyExists.into());
         }
 
+        // The genesis block header is used in the handshake.
         let genesis_block_header = CurrentNetwork::genesis_block().header();
 
         // Send a challenge request to the peer.
@@ -155,13 +136,14 @@ impl Handshake for SynthNode {
             self.state.local_nonce,
             0,
         );
-        trace!(parent: self.node().span(), "sending a challenge request to {}", peer_ip);
+        trace!(parent: self.node().span(), "sending a challenge request to {}", peer_addr);
         let mut msg = Vec::new();
         own_request.serialize_into(&mut msg).unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
         connection.writer().write_all(&len).await?;
         connection.writer().write_all(&msg).await?;
 
+        // A buffer for reading handshake messages.
         let mut buf = [0u8; 1024];
 
         // Read the challenge request from the peer.
@@ -171,44 +153,38 @@ impl Handshake for SynthNode {
         let peer_request = ClientMessage::deserialize(&mut io::Cursor::new(&buf[..len]));
 
         // Register peer's nonce.
-        let (peer_listening_addr, peer_nonce) = if let Ok(Message::ChallengeRequest(
+        let (peer_listening_addr, peer_nonce, peer_node_type, cumulative_weight, peer_version) = if let Ok(Message::ChallengeRequest(
             peer_version,
             _peer_fork_depth,
-            _peer_node_type,
+            peer_node_type,
             _peer_status,
             peer_listening_port,
             peer_nonce,
-            _cumulative_weight,
+            cumulative_weight,
         )) = peer_request
         {
-            if peer_version < MESSAGE_VERSION {
-                warn!(parent: self.node().span(), "dropping {} due to outdated version ({})", peer_ip, peer_version);
-                return Err(io::ErrorKind::InvalidData.into());
-            }
+            // Don't reject peers due to the client version in order to keep track of non-compliant peers.
 
-            let peer_listening_ip = SocketAddr::from((peer_ip.ip(), peer_listening_port));
+            let peer_listening_addr = SocketAddr::from((peer_addr.ip(), peer_listening_port));
 
-            if locked_peers
-                .iter()
-                .any(|peer| peer.nonce == peer_nonce || peer.listening_addr == peer_listening_ip)
-            {
+            if self.state.peers.read().contains_key(&peer_listening_addr) {
                 return Err(io::ErrorKind::AlreadyExists.into());
             }
 
-            trace!(parent: self.node().span(), "received a challenge request from {}", peer_ip);
+            trace!(parent: self.node().span(), "received a challenge request from {}", peer_addr);
 
-            (peer_listening_ip, peer_nonce)
+            (peer_listening_addr, peer_nonce, peer_node_type, cumulative_weight, peer_version)
         } else if let Ok(Message::Disconnect(reason)) = peer_request {
-            warn!(parent: self.node().span(), "{} disconnected: {:?}", peer_ip, reason);
+            warn!(parent: self.node().span(), "{} disconnected: {:?}", peer_addr, reason);
             return Err(io::ErrorKind::NotConnected.into());
         } else {
-            error!(parent: self.node().span(), "invalid challenge request from {}", peer_ip);
+            error!(parent: self.node().span(), "invalid challenge request from {}", peer_addr);
             return Err(io::ErrorKind::InvalidData.into());
         };
 
         // Respond with own challenge request.
         let own_response = ClientMessage::ChallengeResponse(Data::Object(genesis_block_header.clone()));
-        trace!(parent: self.node().span(), "sending a challenge response to {}", peer_ip);
+        trace!(parent: self.node().span(), "sending a challenge response to {}", peer_addr);
         let mut msg = Vec::new();
         own_response.serialize_into(&mut msg).unwrap();
         let len = u32::to_le_bytes(msg.len() as u32);
@@ -224,26 +200,41 @@ impl Handshake for SynthNode {
         if let Ok(Message::ChallengeResponse(block_header)) = peer_response {
             let block_header = block_header.deserialize().await.unwrap();
 
-            trace!(parent: self.node().span(), "received a challenge response from {}", peer_ip);
-            if block_header.height() == CHALLENGE_HEIGHT && &block_header == genesis_block_header && block_header.is_valid() {
+            trace!(parent: self.node().span(), "received a challenge response from {}", peer_addr);
+            if &block_header == genesis_block_header {
+                let mut locked_peers = self.state.peers.write();
+                let mut locked_addr_map = self.state.address_map.write();
+
+                if locked_addr_map.contains_key(&peer_addr) || locked_peers.contains_key(&peer_listening_addr) {
+                    return Err(io::ErrorKind::AlreadyExists.into());
+                }
+
+                locked_addr_map.insert(peer_addr, peer_listening_addr);
+
                 // Register the newly connected snarkOS peer.
-                locked_peers.push(ClientPeer {
-                    connected_addr: peer_ip,
-                    listening_addr: peer_listening_addr,
+                locked_peers.insert(peer_listening_addr, ClientPeer {
+                    connected_addr: peer_addr,
                     nonce: peer_nonce,
+                    node_type: peer_node_type,
+                    cumulative_weight,
+                    peer_version,
                 });
-                debug!(parent: self.node().span(), "connected to {} (listening addr: {})", peer_ip, peer_listening_addr);
+
+                drop(locked_addr_map);
+                drop(locked_peers);
+
+                debug!(parent: self.node().span(), "connected to {} (listening addr: {})", peer_addr, peer_listening_addr);
 
                 Ok(connection)
             } else {
-                error!(parent: self.node().span(), "invalid challenge response from {}", peer_ip);
+                error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
                 Err(io::ErrorKind::InvalidData.into())
             }
         } else if let Ok(Message::Disconnect(reason)) = peer_response {
-            warn!(parent: self.node().span(), "{} disconnected: {:?}", peer_ip, reason);
+            warn!(parent: self.node().span(), "{} disconnected: {:?}", peer_addr, reason);
             return Err(io::ErrorKind::NotConnected.into());
         } else {
-            error!(parent: self.node().span(), "invalid challenge response from {}", peer_ip);
+            error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
             Err(io::ErrorKind::InvalidData.into())
         }
     }
@@ -267,16 +258,9 @@ impl Writing for SynthNode {
 #[async_trait::async_trait]
 impl Disconnect for SynthNode {
     async fn handle_disconnect(&self, disconnecting_addr: SocketAddr) {
-        let mut locked_peers = self.state.peers.lock().await;
-        locked_peers.retain(|peer| peer.connected_addr != disconnecting_addr);
-        assert_eq!(
-            locked_peers.len(),
-            locked_peers
-                .iter()
-                .map(|peer| (peer.listening_addr, peer.connected_addr))
-                .collect::<HashSet<_>>()
-                .len()
-        );
+        if let Some(listening_addr) = self.state.address_map.write().remove(&disconnecting_addr) {
+            self.state.peers.write().remove(&listening_addr);
+        }
     }
 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,7 @@ name = "snarkos-synthetic-node"
 version = "2.0.2"
 dependencies = [
  "async-trait",
+ "parking_lot 0.12.0",
  "pea2pea",
  "rand",
  "snarkos-environment",

--- a/environment/src/helpers/node_type.rs
+++ b/environment/src/helpers/node_type.rs
@@ -17,7 +17,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[repr(u8)]
 pub enum NodeType {
     /// A client node is a full node, capable of sending and receiving blocks.

--- a/environment/src/helpers/status.rs
+++ b/environment/src/helpers/status.rs
@@ -23,7 +23,7 @@ use std::{
     },
 };
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[repr(u8)]
 pub enum State {
     /// The ledger is ready to handle requests.


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/1668, only the last 2 commits are new (squashed due to rebases becoming tricky; [relevant diff](https://github.com/AleoHQ/snarkOS/pull/1672/files/fd2709527cfbe8a5471f557a9b8c05ee58edfc47..6fcc8a7065aeee0fa29305afab6d5d841c3256e6)).

This PR documents the network-based crawler, makes it _much_ faster (the same improvement extends to the underlying synthetic node used in the network integration tests), and tweaks its default configuration.