### PR TITLE
Add feature-gated persistent storage to the network crawler

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -16,7 +16,14 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+postgres = [ "tokio-postgres" ]
+postgres-tls = [ "native-tls", "postgres", "postgres-native-tls" ]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.anyhow]
+version = "1"
 
 [dependencies.async-trait]
 version = "0.1"
@@ -24,11 +31,19 @@ version = "0.1"
 [dependencies.bincode]
 version = "1"
 
+[dependencies.native-tls]
+version = "0.2"
+optional = true
+
 [dependencies.parking_lot]
 version = "0.12"
 
 [dependencies.pea2pea]
 version = "0.34"
+
+[dependencies.postgres-native-tls]
+version = "0.5"
+optional = true
 
 [dependencies.rand]
 version = "0.8"
@@ -67,6 +82,11 @@ features = ["local-offset"]
 
 [dependencies.tokio]
 version = "1"
+
+[dependencies.tokio-postgres]
+version = "0.7"
+features = [ "with-time-0_3" ]
+optional = true
 
 [dependencies.tracing]
 version = "0.1"

--- a/.crawler/src/constants.rs
+++ b/.crawler/src/constants.rs
@@ -26,6 +26,8 @@ pub const ACCEPTED_MESSAGE_IDS: &'static [u16] = &[
 ];
 /// The interval for revisiting successfully crawled nodes.
 pub const CRAWL_INTERVAL_MINS: i64 = 10;
+/// The amount of time (in seconds) between database writes containing crawling information.
+pub const DB_WRITE_INTERVAL_SECS: u8 = 10;
 /// The amount of time (in seconds) between crawling logs.
 pub const LOG_INTERVAL_SECS: u64 = 10;
 /// The maximum number of peers the crawler can have at a time.

--- a/.crawler/src/known_network.rs
+++ b/.crawler/src/known_network.rs
@@ -31,10 +31,10 @@ use crate::{
 /// The current state of a crawled node.
 #[derive(Debug, Clone)]
 pub struct NodeState {
-    node_type: NodeType,
-    version: u32,
-    height: u32,
-    state: State,
+    pub node_type: NodeType,
+    pub version: u32,
+    pub height: u32,
+    pub state: State,
 }
 
 /// A summary of the state of the known nodes.
@@ -79,13 +79,13 @@ pub struct NodeMeta {
     // The details of the node's state.
     pub state: Option<NodeState>,
     // The last interaction timestamp.
-    timestamp: Option<OffsetDateTime>,
+    pub timestamp: Option<OffsetDateTime>,
     // The number of lists of peers received from the node.
     received_peer_sets: u8,
     // The number of subsequent connection failures.
     connection_failures: u8,
     // The time it took to connect to the node.
-    handshake_time: Option<Duration>,
+    pub handshake_time: Option<Duration>,
 }
 
 impl NodeMeta {
@@ -293,6 +293,16 @@ impl KnownNetwork {
     /// Returns a snapshot of all the nodes.
     pub fn nodes(&self) -> HashMap<SocketAddr, NodeMeta> {
         self.nodes.read().clone()
+    }
+
+    /// Returns the number of all the known connections.
+    pub fn num_connections(&self) -> usize {
+        self.connections.read().len()
+    }
+
+    /// Returns the number of all the known nodes.
+    pub fn num_nodes(&self) -> usize {
+        self.nodes.read().len()
     }
 
     /// Returns a state summary for the known nodes.

--- a/.crawler/src/lib.rs
+++ b/.crawler/src/lib.rs
@@ -18,3 +18,5 @@ mod connection;
 pub mod constants;
 pub mod crawler;
 pub mod known_network;
+#[cfg(feature = "postgres")]
+pub mod storage;

--- a/.crawler/src/storage.rs
+++ b/.crawler/src/storage.rs
@@ -1,0 +1,154 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(feature = "postgres-tls")]
+use std::fs;
+
+#[cfg(feature = "postgres-tls")]
+use native_tls::{Certificate, TlsConnector};
+#[cfg(feature = "postgres-tls")]
+use postgres_native_tls::MakeTlsConnector;
+use time::OffsetDateTime;
+#[cfg(not(feature = "postgres-tls"))]
+use tokio_postgres::NoTls;
+use tokio_postgres::{types::Type, Client, Error};
+use tracing::*;
+
+use crate::crawler::{Crawler, Opts};
+
+/// Connects to a PostgreSQL database and creates the needed tables if they don't exist yet.
+pub async fn initialize_storage(opts: &Opts) -> Result<Client, anyhow::Error> {
+    // Prepare the connection config.
+    let config = format!(
+        "host={} port={} user={} password={} dbname={}",
+        opts.postgres_host, opts.postgres_port, opts.postgres_user, opts.postgres_pass, opts.postgres_dbname
+    );
+
+    // Connect to the PostgreSQL database.
+    #[cfg(feature = "postgres-tls")]
+    let (client, connection) = {
+        let cert = fs::read(&opts.postgres_cert_path)?;
+        let cert = Certificate::from_pem(&cert)?;
+        let connector = TlsConnector::builder().add_root_certificate(cert).build()?;
+        let connector = MakeTlsConnector::new(connector);
+
+        tokio_postgres::connect(&config, connector).await?
+    };
+
+    #[cfg(not(feature = "postgres-tls"))]
+    let (client, connection) = tokio_postgres::connect(&config, NoTls).await?;
+
+    // The connection object performs the actual communication with the database,
+    // so spawn it off to run on its own.
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            error!("Storage connection error: {}", e);
+        }
+    });
+
+    if opts.postgres_clean {
+        client
+            .batch_execute("DROP TABLE IF EXISTS nodes; DROP TABLE IF EXISTS network;")
+            .await?;
+        debug!("Persistent storage was cleaned");
+    }
+
+    client
+        .batch_execute(
+            "
+        CREATE TABLE IF NOT EXISTS nodes (
+            ip              INET NOT NULL,
+            port            INTEGER NOT NULL,
+            timestamp       TIMESTAMP WITH TIME ZONE,
+            type            SMALLINT,
+            version         INTEGER,
+            state           SMALLINT,
+            height          INTEGER,
+            handshake_ms    INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS network (
+            timestamp      TIMESTAMP WITH TIME ZONE NOT NULL,
+            nodes          INTEGER NOT NULL,
+            connections    INTEGER NOT NULL
+        );
+    ",
+        )
+        .await?;
+
+    debug!("Persistent storage is ready");
+
+    Ok(client)
+}
+
+impl Crawler {
+    pub async fn write_crawling_data(&self) -> Result<(), Error> {
+        if let Some(ref storage) = self.storage {
+            let nodes = self.known_network.nodes();
+
+            let mut storage = storage.lock().await;
+            let transaction = storage.transaction().await?;
+
+            let per_node_stmt = transaction
+                .prepare_typed("INSERT INTO nodes VALUES ($1, $2, $3, $4, $5, $6, $7, $8);", &[
+                    Type::INET,
+                    Type::INT4,
+                    Type::TIMESTAMPTZ,
+                    Type::INT2,
+                    Type::INT4,
+                    Type::INT2,
+                    Type::INT8,
+                    Type::INT4,
+                ])
+                .await?;
+
+            for (addr, meta) in nodes.into_iter().filter(|(_, meta)| meta.timestamp.is_some()) {
+                transaction
+                    .execute(&per_node_stmt, &[
+                        &addr.ip(),
+                        &(addr.port() as i32),
+                        &meta.timestamp.unwrap(),
+                        &meta.state.as_ref().map(|s| s.node_type as i16),
+                        &meta.state.as_ref().map(|s| s.version as i32),
+                        &meta.state.as_ref().map(|s| s.state as i16),
+                        &meta.state.as_ref().map(|s| s.height as i64),
+                        &meta.handshake_time.map(|t| t.whole_milliseconds() as i32),
+                    ])
+                    .await?;
+            }
+
+            let network_stmt = transaction
+                .prepare_typed("INSERT INTO network VALUES ($1, $2, $3);", &[
+                    Type::TIMESTAMPTZ,
+                    Type::INT4,
+                    Type::INT4,
+                ])
+                .await?;
+
+            transaction
+                .execute(&network_stmt, &[
+                    &OffsetDateTime::now_utc(),
+                    &(self.known_network.num_nodes() as i32),
+                    &(self.known_network.num_connections() as i32),
+                ])
+                .await?;
+
+            transaction.commit().await?;
+        }
+
+        Ok(())
+    }
+}

--- a/.crawler/tests/peering.rs
+++ b/.crawler/tests/peering.rs
@@ -17,6 +17,7 @@
 use pea2pea::Pea2Pea;
 use snarkos_crawler::crawler::{Crawler, Opts};
 use snarkos_integration::{wait_until, TestNode};
+use structopt::StructOpt;
 
 const NUM_NODES: usize = 10;
 
@@ -55,10 +56,8 @@ async fn basics() {
     }
 
     // Start the crawler.
-    let opts = Opts {
-        node: "127.0.0.1:0".parse().unwrap(),
-    };
-    let crawler = Crawler::new(opts).await;
+    let opts = Opts::from_iter(&["snarkos_crawler_test", "--node", "127.0.0.1:0"]);
+    let crawler = Crawler::new(opts, None).await;
 
     // "Seed" the crawler with the address of the first node.
     crawler.known_network.add_node(test_node_addrs[0]);

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -876,6 +877,12 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -1161,6 +1168,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
 
 [[package]]
 name = "http"
@@ -1522,6 +1538,15 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "md-5"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+dependencies = [
+ "digest 0.10.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1937,6 +1962,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2023,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ec03bce71f18b4a27c4c64c6ba2ddf74686d69b91d8714fb32ead3adaed713"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2 0.10.2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -2618,6 +2704,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,10 +2758,13 @@ dependencies = [
 name = "snarkos-crawler"
 version = "2.0.2"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
+ "native-tls",
  "parking_lot 0.12.0",
  "pea2pea",
+ "postgres-native-tls",
  "rand",
  "snarkos-environment",
  "snarkos-integration",
@@ -2681,6 +2776,7 @@ dependencies = [
  "structopt",
  "time 0.3.7",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3102,6 +3198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3431,29 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c8b33df661b548dcd8f9bf87debb8c56c05657ed291122e1188698c2ece95"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log",
+ "parking_lot 0.11.2",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2",
+ "tokio",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds optional persistent storage to the network crawler. The new dedicated features are `postgres` and `postgres-tls`.

Cc @zosorock 