### PR TITLE
Feature: get all the ciphertexts from the LedgerState

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -467,7 +467,7 @@ impl<N: Network> LedgerState<N> {
     }
 
     // Returns all the ciphertexts in ledger.
-    pub fn get_ciphertexts(&self) -> Result<impl Iterator<Item = N::RecordCiphertext> + '_> {
+    pub fn get_ciphertexts(&self) -> impl Iterator<Item = Result<N::RecordCiphertext>> + '_ {
         self.blocks.get_ciphertexts()
     }
 
@@ -1298,7 +1298,7 @@ impl<N: Network> BlockState<N> {
     }
 
     // Returns all the record ciphertexts.
-    fn get_ciphertexts(&self) -> Result<impl Iterator<Item = N::RecordCiphertext> + '_> {
+    fn get_ciphertexts(&self) -> impl Iterator<Item = Result<N::RecordCiphertext>> + '_ {
         self.transactions.get_ciphertexts()
     }
 
@@ -1578,11 +1578,8 @@ impl<N: Network> TransactionState<N> {
     }
 
     // Returns all the record ciphertexts.
-    fn get_ciphertexts(&self) -> Result<impl Iterator<Item = N::RecordCiphertext> + '_> {
-        Ok(self
-            .commitments
-            .keys()
-            .map(move |commitment| self.get_ciphertext(&commitment).unwrap()))
+    fn get_ciphertexts(&self) -> impl Iterator<Item = Result<N::RecordCiphertext>> + '_ {
+        self.commitments.keys().map(move |commitment| self.get_ciphertext(&commitment))
     }
 
     /// Returns the transition for a given transition ID.

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -466,7 +466,7 @@ impl<N: Network> LedgerState<N> {
         self.blocks.get_previous_ledger_root(block_height)
     }
 
-    // Returns the record ciphertexts for a given block.
+    // Returns all the ciphertexts in ledger.
     pub fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
         self.blocks.get_ciphertexts()
     }
@@ -1297,6 +1297,7 @@ impl<N: Network> BlockState<N> {
         self.transactions.get_ciphertext(commitment)
     }
 
+    // Returns all the record ciphertexts.
     fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
         self.transactions.get_ciphertexts()
     }
@@ -1576,11 +1577,12 @@ impl<N: Network> TransactionState<N> {
         Err(anyhow!("Commitment {} is missing in storage", commitment))
     }
 
+    // Returns all the record ciphertexts.
     fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
         Ok(self
             .commitments
-            .iter()
-            .map(|(commitment, _)| self.get_ciphertext(&commitment).unwrap())
+            .keys()
+            .map(|commitment| self.get_ciphertext(&commitment).unwrap())
             .collect::<Vec<N::RecordCiphertext>>())
     }
 

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -466,6 +466,11 @@ impl<N: Network> LedgerState<N> {
         self.blocks.get_previous_ledger_root(block_height)
     }
 
+    // Returns the record ciphertexts for a given block.
+    pub fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
+        self.blocks.get_ciphertexts()
+    }
+
     /// Returns the block locators of the current ledger, from the given block height.
     pub fn get_block_locators(&self, block_height: u32) -> Result<BlockLocators<N>> {
         // Initialize the current block height that a block locator is obtained from.
@@ -1292,6 +1297,10 @@ impl<N: Network> BlockState<N> {
         self.transactions.get_ciphertext(commitment)
     }
 
+    fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
+        self.transactions.get_ciphertexts()
+    }
+
     /// Returns the transition for a given transition ID.
     fn get_transition(&self, transition_id: &N::TransitionID) -> Result<Transition<N>> {
         self.transactions.get_transition(transition_id)
@@ -1565,6 +1574,14 @@ impl<N: Network> TransactionState<N> {
         }
 
         Err(anyhow!("Commitment {} is missing in storage", commitment))
+    }
+
+    fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
+        Ok(self
+            .commitments
+            .iter()
+            .map(|(commitment, _)| self.get_ciphertext(&commitment).unwrap())
+            .collect::<Vec<N::RecordCiphertext>>())
     }
 
     /// Returns the transition for a given transition ID.

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -467,7 +467,7 @@ impl<N: Network> LedgerState<N> {
     }
 
     // Returns all the ciphertexts in ledger.
-    pub fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
+    pub fn get_ciphertexts(&self) -> Result<impl Iterator<Item = N::RecordCiphertext> + '_> {
         self.blocks.get_ciphertexts()
     }
 
@@ -1298,7 +1298,7 @@ impl<N: Network> BlockState<N> {
     }
 
     // Returns all the record ciphertexts.
-    fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
+    fn get_ciphertexts(&self) -> Result<impl Iterator<Item = N::RecordCiphertext> + '_> {
         self.transactions.get_ciphertexts()
     }
 
@@ -1578,12 +1578,11 @@ impl<N: Network> TransactionState<N> {
     }
 
     // Returns all the record ciphertexts.
-    fn get_ciphertexts(&self) -> Result<Vec<N::RecordCiphertext>> {
+    fn get_ciphertexts(&self) -> Result<impl Iterator<Item = N::RecordCiphertext> + '_> {
         Ok(self
             .commitments
             .keys()
-            .map(|commitment| self.get_ciphertext(&commitment).unwrap())
-            .collect::<Vec<N::RecordCiphertext>>())
+            .map(move |commitment| self.get_ciphertext(&commitment).unwrap()))
     }
 
     /// Returns the transition for a given transition ID.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -381,7 +381,7 @@ fn test_get_all_ciphertexts() {
             .map(|commitment| ledger.get_ciphertext(commitment).unwrap())
             .collect::<Vec<_>>(),
     );
-    let ciphertexts_set = to_hash_set_test::<Testnet2>(ledger.get_ciphertexts().unwrap());
+    let ciphertexts_set = to_hash_set_test::<Testnet2>(ledger.get_ciphertexts().unwrap().collect());
 
     assert_eq!(expected_ciphertexts_set, ciphertexts_set);
 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Get all the ciphertexts directly from `LedgerState` to avoid iterating over all the transactions and commitments to get them.

## Test Plan

<!-- If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

There is a new test created in `storage/src/state/tests.rs`
- `test_get_all_ciphertexts` - This test asserts that this function gets all the ciphertexts in the ledger without a specific order.