### PR TITLE
Restore missing CI integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
             TEST_NAMES=$(circleci tests split test_names.txt)
             for i in $(echo $TEST_NAMES | sed "s/ / /g")
             do
-                RUST_MIN_STACK=8388608 cargo test $i
+                RUST_MIN_STACK=8388608 cargo test --features=<< parameters.features >> $i
             done
 
   install_rust_nightly:


### PR DESCRIPTION
It seems that after https://github.com/AleoHQ/snarkOS/pull/1688 they are compiled, but not run.

I think I found the missing config bit, going to mark the PR as a draft until I've confirmed it.