### PR TITLE
Simplify the handshake impl in the synth node

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -31,6 +31,9 @@ version = "0.1"
 [dependencies.bincode]
 version = "1"
 
+[dependencies.bytes]
+version = "1"
+
 [dependencies.clap]
 version = "3.1"
 features = [ "derive" ]
@@ -46,7 +49,7 @@ optional = true
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.34"
+version = "0.35"
 
 [dependencies.postgres-native-tls]
 version = "0.5"
@@ -91,6 +94,9 @@ version = "1"
 version = "0.7"
 features = [ "with-time-0_3" ]
 optional = true
+
+[dependencies.tokio-util]
+version = "0.7"
 
 [dependencies.tracing]
 version = "0.1"

--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -19,13 +19,16 @@ use crate::storage::PostgresOpts;
 use crate::{constants::*, known_network::KnownNetwork, metrics::NetworkMetrics};
 use snarkos_environment::{
     helpers::{NodeType, State},
+    Client,
     CurrentNetwork,
+    Environment,
 };
 use snarkos_network::Data;
 use snarkos_storage::BlockLocators;
-use snarkos_synthetic_node::{ClientMessage, SynthNode, MESSAGE_LENGTH_PREFIX_SIZE};
+use snarkos_synthetic_node::{ClientMessage, SynthNode};
 use snarkvm::traits::Network;
 
+use bytes::{Buf, BytesMut};
 use clap::Parser;
 use pea2pea::{
     protocols::{Disconnect, Handshake, Reading, Writing},
@@ -34,18 +37,12 @@ use pea2pea::{
     Pea2Pea,
 };
 use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
-use std::{
-    convert::TryInto,
-    io::{self, Read},
-    net::SocketAddr,
-    ops::Deref,
-    sync::Arc,
-    time::Duration,
-};
+use std::{io, marker::PhantomData, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use tokio::{sync::Mutex, task};
 #[cfg(feature = "postgres")]
 use tokio_postgres::Client as StorageClient;
+use tokio_util::codec::{Decoder, LengthDelimitedCodec};
 use tracing::*;
 
 #[cfg(not(feature = "postgres"))]
@@ -93,7 +90,6 @@ impl Crawler {
             desired_listening_port: Some(opts.addr.port()),
             max_connections: MAXIMUM_NUMBER_OF_PEERS as u16,
             max_handshake_time_ms: MAX_HANDSHAKE_TIME_MS,
-            read_buffer_size: READ_BUFFER_SIZE,
             ..Default::default()
         };
 
@@ -232,67 +228,72 @@ pub enum InboundMessage {
     Unhandled(u16),
 }
 
-/// Inbound message processing logic for the crawler nodes.
-#[async_trait::async_trait]
-impl Reading for Crawler {
-    type Message = InboundMessage;
+pub struct CrawlerDecoder<E: Environment> {
+    codec: LengthDelimitedCodec,
+    span: Span,
+    addr: SocketAddr,
+    _phantom: PhantomData<E>,
+}
 
-    // This implementation is slightly low-level in order to discard unwanted messages without a performance penalty.
-    fn read_message<R: io::Read>(&self, source: SocketAddr, reader: &mut R) -> io::Result<Option<Self::Message>> {
-        // The read buffer should be just enough to read the longest expected message.
-        let mut buf = [0u8; READ_BUFFER_SIZE];
+impl<E: Environment> CrawlerDecoder<E> {
+    fn new(addr: SocketAddr, span: Span) -> Self {
+        Self {
+            codec: LengthDelimitedCodec::builder()
+                .max_frame_length(E::MAXIMUM_MESSAGE_SIZE)
+                .little_endian()
+                .new_codec(),
+            span,
+            addr,
+            _phantom: PhantomData,
+        }
+    }
+}
 
-        // Read the length of the inbound message.
-        let read_len = reader.read(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE])?;
+impl<E: Environment> Decoder for CrawlerDecoder<E> {
+    type Error = io::Error;
+    type Item = InboundMessage;
 
-        // This is unlikely, but mark the message as incomplete if too few bytes are available.
-        if read_len < MESSAGE_LENGTH_PREFIX_SIZE {
+    fn decode(&mut self, source: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let bytes = self.codec.decode(source)?;
+
+        let bytes = if let Some(bytes) = bytes {
+            bytes
+        } else {
             return Ok(None);
+        };
+
+        if bytes.len() < 2 {
+            return Err(io::ErrorKind::InvalidData.into());
         }
 
-        // Read the message's length.
-        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+        let message_id = (&bytes.chunk()[..2]).get_u16_le();
 
-        // Only read the message ID first.
-        let read_len = reader.read(&mut buf[..2])?;
-
-        // This is unlikely, but mark the message as incomplete if too few bytes are available.
-        if read_len < 2 {
-            return Ok(None);
-        }
-
-        // Read the message ID to filter out undesirable messages.
-        let message_id: u16 = bincode::deserialize(&buf[..2]).map_err(|_| io::ErrorKind::InvalidData)?;
-
-        // Discard unwanted messages and those longer than the buffer's capacity.
-        if !ACCEPTED_MESSAGE_IDS.contains(&message_id) || len > buf.len() {
-            // Advance the reader to discard the unwanted bytes.
-            let read_len = io::copy(&mut reader.take(len as u64 - 2), &mut io::sink())?;
-            if read_len != len as u64 - 2 {
-                return Ok(None);
-            }
+        if !ACCEPTED_MESSAGE_IDS.contains(&message_id) {
             return Ok(Some(InboundMessage::Unhandled(message_id)));
         }
 
-        // Read the remaining number of bytes indicated by the length prefix.
-        let read_len = reader.read(&mut buf[2..][..len - 2])?;
-
-        // This one is likely: mark the message as incomplete if it's lacking bytes.
-        if read_len != len - 2 {
-            return Ok(None);
-        }
-
         // Only deserialize the desired messages.
-        match ClientMessage::deserialize(&mut io::Cursor::new(&buf[..len])) {
+        match ClientMessage::deserialize(&mut io::Cursor::new(bytes.chunk())) {
             Ok(msg) => {
-                debug!(parent: self.node().span(), "received a {} from {}", msg.name(), source);
+                debug!(parent: &self.span, "received a {} from {}", msg.name(), self.addr);
                 Ok(Some(InboundMessage::Handled(Box::new(msg))))
             }
             Err(e) => {
-                error!(parent: self.node().span(), "a message from {} failed to deserialize: {}", source, e);
+                error!(parent: &self.span, "a message from {} failed to deserialize: {}", self.addr, e);
                 Err(io::ErrorKind::InvalidData.into())
             }
         }
+    }
+}
+
+/// Inbound message processing logic for the crawler nodes.
+#[async_trait::async_trait]
+impl Reading for Crawler {
+    type Codec = CrawlerDecoder<Client<CurrentNetwork>>;
+    type Message = InboundMessage;
+
+    fn codec(&self, addr: SocketAddr) -> Self::Codec {
+        Self::Codec::new(addr, self.node().span().clone())
     }
 
     async fn process_message(&self, source: SocketAddr, message: Self::Message) -> io::Result<()> {

--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -26,7 +26,7 @@ version = "0.1"
 version = "1"
 
 [dependencies.pea2pea]
-version = "0.34"
+version = "0.35"
 
 [dependencies.peak_alloc]
 version = "0.1"

--- a/.integration/src/test_node.rs
+++ b/.integration/src/test_node.rs
@@ -20,9 +20,9 @@ use snarkos_environment::{
     CurrentNetwork,
     Environment,
 };
-use snarkos_network::Data;
+use snarkos_network::{Data, MessageCodec};
 use snarkos_storage::BlockLocators;
-use snarkos_synthetic_node::{ClientMessage, ClientState, SynthNode, MAXIMUM_FORK_DEPTH, MESSAGE_LENGTH_PREFIX_SIZE, MESSAGE_VERSION};
+use snarkos_synthetic_node::{ClientMessage, ClientState, SynthNode, MAXIMUM_FORK_DEPTH, MESSAGE_VERSION};
 use snarkvm::traits::Network;
 
 use pea2pea::{
@@ -32,7 +32,6 @@ use pea2pea::{
     Pea2Pea,
 };
 use std::{
-    convert::TryInto,
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     ops::Deref,
@@ -140,29 +139,11 @@ impl TestNode {
 /// Inbound message processing logic for the test nodes.
 #[async_trait::async_trait]
 impl Reading for TestNode {
+    type Codec = MessageCodec<CurrentNetwork, Client<CurrentNetwork>>;
     type Message = ClientMessage;
 
-    fn read_message<R: io::Read>(&self, source: SocketAddr, reader: &mut R) -> io::Result<Option<Self::Message>> {
-        // FIXME: use the maximum message size allowed by the protocol or (better) use streaming deserialization.
-        let mut buf = [0u8; 8 * 1024];
-
-        reader.read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE])?;
-        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
-
-        if reader.read_exact(&mut buf[..len]).is_err() {
-            return Ok(None);
-        }
-
-        match ClientMessage::deserialize(&mut io::Cursor::new(&buf[..len])) {
-            Ok(msg) => {
-                info!(parent: self.node().span(), "received a {} from {}", msg.name(), source);
-                Ok(Some(msg))
-            }
-            Err(e) => {
-                error!("a message from {} failed to deserialize: {}", source, e);
-                Err(io::ErrorKind::InvalidData.into())
-            }
-        }
+    fn codec(&self, _addr: SocketAddr) -> Self::Codec {
+        Default::default()
     }
 
     async fn process_message(&self, source: SocketAddr, message: Self::Message) -> io::Result<()> {

--- a/.synthetic_node/Cargo.toml
+++ b/.synthetic_node/Cargo.toml
@@ -21,11 +21,14 @@ edition = "2021"
 [dependencies.async-trait]
 version = "0.1"
 
+[dependencies.futures-util]
+version = "0.3"
+
 [dependencies.parking_lot]
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.34"
+version = "0.35"
 
 [dependencies.rand]
 version = "0.8"
@@ -43,6 +46,9 @@ version = "0.8.0"
 
 [dependencies.tokio]
 version = "1"
+
+[dependencies.tokio-util]
+version = "0.7"
 
 [dependencies.tracing]
 version = "0.1"

--- a/.synthetic_node/src/lib.rs
+++ b/.synthetic_node/src/lib.rs
@@ -20,9 +20,10 @@ use snarkos_environment::{
     CurrentNetwork,
     Environment,
 };
-use snarkos_network::{Data, DisconnectReason, Message};
+use snarkos_network::{Data, DisconnectReason, Message, MessageCodec};
 use snarkvm::traits::Network;
 
+use futures_util::{sink::SinkExt, TryStreamExt};
 use parking_lot::RwLock;
 use pea2pea::{
     protocols::{Disconnect, Handshake, Writing},
@@ -31,13 +32,10 @@ use pea2pea::{
     Pea2Pea,
 };
 use rand::{thread_rng, Rng};
-use std::{collections::HashMap, convert::TryInto, io, net::SocketAddr, sync::Arc};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::{collections::HashMap, io, net::SocketAddr, sync::Arc};
+use tokio_util::codec::Framed;
 use tracing::*;
 use tracing_subscriber::filter::LevelFilter;
-
-/// The number of bytes indicating the length of network messages.
-pub const MESSAGE_LENGTH_PREFIX_SIZE: usize = 4;
 
 /// These 3 values are checked during the handshake.
 pub const MESSAGE_VERSION: u32 = <Client<CurrentNetwork>>::MESSAGE_VERSION;
@@ -120,7 +118,7 @@ impl SynthNode {
 impl Handshake for SynthNode {
     async fn perform_handshake(&self, mut connection: Connection) -> io::Result<Connection> {
         let own_ip = self.node().listening_addr()?;
-        let peer_addr = connection.addr;
+        let peer_addr = connection.addr();
 
         // An immediate duplicate connection check.
         if self.state.address_map.read().contains_key(&peer_addr) {
@@ -129,6 +127,9 @@ impl Handshake for SynthNode {
 
         // The genesis block header is used in the handshake.
         let genesis_block_header = CurrentNetwork::genesis_block().header();
+
+        let stream = self.borrow_stream(&mut connection);
+        let mut framed = Framed::new(stream, MessageCodec::default());
 
         // Send a challenge request to the peer.
         let own_request = ClientMessage::ChallengeRequest(
@@ -141,23 +142,13 @@ impl Handshake for SynthNode {
             0,
         );
         trace!(parent: self.node().span(), "sending a challenge request to {}", peer_addr);
-        let mut msg = Vec::new();
-        own_request.serialize_into(&mut msg).unwrap();
-        let len = u32::to_le_bytes(msg.len() as u32);
-        connection.writer().write_all(&len).await?;
-        connection.writer().write_all(&msg).await?;
-
-        // A buffer for reading handshake messages.
-        let mut buf = [0u8; 1024];
+        framed.send(own_request).await?;
 
         // Read the challenge request from the peer.
-        connection.reader().read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE]).await?;
-        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
-        connection.reader().read_exact(&mut buf[..len]).await?;
-        let peer_request = ClientMessage::deserialize(&mut io::Cursor::new(&buf[..len]));
+        let peer_request = framed.try_next().await?;
 
         // Register peer's nonce.
-        let (peer_listening_addr, peer_nonce, peer_node_type, cumulative_weight, peer_version) = if let Ok(Message::ChallengeRequest(
+        let (peer_listening_addr, peer_nonce, peer_node_type, cumulative_weight, peer_version) = if let Some(Message::ChallengeRequest(
             peer_version,
             _peer_fork_depth,
             peer_node_type,
@@ -178,7 +169,7 @@ impl Handshake for SynthNode {
             trace!(parent: self.node().span(), "received a challenge request from {}", peer_addr);
 
             (peer_listening_addr, peer_nonce, peer_node_type, cumulative_weight, peer_version)
-        } else if let Ok(Message::Disconnect(reason)) = peer_request {
+        } else if let Some(Message::Disconnect(reason)) = peer_request {
             warn!(parent: self.node().span(), "{} disconnected: {:?}", peer_addr, reason);
             return Err(io::ErrorKind::NotConnected.into());
         } else {
@@ -189,19 +180,12 @@ impl Handshake for SynthNode {
         // Respond with own challenge request.
         let own_response = ClientMessage::ChallengeResponse(Data::Object(genesis_block_header.clone()));
         trace!(parent: self.node().span(), "sending a challenge response to {}", peer_addr);
-        let mut msg = Vec::new();
-        own_response.serialize_into(&mut msg).unwrap();
-        let len = u32::to_le_bytes(msg.len() as u32);
-        connection.writer().write_all(&len).await?;
-        connection.writer().write_all(&msg).await?;
+        framed.send(own_response).await?;
 
         // Wait for the challenge response to come in.
-        connection.reader().read_exact(&mut buf[..MESSAGE_LENGTH_PREFIX_SIZE]).await?;
-        let len = u32::from_le_bytes(buf[..MESSAGE_LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
-        connection.reader().read_exact(&mut buf[..len]).await?;
-        let peer_response = ClientMessage::deserialize(&mut io::Cursor::new(&buf[..len]));
+        let peer_response = framed.try_next().await?;
 
-        if let Ok(Message::ChallengeResponse(block_header)) = peer_response {
+        if let Some(Message::ChallengeResponse(block_header)) = peer_response {
             let block_header = block_header.deserialize().await.unwrap();
 
             trace!(parent: self.node().span(), "received a challenge response from {}", peer_addr);
@@ -234,7 +218,7 @@ impl Handshake for SynthNode {
                 error!(parent: self.node().span(), "invalid challenge response from {}", peer_addr);
                 Err(io::ErrorKind::InvalidData.into())
             }
-        } else if let Ok(Message::Disconnect(reason)) = peer_response {
+        } else if let Some(Message::Disconnect(reason)) = peer_response {
             warn!(parent: self.node().span(), "{} disconnected: {:?}", peer_addr, reason);
             return Err(io::ErrorKind::NotConnected.into());
         } else {
@@ -246,15 +230,11 @@ impl Handshake for SynthNode {
 
 /// Outbound message processing logic for the test nodes.
 impl Writing for SynthNode {
+    type Codec = MessageCodec<CurrentNetwork, Client<CurrentNetwork>>;
     type Message = ClientMessage;
 
-    fn write_message<W: io::Write>(&self, _target: SocketAddr, payload: &Self::Message, writer: &mut W) -> io::Result<()> {
-        let mut msg = Vec::new();
-        payload.serialize_into(&mut msg).unwrap();
-        let len = u32::to_le_bytes(msg.len() as u32);
-
-        writer.write_all(&len)?;
-        writer.write_all(&msg)
+    fn codec(&self, _addr: SocketAddr) -> Self::Codec {
+        Default::default()
     }
 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,14 +2027,17 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pea2pea"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d90feae3311b6204e24def79e34e663816bed86264bf3788de3a1c20a391f7e"
+checksum = "9d7e5fcdd19c10159e75fe65227f3c6fd2290df79a91e1ce1400362911bc4ac7"
 dependencies = [
  "async-trait",
+ "bytes",
+ "futures-util",
  "once_cell",
  "parking_lot 0.12.0",
  "tokio",
+ "tokio-util 0.7.0",
  "tracing",
 ]
 
@@ -2893,6 +2896,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "bytes",
  "clap 3.1.6",
  "nalgebra",
  "native-tls",
@@ -2910,6 +2914,7 @@ dependencies = [
  "time 0.3.7",
  "tokio",
  "tokio-postgres",
+ "tokio-util 0.7.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3038,6 +3043,7 @@ name = "snarkos-synthetic-node"
 version = "2.0.2"
 dependencies = [
  "async-trait",
+ "futures-util",
  "parking_lot 0.12.0",
  "pea2pea",
  "rand",
@@ -3045,6 +3051,7 @@ dependencies = [
  "snarkos-network",
  "snarkvm",
  "tokio",
+ "tokio-util 0.7.0",
  "tracing",
  "tracing-subscriber",
 ]

--- a/network/src/message.rs
+++ b/network/src/message.rs
@@ -338,7 +338,17 @@ impl<N: Network, E: Environment> Message<N, E> {
     }
 }
 
-impl<N: Network, E: Environment> Encoder<Message<N, E>> for Message<N, E> {
+/// The codec used to decode and encode network `Message`s.
+// note: it's very similar to `LengthDelimitedCodec`, but omits the `Bytes` allocation it would require.
+pub struct MessageCodec<N: Network, E: Environment>(PhantomData<N>, PhantomData<E>);
+
+impl<N: Network, E: Environment> Default for MessageCodec<N, E> {
+    fn default() -> Self {
+        Self(PhantomData, PhantomData)
+    }
+}
+
+impl<N: Network, E: Environment> Encoder<Message<N, E>> for MessageCodec<N, E> {
     type Error = anyhow::Error;
 
     fn encode(&mut self, message: Message<N, E>, dst: &mut BytesMut) -> Result<(), Self::Error> {
@@ -358,7 +368,7 @@ impl<N: Network, E: Environment> Encoder<Message<N, E>> for Message<N, E> {
     }
 }
 
-impl<N: Network, E: Environment> Decoder for Message<N, E> {
+impl<N: Network, E: Environment> Decoder for MessageCodec<N, E> {
     type Error = std::io::Error;
     type Item = Message<N, E>;
 

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -22,6 +22,7 @@ use crate::{
     LedgerRequest,
     LedgerRouter,
     Message,
+    MessageCodec,
     OperatorRequest,
     OperatorRouter,
     PeersRequest,
@@ -68,7 +69,7 @@ pub(crate) struct Peer<N: Network, E: Environment> {
     /// The timestamp of the last message received from this peer.
     last_seen: Instant,
     /// The TCP socket that handles sending and receiving data with this peer.
-    outbound_socket: Framed<TcpStream, Message<N, E>>,
+    outbound_socket: Framed<TcpStream, MessageCodec<N, E>>,
     /// The `outbound_handler` half of the MPSC message channel, used to receive messages from peers.
     /// When a message is received on this `OutboundHandler`, it will be written to the socket.
     outbound_handler: OutboundHandler<N, E>,
@@ -93,7 +94,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
         connected_nonces: &[u64],
     ) -> Result<Self> {
         // Construct the socket.
-        let mut outbound_socket = Framed::new(stream, Message::<N, E>::PeerRequest);
+        let mut outbound_socket = Framed::new(stream, MessageCodec::default());
 
         // Perform the handshake before proceeding.
         let (peer_ip, peer_nonce, node_type, status) = Peer::handshake(
@@ -155,7 +156,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
 
     /// Performs the handshake protocol, returning the listener IP and nonce of the peer upon success.
     async fn handshake(
-        outbound_socket: &mut Framed<TcpStream, Message<N, E>>,
+        outbound_socket: &mut Framed<TcpStream, MessageCodec<N, E>>,
         local_ip: SocketAddr,
         local_nonce: u64,
         local_cumulative_weight: u128,


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/snarkOS/pull/1693; only the last 2 commits are new, of which only https://github.com/AleoHQ/snarkOS/commit/b310471f6306f4aef10143a39614f65ea454aef1 is of interest.

This PR makes the handshake impl of the synthetic node much more similar to the one in the true node.

In addition, `pea2pea` is updated to `0.35`.