### PR TITLE
Feat: round trip time metrics for request/response cycles

### DIFF
--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -304,7 +304,7 @@ impl Reading for Crawler {
                     self.process_peer_request(source)?;
                     Ok(())
                 }
-                ClientMessage::PeerResponse(peer_ips) => {
+                ClientMessage::PeerResponse(peer_ips, _) => {
                     self.process_peer_response(source, peer_ips)?;
                     Ok(())
                 }
@@ -342,7 +342,7 @@ impl Crawler {
             .choose_multiple(&mut self.rng(), SHARED_PEER_COUNT);
 
         debug!(parent: self.node().span(), "sending a PeerResponse to {}", source);
-        self.send_direct_message(source, ClientMessage::PeerResponse(peers))?;
+        self.send_direct_message(source, ClientMessage::PeerResponse(peers, None))?;
 
         Ok(())
     }

--- a/.integration/src/test_node.rs
+++ b/.integration/src/test_node.rs
@@ -153,7 +153,7 @@ impl Reading for TestNode {
                 debug!("Peer {} disconnected for the following reason: {:?}", source, reason);
             }
             ClientMessage::PeerRequest => self.process_peer_request(source).await?,
-            ClientMessage::PeerResponse(peer_addrs) => self.process_peer_response(source, peer_addrs).await?,
+            ClientMessage::PeerResponse(peer_addrs, _) => self.process_peer_response(source, peer_addrs).await?,
             ClientMessage::Ping(version, _fork_depth, _peer_type, _peer_state, _block_hash, block_header) => {
                 // Deserialise the block header.
                 let block_header = block_header.deserialize().await.unwrap();
@@ -176,7 +176,7 @@ impl Reading for TestNode {
 impl TestNode {
     async fn process_peer_request(&self, source: SocketAddr) -> io::Result<()> {
         let peers = self.state.peers.read().keys().copied().collect::<Vec<_>>();
-        let msg = ClientMessage::PeerResponse(peers);
+        let msg = ClientMessage::PeerResponse(peers, None);
         info!(parent: self.node().span(), "sending a PeerResponse to {}", source);
 
         self.send_direct_message(source, msg)?;

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -61,7 +61,7 @@
             "stacking": {
               "group": "A",
               "mode": "none"
-            },
+           },
             "thresholdsStyle": {
               "mode": "off"
             }
@@ -229,8 +229,116 @@
       ],
       "title": "Block Height",
       "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_ping_sum[$__rate_interval])/rate(snarkos_internal_rtt_ping_count[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "ping",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_pong_sum[$__rate_interval])/rate(snarkos_internal_rtt_pong_count[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "pong (processing, no response)",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_peers_request_sum[$__rate_interval])/rate(snarkos_internal_rtt_peers_request_count[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "peers_request",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(snarkos_internal_rtt_block_request_sum[$__rate_interval])/rate(snarkos_internal_rtt_block_request_count[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "block_request",
+          "refId": "D"
+        }
+      ],
+      "title": "Internal RTT for request/response cycles",
+      "type": "timeseries"
     }
   ],
+  "refresh": "10s",
   "schemaVersion": 31,
   "style": "dark",
   "tags": [],
@@ -238,12 +346,12 @@
     "list": []
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "snarkOS v2",
   "uid": "f7OaOQB7z",
-  "version": 2
+  "version": 6
 }

--- a/metrics/grafana/dashboard.json
+++ b/metrics/grafana/dashboard.json
@@ -319,10 +319,10 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(snarkos_internal_rtt_peers_request_sum[$__rate_interval])/rate(snarkos_internal_rtt_peers_request_count[$__rate_interval])",
+          "expr": "rate(snarkos_internal_rtt_peer_request_sum[$__rate_interval])/rate(snarkos_internal_rtt_peer_request_count[$__rate_interval])",
           "hide": false,
           "interval": "",
-          "legendFormat": "peers_request",
+          "legendFormat": "peer_request",
           "refId": "C"
         },
         {

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -64,9 +64,12 @@ pub fn initialize() -> Snapshotter {
     snapshotter
 }
 
-#[cfg(feature = "test")]
 fn register_metrics() {
     for name in GAUGE_NAMES {
         register_gauge!(name);
+    }
+
+    for name in HISTOGRAM_NAMES {
+        register_histogram!(name);
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -65,11 +65,11 @@ pub fn initialize() -> Snapshotter {
 }
 
 fn register_metrics() {
-    for name in GAUGE_NAMES {
+    for name in GAUGES {
         register_gauge!(name);
     }
 
-    for name in HISTOGRAM_NAMES {
+    for name in HISTOGRAMS {
         register_histogram!(name);
     }
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
-pub const HISTOGRAM_NAMES: [&str; 2] = [internal_rtt::PING, internal_rtt::PONG];
+pub const HISTOGRAM_NAMES: [&str; 3] = [internal_rtt::PING, internal_rtt::PONG, internal_rtt::BLOCK_REQUEST];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
@@ -30,4 +30,5 @@ pub mod peers {
 pub mod internal_rtt {
     pub const PING: &str = "snarkos_internal_rtt_ping";
     pub const PONG: &str = "snarkos_internal_rtt_pong";
+    pub const BLOCK_REQUEST: &str = "snarkos_internal_rtt_block_request";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
-pub const HISTOGRAM_NAMES: [&str; 4] = [
+pub const GAUGES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
+pub const HISTOGRAMS: [&str; 4] = [
     internal_rtt::PING,
     internal_rtt::PONG,
     internal_rtt::PEER_REQUEST,

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
-pub const HISTOGRAM_NAMES: [&str; 1] = [internal_rtt::PING];
+pub const HISTOGRAM_NAMES: [&str; 2] = [internal_rtt::PING, internal_rtt::PONG];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
@@ -29,4 +29,5 @@ pub mod peers {
 
 pub mod internal_rtt {
     pub const PING: &str = "snarkos_internal_rtt_ping";
+    pub const PONG: &str = "snarkos_internal_rtt_pong";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -15,7 +15,12 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
-pub const HISTOGRAM_NAMES: [&str; 3] = [internal_rtt::PING, internal_rtt::PONG, internal_rtt::BLOCK_REQUEST];
+pub const HISTOGRAM_NAMES: [&str; 4] = [
+    internal_rtt::PING,
+    internal_rtt::PONG,
+    internal_rtt::PEERS_REQUEST,
+    internal_rtt::BLOCK_REQUEST,
+];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
@@ -30,5 +35,6 @@ pub mod peers {
 pub mod internal_rtt {
     pub const PING: &str = "snarkos_internal_rtt_ping";
     pub const PONG: &str = "snarkos_internal_rtt_pong";
+    pub const PEERS_REQUEST: &str = "snarkos_internal_rtt_peers_request";
     pub const BLOCK_REQUEST: &str = "snarkos_internal_rtt_block_request";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CANDIDATE, peers::RESTRICTED];
+pub const HISTOGRAM_NAMES: [&str; 1] = [internal_rtt::PING];
 
 pub mod blocks {
     pub const HEIGHT: &str = "snarkos_blocks_height_total";
@@ -24,4 +25,8 @@ pub mod peers {
     pub const CONNECTED: &str = "snarkos_peers_connected_total";
     pub const CANDIDATE: &str = "snarkos_peers_candidate_total";
     pub const RESTRICTED: &str = "snarkos_peers_restricted_total";
+}
+
+pub mod internal_rtt {
+    pub const PING: &str = "snarkos_internal_rtt_ping";
 }

--- a/metrics/src/names.rs
+++ b/metrics/src/names.rs
@@ -18,7 +18,7 @@ pub const GAUGE_NAMES: [&str; 4] = [blocks::HEIGHT, peers::CONNECTED, peers::CAN
 pub const HISTOGRAM_NAMES: [&str; 4] = [
     internal_rtt::PING,
     internal_rtt::PONG,
-    internal_rtt::PEERS_REQUEST,
+    internal_rtt::PEER_REQUEST,
     internal_rtt::BLOCK_REQUEST,
 ];
 
@@ -35,6 +35,6 @@ pub mod peers {
 pub mod internal_rtt {
     pub const PING: &str = "snarkos_internal_rtt_ping";
     pub const PONG: &str = "snarkos_internal_rtt_pong";
-    pub const PEERS_REQUEST: &str = "snarkos_internal_rtt_peers_request";
+    pub const PEER_REQUEST: &str = "snarkos_internal_rtt_peer_request";
     pub const BLOCK_REQUEST: &str = "snarkos_internal_rtt_block_request";
 }

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -497,6 +497,10 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                             break;
                                         }
                                     }
+
+                                    // Stop the clock on internal RTT.
+                                    #[cfg(any(feature = "test", feature = "prometheus"))]
+                                    metrics::histogram!(metrics::internal_rtt::BLOCK_REQUEST, rtt_start.elapsed());
                                 },
                                 Message::BlockResponse(block) => {
                                     // Perform the deferred non-blocking deserialization of the block.
@@ -596,7 +600,6 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         Ok(expected_block_hash) => Some(expected_block_hash != block_hash),
                                         Err(_) => None,
                                     };
-
 
                                     // Stop the clock on internal RTT.
                                     #[cfg(any(feature = "test", feature = "prometheus"))]

--- a/network/src/peer.rs
+++ b/network/src/peer.rs
@@ -437,7 +437,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                 Message::PeerResponse(_, _rtt_start) => {
                                     // Stop the clock on internal RTT.
                                     #[cfg(any(feature = "test", feature = "prometheus"))]
-                                    metrics::histogram!(metrics::internal_rtt::PEERS_REQUEST, _rtt_start.expect("rtt should be present with metrics enabled").elapsed());
+                                    metrics::histogram!(metrics::internal_rtt::PEER_REQUEST, _rtt_start.expect("rtt should be present with metrics enabled").elapsed());
 
                                     true
                                 }

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -83,7 +83,8 @@ pub enum PeersRequest<N: Network, E: Environment> {
     PeerDisconnected(SocketAddr),
     /// PeerRestricted := (peer_ip)
     PeerRestricted(SocketAddr),
-    /// SendPeerResponse := (peer_ip)
+    /// SendPeerResponse := (peer_ip, rtt_start)
+    /// Note: rtt_start is for the request/response cycle for sharing peers.
     SendPeerResponse(SocketAddr, Option<Instant>),
     /// ReceivePeerResponse := (\[peer_ip\])
     ReceivePeerResponse(Vec<SocketAddr>),

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -84,7 +84,7 @@ pub enum PeersRequest<N: Network, E: Environment> {
     /// PeerRestricted := (peer_ip)
     PeerRestricted(SocketAddr),
     /// SendPeerResponse := (peer_ip)
-    SendPeerResponse(SocketAddr),
+    SendPeerResponse(SocketAddr, Option<Instant>),
     /// ReceivePeerResponse := (\[peer_ip\])
     ReceivePeerResponse(Vec<SocketAddr>),
 }
@@ -622,10 +622,10 @@ impl<N: Network, E: Environment> Peers<N, E> {
                     metrics::gauge!(metrics::peers::RESTRICTED, number_of_restricted_peers as f64);
                 }
             }
-            PeersRequest::SendPeerResponse(recipient) => {
+            PeersRequest::SendPeerResponse(recipient, rtt_start) => {
                 // Send a `PeerResponse` message.
                 let connected_peers = self.connected_peers().await;
-                self.send(recipient, Message::PeerResponse(connected_peers)).await;
+                self.send(recipient, Message::PeerResponse(connected_peers, rtt_start)).await;
             }
             PeersRequest::ReceivePeerResponse(peer_ips) => {
                 self.add_candidate_peers(peer_ips.iter()).await;


### PR DESCRIPTION
This PR introduces some internal RTT metrics for certain request/response cycles. It also updates the grafana dashboard to display these. Unfortunately there is currently no perfectly clean way of introducing them with feature flags so the occasional `Option` is necessary.

The `Pong` message isn't technically a cycle but as it does some operations based on the block locators, I thought it would be interesting to have a sense of how expensive that is.
