### PR TITLE
Network refactor: routeless

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -32,6 +32,9 @@ version = "0.2"
 version = "0.3.21"
 features = [ "thread-pool" ]
 
+[dependencies.once_cell]
+version = "1.10"
+
 [dependencies.rand]
 version = "0.8"
 

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -356,9 +356,15 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.unconfirmed_blocks.write().await.clear();
 
             // Reset the memory pool of its transactions.
-            if let Err(error) = prover_router.send(ProverRequest::MemoryPoolClear(None)).await {
-                error!("[MemoryPoolClear]: {}", error);
-            }
+            self.network_state
+                .get()
+                .expect("network state must be set")
+                .prover
+                .update(ProverRequest::MemoryPoolClear(None))
+                .await;
+            // if let Err(error) = prover_router.send(ProverRequest::MemoryPoolClear(None)).await {
+            //     error!("[MemoryPoolClear]: {}", error);
+            // }
 
             self.block_requests
                 .write()
@@ -500,9 +506,15 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                         self.unconfirmed_blocks.write().await.remove(&unconfirmed_previous_block_hash);
 
                         // On success, filter the memory pool of its transactions, if they exist.
-                        if let Err(error) = prover_router.send(ProverRequest::MemoryPoolClear(Some(unconfirmed_block))).await {
-                            error!("[MemoryPoolClear]: {}", error);
-                        }
+                        self.network_state
+                            .get()
+                            .expect("network state must be set")
+                            .prover
+                            .update(ProverRequest::MemoryPoolClear(Some(unconfirmed_block)))
+                            .await;
+                        //  if let Err(error) = prover_router.send(ProverRequest::MemoryPoolClear(Some(unconfirmed_block))).await {
+                        //      error!("[MemoryPoolClear]: {}", error);
+                        //  }
 
                         return true;
                     }

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -142,27 +142,27 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         });
 
         // Initialize the handler for the ledger.
-        {
-            let ledger = ledger.clone();
-            let (router, handler) = oneshot::channel();
-            E::resources().register_task(
-                None, // No need to provide an id, as the task will run indefinitely.
-                task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    // Asynchronously wait for a ledger request.
-                    while let Some(request) = ledger_handler.recv().await {
-                        // Update the state of the ledger.
-                        // Note: Do not wrap this call in a `task::spawn` as `BlockResponse` messages
-                        // will end up being processed out of order.
-                        ledger.update(request).await;
-                    }
-                }),
-            );
+        // {
+        //     let ledger = ledger.clone();
+        //     let (router, handler) = oneshot::channel();
+        //     E::resources().register_task(
+        //         None, // No need to provide an id, as the task will run indefinitely.
+        //         task::spawn(async move {
+        //             // Notify the outer function that the task is ready.
+        //             let _ = router.send(());
+        //             // Asynchronously wait for a ledger request.
+        //             while let Some(request) = ledger_handler.recv().await {
+        //                 // Update the state of the ledger.
+        //                 // Note: Do not wrap this call in a `task::spawn` as `BlockResponse` messages
+        //                 // will end up being processed out of order.
+        //                 ledger.update(request).await;
+        //             }
+        //         }),
+        //     );
 
-            // Wait until the ledger handler is ready.
-            let _ = handler.await;
-        }
+        //     // Wait until the ledger handler is ready.
+        //     let _ = handler.await;
+        // }
 
         Ok(ledger)
     }
@@ -204,7 +204,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Performs the given `request` to the ledger.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(&self, request: LedgerRequest<N>) {
+    pub async fn update(&self, request: LedgerRequest<N>) {
         match request {
             LedgerRequest::BlockResponse(peer_ip, block, prover_router) => {
                 // Remove the block request from the ledger.

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -17,7 +17,6 @@
 use crate::{
     helpers::{block_requests::*, BlockRequest, CircularMap},
     state::NetworkState,
-    PeersRequest,
     ProverRequest,
 };
 

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -127,6 +127,10 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.network_state.set(network_state).expect("network state can only be set once");
     }
 
+    fn expect_network_state(&self) -> &NetworkState<N, E> {
+        self.network_state.get().expect("network state must be set")
+    }
+
     /// Returns an instance of the ledger reader.
     pub fn reader(&self) -> LedgerReader<N> {
         self.canon_reader.clone()
@@ -354,9 +358,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.unconfirmed_blocks.write().await.clear();
 
             // Reset the memory pool of its transactions.
-            self.network_state
-                .get()
-                .expect("network state must be set")
+            self.expect_network_state()
                 .prover
                 .update(ProverRequest::MemoryPoolClear(None))
                 .await;
@@ -501,9 +503,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                         self.unconfirmed_blocks.write().await.remove(&unconfirmed_previous_block_hash);
 
                         // On success, filter the memory pool of its transactions, if they exist.
-                        self.network_state
-                            .get()
-                            .expect("network state must be set")
+                        self.expect_network_state()
                             .prover
                             .update(ProverRequest::MemoryPoolClear(Some(unconfirmed_block)))
                             .await;

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -172,6 +172,10 @@ impl<N: Network, E: Environment> Operator<N, E> {
         self.network_state.set(network_state).expect("network state can only be set once");
     }
 
+    fn expect_network_state(&self) -> &NetworkState<N, E> {
+        self.network_state.get().expect("network state must be set")
+    }
+
     /// Returns all the shares in storage.
     pub fn to_shares(&self) -> Vec<((u32, Record<N>), HashMap<Address<N>, u64>)> {
         self.state.to_shares()
@@ -213,12 +217,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
 
                     // Route a `PoolRequest` to the peer.
                     let message = Message::PoolRequest(share_difficulty, Data::Object(block_template));
-                    self.network_state
-                        .get()
-                        .expect("network state must be set")
-                        .peers
-                        .send(peer_ip, message)
-                        .await
+                    self.expect_network_state().peers.send(peer_ip, message).await
                 } else {
                     warn!("[PoolRegister] No current block template exists");
                 }
@@ -290,12 +289,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
                         if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
                             info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
 
-                            self.network_state
-                                .get()
-                                .expect("network state must be set")
-                                .ledger
-                                .unconfirmed_block(self.local_ip, block)
-                                .await;
+                            self.expect_network_state().ledger.unconfirmed_block(self.local_ip, block).await;
                         }
                     }
                 } else {

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{state::NetworkState, LedgerReader, LedgerRequest};
+use crate::{state::NetworkState, LedgerReader};
 use snarkos_environment::{
     helpers::NodeType,
     network::{Data, Message},
@@ -289,13 +289,12 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     ) {
                         if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
                             info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
-                            let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block);
 
                             self.network_state
                                 .get()
                                 .expect("network state must be set")
                                 .ledger
-                                .update(request)
+                                .unconfirmed_block(self.local_ip, block)
                                 .await;
                         }
                     }

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -217,7 +217,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
                         .get()
                         .expect("network state must be set")
                         .peers
-                        .update(PeersRequest::MessageSend(peer_ip, message))
+                        .send(peer_ip, message)
                         .await
                 } else {
                     warn!("[PoolRegister] No current block template exists");

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{state::NetworkState, LedgerReader, LedgerRequest, PeersRequest, PeersRouter, ProverRouter};
+use crate::{state::NetworkState, LedgerReader, LedgerRequest, PeersRequest, PeersRouter};
 use snarkos_environment::{
     helpers::NodeType,
     network::{Data, Message},
@@ -86,8 +86,6 @@ pub struct Operator<N: Network, E: Environment> {
     peers_router: PeersRouter<N, E>,
     /// The ledger state of the node.
     ledger_reader: LedgerReader<N>,
-    /// The prover router of the node.
-    prover_router: ProverRouter<N>,
 }
 
 impl<N: Network, E: Environment> Operator<N, E> {
@@ -100,7 +98,6 @@ impl<N: Network, E: Environment> Operator<N, E> {
         memory_pool: Arc<RwLock<MemoryPool<N>>>,
         peers_router: PeersRouter<N, E>,
         ledger_reader: LedgerReader<N>,
-        prover_router: ProverRouter<N>,
     ) -> Result<Arc<Self>> {
         // Initialize an mpsc channel for sending requests to the `Operator` struct.
         let (operator_router, mut operator_handler) = mpsc::channel(1024);
@@ -117,7 +114,6 @@ impl<N: Network, E: Environment> Operator<N, E> {
             memory_pool,
             peers_router,
             ledger_reader,
-            prover_router,
         });
 
         if E::NODE_TYPE == NodeType::Operator {
@@ -330,7 +326,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     ) {
                         if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
                             info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
-                            let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block, self.prover_router.clone());
+                            let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block);
 
                             self.network_state
                                 .get()

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -34,15 +34,9 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{mpsc, oneshot, RwLock},
+    sync::{oneshot, RwLock},
     task,
 };
-
-/// Shorthand for the parent half of the `Operator` message channel.
-pub type OperatorRouter<N> = mpsc::Sender<OperatorRequest<N>>;
-#[allow(unused)]
-/// Shorthand for the child half of the `Operator` message channel.
-type OperatorHandler<N> = mpsc::Receiver<OperatorRequest<N>>;
 
 ///
 /// An enum of requests that the `Operator` struct processes.
@@ -110,26 +104,6 @@ impl<N: Network, E: Environment> Operator<N, E> {
             peers_router,
             ledger_reader,
         });
-
-        // if E::NODE_TYPE == NodeType::Operator {
-        //     // Initialize the handler for the operator.
-        //     let operator_clone = operator.clone();
-        //     let (router, handler) = oneshot::channel();
-        //     E::resources().register_task(
-        //         None, // No need to provide an id, as the task will run indefinitely.
-        //         task::spawn(async move {
-        //             // Notify the outer function that the task is ready.
-        //             let _ = router.send(());
-        //             // Asynchronously wait for a operator request.
-        //             while let Some(request) = operator_handler.recv().await {
-        //                 operator_clone.update(request).await;
-        //             }
-        //         }),
-        //     );
-
-        //     // Wait until the operator handler is ready.
-        //     let _ = handler.await;
-        // }
 
         if E::NODE_TYPE == NodeType::Operator {
             if let Some(recipient) = operator.address {

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -335,9 +335,13 @@ impl<N: Network, E: Environment> Operator<N, E> {
                         if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
                             info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
                             let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block, self.prover_router.clone());
-                            if let Err(error) = self.ledger_router.send(request).await {
-                                warn!("Failed to broadcast mined block - {}", error);
-                            }
+
+                            self.network_state
+                                .get()
+                                .expect("network state must be set")
+                                .ledger
+                                .update(request)
+                                .await;
                         }
                     }
                 } else {

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerReader, LedgerRequest, LedgerRouter, NetworkState, PeersRequest, PeersRouter, ProverRouter};
+use crate::{state::NetworkState, LedgerReader, LedgerRequest, PeersRequest, PeersRouter, ProverRouter};
 use snarkos_environment::{
     helpers::NodeType,
     network::{Data, Message},
@@ -86,8 +86,6 @@ pub struct Operator<N: Network, E: Environment> {
     peers_router: PeersRouter<N, E>,
     /// The ledger state of the node.
     ledger_reader: LedgerReader<N>,
-    /// The ledger router of the node.
-    ledger_router: LedgerRouter<N>,
     /// The prover router of the node.
     prover_router: ProverRouter<N>,
 }
@@ -102,7 +100,6 @@ impl<N: Network, E: Environment> Operator<N, E> {
         memory_pool: Arc<RwLock<MemoryPool<N>>>,
         peers_router: PeersRouter<N, E>,
         ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
         prover_router: ProverRouter<N>,
     ) -> Result<Arc<Self>> {
         // Initialize an mpsc channel for sending requests to the `Operator` struct.
@@ -120,7 +117,6 @@ impl<N: Network, E: Environment> Operator<N, E> {
             memory_pool,
             peers_router,
             ledger_reader,
-            ledger_router,
             prover_router,
         });
 

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{state::NetworkState, LedgerReader, LedgerRequest, PeersRequest};
+use crate::{state::NetworkState, LedgerReader, LedgerRequest};
 use snarkos_environment::{
     helpers::NodeType,
     network::{Data, Message},

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -79,7 +79,7 @@ pub(crate) struct Peer<N: Network, E: Environment> {
     /// TODO: make atomic?
     last_seen: RwLock<Instant>,
     /// The TCP socket that handles sending and receiving data with this peer.
-    outbound_sender: mpsc::Sender<Message<N, E>>,
+    pub outbound_sender: mpsc::Sender<Message<N, E>>,
     /// The map of block hashes to their last seen timestamp.
     seen_inbound_blocks: RwLock<HashMap<N::BlockHash, SystemTime>>,
     /// The map of transaction IDs to their last seen timestamp.
@@ -92,7 +92,7 @@ pub(crate) struct Peer<N: Network, E: Environment> {
 
 impl<N: Network, E: Environment> Peer<N, E> {
     /// Create a new instance of `Peer`.
-    async fn new(
+    pub async fn new(
         network_state: NetworkState<N, E>,
         stream: TcpStream,
         local_ip: SocketAddr,
@@ -472,7 +472,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
             tokio::spawn(async move {
                 loop {
                     match outbound_receiver.recv().await {
-                        Some(message) => outbound_socket.send(message),
+                        Some(message) => outbound_socket.send(message).await,
                         None => break,
                     };
                 }

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -18,7 +18,6 @@ use crate::{
     ConnectionResult,
     LedgerReader,
     LedgerRequest,
-    LedgerRouter,
     OperatorRequest,
     OperatorRouter,
     PeersRequest,
@@ -328,7 +327,6 @@ impl<N: Network, E: Environment> Peer<N, E> {
         local_nonce: u64,
         peers_router: &PeersRouter<N, E>,
         ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
         prover_router: ProverRouter<N>,
         operator_router: OperatorRouter<N>,
         connected_nonces: Vec<u64>,
@@ -765,12 +763,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
 
             // When this is reached, it means the peer has disconnected.
             // Route a `Disconnect` to the ledger.
-            if let Err(error) = ledger_router
-                .send(LedgerRequest::Disconnect(peer_ip, DisconnectReason::PeerHasDisconnected))
-                .await
-            {
-                warn!("[Peer::Disconnect] {}", error);
-            }
+            peer.network_state.ledger.update(LedgerRequest::Disconnect(peer_ip, DisconnectReason::PeerHasDisconnected)).await;
 
             E::resources().deregister(peer_resource_id);
         }));

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -711,10 +711,11 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                                 trace!("Skipping 'UnconfirmedTransaction {}' from {}", transaction.transaction_id(), peer_ip);
                                             } else {
                                                 // Route the `UnconfirmedTransaction` to the prover.
-                                                if let Err(error) = prover_router.send(ProverRequest::UnconfirmedTransaction(peer_ip, transaction)).await {
-                                                    warn!("[UnconfirmedTransaction] {}", error);
+                                                peer.network_state.prover.update(ProverRequest::UnconfirmedTransaction(peer_ip, transaction)).await;
+                                               //  if let Err(error) = prover_router.send(ProverRequest::UnconfirmedTransaction(peer_ip, transaction)).await {
+                                               //      warn!("[UnconfirmedTransaction] {}", error);
 
-                                                }
+                                               //  }
                                             }
 
                                         }
@@ -732,9 +733,10 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     if E::NODE_TYPE != NodeType::Prover {
                                         trace!("Skipping 'PoolRequest' from {}", peer_ip);
                                     } else if let Ok(block_template) = block_template.deserialize().await {
-                                        if let Err(error) = prover_router.send(ProverRequest::PoolRequest(peer_ip, share_difficulty, block_template)).await {
-                                            warn!("[PoolRequest] {}", error);
-                                        }
+                                    peer.network_state.prover.update(ProverRequest::PoolRequest(peer_ip, share_difficulty, block_template)).await;
+                                       //  if let Err(error) = prover_router.send(ProverRequest::PoolRequest(peer_ip, share_difficulty, block_template)).await {
+                                       //      warn!("[PoolRequest] {}", error);
+                                       //  }
                                     } else {
                                         warn!("[PoolRequest] could not deserialize block template");
                                     }

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerRequest, OperatorRequest, PeersRequest, ProverRequest};
+use crate::{LedgerRequest, OperatorRequest, ProverRequest};
 use snarkos_environment::{
     helpers::{NodeType, State, Status},
     network::{Data, DisconnectReason, Message},

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -44,33 +44,6 @@ use tokio::{
 pub(crate) type ConnectionResult = oneshot::Sender<Result<()>>;
 
 ///
-/// An enum of requests that the `Peers` struct processes.
-///
-#[derive(Debug)]
-pub enum PeersRequest<N: Network, E: Environment> {
-    /// Connect := (peer_ip, connection_result)
-    Connect(SocketAddr, ConnectionResult),
-    /// Heartbeat : ()
-    Heartbeat,
-    /// MessagePropagate := (peer_ip, message)
-    MessagePropagate(SocketAddr, Message<N, E>),
-    /// MessageSend := (peer_ip, message)
-    MessageSend(SocketAddr, Message<N, E>),
-    /// PeerConnecting := (stream, peer_ip)
-    PeerConnecting(TcpStream, SocketAddr),
-    /// PeerConnected := (peer_ip, peer_nonce)
-    PeerConnected(SocketAddr, u64),
-    /// PeerDisconnected := (peer_ip)
-    PeerDisconnected(SocketAddr),
-    /// PeerRestricted := (peer_ip)
-    PeerRestricted(SocketAddr),
-    /// SendPeerResponse := (peer_ip)
-    SendPeerResponse(SocketAddr),
-    /// ReceivePeerResponse := (\[peer_ip\])
-    ReceivePeerResponse(Vec<SocketAddr>),
-}
-
-///
 /// A list of peers connected to the node server.
 ///
 #[derive(Debug)]

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -324,6 +324,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                             Ok(stream) => match stream {
                                 Ok(stream) => {
                                     Peer::handler(
+                                        self.network_state.get().expect("network state must be set").clone(),
                                         stream,
                                         self.local_ip,
                                         self.local_nonce,
@@ -571,6 +572,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
 
                         // Initialize the peer handler.
                         Peer::handler(
+                            self.network_state.get().expect("network state must be set").clone(),
                             stream,
                             self.local_ip,
                             self.local_nonce,

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -350,14 +350,14 @@ impl<N: Network, E: Environment> Peers<N, E> {
             for peer_ip in disconnected_trusted_nodes {
                 // Initialize the connection process.
                 let (router, handler) = oneshot::channel();
-                let request = PeersRequest::Connect(peer_ip, router);
                 self.network_state
                     .get()
                     .expect("network state must be set")
                     .peers
-                    .update(request)
+                    .connect(peer_ip, router)
                     .await;
 
+                // TODO: remove routing.
                 // Do not wait for the result of each connection.
                 // Procure a resource id to register the task with, as it might be terminated at any point in time.
                 let resource_id = E::resources().procure_id();

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -88,6 +88,7 @@ pub struct Peers<N: Network, E: Environment> {
     local_ip: SocketAddr,
     /// The local nonce for this node session.
     local_nonce: u64,
+    peers: RwLock<HashMap<SocketAddr, Peer<N, E>>>,
     /// The map connected peer IPs to their nonce.
     connected_peers: RwLock<HashMap<SocketAddr, u64>>,
     /// The set of candidate peer IPs.
@@ -120,6 +121,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             peers_router,
             local_ip,
             local_nonce,
+            peers: Default::default(),
             connected_peers: Default::default(),
             candidate_peers: Default::default(),
             restricted_peers: Default::default(),

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerReader, NetworkState, OperatorRouter, OutboundRouter, Peer, ProverRouter};
+use crate::{LedgerReader, NetworkState, OperatorRouter, OutboundRouter, Peer};
 use snarkos_environment::{
     network::{Data, DisconnectReason, Message},
     Environment,
@@ -54,16 +54,16 @@ pub(crate) type ConnectionResult = oneshot::Sender<Result<()>>;
 ///
 #[derive(Debug)]
 pub enum PeersRequest<N: Network, E: Environment> {
-    /// Connect := (peer_ip, ledger_reader, operator_router, prover_router, connection_result)
-    Connect(SocketAddr, LedgerReader<N>, OperatorRouter<N>, ProverRouter<N>, ConnectionResult),
-    /// Heartbeat := (ledger_reader, operator_router, prover_router)
-    Heartbeat(LedgerReader<N>, OperatorRouter<N>, ProverRouter<N>),
+    /// Connect := (peer_ip, ledger_reader, operator_router, connection_result)
+    Connect(SocketAddr, LedgerReader<N>, OperatorRouter<N>, ConnectionResult),
+    /// Heartbeat := (ledger_reader, operator_router)
+    Heartbeat(LedgerReader<N>, OperatorRouter<N>),
     /// MessagePropagate := (peer_ip, message)
     MessagePropagate(SocketAddr, Message<N, E>),
     /// MessageSend := (peer_ip, message)
     MessageSend(SocketAddr, Message<N, E>),
-    /// PeerConnecting := (stream, peer_ip, ledger_reader, ledger_router, operator_router, prover_router)
-    PeerConnecting(TcpStream, SocketAddr, LedgerReader<N>, OperatorRouter<N>, ProverRouter<N>),
+    /// PeerConnecting := (stream, peer_ip, ledger_reader, ledger_router, operator_router)
+    PeerConnecting(TcpStream, SocketAddr, LedgerReader<N>, OperatorRouter<N>),
     /// PeerConnected := (peer_ip, peer_nonce, outbound_router)
     PeerConnected(SocketAddr, u64, OutboundRouter<N, E>),
     /// PeerDisconnected := (peer_ip)
@@ -268,7 +268,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     pub(super) async fn update(&self, request: PeersRequest<N, E>) {
         match request {
-            PeersRequest::Connect(peer_ip, ledger_reader, operator_router, prover_router, connection_result) => {
+            PeersRequest::Connect(peer_ip, ledger_reader, operator_router, connection_result) => {
                 // Ensure the peer IP is not this node.
                 if peer_ip == self.local_ip
                     || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
@@ -316,7 +316,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                                         self.local_nonce,
                                         &self.peers_router,
                                         ledger_reader,
-                                        prover_router,
                                         operator_router,
                                         self.connected_nonces().await,
                                         Some(connection_result),
@@ -336,7 +335,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     }
                 }
             }
-            PeersRequest::Heartbeat(ledger_reader, operator_router, prover_router) => {
+            PeersRequest::Heartbeat(ledger_reader, operator_router) => {
                 // Obtain the number of connected peers.
                 let number_of_connected_peers = self.number_of_connected_peers().await;
                 // Ensure the number of connected peers is below the maximum threshold.
@@ -397,13 +396,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     for peer_ip in disconnected_trusted_nodes {
                         // Initialize the connection process.
                         let (router, handler) = oneshot::channel();
-                        let request = PeersRequest::Connect(
-                            peer_ip,
-                            ledger_reader.clone(),
-                            operator_router.clone(),
-                            prover_router.clone(),
-                            router,
-                        );
+                        let request = PeersRequest::Connect(peer_ip, ledger_reader.clone(), operator_router.clone(), router);
                         if let Err(error) = self.peers_router.send(request).await {
                             warn!("Failed to transmit the request: '{}'", error);
                         }
@@ -462,13 +455,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
 
                         // Initialize the connection process.
                         let (router, handler) = oneshot::channel();
-                        let request = PeersRequest::Connect(
-                            peer_ip,
-                            ledger_reader.clone(),
-                            operator_router.clone(),
-                            prover_router.clone(),
-                            router,
-                        );
+                        let request = PeersRequest::Connect(peer_ip, ledger_reader.clone(), operator_router.clone(), router);
                         if let Err(error) = self.peers_router.send(request).await {
                             warn!("Failed to transmit the request: '{}'", error);
                         }
@@ -492,7 +479,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             PeersRequest::MessageSend(sender, message) => {
                 self.send(sender, message).await;
             }
-            PeersRequest::PeerConnecting(stream, peer_ip, ledger_reader, operator_router, prover_router) => {
+            PeersRequest::PeerConnecting(stream, peer_ip, ledger_reader, operator_router) => {
                 // Ensure the peer IP is not this node.
                 if peer_ip == self.local_ip
                     || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
@@ -561,7 +548,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                             self.local_nonce,
                             &self.peers_router,
                             ledger_reader,
-                            prover_router,
                             operator_router,
                             self.connected_nonces().await,
                             None,

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -105,7 +105,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
         };
 
         // Initialize the peers.
-        let peers = Arc::new(Self {
+        Arc::new(Self {
             network_state: OnceCell::new(),
             local_ip,
             local_nonce,
@@ -115,9 +115,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             restricted_peers: Default::default(),
             seen_inbound_connections: Default::default(),
             seen_outbound_connections: Default::default(),
-        });
-
-        peers
+        })
     }
 
     pub fn set_network_state(&self, network_state: NetworkState<N, E>) {

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -256,7 +256,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     /// Returns the list of nonces for the connected peers.
     ///
     pub(crate) async fn connected_nonces(&self) -> Vec<u64> {
-        self.connected_peers.read().await.values().map(|peer_nonce| *peer_nonce).collect()
+        self.connected_peers.read().await.values().copied().collect()
     }
 
     ///

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -291,6 +291,149 @@ impl<N: Network, E: Environment> Peers<N, E> {
         }
     }
 
+    pub async fn heartbeat(&self) {
+        // Obtain the number of connected peers.
+        let number_of_connected_peers = self.number_of_connected_peers().await;
+        // Ensure the number of connected peers is below the maximum threshold.
+        if number_of_connected_peers > E::MAXIMUM_NUMBER_OF_PEERS {
+            debug!("Exceeded maximum number of connected peers");
+
+            // Determine the peers to disconnect from.
+            let num_excess_peers = number_of_connected_peers.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
+            let peer_ips_to_disconnect = self
+                .connected_peers
+                .read()
+                .await
+                .iter()
+                .filter(|(peer_ip, _)| {
+                    !E::sync_nodes().contains(peer_ip) && !E::beacon_nodes().contains(peer_ip) && !E::trusted_nodes().contains(peer_ip)
+                })
+                .take(num_excess_peers)
+                .map(|(&peer_ip, _)| peer_ip)
+                .collect::<Vec<SocketAddr>>();
+
+            // Proceed to send disconnect requests to these peers.
+            for peer_ip in peer_ips_to_disconnect {
+                info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
+                self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
+                // Add an entry for this `Peer` in the restricted peers.
+                self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+            }
+        }
+
+        // TODO (howardwu): This logic can be optimized and unified with the context around it.
+        // Determine if the node is connected to more sync nodes than expected.
+        let connected_sync_nodes = self.connected_sync_nodes().await;
+        let number_of_connected_sync_nodes = connected_sync_nodes.len();
+        let num_excess_sync_nodes = number_of_connected_sync_nodes.saturating_sub(1);
+        if num_excess_sync_nodes > 0 {
+            debug!("Exceeded maximum number of sync nodes");
+
+            // Proceed to send disconnect requests to these peers.
+            for peer_ip in connected_sync_nodes
+                .iter()
+                .copied()
+                .choose_multiple(&mut OsRng::default(), num_excess_sync_nodes)
+            {
+                info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
+                self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
+                // Add an entry for this `Peer` in the restricted peers.
+                self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+            }
+        }
+
+        // Ensure that the trusted nodes are connected.
+        if !E::trusted_nodes().is_empty() {
+            let connected_peers = self.connected_peers().await.into_iter().collect::<HashSet<_>>();
+            let trusted_nodes = E::trusted_nodes();
+            let disconnected_trusted_nodes = trusted_nodes.difference(&connected_peers).copied();
+            for peer_ip in disconnected_trusted_nodes {
+                // Initialize the connection process.
+                let (router, handler) = oneshot::channel();
+                let request = PeersRequest::Connect(peer_ip, router);
+                self.network_state
+                    .get()
+                    .expect("network state must be set")
+                    .peers
+                    .update(request)
+                    .await;
+
+                // Do not wait for the result of each connection.
+                // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                let resource_id = E::resources().procure_id();
+                E::resources().register_task(
+                    Some(resource_id),
+                    task::spawn(async move {
+                        let _ = handler.await;
+
+                        E::resources().deregister(resource_id);
+                    }),
+                );
+            }
+        }
+
+        // Skip if the number of connected peers is above the minimum threshold.
+        match number_of_connected_peers < E::MINIMUM_NUMBER_OF_PEERS {
+            true => {
+                trace!("Sending request for more peer connections");
+                // Request more peers if the number of connected peers is below the threshold.
+                for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 3) {
+                    self.send(*peer_ip, Message::PeerRequest).await;
+                }
+            }
+            false => return,
+        };
+
+        // Add the sync nodes to the list of candidate peers.
+        if number_of_connected_sync_nodes == 0 {
+            self.add_candidate_peers(E::sync_nodes().iter()).await;
+        }
+
+        // Add the beacon nodes to the list of candidate peers.
+        self.add_candidate_peers(E::beacon_nodes().iter()).await;
+
+        // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
+        // Select the peers randomly from the list of candidate peers.
+        let midpoint_number_of_peers = E::MINIMUM_NUMBER_OF_PEERS.saturating_add(E::MAXIMUM_NUMBER_OF_PEERS) / 2;
+        for peer_ip in self
+            .candidate_peers()
+            .await
+            .iter()
+            .copied()
+            .choose_multiple(&mut OsRng::default(), midpoint_number_of_peers)
+        {
+            // Ensure this node is not connected to more than the permitted number of sync nodes.
+            if E::sync_nodes().contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {
+                continue;
+            }
+
+            if !self.is_connected_to(peer_ip).await {
+                trace!("Attempting connection to {}...", peer_ip);
+
+                // Initialize the connection process.
+                let (router, handler) = oneshot::channel();
+                let request = PeersRequest::Connect(peer_ip, router);
+                self.network_state
+                    .get()
+                    .expect("network state must be set")
+                    .peers
+                    .update(request)
+                    .await;
+                // Do not wait for the result of each connection.
+                // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                let resource_id = E::resources().procure_id();
+                E::resources().register_task(
+                    Some(resource_id),
+                    task::spawn(async move {
+                        let _ = handler.await;
+
+                        E::resources().deregister(resource_id);
+                    }),
+                );
+            }
+        }
+    }
+
     ///
     /// Performs the given `request` to the peers.
     /// All requests must go through this `update`, so that a unified view is preserved.
@@ -301,148 +444,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
         // match request {
         //     PeersRequest::Connect(peer_ip, conn_result_router) => {}
         //     PeersRequest::Heartbeat => {
-        //         // Obtain the number of connected peers.
-        //         let number_of_connected_peers = self.number_of_connected_peers().await;
-        //         // Ensure the number of connected peers is below the maximum threshold.
-        //         if number_of_connected_peers > E::MAXIMUM_NUMBER_OF_PEERS {
-        //             debug!("Exceeded maximum number of connected peers");
-
-        //             // Determine the peers to disconnect from.
-        //             let num_excess_peers = number_of_connected_peers.saturating_sub(E::MAXIMUM_NUMBER_OF_PEERS);
-        //             let peer_ips_to_disconnect = self
-        //                 .connected_peers
-        //                 .read()
-        //                 .await
-        //                 .iter()
-        //                 .filter(|(peer_ip, _)| {
-        //                     !E::sync_nodes().contains(peer_ip)
-        //                         && !E::beacon_nodes().contains(peer_ip)
-        //                         && !E::trusted_nodes().contains(peer_ip)
-        //                 })
-        //                 .take(num_excess_peers)
-        //                 .map(|(&peer_ip, _)| peer_ip)
-        //                 .collect::<Vec<SocketAddr>>();
-
-        //             // Proceed to send disconnect requests to these peers.
-        //             for peer_ip in peer_ips_to_disconnect {
-        //                 info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
-        //                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
-        //                 // Add an entry for this `Peer` in the restricted peers.
-        //                 self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-        //             }
-        //         }
-
-        //         // TODO (howardwu): This logic can be optimized and unified with the context around it.
-        //         // Determine if the node is connected to more sync nodes than expected.
-        //         let connected_sync_nodes = self.connected_sync_nodes().await;
-        //         let number_of_connected_sync_nodes = connected_sync_nodes.len();
-        //         let num_excess_sync_nodes = number_of_connected_sync_nodes.saturating_sub(1);
-        //         if num_excess_sync_nodes > 0 {
-        //             debug!("Exceeded maximum number of sync nodes");
-
-        //             // Proceed to send disconnect requests to these peers.
-        //             for peer_ip in connected_sync_nodes
-        //                 .iter()
-        //                 .copied()
-        //                 .choose_multiple(&mut OsRng::default(), num_excess_sync_nodes)
-        //             {
-        //                 info!("Disconnecting from {} (exceeded maximum connections)", peer_ip);
-        //                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers)).await;
-        //                 // Add an entry for this `Peer` in the restricted peers.
-        //                 self.restricted_peers.write().await.insert(peer_ip, Instant::now());
-        //             }
-        //         }
-
-        //         // Ensure that the trusted nodes are connected.
-        //         if !E::trusted_nodes().is_empty() {
-        //             let connected_peers = self.connected_peers().await.into_iter().collect::<HashSet<_>>();
-        //             let trusted_nodes = E::trusted_nodes();
-        //             let disconnected_trusted_nodes = trusted_nodes.difference(&connected_peers).copied();
-        //             for peer_ip in disconnected_trusted_nodes {
-        //                 // Initialize the connection process.
-        //                 let (router, handler) = oneshot::channel();
-        //                 let request = PeersRequest::Connect(peer_ip, router);
-        //                 self.network_state
-        //                     .get()
-        //                     .expect("network state must be set")
-        //                     .peers
-        //                     .update(request)
-        //                     .await;
-
-        //                 // Do not wait for the result of each connection.
-        //                 // Procure a resource id to register the task with, as it might be terminated at any point in time.
-        //                 let resource_id = E::resources().procure_id();
-        //                 E::resources().register_task(
-        //                     Some(resource_id),
-        //                     task::spawn(async move {
-        //                         let _ = handler.await;
-
-        //                         E::resources().deregister(resource_id);
-        //                     }),
-        //                 );
-        //             }
-        //         }
-
-        //         // Skip if the number of connected peers is above the minimum threshold.
-        //         match number_of_connected_peers < E::MINIMUM_NUMBER_OF_PEERS {
-        //             true => {
-        //                 trace!("Sending request for more peer connections");
-        //                 // Request more peers if the number of connected peers is below the threshold.
-        //                 for peer_ip in self.connected_peers().await.iter().choose_multiple(&mut OsRng::default(), 3) {
-        //                     self.send(*peer_ip, Message::PeerRequest).await;
-        //                 }
-        //             }
-        //             false => return,
-        //         };
-
-        //         // Add the sync nodes to the list of candidate peers.
-        //         if number_of_connected_sync_nodes == 0 {
-        //             self.add_candidate_peers(E::sync_nodes().iter()).await;
-        //         }
-
-        //         // Add the beacon nodes to the list of candidate peers.
-        //         self.add_candidate_peers(E::beacon_nodes().iter()).await;
-
-        //         // Attempt to connect to more peers if the number of connected peers is below the minimum threshold.
-        //         // Select the peers randomly from the list of candidate peers.
-        //         let midpoint_number_of_peers = E::MINIMUM_NUMBER_OF_PEERS.saturating_add(E::MAXIMUM_NUMBER_OF_PEERS) / 2;
-        //         for peer_ip in self
-        //             .candidate_peers()
-        //             .await
-        //             .iter()
-        //             .copied()
-        //             .choose_multiple(&mut OsRng::default(), midpoint_number_of_peers)
-        //         {
-        //             // Ensure this node is not connected to more than the permitted number of sync nodes.
-        //             if E::sync_nodes().contains(&peer_ip) && number_of_connected_sync_nodes >= 1 {
-        //                 continue;
-        //             }
-
-        //             if !self.is_connected_to(peer_ip).await {
-        //                 trace!("Attempting connection to {}...", peer_ip);
-
-        //                 // Initialize the connection process.
-        //                 let (router, handler) = oneshot::channel();
-        //                 let request = PeersRequest::Connect(peer_ip, router);
-        //                 self.network_state
-        //                     .get()
-        //                     .expect("network state must be set")
-        //                     .peers
-        //                     .update(request)
-        //                     .await;
-        //                 // Do not wait for the result of each connection.
-        //                 // Procure a resource id to register the task with, as it might be terminated at any point in time.
-        //                 let resource_id = E::resources().procure_id();
-        //                 E::resources().register_task(
-        //                     Some(resource_id),
-        //                     task::spawn(async move {
-        //                         let _ = handler.await;
-
-        //                         E::resources().deregister(resource_id);
-        //                     }),
-        //                 );
-        //             }
-        //         }
         //     }
         //     PeersRequest::MessagePropagate(sender, message) => {
         //         self.propagate(sender, message).await;

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerReader, LedgerRouter, NetworkState, OperatorRouter, OutboundRouter, Peer, ProverRouter};
+use crate::{LedgerReader, NetworkState, OperatorRouter, OutboundRouter, Peer, ProverRouter};
 use snarkos_environment::{
     network::{Data, DisconnectReason, Message},
     Environment,
@@ -54,30 +54,16 @@ pub(crate) type ConnectionResult = oneshot::Sender<Result<()>>;
 ///
 #[derive(Debug)]
 pub enum PeersRequest<N: Network, E: Environment> {
-    /// Connect := (peer_ip, ledger_reader, ledger_router, operator_router, prover_router, connection_result)
-    Connect(
-        SocketAddr,
-        LedgerReader<N>,
-        LedgerRouter<N>,
-        OperatorRouter<N>,
-        ProverRouter<N>,
-        ConnectionResult,
-    ),
-    /// Heartbeat := (ledger_reader, ledger_router, operator_router, prover_router)
-    Heartbeat(LedgerReader<N>, LedgerRouter<N>, OperatorRouter<N>, ProverRouter<N>),
+    /// Connect := (peer_ip, ledger_reader, operator_router, prover_router, connection_result)
+    Connect(SocketAddr, LedgerReader<N>, OperatorRouter<N>, ProverRouter<N>, ConnectionResult),
+    /// Heartbeat := (ledger_reader, operator_router, prover_router)
+    Heartbeat(LedgerReader<N>, OperatorRouter<N>, ProverRouter<N>),
     /// MessagePropagate := (peer_ip, message)
     MessagePropagate(SocketAddr, Message<N, E>),
     /// MessageSend := (peer_ip, message)
     MessageSend(SocketAddr, Message<N, E>),
     /// PeerConnecting := (stream, peer_ip, ledger_reader, ledger_router, operator_router, prover_router)
-    PeerConnecting(
-        TcpStream,
-        SocketAddr,
-        LedgerReader<N>,
-        LedgerRouter<N>,
-        OperatorRouter<N>,
-        ProverRouter<N>,
-    ),
+    PeerConnecting(TcpStream, SocketAddr, LedgerReader<N>, OperatorRouter<N>, ProverRouter<N>),
     /// PeerConnected := (peer_ip, peer_nonce, outbound_router)
     PeerConnected(SocketAddr, u64, OutboundRouter<N, E>),
     /// PeerDisconnected := (peer_ip)
@@ -282,7 +268,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     pub(super) async fn update(&self, request: PeersRequest<N, E>) {
         match request {
-            PeersRequest::Connect(peer_ip, ledger_reader, ledger_router, operator_router, prover_router, connection_result) => {
+            PeersRequest::Connect(peer_ip, ledger_reader, operator_router, prover_router, connection_result) => {
                 // Ensure the peer IP is not this node.
                 if peer_ip == self.local_ip
                     || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
@@ -330,7 +316,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                                         self.local_nonce,
                                         &self.peers_router,
                                         ledger_reader,
-                                        ledger_router,
                                         prover_router,
                                         operator_router,
                                         self.connected_nonces().await,
@@ -351,7 +336,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     }
                 }
             }
-            PeersRequest::Heartbeat(ledger_reader, ledger_router, operator_router, prover_router) => {
+            PeersRequest::Heartbeat(ledger_reader, operator_router, prover_router) => {
                 // Obtain the number of connected peers.
                 let number_of_connected_peers = self.number_of_connected_peers().await;
                 // Ensure the number of connected peers is below the maximum threshold.
@@ -415,7 +400,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         let request = PeersRequest::Connect(
                             peer_ip,
                             ledger_reader.clone(),
-                            ledger_router.clone(),
                             operator_router.clone(),
                             prover_router.clone(),
                             router,
@@ -481,7 +465,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                         let request = PeersRequest::Connect(
                             peer_ip,
                             ledger_reader.clone(),
-                            ledger_router.clone(),
                             operator_router.clone(),
                             prover_router.clone(),
                             router,
@@ -509,7 +492,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
             PeersRequest::MessageSend(sender, message) => {
                 self.send(sender, message).await;
             }
-            PeersRequest::PeerConnecting(stream, peer_ip, ledger_reader, ledger_router, operator_router, prover_router) => {
+            PeersRequest::PeerConnecting(stream, peer_ip, ledger_reader, operator_router, prover_router) => {
                 // Ensure the peer IP is not this node.
                 if peer_ip == self.local_ip
                     || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
@@ -578,7 +561,6 @@ impl<N: Network, E: Environment> Peers<N, E> {
                             self.local_nonce,
                             &self.peers_router,
                             ledger_reader,
-                            ledger_router,
                             prover_router,
                             operator_router,
                             self.connected_nonces().await,

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{state::NetworkState, LedgerReader, LedgerRequest};
+use crate::{state::NetworkState, LedgerReader};
 use snarkos_environment::{
     helpers::{NodeType, State},
     network::{Data, Message},
@@ -344,14 +344,12 @@ impl<N: Network, E: Environment> Prover<N, E> {
                                                 }
 
                                                 // Broadcast the next block.
-                                                let request = LedgerRequest::UnconfirmedBlock(local_ip, block);
-
                                                 prover_clone
                                                     .network_state
                                                     .get()
                                                     .expect("network state must be set")
                                                     .ledger
-                                                    .update(request)
+                                                    .unconfirmed_block(local_ip, block)
                                                     .await;
                                             }
                                             Ok(Err(error)) | Err(error) => trace!("{}", error),

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{state::NetworkState, LedgerReader, LedgerRequest, PeersRequest};
+use crate::{state::NetworkState, LedgerReader, LedgerRequest};
 use snarkos_environment::{
     helpers::{NodeType, State},
     network::{Data, Message},

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerReader, LedgerRequest, LedgerRouter, NetworkState, PeersRequest, PeersRouter};
+use crate::{state::NetworkState, LedgerReader, LedgerRequest, PeersRequest, PeersRouter};
 use snarkos_environment::{
     helpers::{NodeType, State},
     network::{Data, Message},
@@ -79,8 +79,6 @@ pub struct Prover<N: Network, E: Environment> {
     peers_router: PeersRouter<N, E>,
     /// The ledger state of the node.
     ledger_reader: LedgerReader<N>,
-    /// The ledger router of the node.
-    ledger_router: LedgerRouter<N>,
 }
 
 impl<N: Network, E: Environment> Prover<N, E> {
@@ -92,7 +90,6 @@ impl<N: Network, E: Environment> Prover<N, E> {
         pool_ip: Option<SocketAddr>,
         peers_router: PeersRouter<N, E>,
         ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
     ) -> Result<Arc<Self>> {
         // Initialize an mpsc channel for sending requests to the `Prover` struct.
         let (prover_router, mut prover_handler) = mpsc::channel(1024);
@@ -106,7 +103,6 @@ impl<N: Network, E: Environment> Prover<N, E> {
             memory_pool: Arc::new(RwLock::new(MemoryPool::new())),
             peers_router,
             ledger_reader,
-            ledger_router,
         });
 
         // Initialize the handler for the prover.
@@ -348,7 +344,6 @@ impl<N: Network, E: Environment> Prover<N, E> {
                                 let state = prover.state.clone();
                                 let canon = prover.ledger_reader.clone(); // This is *safe* as the ledger only reads.
                                 let unconfirmed_transactions = prover.memory_pool.read().await.transactions();
-                                let ledger_router = prover.ledger_router.clone();
                                 let prover_router = prover.prover_router.clone();
 
                                 // Procure a resource id to register the task with, as it might be terminated at any point in time.

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -106,25 +106,25 @@ impl<N: Network, E: Environment> Prover<N, E> {
         });
 
         // Initialize the handler for the prover.
-        {
-            let prover = prover.clone();
-            let (router, handler) = oneshot::channel();
-            E::resources().register_task(
-                None, // No need to provide an id, as the task will run indefinitely.
-                task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    // Asynchronously wait for a prover request.
-                    while let Some(request) = prover_handler.recv().await {
-                        // Update the state of the prover.
-                        prover.update(request).await;
-                    }
-                }),
-            );
+        // {
+        //     let prover = prover.clone();
+        //     let (router, handler) = oneshot::channel();
+        //     E::resources().register_task(
+        //         None, // No need to provide an id, as the task will run indefinitely.
+        //         task::spawn(async move {
+        //             // Notify the outer function that the task is ready.
+        //             let _ = router.send(());
+        //             // Asynchronously wait for a prover request.
+        //             while let Some(request) = prover_handler.recv().await {
+        //                 // Update the state of the prover.
+        //                 prover.update(request).await;
+        //             }
+        //         }),
+        //     );
 
-            // Wait until the prover handler is ready.
-            let _ = handler.await;
-        }
+        //     // Wait until the prover handler is ready.
+        //     let _ = handler.await;
+        // }
 
         // Initialize the miner, if the node type is a miner.
         if E::NODE_TYPE == NodeType::Miner && prover.pool.is_none() {
@@ -183,7 +183,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
     /// Performs the given `request` to the prover.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(&self, request: ProverRequest<N>) {
+    pub async fn update(&self, request: ProverRequest<N>) {
         match request {
             ProverRequest::PoolRequest(operator_ip, share_difficulty, block_template) => {
                 // Process the pool request message.

--- a/network/src/state.rs
+++ b/network/src/state.rs
@@ -35,3 +35,29 @@ pub struct NetworkState<N: Network, E: Environment> {
     /// The prover of the node.
     pub prover: Arc<Prover<N, E>>,
 }
+
+impl<N: Network, E: Environment> NetworkState<N, E> {
+    pub fn new(
+        local_ip: SocketAddr,
+        peers: Arc<Peers<N, E>>,
+        ledger: Arc<Ledger<N, E>>,
+        operator: Arc<Operator<N, E>>,
+        prover: Arc<Prover<N, E>>,
+    ) -> Self {
+        let network_state = Self {
+            local_ip,
+            peers,
+            ledger,
+            operator,
+            prover,
+        };
+
+        // Set the network state reference on the various services.
+        network_state.peers.set_network_state(network_state.clone());
+        network_state.ledger.set_network_state(network_state.clone());
+        network_state.operator.set_network_state(network_state.clone());
+        network_state.prover.set_network_state(network_state.clone());
+
+        network_state
+    }
+}

--- a/network/src/state.rs
+++ b/network/src/state.rs
@@ -22,7 +22,7 @@ use snarkvm::prelude::*;
 use std::{net::SocketAddr, sync::Arc};
 
 /// The network state of the node.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct NetworkState<N: Network, E: Environment> {
     /// The local address of the node.
     pub local_ip: SocketAddr,

--- a/network/src/state.rs
+++ b/network/src/state.rs
@@ -14,30 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-#![forbid(unsafe_code)]
-#![allow(clippy::module_inception)]
-#![allow(clippy::suspicious_else_formatting)]
-#![allow(clippy::type_complexity)]
+use crate::{ledger::Ledger, operator::Operator, peers::Peers, prover::Prover};
 
-#[macro_use]
-extern crate tracing;
+use snarkos_environment::Environment;
+use snarkvm::prelude::*;
 
-pub mod helpers;
+use std::{net::SocketAddr, sync::Arc};
 
-pub mod ledger;
-pub use ledger::*;
-
-pub mod state;
-pub use state::*;
-
-pub mod operator;
-pub use operator::*;
-
-pub(crate) mod peer;
-pub(crate) use peer::*;
-
-pub mod peers;
-pub use peers::*;
-
-pub mod prover;
-pub use prover::*;
+/// The network state of the node.
+#[derive(Clone)]
+pub struct NetworkState<N: Network, E: Environment> {
+    /// The local address of the node.
+    pub local_ip: SocketAddr,
+    /// The list of peers for the node.
+    pub peers: Arc<Peers<N, E>>,
+    /// The ledger of the node.
+    pub ledger: Arc<Ledger<N, E>>,
+    /// The operator of the node.
+    pub operator: Arc<Operator<N, E>>,
+    /// The prover of the node.
+    pub prover: Arc<Prover<N, E>>,
+}

--- a/rpc/src/context.rs
+++ b/rpc/src/context.rs
@@ -18,7 +18,7 @@
 
 use crate::RpcFunctions;
 use snarkos_environment::Environment;
-use snarkos_network::{LedgerReader, Operator, Peers, ProverRouter};
+use snarkos_network::{LedgerReader, NetworkState, Operator, Peers, ProverRouter};
 use snarkvm::dpc::{Address, MemoryPool, Network};
 
 use futures::TryFutureExt;
@@ -42,11 +42,7 @@ const ALL_CONCURRENT_REQUESTS_LIMIT: u16 = 10;
 #[doc(hidden)]
 pub struct RpcInner<N: Network, E: Environment> {
     pub(crate) address: Option<Address<N>>,
-    pub(crate) peers: Arc<Peers<N, E>>,
-    pub(crate) ledger: LedgerReader<N>,
-    pub(crate) operator: Arc<Operator<N, E>>,
-    pub(crate) prover_router: ProverRouter<N>,
-    pub(crate) memory_pool: Arc<RwLock<MemoryPool<N>>>,
+    pub(crate) network_state: NetworkState<N, E>,
     /// RPC credentials for accessing guarded endpoints
     #[allow(unused)]
     pub(crate) credentials: RpcCredentials,
@@ -68,23 +64,10 @@ impl<N: Network, E: Environment> Deref for RpcContext<N, E> {
 impl<N: Network, E: Environment> RpcContext<N, E> {
     /// Creates a new struct for calling public and private RPC endpoints.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        username: String,
-        password: String,
-        address: Option<Address<N>>,
-        peers: Arc<Peers<N, E>>,
-        ledger: LedgerReader<N>,
-        operator: Arc<Operator<N, E>>,
-        prover_router: ProverRouter<N>,
-        memory_pool: Arc<RwLock<MemoryPool<N>>>,
-    ) -> Self {
+    pub fn new(username: String, password: String, address: Option<Address<N>>, network_state: NetworkState<N, E>) -> Self {
         Self(Arc::new(RpcInner {
             address,
-            peers,
-            ledger,
-            operator,
-            prover_router,
-            memory_pool,
+            network_state,
             credentials: RpcCredentials { username, password },
             launched: Instant::now(),
         }))

--- a/rpc/src/context.rs
+++ b/rpc/src/context.rs
@@ -18,8 +18,8 @@
 
 use crate::RpcFunctions;
 use snarkos_environment::Environment;
-use snarkos_network::{LedgerReader, NetworkState, Operator, Peers, ProverRouter};
-use snarkvm::dpc::{Address, MemoryPool, Network};
+use snarkos_network::NetworkState;
+use snarkvm::dpc::{Address, Network};
 
 use futures::TryFutureExt;
 use jsonrpsee::{
@@ -28,7 +28,7 @@ use jsonrpsee::{
 };
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::oneshot;
 
 // The details on resource-limiting can be found at https://github.com/paritytech/jsonrpsee/blob/master/core/src/server/resource_limiting.rs
 // note: jsonrpsee expects string literals as resource names; we'll be distinguishing

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -187,6 +187,7 @@ impl<N: Network, E: Environment> Server<N, E> {
 
         // Set the network state reference on the peers.
         network_state.peers.set_network_state(network_state.clone());
+        network_state.ledger.set_network_state(network_state.clone());
 
         Ok(Self { network_state })
     }

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -185,9 +185,11 @@ impl<N: Network, E: Environment> Server<N, E> {
             prover,
         };
 
-        // Set the network state reference on the peers.
+        // Set the network state reference on the various services.
         network_state.peers.set_network_state(network_state.clone());
         network_state.ledger.set_network_state(network_state.clone());
+        network_state.operator.set_network_state(network_state.clone());
+        network_state.prover.set_network_state(network_state.clone());
 
         Ok(Self { network_state })
     }

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -22,7 +22,7 @@ use snarkos_environment::{
 use snarkos_network::{
     ledger::{Ledger, LedgerReader, LedgerRequest},
     operator::Operator,
-    peers::{Peers, PeersRequest},
+    peers::Peers,
     prover::Prover,
     state::NetworkState,
 };

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -177,15 +177,18 @@ impl<N: Network, E: Environment> Server<N, E> {
         #[cfg(any(feature = "test", feature = "prometheus"))]
         Self::initialize_metrics(ledger.reader());
 
-        Ok(Self {
-            network_state: NetworkState {
-                local_ip,
-                peers,
-                ledger,
-                operator,
-                prover,
-            },
-        })
+        let network_state = NetworkState {
+            local_ip,
+            peers,
+            ledger,
+            operator,
+            prover,
+        };
+
+        // Set the network state reference on the peers.
+        network_state.peers.set_network_state(network_state.clone());
+
+        Ok(Self { network_state })
     }
 
     /// Returns the IP address of this node.

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -76,19 +76,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         let operator =
             Operator::open::<RocksDB, _>(&operator_storage_path, address, local_ip, prover.memory_pool(), ledger.reader()).await?;
 
-        let network_state = NetworkState {
-            local_ip,
-            peers: peers.clone(),
-            ledger: ledger.clone(),
-            operator: operator.clone(),
-            prover: prover.clone(),
-        };
-
-        // Set the network state reference on the various services.
-        network_state.peers.set_network_state(network_state.clone());
-        network_state.ledger.set_network_state(network_state.clone());
-        network_state.operator.set_network_state(network_state.clone());
-        network_state.prover.set_network_state(network_state.clone());
+        let network_state = NetworkState::new(local_ip, peers.clone(), ledger.clone(), operator.clone(), prover.clone());
 
         // TODO (howardwu): This is a hack for the prover.
         // Check that the prover is connected to the pool before sending a PoolRegister message.

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -90,13 +90,8 @@ impl<N: Network, E: Environment> Server<N, E> {
                     // Notify the outer function that the task is ready.
                     let _ = router.send(());
                     loop {
-                        // Initialize the connection process.
-                        let (router, handler) = oneshot::channel();
                         // Route a `Connect` request to the pool.
-                        peers.connect(pool_ip, router).await;
-
-                        // Wait until the connection task is initialized.
-                        let _ = handler.await;
+                        peers.connect(pool_ip).await;
 
                         // Sleep for `30` seconds.
                         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
@@ -151,15 +146,9 @@ impl<N: Network, E: Environment> Server<N, E> {
     /// Sends a connection request to the given IP address.
     ///
     #[inline]
-    pub async fn connect_to(&self, peer_ip: SocketAddr) -> Result<()> {
-        // Initialize the connection process.
-        let (router, handler) = oneshot::channel();
-
+    pub async fn connect_to(&self, peer_ip: SocketAddr) {
         // Route a `Connect` request to the peer manager.
-        self.network_state.peers.connect(peer_ip, router).await;
-
-        // Wait until the connection task is initialized.
-        handler.await.map(|_| ()).map_err(|e| e.into())
+        self.network_state.peers.connect(peer_ip).await
     }
 
     ///

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -84,6 +84,12 @@ impl<N: Network, E: Environment> Server<N, E> {
             prover: prover.clone(),
         };
 
+        // Set the network state reference on the various services.
+        network_state.peers.set_network_state(network_state.clone());
+        network_state.ledger.set_network_state(network_state.clone());
+        network_state.operator.set_network_state(network_state.clone());
+        network_state.prover.set_network_state(network_state.clone());
+
         // TODO (howardwu): This is a hack for the prover.
         // Check that the prover is connected to the pool before sending a PoolRegister message.
         if let Some(pool_ip) = pool_ip {
@@ -134,12 +140,6 @@ impl<N: Network, E: Environment> Server<N, E> {
         // Initialise the metrics exporter.
         #[cfg(any(feature = "test", feature = "prometheus"))]
         Self::initialize_metrics(ledger.reader());
-
-        // Set the network state reference on the various services.
-        network_state.peers.set_network_state(network_state.clone());
-        network_state.ledger.set_network_state(network_state.clone());
-        network_state.operator.set_network_state(network_state.clone());
-        network_state.prover.set_network_state(network_state.clone());
 
         Ok(Self { network_state })
     }

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -20,7 +20,7 @@ use snarkos_environment::{
     Environment,
 };
 use snarkos_network::{
-    ledger::{Ledger, LedgerReader, LedgerRequest},
+    ledger::{Ledger, LedgerReader},
     operator::Operator,
     peers::Peers,
     prover::Prover,
@@ -232,7 +232,7 @@ impl<N: Network, E: Environment> Server<N, E> {
                 let _ = router.send(());
                 loop {
                     // Transmit a heartbeat request to the ledger.
-                    network_state.ledger.update(LedgerRequest::Heartbeat).await;
+                    network_state.ledger.heartbeat().await;
 
                     // Transmit a heartbeat request to the peers.
                     network_state.peers.heartbeat().await;

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -91,7 +91,8 @@ impl<N: Network, E: Environment> Server<N, E> {
                     let _ = router.send(());
                     loop {
                         // Route a `Connect` request to the pool.
-                        peers.connect(pool_ip).await;
+                        // TODO: handle error?
+                        let _ = peers.connect(pool_ip).await;
 
                         // Sleep for `30` seconds.
                         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
@@ -146,7 +147,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     /// Sends a connection request to the given IP address.
     ///
     #[inline]
-    pub async fn connect_to(&self, peer_ip: SocketAddr) {
+    pub async fn connect_to(&self, peer_ip: SocketAddr) -> Result<()> {
         // Route a `Connect` request to the peer manager.
         self.network_state.peers.connect(peer_ip).await
     }


### PR DESCRIPTION
The purpose of this PR is to explore the possibility of shifting from actors to shared memory within the snarkOS network implementation. This will, in time, allow for the removal of routing logic that isn't necessary with the new model as every structure now has access to the `NetworkState`. 

This is a work in progress. I'd consider the main structural changes to be in place, though there is still quite a bit of refactoring, optimising and cleanup to be done. I would not consider the APIs stable at this point as I plan on breaking up the newly introduced methods further. 

