### PR TITLE
Restructure crawler args, introduce a new storage table

### DIFF
--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "postgres")]
+use crate::storage::PostgresOpts;
 use crate::{constants::*, known_network::KnownNetwork, metrics::NetworkMetrics};
 use snarkos_environment::{
     helpers::{NodeType, State},
@@ -32,8 +34,6 @@ use pea2pea::{
     Pea2Pea,
 };
 use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
-#[cfg(feature = "postgres-tls")]
-use std::path::PathBuf;
 use std::{
     convert::TryInto,
     io::{self, Read},
@@ -57,34 +57,9 @@ pub struct Opts {
     /// Specify the IP address and port for the node server.
     #[clap(long = "addr", short = 'a', parse(try_from_str), default_value = "0.0.0.0:4132")]
     pub addr: SocketAddr,
-    /// The path to a certificate file to be used for a TLS connection with the postgres instance.
-    #[cfg(feature = "postgres-tls")]
-    #[clap(long = "postgres-cert-path")]
-    pub postgres_cert_path: PathBuf,
-    /// The hostname of the postgres instance (defaults to "localhost").
     #[cfg(feature = "postgres")]
-    #[clap(long = "postgres-host", default_value = "localhost")]
-    pub postgres_host: String,
-    /// The port of the postgres instance (defaults to 5432).
-    #[cfg(feature = "postgres")]
-    #[clap(long = "postgres-port", default_value = "5432")]
-    pub postgres_port: u16,
-    /// The user of the postgres instance (defaults to "postgres").
-    #[cfg(feature = "postgres")]
-    #[clap(long = "postgres-user", default_value = "postgres")]
-    pub postgres_user: String,
-    /// The password for the postgres instance (defaults to nothing).
-    #[cfg(feature = "postgres")]
-    #[clap(long = "postgres-pass", default_value = "")]
-    pub postgres_pass: String,
-    /// The hostname of the postgres instance (defaults to "postgres").
-    #[cfg(feature = "postgres")]
-    #[clap(long = "postgres-dbname", default_value = "postgres")]
-    pub postgres_dbname: String,
-    /// If set to `true`, re-creates the crawler's database tables.
-    #[cfg(feature = "postgres")]
-    #[clap(long = "postgres-clean")]
-    pub postgres_clean: bool,
+    #[clap(flatten)]
+    pub postgres: PostgresOpts,
 }
 
 /// Represents the crawler together with network metrics it has collected.

--- a/.crawler/src/storage.rs
+++ b/.crawler/src/storage.rs
@@ -16,8 +16,9 @@
 
 use std::collections::HashSet;
 #[cfg(feature = "postgres-tls")]
-use std::fs;
+use std::{fs, path::PathBuf};
 
+use clap::Parser;
 #[cfg(feature = "postgres-tls")]
 use native_tls::{Certificate, TlsConnector};
 #[cfg(feature = "postgres-tls")]
@@ -34,18 +35,44 @@ use crate::{
     metrics::NetworkMetrics,
 };
 
+#[derive(Debug, Parser)]
+pub struct PostgresOpts {
+    /// The hostname of the postgres instance (defaults to "localhost").
+    #[clap(long = "postgres-host", default_value = "localhost")]
+    pub host: String,
+    /// The port of the postgres instance (defaults to 5432).
+    #[clap(long = "postgres-port", default_value = "5432")]
+    pub port: u16,
+    /// The user of the postgres instance (defaults to "postgres").
+    #[clap(long = "postgres-user", default_value = "postgres")]
+    pub user: String,
+    /// The password for the postgres instance (defaults to nothing).
+    #[clap(long = "postgres-pass", default_value = "")]
+    pub pass: String,
+    /// The hostname of the postgres instance (defaults to "postgres").
+    #[clap(long = "postgres-dbname", default_value = "postgres")]
+    pub dbname: String,
+    /// If set to `true`, re-creates the crawler's database tables.
+    #[clap(long = "postgres-clean")]
+    pub clean: bool,
+    /// The path to a certificate file to be used for a TLS connection with the postgres instance.
+    #[cfg(feature = "postgres-tls")]
+    #[clap(long = "postgres-cert-path")]
+    pub cert_path: PathBuf,
+}
+
 /// Connects to a PostgreSQL database and creates the needed tables if they don't exist yet.
 pub async fn initialize_storage(opts: &Opts) -> Result<Client, anyhow::Error> {
     // Prepare the connection config.
     let config = format!(
         "host={} port={} user={} password={} dbname={}",
-        opts.postgres_host, opts.postgres_port, opts.postgres_user, opts.postgres_pass, opts.postgres_dbname
+        opts.postgres.host, opts.postgres.port, opts.postgres.user, opts.postgres.pass, opts.postgres.dbname
     );
 
     // Connect to the PostgreSQL database.
     #[cfg(feature = "postgres-tls")]
     let (client, connection) = {
-        let cert = fs::read(&opts.postgres_cert_path)?;
+        let cert = fs::read(&opts.postgres.cert_path)?;
         let cert = Certificate::from_pem(&cert)?;
         let connector = TlsConnector::builder().add_root_certificate(cert).build()?;
         let connector = MakeTlsConnector::new(connector);
@@ -64,7 +91,7 @@ pub async fn initialize_storage(opts: &Opts) -> Result<Client, anyhow::Error> {
         }
     });
 
-    if opts.postgres_clean {
+    if opts.postgres.clean {
         client
             .batch_execute("DROP TABLE IF EXISTS nodes; DROP TABLE IF EXISTS network; DROP TABLE IF EXISTS connections;")
             .await?;


### PR DESCRIPTION
This PR consists of the following changes related to the network crawler:
- the postgres-specific arguments were moved to a dedicated `struct`
- the `nodes` table was renamed to `node_states` and its last 3 columns were moved to a new `node_centrality` table
- `node_states` now enforces uniqueness on the `(ip, port, timestamp)` triplet and has a related index; the records are now no longer duplicated

I initially considered only updating the node centrality metrics (without adding the new table - see https://github.com/AleoHQ/snarkOS/pull/1694/commits/82dd6f9d44ee17643945d934ced0b1bd43f3b310), but that would erase the older values, which would remove the related history for nodes that can't be connected to.

Cc @zosorock 