### PR TITLE
Tweaks to the node's cleanups

### DIFF
--- a/.integration/src/client_node.rs
+++ b/.integration/src/client_node.rs
@@ -64,16 +64,16 @@ impl ClientNode {
 
         ClientNode { server }
     }
+
+    pub async fn shut_down(&self) {
+        self.server.shut_down().await;
+    }
 }
 
 // Remove the storage artifacts after each test.
 impl Drop for ClientNode {
     fn drop(&mut self) {
         // TODO (howardwu): @ljedrz to implement a wrapping scope for Display within Node/Server.
-        #[allow(unused_must_use)]
-        {
-            self.server.shut_down();
-        }
 
         let db_path = format!("/tmp/snarkos-test-ledger-{}", self.local_addr().port());
         assert!(

--- a/.integration/tests/network/cleanups.rs
+++ b/.integration/tests/network/cleanups.rs
@@ -45,7 +45,8 @@ async fn measure_node_overhead() {
 }
 
 #[tokio::test]
-#[ignore = "TODO@ljedrz: no obvious leaks anymore; investigate larger conn counts and a Ping workaround"]
+// TODO@ljedrz: investigate larger connection counts
+// latest result: 46.37 KB
 async fn inbound_connect_and_disconnect_doesnt_leak() {
     // Start a test node.
     let test_node = TestNode::default().await;
@@ -80,18 +81,13 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
         }
     }
 
-    // Sleeping here for a time a few seconds more than `PING_SLEEP_IN_SECS` results in a pass, as expected.
-
-    // Measure memory use after the repeated connections.
-    let final_mem = PEAK_ALLOC.current_usage();
-
     // Check if there is a connection-related leak.
-    let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
-    assert_eq!(leaked_mem, 0);
+    wait_until!(3, PEAK_ALLOC.current_usage().saturating_sub(first_conn_mem.unwrap()) == 0);
 }
 
 #[tokio::test]
-#[ignore = "TODO@ljedrz: no obvious leaks anymore; investigate larger conn counts and a Ping workaround"]
+// TODO@ljedrz: investigate larger connection counts
+// latest result: 46.01 KB
 async fn outbound_connect_and_disconnect_doesnt_leak() {
     // Start a snarkOS node.
     let client_node = ClientNode::default().await;
@@ -128,14 +124,8 @@ async fn outbound_connect_and_disconnect_doesnt_leak() {
         }
     }
 
-    // Sleeping here for a time a few seconds more than `PING_SLEEP_IN_SECS` results in a pass, as expected.
-
-    // Measure memory use after the repeated connections.
-    let final_mem = PEAK_ALLOC.current_usage();
-
     // Check if there is a connection-related leak.
-    let leaked_mem = final_mem.saturating_sub(first_conn_mem.unwrap());
-    assert_eq!(leaked_mem, 0);
+    wait_until!(3, PEAK_ALLOC.current_usage().saturating_sub(first_conn_mem.unwrap()) == 0);
 }
 
 #[tokio::test]

--- a/.integration/tests/network/cleanups.rs
+++ b/.integration/tests/network/cleanups.rs
@@ -16,6 +16,7 @@
 
 use crate::common::display_bytes;
 use snarkos_integration::{wait_until, ClientNode, TestNode};
+use snarkvm::dpc::Network;
 
 use pea2pea::Pea2Pea;
 use peak_alloc::PeakAlloc;
@@ -25,8 +26,11 @@ use peak_alloc::PeakAlloc;
 static PEAK_ALLOC: PeakAlloc = PeakAlloc;
 
 #[tokio::test]
-#[ignore = "this test is purely informational; latest result: 159.81 MB"]
+#[ignore = "this test is purely informational; latest result: 11.73 MB"]
 async fn measure_node_overhead() {
+    // It takes a lot of memory to set up the snarkVM bits related to the Network, so filter it out.
+    let _genesis_block = snarkos_environment::CurrentNetwork::genesis_block();
+
     // Register initial memory use.
     let initial_mem = PEAK_ALLOC.current_usage();
 

--- a/.integration/tests/network/cleanups.rs
+++ b/.integration/tests/network/cleanups.rs
@@ -74,7 +74,7 @@ async fn inbound_connect_and_disconnect_doesnt_leak() {
             // Measure memory use caused by the 1st connect and disconnect.
             first_conn_mem = Some(PEAK_ALLOC.current_usage());
             println!(
-                "Memory increase after a single outbound connection: {}",
+                "Memory increase after a single inbound connection: {}",
                 display_bytes((first_conn_mem.unwrap() - pre_connection_mem) as f64)
             );
         }

--- a/environment/src/helpers/resources.rs
+++ b/environment/src/helpers/resources.rs
@@ -103,10 +103,15 @@ impl Resources {
             while let Some(request) = receiver.recv().await {
                 match request {
                     ResourceRequest::Register(resource, id) => {
+                        let resource_name = match resource {
+                            Resource::Task(..) => "task",
+                            Resource::Thread(..) => "thread",
+                        };
+
                         if resources.insert(id, resource).is_some() {
-                            error!("A resource with the id {} already exists!", id);
+                            error!("A resource with id {} already exists!", id);
                         } else {
-                            trace!("Registered a resource under the id {}", id);
+                            trace!("Registered a {} as resource {}", resource_name, id);
                         }
                     }
                     ResourceRequest::Deregister(id) => {
@@ -115,11 +120,11 @@ impl Resources {
                             // to-be-aborted task to free its resources.
                             tokio::spawn(async move {
                                 sleep(Duration::from_secs(1)).await;
-                                trace!("Aborting resource with the id {}", id);
+                                trace!("Aborting resource with id {}", id);
                                 resource.abort().await;
                             });
                         } else {
-                            error!("Resource with the id {} was not found", id);
+                            error!("Resource with id {} was not found", id);
                         }
                     }
                     ResourceRequest::Shutdown => break,
@@ -141,7 +146,7 @@ impl Resources {
             resources.sort_unstable_by_key(|(id, _res)| *id);
 
             for (id, resource) in resources.into_iter().rev() {
-                trace!("Aborting resource with the id {}", id);
+                trace!("Aborting resource with id {}", id);
                 resource.abort().await;
             }
         });

--- a/environment/src/helpers/resources.rs
+++ b/environment/src/helpers/resources.rs
@@ -136,7 +136,12 @@ impl Resources {
                     }
                 }
             }
-            for resource in resources.into_values() {
+
+            let mut resources = resources.into_iter().collect::<Vec<_>>();
+            resources.sort_unstable_by_key(|(id, _res)| *id);
+
+            for (id, resource) in resources.into_iter().rev() {
+                trace!("Aborting resource with the id {}", id);
                 resource.abort().await;
             }
         });

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -61,8 +61,8 @@ pub(crate) struct Peer<N: Network, E: Environment> {
     node_type: NodeType,
     /// The node type of the peer.
     status: Status,
-    /// The block header of the peer.
-    block_header: BlockHeader<N>,
+    /// The block height of the peer.
+    block_height: u32,
     /// The timestamp of the last message received from this peer.
     last_seen: Instant,
     /// The TCP socket that handles sending and receiving data with this peer.
@@ -128,7 +128,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
             version: 0,
             node_type,
             status,
-            block_header: N::genesis_block().header().clone(),
+            block_height: 0,
             last_seen: Instant::now(),
             outbound_socket,
             outbound_handler,
@@ -571,8 +571,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                                 break;
                                             }
 
-                                            // Update the block header of the peer.
-                                            peer.block_header = block_header;
+                                            // Update peer's block height.
+                                            peer.block_height = block_header.height();
                                         }
                                         Err(error) => warn!("[Ping] {}", error),
                                     }
@@ -585,7 +585,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     peer.status.update(status);
 
                                     // Determine if the peer is on a fork (or unknown).
-                                    let is_fork = match ledger_reader.get_block_hash(peer.block_header.height()) {
+                                    let is_fork = match ledger_reader.get_block_hash(peer.block_height) {
                                         Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
                                         Err(_) => None,
                                     };

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -432,10 +432,12 @@ impl<N: Network, E: Environment> Peers<N, E> {
                 // Skip if the number of connected peers is above the minimum threshold.
                 match number_of_connected_peers < E::MINIMUM_NUMBER_OF_PEERS {
                     true => {
-                        trace!("Sending request for more peer connections");
-                        // Request more peers if the number of connected peers is below the threshold.
-                        for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 3) {
-                            self.send(*peer_ip, Message::PeerRequest).await;
+                        if number_of_connected_peers > 0 {
+                            trace!("Sending requests for more peer connections");
+                            // Request more peers if the number of connected peers is below the threshold.
+                            for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 3) {
+                                self.send(*peer_ip, Message::PeerRequest).await;
+                            }
                         }
                     }
                     false => return,


### PR DESCRIPTION
This PR is the result of further work on the node cleanup tests; it enables the connection cleanup tests by default, tweaks the other cleanup tests and resource-related logs, and introduces the following changes found while working on them:
- [store the peer's current height instead of last header](https://github.com/AleoHQ/snarkOS/commit/ba5f9d582fc5545d241086784f4b993ab48f29d5) (reduces per-peer memory use)
- ~[remove the default dev sync node address](https://github.com/AleoHQ/snarkOS/commit/ae9a308da6cb64599b5ba0c65caabf0037624690) (it can interfere with network integration tests)~
- [don't attempt to ask for peers without any peers](https://github.com/AleoHQ/snarkOS/commit/ec6de4018f2aaa1862192b4b28d6411c01102fee) (a small performance improvement)