### PR TITLE
Include more network metrics in the crawler, store connections

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -31,6 +31,9 @@ version = "0.1"
 [dependencies.bincode]
 version = "1"
 
+[dependencies.nalgebra]
+version = "0.30"
+
 [dependencies.native-tls]
 version = "0.2"
 optional = true

--- a/.crawler/src/constants.rs
+++ b/.crawler/src/constants.rs
@@ -18,7 +18,7 @@ use snarkos_environment::{ClientTrial, CurrentNetwork, Environment};
 
 /// The IDs of messages that are accepted by the crawler.
 // note: ChallengeRequest and ChallengeResponse are only expected during the handshake.
-pub const ACCEPTED_MESSAGE_IDS: &'static [u16] = &[
+pub const ACCEPTED_MESSAGE_IDS: &[u16] = &[
     4, // Disconnect
     5, // PeerRequest
     6, // PeerResponse
@@ -35,7 +35,7 @@ pub const MAXIMUM_NUMBER_OF_PEERS: usize = 1000;
 /// The amount of time (in seconds) between peer updates.
 pub const PEER_UPDATE_INTERVAL_SECS: u64 = 10;
 /// The list of sync nodes to begin crawling with.
-pub const SYNC_NODES: &'static [&'static str] = <ClientTrial<CurrentNetwork>>::SYNC_NODES;
+pub const SYNC_NODES: &[&str] = <ClientTrial<CurrentNetwork>>::SYNC_NODES;
 /// Connections that haven't been seen within this time (in hours) are forgotten.
 pub const STALE_CONNECTION_CUTOFF_TIME_HRS: i64 = 4;
 /// The number of lists of peers that a single peer needs to provide before it's disconnected from.

--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{constants::*, known_network::KnownNetwork};
+use crate::{constants::*, known_network::KnownNetwork, metrics::NetworkMetrics};
 use snarkos_environment::{
     helpers::{NodeType, State},
     CurrentNetwork,
@@ -163,7 +163,7 @@ impl Crawler {
         let node = self.clone();
         task::spawn(async move {
             loop {
-                debug!(parent: node.node().span(), "crawling the network for more peers; asking peers for their peers");
+                info!(parent: node.node().span(), "crawling the network for more peers; asking peers for their peers");
                 node.send_broadcast(ClientMessage::PeerRequest).unwrap();
 
                 // Disconnect from peers that we've collected sufficient information on or that have become stale.
@@ -211,7 +211,11 @@ impl Crawler {
         let node = self.clone();
         tokio::spawn(async move {
             loop {
-                if let Err(e) = node.write_crawling_data().await {
+                let connections = node.known_network.connections();
+                let nodes = node.known_network.nodes();
+                let metrics = task::spawn_blocking(move || NetworkMetrics::new(connections, nodes)).await.unwrap();
+
+                if let Err(e) = node.write_crawling_data(metrics).await {
                     error!(parent: node.node().span(), "storage write error: {}", e);
                 }
                 tokio::time::sleep(Duration::from_secs(DB_WRITE_INTERVAL_SECS.into())).await;
@@ -225,8 +229,14 @@ impl Crawler {
         let node = self.clone();
         tokio::spawn(async move {
             loop {
-                info!(parent: node.node().span(), "connected peers: {}", node.node().num_connected());
-                info!(parent: node.node().span(), "\n{:#?}", node.known_network.get_node_summary());
+                let connections = node.known_network.connections();
+                let nodes = node.known_network.nodes();
+                let summary = task::spawn_blocking(move || NetworkMetrics::new(connections, nodes).map(|metrics| metrics.summary()))
+                    .await
+                    .unwrap();
+                if let Some(summary) = summary {
+                    info!(parent: node.node().span(), "{}", summary);
+                }
                 tokio::time::sleep(Duration::from_secs(LOG_INTERVAL_SECS)).await;
             }
         });

--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -211,11 +211,12 @@ impl Crawler {
         let node = self.clone();
         tokio::spawn(async move {
             loop {
-                let connections = node.known_network.connections();
                 let nodes = node.known_network.nodes();
-                let metrics = task::spawn_blocking(move || NetworkMetrics::new(connections, nodes)).await.unwrap();
+                let connections = node.known_network.connections();
+                let conns = connections.clone();
+                let metrics = task::spawn_blocking(move || NetworkMetrics::new(conns, nodes)).await.unwrap();
 
-                if let Err(e) = node.write_crawling_data(metrics).await {
+                if let Err(e) = node.write_crawling_data(connections, metrics).await {
                     error!(parent: node.node().span(), "storage write error: {}", e);
                 }
                 tokio::time::sleep(Duration::from_secs(DB_WRITE_INTERVAL_SECS.into())).await;

--- a/.crawler/src/known_network.rs
+++ b/.crawler/src/known_network.rs
@@ -145,9 +145,7 @@ impl KnownNetwork {
 
             // Create new node objects based on connection addresses.
             for addr in node_addrs_from_conns {
-                if !nodes_g.contains_key(&addr) {
-                    nodes_g.insert(addr, NodeMeta::default());
-                }
+                nodes_g.entry(addr).or_default();
             }
         }
     }

--- a/.crawler/src/lib.rs
+++ b/.crawler/src/lib.rs
@@ -18,5 +18,6 @@ mod connection;
 pub mod constants;
 pub mod crawler;
 pub mod known_network;
+pub mod metrics;
 #[cfg(feature = "postgres")]
 pub mod storage;

--- a/.crawler/src/metrics.rs
+++ b/.crawler/src/metrics.rs
@@ -1,0 +1,416 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(not(feature = "postgres"))]
+use std::{cmp, fmt};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    net::SocketAddr,
+    ops::Sub,
+};
+
+use nalgebra::{DMatrix, DVector, SymmetricEigen};
+#[cfg(not(feature = "postgres"))]
+use snarkos_environment::helpers::{NodeType, State};
+#[cfg(not(feature = "postgres"))]
+use time::Duration;
+
+use crate::{connection::Connection, known_network::NodeMeta};
+
+/// A summary of the state of the known nodes.
+#[cfg(not(feature = "postgres"))]
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct NetworkSummary {
+    // The number of all known nodes.
+    num_known_nodes: usize,
+    // The number of all known connections.
+    num_known_connections: usize,
+    // The number of nodes that haven't provided their state yet.
+    nodes_pending_state: usize,
+    // The types of nodes and their respective counts.
+    types: HashMap<NodeType, usize>,
+    // The versions of nodes and their respective counts.
+    versions: HashMap<u32, usize>,
+    // The node states of nodes and their respective counts.
+    states: HashMap<State, usize>,
+    // The heights of nodes and their respective counts.
+    heights: HashMap<u32, usize>,
+    // Corresponds to the same field in the NetworkMetrics.
+    density: f64,
+    // Corresponds to the same field in the NetworkMetrics.
+    algebraic_connectivity: f64,
+    // Corresponds to the same field in the NetworkMetrics.
+    degree_centrality_delta: u16,
+    // Average number of node connections.
+    avg_degree_centrality: u16,
+    // Average node height.
+    avg_height: Option<u32>,
+    // The average handshake time in the network.
+    avg_handshake_time_ms: Option<i64>,
+}
+
+#[cfg(not(feature = "postgres"))]
+impl fmt::Display for NetworkSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn print_breakdown<T: fmt::Display>(f: &mut fmt::Formatter<'_>, counts: &HashMap<T, usize>, limit: usize) -> fmt::Result {
+            let mut vec: Vec<(&T, &usize)> = counts.iter().collect();
+            vec.sort_by_key(|(_, count)| cmp::Reverse(*count));
+
+            let limit = if limit == 0 { vec.len() } else { limit };
+            for (i, (item, count)) in vec.iter().enumerate().take(limit) {
+                write!(f, "{}: {}{}", item, count, if i < limit - 1 { ", " } else { "\n" })?;
+            }
+
+            Ok(())
+        }
+
+        writeln!(f, "\nNetwork summary:")?;
+        writeln!(
+            f,
+            "there are {} nodes with {} connections between them",
+            self.num_known_nodes, self.num_known_connections
+        )?;
+        if self.nodes_pending_state > 0 {
+            writeln!(f, "{} node(s) have not been successfully crawled yet", self.nodes_pending_state)?;
+        }
+
+        writeln!(f, "\nBreakdown:")?;
+        write!(f, "by node type: ")?;
+        print_breakdown(f, &self.types, 0)?;
+        write!(f, "by protocol version: ")?;
+        print_breakdown(f, &self.versions, 0)?;
+        write!(f, "by current state: ")?;
+        print_breakdown(f, &self.states, 0)?;
+
+        writeln!(f, "\nNetwork metrics:")?;
+        writeln!(f, "density: {:.4}", self.density)?;
+        writeln!(f, "algebraic connectivity: {:.4}", self.algebraic_connectivity)?;
+        writeln!(f, "degree centrality delta: {}", self.degree_centrality_delta)?;
+        writeln!(f, "average number of node connections: {}", self.avg_degree_centrality)?;
+        if let Some(ms) = self.avg_handshake_time_ms {
+            writeln!(f, "average handshake time: {}ms", ms)?;
+        }
+
+        writeln!(f, "\nBlockchain-related details:")?;
+        if let Some(h) = self.heights.keys().max() {
+            writeln!(f, "maximum found height: {}", h)?;
+        }
+        write!(f, "5 most common heights: ")?;
+        print_breakdown(f, &self.heights, 5)?;
+        if let Some(h) = self.avg_height {
+            writeln!(f, "average height: {}", h)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Network topology measurements.
+#[derive(Debug)]
+pub struct NetworkMetrics {
+    /// The total node count of the network.
+    pub node_count: usize,
+    /// The total connection count for the network.
+    pub connection_count: usize,
+    /// The network density.
+    ///
+    /// This is defined as actual connections divided by the total number of possible connections.
+    pub density: f64,
+    /// The algebraic connectivity of the network.
+    ///
+    /// This is the value of the Fiedler eigenvalue, the second-smallest eigenvalue of the network's
+    /// Laplacian matrix.
+    pub algebraic_connectivity: f64,
+    /// The difference between the node with the largest connection count and the node with the
+    /// lowest.
+    pub degree_centrality_delta: u16,
+    /// Per-node metrics.
+    pub per_node: Vec<(SocketAddr, NodeMeta, NodeCentrality)>,
+}
+
+impl NetworkMetrics {
+    /// Returns the network metrics for the state described by the connections list.
+    pub fn new(connections: HashSet<Connection>, nodes: HashMap<SocketAddr, NodeMeta>) -> Option<Self> {
+        // Don't compute the metrics for an empty set of connections.
+        if connections.is_empty() {
+            // Returns all metrics set to `0`.
+            return None;
+        }
+
+        let node_count = nodes.len();
+        let connection_count = connections.len();
+        let density = calculate_density(node_count as f64, connection_count as f64);
+
+        // Create an index of nodes to introduce some notion of order the rows and columns all matrices will follow.
+        let index: BTreeMap<SocketAddr, usize> = nodes.keys().enumerate().map(|(i, addr)| (*addr, i)).collect();
+
+        // Not stored on the struct but can be pretty inspected with `println!`.
+        // The adjacency matrix can be built from the node index and the connections list.
+        let adjacency_matrix = adjacency_matrix(&index, &connections);
+        // The degree matrix can be built from the adjacency matrix (row sum is connection count).
+        let degree_matrix = degree_matrix(&index, &adjacency_matrix);
+        // The laplacian matrix is degree matrix minus the adjacence matrix.
+        let laplacian_matrix = degree_matrix.clone().sub(&adjacency_matrix);
+
+        let degree_centrality = degree_centrality(&index, &degree_matrix);
+        let degree_centrality_delta = degree_centrality_delta(&degree_matrix);
+        let eigenvector_centrality = eigenvector_centrality(&index, adjacency_matrix);
+        let (algebraic_connectivity, fiedler_vector_indexed) = fiedler(&index, laplacian_matrix);
+
+        // Create the `NodeCentrality` instances for each node.
+        let per_node = nodes
+            .into_iter()
+            .map(|(addr, meta)| {
+                // Must contain values for this node since it was constructed using same set of
+                // nodes.
+                let dc = degree_centrality.get(&addr).unwrap();
+                let ec = eigenvector_centrality.get(&addr).unwrap();
+                let fv = fiedler_vector_indexed.get(&addr).unwrap();
+                let nc = NodeCentrality::new(*dc, *ec, *fv);
+
+                (addr, meta, nc)
+            })
+            .collect();
+
+        let metrics = Self {
+            node_count,
+            connection_count,
+            density,
+            algebraic_connectivity,
+            degree_centrality_delta,
+            per_node,
+        };
+
+        Some(metrics)
+    }
+
+    /// Returns a state summary for the known nodes.
+    #[cfg(not(feature = "postgres"))]
+    pub fn summary(&self) -> NetworkSummary {
+        let mut versions = HashMap::with_capacity(self.node_count);
+        let mut states = HashMap::with_capacity(self.node_count);
+        let mut types = HashMap::with_capacity(self.node_count);
+        let mut heights = HashMap::with_capacity(self.node_count);
+
+        let mut handshake_times = Vec::with_capacity(self.node_count);
+        let mut degree_centralities = Vec::with_capacity(self.node_count);
+        let mut nodes_pending_state: usize = 0;
+
+        for (_, meta, centrality) in &self.per_node {
+            if let Some(ref state) = meta.state {
+                versions.entry(state.version).and_modify(|count| *count += 1).or_insert(1);
+                states.entry(state.state).and_modify(|count| *count += 1).or_insert(1);
+                types.entry(state.node_type).and_modify(|count| *count += 1).or_insert(1);
+                heights.entry(state.height).and_modify(|count| *count += 1).or_insert(1);
+            } else {
+                nodes_pending_state += 1;
+            }
+            degree_centralities.push(centrality.degree_centrality);
+            if let Some(time) = meta.handshake_time {
+                handshake_times.push(time);
+            }
+        }
+
+        let avg_degree_centrality = degree_centralities.iter().map(|v| *v as u64).sum::<u64>() / degree_centralities.len() as u64;
+
+        let avg_height = if !heights.is_empty() {
+            let avg = heights.keys().map(|h| *h as u64).sum::<u64>() / heights.len() as u64;
+            Some(avg as u32)
+        } else {
+            None
+        };
+
+        let avg_handshake_time_ms = if !handshake_times.is_empty() {
+            let avg = handshake_times.iter().sum::<Duration>().whole_milliseconds() as i64 / handshake_times.len() as i64;
+            Some(avg)
+        } else {
+            None
+        };
+
+        NetworkSummary {
+            num_known_nodes: self.node_count,
+            num_known_connections: self.connection_count,
+            nodes_pending_state,
+            versions,
+            heights,
+            states,
+            types,
+            density: self.density,
+            algebraic_connectivity: self.algebraic_connectivity,
+            degree_centrality_delta: self.degree_centrality_delta,
+            avg_height,
+            avg_degree_centrality: avg_degree_centrality as u16,
+            avg_handshake_time_ms,
+        }
+    }
+}
+
+/// Centrality measurements of a node.
+///
+/// These include degree centrality, eigenvector centrality (the relative importance of a node
+/// in the network) and Fiedler vector (describes a possible partitioning of the network).
+#[derive(Debug)]
+pub struct NodeCentrality {
+    /// Connection count of the node.
+    pub degree_centrality: u16,
+    /// A measure of the relative importance of the node in the network.
+    ///
+    /// Summing the values of each node adds up to the number of nodes in the network. This was
+    /// done to allow comparison between different network topologies irrespective of node count.
+    pub eigenvector_centrality: f64,
+    /// This value is extracted from the Fiedler eigenvector corresponding to the second smallest
+    /// eigenvalue of the Laplacian matrix of the network.
+    ///
+    /// The network can be partitioned on the basis of these values (positive, negative and when
+    /// relevant close to zero).
+    pub fiedler_value: f64,
+}
+
+impl NodeCentrality {
+    fn new(degree_centrality: u16, eigenvector_centrality: f64, fiedler_value: f64) -> Self {
+        Self {
+            degree_centrality,
+            eigenvector_centrality,
+            fiedler_value,
+        }
+    }
+}
+
+pub fn calculate_density(n: f64, ac: f64) -> f64 {
+    // Calculate the total number of possible connections given a node count.
+    let pc = n * (n - 1.0) / 2.0;
+    // Actual connections divided by the possbile connections gives the density.
+    ac / pc
+}
+
+/// Returns the degree matrix for the network with values ordered by the index.
+fn degree_matrix(index: &BTreeMap<SocketAddr, usize>, adjacency_matrix: &DMatrix<f64>) -> DMatrix<f64> {
+    let n = index.len();
+    let mut matrix = DMatrix::<f64>::zeros(n, n);
+
+    for (i, row) in adjacency_matrix.row_iter().enumerate() {
+        // Set the diagonal to be the sum of connections in that row. The index isn't necessary
+        // here since the rows are visited in order and the adjacency matrix is ordered after the
+        // index.
+        matrix[(i, i)] = row.sum()
+    }
+
+    matrix
+}
+
+/// Returns the adjacency matrix for the network with values ordered by the index.
+fn adjacency_matrix(index: &BTreeMap<SocketAddr, usize>, connections: &HashSet<Connection>) -> DMatrix<f64> {
+    let n = index.len();
+    let mut matrix = DMatrix::<f64>::zeros(n, n);
+
+    // Compute the adjacency matrix. As our network is an undirected graph, the adjacency matrix is
+    // symmetric.
+    for connection in connections {
+        // Addresses must be present.
+        // Get the indices for each address in the connection.
+        let i = index.get(&connection.source).unwrap();
+        let j = index.get(&connection.target).unwrap();
+
+        // Since connections are unique both the upper and lower triangles must be writted (as the
+        // graph is unidrected) for each connection.
+        matrix[(*i, *j)] = 1.0;
+        matrix[(*j, *i)] = 1.0;
+    }
+
+    matrix
+}
+
+/// Returns the difference between the highest and lowest degree centrality in the network.
+fn degree_centrality_delta(degree_matrix: &DMatrix<f64>) -> u16 {
+    let max = degree_matrix.max();
+    let min = degree_matrix.min();
+
+    (max - min) as u16
+}
+
+/// Returns the degree centrality of a node.
+///
+/// This is defined as the connection count of the node.
+fn degree_centrality(index: &BTreeMap<SocketAddr, usize>, degree_matrix: &DMatrix<f64>) -> HashMap<SocketAddr, u16> {
+    let diag = degree_matrix.diagonal();
+    index.keys().zip(diag.iter()).map(|(addr, dc)| (*addr, *dc as u16)).collect()
+}
+
+/// Returns the eigenvalue centrality of each node in the network.
+fn eigenvector_centrality(index: &BTreeMap<SocketAddr, usize>, adjacency_matrix: DMatrix<f64>) -> HashMap<SocketAddr, f64> {
+    // Compute the eigenvectors and corresponding eigenvalues and sort in descending order.
+    let ascending = false;
+    let eigenvalue_vector_pairs = sorted_eigenvalue_vector_pairs(adjacency_matrix, ascending);
+    let (_highest_eigenvalue, highest_eigenvector) = &eigenvalue_vector_pairs[0];
+
+    // The eigenvector is a relative score of node importance (normalised by the norm), to obtain an absolute score for each
+    // node, we normalise so that the sum of the components are equal to 1.
+    let sum = highest_eigenvector.sum() / index.len() as f64;
+    let normalised = highest_eigenvector.unscale(sum);
+
+    // Map addresses to their eigenvalue centrality.
+    index
+        .keys()
+        .zip(normalised.column(0).iter())
+        .map(|(addr, ec)| (*addr, *ec))
+        .collect()
+}
+
+/// Returns the Fiedler values for each node in the network.
+fn fiedler(index: &BTreeMap<SocketAddr, usize>, laplacian_matrix: DMatrix<f64>) -> (f64, HashMap<SocketAddr, f64>) {
+    // Compute the eigenvectors and corresponding eigenvalues and sort in ascending order.
+    let ascending = true;
+    let pairs = sorted_eigenvalue_vector_pairs(laplacian_matrix, ascending);
+
+    // Second-smallest eigenvalue is the Fiedler value (algebraic connectivity), the associated
+    // eigenvector is the Fiedler vector.
+    let (algebraic_connectivity, fiedler_vector) = &pairs[1];
+
+    // Map addresses to their Fiedler values.
+    let fiedler_values_indexed = index
+        .keys()
+        .zip(fiedler_vector.column(0).iter())
+        .map(|(addr, fiedler_value)| (*addr, *fiedler_value))
+        .collect();
+
+    (*algebraic_connectivity, fiedler_values_indexed)
+}
+
+/// Computes the eigenvalues and corresponding eigenvalues from the supplied symmetric matrix.
+fn sorted_eigenvalue_vector_pairs(matrix: DMatrix<f64>, ascending: bool) -> Vec<(f64, DVector<f64>)> {
+    // Compute eigenvalues and eigenvectors.
+    let eigen = SymmetricEigen::new(matrix);
+
+    // Map eigenvalues to their eigenvectors.
+    let mut pairs: Vec<(f64, DVector<f64>)> = eigen
+        .eigenvalues
+        .iter()
+        .zip(eigen.eigenvectors.column_iter())
+        .map(|(value, vector)| (*value, vector.clone_owned()))
+        .collect();
+
+    // Sort eigenvalue-vector pairs in descending order.
+    pairs.sort_unstable_by(|(a, _), (b, _)| {
+        if ascending {
+            a.partial_cmp(b).unwrap()
+        } else {
+            b.partial_cmp(a).unwrap()
+        }
+    });
+
+    pairs
+}

--- a/.crawler/src/storage.rs
+++ b/.crawler/src/storage.rs
@@ -27,7 +27,10 @@ use tokio_postgres::NoTls;
 use tokio_postgres::{types::Type, Client, Error};
 use tracing::*;
 
-use crate::crawler::{Crawler, Opts};
+use crate::{
+    crawler::{Crawler, Opts},
+    metrics::NetworkMetrics,
+};
 
 /// Connects to a PostgreSQL database and creates the needed tables if they don't exist yet.
 pub async fn initialize_storage(opts: &Opts) -> Result<Client, anyhow::Error> {
@@ -70,20 +73,26 @@ pub async fn initialize_storage(opts: &Opts) -> Result<Client, anyhow::Error> {
         .batch_execute(
             "
         CREATE TABLE IF NOT EXISTS nodes (
-            ip              INET NOT NULL,
-            port            INTEGER NOT NULL,
-            timestamp       TIMESTAMP WITH TIME ZONE,
-            type            SMALLINT,
-            version         INTEGER,
-            state           SMALLINT,
-            height          INTEGER,
-            handshake_ms    INTEGER
+            ip                  INET NOT NULL,
+            port                INTEGER NOT NULL,
+            timestamp           TIMESTAMP WITH TIME ZONE,
+            type                SMALLINT,
+            version             INTEGER,
+            state               SMALLINT,
+            height              INTEGER,
+            handshake_ms        INTEGER,
+            connection_count    SMALLINT,
+            prestige_score      REAL,
+            fiedler_value       REAL
         );
 
         CREATE TABLE IF NOT EXISTS network (
-            timestamp      TIMESTAMP WITH TIME ZONE NOT NULL,
-            nodes          INTEGER NOT NULL,
-            connections    INTEGER NOT NULL
+            timestamp        TIMESTAMP WITH TIME ZONE NOT NULL,
+            nodes            INTEGER NOT NULL,
+            connections      INTEGER NOT NULL,
+            density          REAL,
+            fiedler_value    REAL,
+            dcd              REAL
         );
     ",
         )
@@ -95,15 +104,19 @@ pub async fn initialize_storage(opts: &Opts) -> Result<Client, anyhow::Error> {
 }
 
 impl Crawler {
-    pub async fn write_crawling_data(&self) -> Result<(), Error> {
-        if let Some(ref storage) = self.storage {
-            let nodes = self.known_network.nodes();
+    pub async fn write_crawling_data(&self, metrics: Option<NetworkMetrics>) -> Result<(), Error> {
+        let metrics = if let Some(metrics) = metrics {
+            metrics
+        } else {
+            return Ok(());
+        };
 
+        if let Some(ref storage) = self.storage {
             let mut storage = storage.lock().await;
             let transaction = storage.transaction().await?;
 
             let per_node_stmt = transaction
-                .prepare_typed("INSERT INTO nodes VALUES ($1, $2, $3, $4, $5, $6, $7, $8);", &[
+                .prepare_typed("INSERT INTO nodes VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);", &[
                     Type::INET,
                     Type::INT4,
                     Type::TIMESTAMPTZ,
@@ -112,28 +125,37 @@ impl Crawler {
                     Type::INT2,
                     Type::INT8,
                     Type::INT4,
+                    Type::INT4,
+                    Type::FLOAT4,
+                    Type::FLOAT4,
                 ])
                 .await?;
 
-            for (addr, meta) in nodes.into_iter().filter(|(_, meta)| meta.timestamp.is_some()) {
+            for (addr, meta, nc) in metrics.per_node {
                 transaction
                     .execute(&per_node_stmt, &[
                         &addr.ip(),
                         &(addr.port() as i32),
-                        &meta.timestamp.unwrap(),
+                        &meta.timestamp,
                         &meta.state.as_ref().map(|s| s.node_type as i16),
                         &meta.state.as_ref().map(|s| s.version as i32),
                         &meta.state.as_ref().map(|s| s.state as i16),
                         &meta.state.as_ref().map(|s| s.height as i64),
                         &meta.handshake_time.map(|t| t.whole_milliseconds() as i32),
+                        &(nc.degree_centrality as i32),
+                        &(nc.eigenvector_centrality as f32),
+                        &(nc.fiedler_value as f32),
                     ])
                     .await?;
             }
 
             let network_stmt = transaction
-                .prepare_typed("INSERT INTO network VALUES ($1, $2, $3);", &[
+                .prepare_typed("INSERT INTO network VALUES ($1, $2, $3, $4, $5, $6);", &[
                     Type::TIMESTAMPTZ,
                     Type::INT4,
+                    Type::INT4,
+                    Type::FLOAT4,
+                    Type::FLOAT4,
                     Type::INT4,
                 ])
                 .await?;
@@ -141,8 +163,11 @@ impl Crawler {
             transaction
                 .execute(&network_stmt, &[
                     &OffsetDateTime::now_utc(),
-                    &(self.known_network.num_nodes() as i32),
-                    &(self.known_network.num_connections() as i32),
+                    &(metrics.node_count as i32),
+                    &(metrics.connection_count as i32),
+                    &(metrics.density as f32),
+                    &(metrics.algebraic_connectivity as f32),
+                    &(metrics.degree_centrality_delta as i32),
                 ])
                 .await?;
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +323,12 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "bytemuck"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 
 [[package]]
 name = "byteorder"
@@ -1540,6 +1555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1706,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb2d0de08694bed883320212c18ee3008576bfe8c306f4c3c4a58b4876998be"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,12 +1797,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2228,6 +2299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2791,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a2609e876d4f77f6ab7ff5254fc39b4f1927ba8e6db3d18be7c32534d3725e"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,6 +2861,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "nalgebra",
  "native-tls",
  "parking_lot 0.12.0",
  "pea2pea",
@@ -3832,6 +3932,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3aba2d1dac31ac7cae82847ac5b8be822aee8f99a4e100f279605016b185c5f"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces some extra node-level and network-level metrics, refactors some of the code, and also stores the found connections in case persistent storage is used.

In addition, a `clippy` pass was done on the crawler code.

Cc @zosorock 