### PR TITLE
Disable some resource logs

### DIFF
--- a/environment/src/helpers/resources.rs
+++ b/environment/src/helpers/resources.rs
@@ -103,11 +103,6 @@ impl Resources {
             while let Some(request) = receiver.recv().await {
                 match request {
                     ResourceRequest::Register(resource, id) => {
-                        let _resource_name = match resource {
-                            Resource::Task(..) => "task",
-                            Resource::Thread(..) => "thread",
-                        };
-
                         if resources.insert(id, resource).is_some() {
                             error!("A resource with id {} already exists!", id);
                         }

--- a/environment/src/helpers/resources.rs
+++ b/environment/src/helpers/resources.rs
@@ -103,15 +103,13 @@ impl Resources {
             while let Some(request) = receiver.recv().await {
                 match request {
                     ResourceRequest::Register(resource, id) => {
-                        let resource_name = match resource {
+                        let _resource_name = match resource {
                             Resource::Task(..) => "task",
                             Resource::Thread(..) => "thread",
                         };
 
                         if resources.insert(id, resource).is_some() {
                             error!("A resource with id {} already exists!", id);
-                        } else {
-                            trace!("Registered a {} as resource {}", resource_name, id);
                         }
                     }
                     ResourceRequest::Deregister(id) => {
@@ -120,7 +118,6 @@ impl Resources {
                             // to-be-aborted task to free its resources.
                             tokio::spawn(async move {
                                 sleep(Duration::from_secs(1)).await;
-                                trace!("Aborting resource with id {}", id);
                                 resource.abort().await;
                             });
                         } else {


### PR DESCRIPTION
They are a bit too verbose, and we don't need to actively inspect them. The logs in question are only commented out, in order to restore them more easily if need be.

Cc @zosorock 