### PR TITLE
Use a proper codec with Framed

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -31,6 +31,9 @@ version = "0.1"
 [dependencies.bincode]
 version = "1"
 
+[dependencies.bytes]
+version = "1"
+
 [dependencies.clap]
 version = "3.1"
 features = [ "derive" ]
@@ -46,7 +49,7 @@ optional = true
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.34"
+version = "0.35"
 
 [dependencies.postgres-native-tls]
 version = "0.5"
@@ -83,6 +86,9 @@ features = [ "macros", "rt-multi-thread" ]
 version = "0.7"
 features = [ "with-time-0_3" ]
 optional = true
+
+[dependencies.tokio-util]
+version = "0.7"
 
 [dependencies.tracing]
 version = "0.1"

--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -27,7 +27,7 @@ optional = true
 version = "0.1"
 
 [dependencies.pea2pea]
-version = "0.34"
+version = "0.35"
 
 [dependencies.peak_alloc]
 version = "0.1"

--- a/.synthetic_node/Cargo.toml
+++ b/.synthetic_node/Cargo.toml
@@ -21,11 +21,14 @@ edition = "2021"
 [dependencies.async-trait]
 version = "0.1"
 
+[dependencies.futures-util]
+version = "0.3"
+
 [dependencies.parking_lot]
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.34"
+version = "0.35"
 
 [dependencies.rand]
 version = "0.8"
@@ -40,6 +43,9 @@ version = "0.8.0"
 
 [dependencies.tokio]
 version = "1"
+
+[dependencies.tokio-util]
+version = "0.7"
 
 [dependencies.tracing]
 version = "0.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,14 +2028,17 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pea2pea"
-version = "0.34.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d90feae3311b6204e24def79e34e663816bed86264bf3788de3a1c20a391f7e"
+checksum = "baa8169b36475d91e7e1612554cf89b58f517a40be3afa5a932fee2b62784f8f"
 dependencies = [
  "async-trait",
+ "bytes",
+ "futures-util",
  "once_cell",
  "parking_lot 0.12.0",
  "tokio",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -2896,6 +2899,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "bytes",
  "clap 3.1.8",
  "nalgebra",
  "native-tls",
@@ -2911,6 +2915,7 @@ dependencies = [
  "time 0.3.9",
  "tokio",
  "tokio-postgres",
+ "tokio-util 0.7.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3040,12 +3045,14 @@ name = "snarkos-synthetic-node"
 version = "2.0.2"
 dependencies = [
  "async-trait",
+ "futures-util",
  "parking_lot 0.12.0",
  "pea2pea",
  "rand",
  "snarkos-environment",
  "snarkvm",
  "tokio",
+ "tokio-util 0.7.1",
  "tracing",
  "tracing-subscriber",
 ]

--- a/environment/src/network/message.rs
+++ b/environment/src/network/message.rs
@@ -252,7 +252,7 @@ impl<N: Network, E: Environment> Message<N, E> {
     /// Deserializes the given buffer into a message.
     #[inline]
     pub fn deserialize(mut bytes: BytesMut) -> Result<Self> {
-        // Make sure there is an id available.
+        // Ensure there is at least a message ID in the buffer.
         if bytes.remaining() < 2 {
             bail!("Missing message ID");
         }
@@ -381,10 +381,9 @@ impl<N: Network, E: Environment> Decoder for MessageCodec<N, E> {
 
     fn decode(&mut self, source: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         // Decode a frame containing bytes belonging to a message.
-        let bytes = if let Some(bytes) = self.codec.decode(source)? {
-            bytes
-        } else {
-            return Ok(None);
+        let bytes = match self.codec.decode(source)? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
         };
 
         // Convert the bytes to a message, or fail if it is not valid.


### PR DESCRIPTION
The current setup is a bit of a hack, and this PR fixes that. No (en/de)coding changes are introduced - just a helper object.

I initially wanted to use [LengthDelimitedCodec](https://docs.rs/tokio-util/latest/tokio_util/codec/length_delimited/struct.LengthDelimitedCodec.html) (which we basically partially implement ourselves), but that one only works with `Bytes`, which would currently require an extra allocation for each network message; I'll revisit this option later on.