### PR TITLE
Move from structopt to clap

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -31,6 +31,10 @@ version = "0.1"
 [dependencies.bincode]
 version = "1"
 
+[dependencies.clap]
+version = "3.1"
+features = [ "derive" ]
+
 [dependencies.nalgebra]
 version = "0.30"
 
@@ -75,9 +79,6 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 version = "0.8.0"
-
-[dependencies.structopt]
-version = "0.3"
 
 [dependencies.time]
 version = "0.3"

--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -24,6 +24,7 @@ use snarkos_storage::BlockLocators;
 use snarkos_synthetic_node::{ClientMessage, SynthNode, MESSAGE_LENGTH_PREFIX_SIZE};
 use snarkvm::traits::Network;
 
+use clap::Parser;
 use pea2pea::{
     protocols::{Disconnect, Handshake, Reading, Writing},
     Config,
@@ -41,7 +42,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use structopt::StructOpt;
 use time::OffsetDateTime;
 use tokio::{sync::Mutex, task};
 #[cfg(feature = "postgres")]
@@ -52,40 +52,38 @@ use tracing::*;
 pub struct StorageClient;
 
 // CLI
-// TODO: investigate using clap instead.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Opts {
     /// Specify the IP address and port for the node server.
-    /// Naming and defaults kept consistent with snarkOS.
-    #[structopt(parse(try_from_str), default_value = "0.0.0.0:4132", long = "node")]
-    pub node: SocketAddr,
+    #[clap(long = "addr", short = 'a', parse(try_from_str), default_value = "0.0.0.0:4132")]
+    pub addr: SocketAddr,
     /// The path to a certificate file to be used for a TLS connection with the postgres instance.
     #[cfg(feature = "postgres-tls")]
-    #[structopt(long = "postgres-cert-path")]
+    #[clap(long = "postgres-cert-path")]
     pub postgres_cert_path: PathBuf,
     /// The hostname of the postgres instance (defaults to "localhost").
     #[cfg(feature = "postgres")]
-    #[structopt(long = "postgres-host", default_value = "localhost")]
+    #[clap(long = "postgres-host", default_value = "localhost")]
     pub postgres_host: String,
     /// The port of the postgres instance (defaults to 5432).
     #[cfg(feature = "postgres")]
-    #[structopt(long = "postgres-port", default_value = "5432")]
+    #[clap(long = "postgres-port", default_value = "5432")]
     pub postgres_port: u16,
     /// The user of the postgres instance (defaults to "postgres").
     #[cfg(feature = "postgres")]
-    #[structopt(long = "postgres-user", default_value = "postgres")]
+    #[clap(long = "postgres-user", default_value = "postgres")]
     pub postgres_user: String,
     /// The password for the postgres instance (defaults to nothing).
     #[cfg(feature = "postgres")]
-    #[structopt(long = "postgres-pass", default_value = "")]
+    #[clap(long = "postgres-pass", default_value = "")]
     pub postgres_pass: String,
     /// The hostname of the postgres instance (defaults to "postgres").
     #[cfg(feature = "postgres")]
-    #[structopt(long = "postgres-dbname", default_value = "postgres")]
+    #[clap(long = "postgres-dbname", default_value = "postgres")]
     pub postgres_dbname: String,
     /// If set to `true`, re-creates the crawler's database tables.
     #[cfg(feature = "postgres")]
-    #[structopt(long = "postgres-clean")]
+    #[clap(long = "postgres-clean")]
     pub postgres_clean: bool,
 }
 
@@ -116,8 +114,8 @@ impl Crawler {
     pub async fn new(opts: Opts, storage: Option<StorageClient>) -> Self {
         let config = Config {
             name: Some("snarkOS crawler".into()),
-            listener_ip: Some(opts.node.ip()),
-            desired_listening_port: Some(opts.node.port()),
+            listener_ip: Some(opts.addr.ip()),
+            desired_listening_port: Some(opts.addr.port()),
             max_connections: MAXIMUM_NUMBER_OF_PEERS as u16,
             max_handshake_time_ms: MAX_HANDSHAKE_TIME_MS,
             read_buffer_size: READ_BUFFER_SIZE,

--- a/.crawler/src/main.rs
+++ b/.crawler/src/main.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use clap::Parser;
 #[cfg(feature = "postgres")]
 use snarkos_crawler::storage::initialize_storage;
 use snarkos_crawler::{
@@ -21,15 +22,13 @@ use snarkos_crawler::{
     crawler::{Crawler, Opts},
 };
 
-use structopt::StructOpt;
-
 #[tokio::main]
 async fn main() {
     // Enable tracing.
     snarkos_synthetic_node::enable_tracing();
 
     // Read configuration options.
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
 
     // Initialize the storage, if enabled.
     #[cfg(feature = "postgres")]

--- a/.crawler/tests/peering.rs
+++ b/.crawler/tests/peering.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use clap::Parser;
 use pea2pea::Pea2Pea;
-use snarkos_crawler::crawler::{Crawler, Opts};
+use snarkos_crawler::crawler::Crawler;
 use snarkos_integration::{wait_until, TestNode};
-use structopt::StructOpt;
 
 const NUM_NODES: usize = 10;
 
@@ -56,7 +56,7 @@ async fn basics() {
     }
 
     // Start the crawler.
-    let opts = Opts::from_iter(&["snarkos_crawler_test", "--node", "127.0.0.1:0"]);
+    let opts = Parser::parse_from(&["snarkos_crawler_test", "--addr", "127.0.0.1:0"]);
     let crawler = Crawler::new(opts, None).await;
 
     // "Seed" the crawler with the address of the first node.

--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -60,8 +60,9 @@ version = "2.0.2"
 [dependencies.snarkvm]
 version = "0.8.0"
 
-[dependencies.structopt]
-version = "0.3"
+[dependencies.clap]
+version = "3.1"
+features = [ "derive" ]
 
 [dependencies.tokio]
 version = "1"

--- a/.integration/src/client_node.rs
+++ b/.integration/src/client_node.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use clap::Parser;
 use snarkos::Server;
 use snarkos_environment::{Client, CurrentNetwork};
 
 use std::{fs, net::SocketAddr};
-use structopt::StructOpt;
 
 /// A facade for a snarkOS client node.
 pub struct ClientNode {
@@ -57,7 +57,7 @@ impl ClientNode {
     pub async fn with_args(extra_args: &[&str]) -> Self {
         let permanent_args = &["snarkos", "--norpc"];
         let combined_args = permanent_args.iter().chain(extra_args.iter());
-        let config = snarkos::Node::from_iter(combined_args);
+        let config = snarkos::Node::parse_from(combined_args);
         let server = Server::<CurrentNetwork, Client<CurrentNetwork>>::initialize(&config, None, None)
             .await
             .unwrap();

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,13 +481,39 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -571,7 +597,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1162,12 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1937,6 +1960,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2833,6 +2865,7 @@ version = "2.0.2"
 dependencies = [
  "aleo-std",
  "anyhow",
+ "clap 3.1.6",
  "colored",
  "crossterm 0.23.0",
  "num_cpus",
@@ -2846,7 +2879,6 @@ dependencies = [
  "snarkos-rpc",
  "snarkos-storage",
  "snarkvm",
- "structopt",
  "thiserror",
  "tokio",
  "tracing",
@@ -2861,6 +2893,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "clap 3.1.6",
  "nalgebra",
  "native-tls",
  "parking_lot 0.12.0",
@@ -2874,7 +2907,6 @@ dependencies = [
  "snarkos-storage",
  "snarkos-synthetic-node",
  "snarkvm",
- "structopt",
  "time 0.3.7",
  "tokio",
  "tokio-postgres",
@@ -2904,6 +2936,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "clap 3.1.6",
  "pea2pea",
  "peak_alloc",
  "snarkos",
@@ -2913,7 +2946,6 @@ dependencies = [
  "snarkos-storage",
  "snarkos-synthetic-node",
  "snarkvm",
- "structopt",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3310,33 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -3390,6 +3398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3424,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3793,12 +3816,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,9 @@ version = "2.0.2"
 [dependencies.snarkvm]
 version = "0.8.0"
 
-[dependencies.structopt]
-version = "0.3"
+[dependencies.clap]
+version = "3.1"
+features = [ "derive" ]
 
 [dependencies.thiserror]
 version = "1.0"

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -17,7 +17,7 @@
 use snarkos::{initialize_logger, Node};
 
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Parser;
 use tokio::runtime;
 
 fn main() -> Result<()> {
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
     }
 
     // Parse the provided arguments.
-    let node = Node::from_args();
+    let node = Node::parse();
 
     // Start logging, if enabled.
     if !node.display {

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -33,64 +33,64 @@ use snarkos_storage::storage::rocksdb::RocksDB;
 use snarkvm::dpc::prelude::*;
 
 use anyhow::{anyhow, Result};
+use clap::Parser;
 use colored::*;
 use crossterm::tty::IsTty;
 use std::{io, net::SocketAddr, path::PathBuf, str::FromStr};
-use structopt::StructOpt;
 use tokio::sync::mpsc;
 use tracing_subscriber::EnvFilter;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "snarkos", author = "The Aleo Team <hello@aleo.org>", setting = structopt::clap::AppSettings::ColoredHelp)]
+#[derive(Debug, Parser)]
+#[clap(name = "snarkos", author = "The Aleo Team <hello@aleo.org>")]
 pub struct Node {
     /// Specify the IP address and port of a peer to connect to.
-    #[structopt(long = "connect")]
+    #[clap(long = "connect")]
     pub connect: Option<String>,
     /// Specify this as a mining node, with the given miner address.
-    #[structopt(long = "miner")]
+    #[clap(long = "miner")]
     pub miner: Option<String>,
     /// Specify this as an operating node, with the given operator address.
-    #[structopt(long = "operator")]
+    #[clap(long = "operator")]
     pub operator: Option<String>,
     /// Specify this as a prover node, with the given prover address.
-    #[structopt(long = "prover")]
+    #[clap(long = "prover")]
     pub prover: Option<String>,
     /// Specify the pool that a prover node is contributing to.
-    #[structopt(long = "pool")]
+    #[clap(long = "pool")]
     pub pool: Option<SocketAddr>,
     /// Specify the network of this node.
-    #[structopt(default_value = "2", long = "network")]
+    #[clap(default_value = "2", long = "network")]
     pub network: u16,
     /// Specify the IP address and port for the node server.
-    #[structopt(parse(try_from_str), default_value = "0.0.0.0:4132", long = "node")]
+    #[clap(parse(try_from_str), default_value = "0.0.0.0:4132", long = "node")]
     pub node: SocketAddr,
     /// Specify the IP address and port for the RPC server.
-    #[structopt(parse(try_from_str), default_value = "0.0.0.0:3032", long = "rpc")]
+    #[clap(parse(try_from_str), default_value = "0.0.0.0:3032", long = "rpc")]
     pub rpc: SocketAddr,
     /// Specify the username for the RPC server.
-    #[structopt(default_value = "root", long = "username")]
+    #[clap(default_value = "root", long = "username")]
     pub rpc_username: String,
     /// Specify the password for the RPC server.
-    #[structopt(default_value = "pass", long = "password")]
+    #[clap(default_value = "pass", long = "password")]
     pub rpc_password: String,
     /// Specify the verbosity of the node [options: 0, 1, 2, 3]
-    #[structopt(default_value = "2", long = "verbosity")]
+    #[clap(default_value = "2", long = "verbosity")]
     pub verbosity: u8,
     /// Enables development mode, specify a unique ID for the local node.
-    #[structopt(long)]
+    #[clap(long)]
     pub dev: Option<u16>,
     /// If the flag is set, the node will render a read-only display.
-    #[structopt(long)]
+    #[clap(long)]
     pub display: bool,
     /// If the flag is set, the node will not initialize the RPC server.
-    #[structopt(long)]
+    #[clap(long)]
     pub norpc: bool,
-    #[structopt(hidden = true, long)]
+    #[clap(hide = true, long)]
     pub trial: bool,
-    #[structopt(hidden = true, long)]
+    #[clap(hide = true, long)]
     pub sync: bool,
     /// Specify an optional subcommand.
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     commands: Option<Command>,
 }
 
@@ -236,15 +236,15 @@ pub fn initialize_logger(verbosity: u8, log_sender: Option<mpsc::Sender<Vec<u8>>
         .try_init();
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub enum Command {
-    #[structopt(name = "clean", about = "Removes the ledger files from storage")]
+    #[clap(name = "clean", about = "Removes the ledger files from storage")]
     Clean(Clean),
-    #[structopt(name = "update", about = "Updates snarkOS to the latest version")]
+    #[clap(name = "update", about = "Updates snarkOS to the latest version")]
     Update(Update),
-    #[structopt(name = "experimental", about = "Experimental features")]
+    #[clap(name = "experimental", about = "Experimental features")]
     Experimental(Experimental),
-    #[structopt(name = "miner", about = "Miner commands and settings")]
+    #[clap(name = "miner", about = "Miner commands and settings")]
     Miner(MinerSubcommand),
 }
 
@@ -291,13 +291,13 @@ impl io::Write for LogWriter {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub struct Clean {
     /// Specify the network of the ledger to remove from storage.
-    #[structopt(default_value = "2", long = "network")]
+    #[clap(default_value = "2", long = "network")]
     pub network: u16,
     /// Enables development mode, specify the unique ID of the local node to clean.
-    #[structopt(long)]
+    #[clap(long)]
     pub dev: Option<u16>,
 }
 
@@ -328,16 +328,16 @@ impl Clean {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub struct Update {
     /// Lists all available versions of snarkOS
-    #[structopt(short = "l", long)]
+    #[clap(short = 'l', long)]
     list: bool,
     /// Suppress outputs to terminal
-    #[structopt(short = "q", long)]
+    #[clap(short = 'q', long)]
     quiet: bool,
     /// Update to specified version
-    #[structopt(short = "v", long)]
+    #[clap(short = 'v', long)]
     version: Option<String>,
 }
 
@@ -371,9 +371,9 @@ impl Update {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub struct Experimental {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     commands: ExperimentalCommands,
 }
 
@@ -385,13 +385,13 @@ impl Experimental {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub enum ExperimentalCommands {
-    #[structopt(name = "new_account", about = "Generate a new Aleo account.")]
+    #[clap(name = "new_account", about = "Generate a new Aleo account.")]
     NewAccount(NewAccount),
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub struct NewAccount {}
 
 impl NewAccount {
@@ -412,9 +412,9 @@ impl NewAccount {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub struct MinerSubcommand {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     commands: MinerCommands,
 }
 
@@ -426,15 +426,15 @@ impl MinerSubcommand {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub enum MinerCommands {
-    #[structopt(name = "stats", about = "Prints statistics for the miner.")]
+    #[clap(name = "stats", about = "Prints statistics for the miner.")]
     Stats(MinerStats),
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Debug, Parser)]
 pub struct MinerStats {
-    #[structopt()]
+    #[clap()]
     address: String,
 }
 
@@ -444,7 +444,7 @@ impl MinerStats {
         let miner = Address::<CurrentNetwork>::from_str(&self.address)?;
 
         // Initialize the node.
-        let node = Node::from_iter(&["snarkos", "--norpc", "--verbosity", "0"]);
+        let node = Node::parse_from(&["snarkos", "--norpc", "--verbosity", "0"]);
 
         let ip = "0.0.0.0:1000".parse().unwrap();
 


### PR DESCRIPTION
The reasoning is provided in the linked issue.

note: the address parameter for the crawler changes from `node` to `addr` in order not to mix it up with the proper node.

Closes https://github.com/AleoHQ/snarkOS/issues/1675.