### PR TITLE
Introduce an object with combined state

### DIFF
--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -18,7 +18,7 @@
 use crate::storage::PostgresOpts;
 use crate::{constants::*, known_network::KnownNetwork, metrics::NetworkMetrics};
 use snarkos_environment::{
-    helpers::{BlockLocators, NodeType, State},
+    helpers::{BlockLocators, NodeType, Status},
     network::Data,
     Client,
     CurrentNetwork,
@@ -383,7 +383,7 @@ impl Crawler {
         Ok(())
     }
 
-    fn process_ping(&self, source: SocketAddr, node_type: NodeType, version: u32, state: State, block_height: u32) -> io::Result<()> {
+    fn process_ping(&self, source: SocketAddr, node_type: NodeType, version: u32, status: Status, block_height: u32) -> io::Result<()> {
         // Don't reject non-compliant peers in order to have the fullest image of the network.
 
         debug!(parent: self.node().span(), "peer {} is at height {}", source, block_height);
@@ -391,7 +391,7 @@ impl Crawler {
         // Update the known network nodes and update the crawl state.
         if let Some(listening_addr) = self.get_peer_listening_addr(source) {
             self.known_network
-                .received_ping(listening_addr, node_type, version, state, block_height);
+                .received_ping(listening_addr, node_type, version, status, block_height);
         }
 
         let genesis = CurrentNetwork::genesis_block();

--- a/.crawler/src/known_network.rs
+++ b/.crawler/src/known_network.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use parking_lot::RwLock;
-use snarkos_environment::helpers::{NodeType, State};
+use snarkos_environment::helpers::{NodeType, Status};
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
@@ -33,7 +33,7 @@ pub struct NodeState {
     pub node_type: NodeType,
     pub version: u32,
     pub height: u32,
-    pub state: State,
+    pub status: Status,
 }
 
 /// Node information collected while crawling.
@@ -151,7 +151,7 @@ impl KnownNetwork {
     }
 
     /// Updates the details of a node based on a Ping message received from it.
-    pub fn received_ping(&self, source: SocketAddr, node_type: NodeType, version: u32, state: State, height: u32) {
+    pub fn received_ping(&self, source: SocketAddr, node_type: NodeType, version: u32, status: Status, height: u32) {
         let timestamp = OffsetDateTime::now_utc();
 
         let mut nodes = self.nodes.write();
@@ -161,7 +161,7 @@ impl KnownNetwork {
             node_type,
             version,
             height,
-            state,
+            status,
         });
         meta.timestamp = Some(timestamp);
     }

--- a/.crawler/src/metrics.rs
+++ b/.crawler/src/metrics.rs
@@ -24,7 +24,7 @@ use std::{
 
 use nalgebra::{DMatrix, DVector, SymmetricEigen};
 #[cfg(not(feature = "postgres"))]
-use snarkos_environment::helpers::{NodeType, State};
+use snarkos_environment::helpers::{NodeType, Status};
 #[cfg(not(feature = "postgres"))]
 use time::Duration;
 
@@ -45,8 +45,8 @@ pub struct NetworkSummary {
     types: HashMap<NodeType, usize>,
     // The versions of nodes and their respective counts.
     versions: HashMap<u32, usize>,
-    // The node states of nodes and their respective counts.
-    states: HashMap<State, usize>,
+    // The node statuses of nodes and their respective counts.
+    statuses: HashMap<Status, usize>,
     // The heights of nodes and their respective counts.
     heights: HashMap<u32, usize>,
     // Corresponds to the same field in the NetworkMetrics.
@@ -94,7 +94,7 @@ impl fmt::Display for NetworkSummary {
         write!(f, "by protocol version: ")?;
         print_breakdown(f, &self.versions, 0)?;
         write!(f, "by current state: ")?;
-        print_breakdown(f, &self.states, 0)?;
+        print_breakdown(f, &self.statuses, 0)?;
 
         writeln!(f, "\nNetwork metrics:")?;
         writeln!(f, "density: {:.4}", self.density)?;
@@ -202,7 +202,7 @@ impl NetworkMetrics {
     #[cfg(not(feature = "postgres"))]
     pub fn summary(&self) -> NetworkSummary {
         let mut versions = HashMap::with_capacity(self.node_count);
-        let mut states = HashMap::with_capacity(self.node_count);
+        let mut statuses = HashMap::with_capacity(self.node_count);
         let mut types = HashMap::with_capacity(self.node_count);
         let mut heights = HashMap::with_capacity(self.node_count);
 
@@ -213,7 +213,7 @@ impl NetworkMetrics {
         for (_, meta, centrality) in &self.per_node {
             if let Some(ref state) = meta.state {
                 versions.entry(state.version).and_modify(|count| *count += 1).or_insert(1);
-                states.entry(state.state).and_modify(|count| *count += 1).or_insert(1);
+                statuses.entry(state.status).and_modify(|count| *count += 1).or_insert(1);
                 types.entry(state.node_type).and_modify(|count| *count += 1).or_insert(1);
                 heights.entry(state.height).and_modify(|count| *count += 1).or_insert(1);
             } else {
@@ -252,7 +252,7 @@ impl NetworkMetrics {
             nodes_pending_state,
             versions,
             heights,
-            states,
+            statuses,
             types,
             density: self.density,
             algebraic_connectivity: self.algebraic_connectivity,

--- a/.crawler/src/storage.rs
+++ b/.crawler/src/storage.rs
@@ -205,7 +205,7 @@ impl Crawler {
                         &meta.timestamp,
                         &meta.state.as_ref().map(|s| s.node_type as i16),
                         &meta.state.as_ref().map(|s| s.version as i32),
-                        &meta.state.as_ref().map(|s| s.state as i16),
+                        &meta.state.as_ref().map(|s| s.status as i16),
                         &meta.state.as_ref().map(|s| s.height as i64),
                         &meta.handshake_time.map(|t| t.whole_milliseconds() as i32),
                     ])

--- a/.integration/src/client_node.rs
+++ b/.integration/src/client_node.rs
@@ -33,7 +33,7 @@ impl ClientNode {
 
     /// Returns the list of connected peers of the node.
     pub async fn connected_peers(&self) -> Vec<SocketAddr> {
-        self.server.peers().connected_peers().await
+        self.server.state.peers().connected_peers().await
     }
 
     /// Returns the number of connected peers of the node.
@@ -44,7 +44,7 @@ impl ClientNode {
     /// Resets the node's known peers. This is practical, as it makes the node not reconnect
     /// to known peers in test cases where it's undesirable.
     pub async fn reset_known_peers(&self) {
-        self.server.peers().reset_known_peers().await
+        self.server.state.peers().reset_known_peers().await
     }
 
     /// Attempts to connect the node to the given address.

--- a/.integration/src/client_node.rs
+++ b/.integration/src/client_node.rs
@@ -38,7 +38,7 @@ impl ClientNode {
 
     /// Returns the number of connected peers of the node.
     pub async fn number_of_connected_peers(&self) -> usize {
-        self.server.peers().number_of_connected_peers().await
+        self.server.state.peers().number_of_connected_peers().await
     }
 
     /// Resets the node's known peers. This is practical, as it makes the node not reconnect

--- a/.integration/src/test_node.rs
+++ b/.integration/src/test_node.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkos_environment::{
-    helpers::{BlockLocators, NodeType, State},
+    helpers::{BlockLocators, NodeType, Status},
     network::{Data, MessageCodec},
     Client,
     CurrentNetwork,
@@ -46,8 +46,7 @@ const DESIRED_CONNECTIONS: usize = <Client<CurrentNetwork>>::MINIMUM_NUMBER_OF_P
 
 pub const MAXIMUM_NUMBER_OF_PEERS: usize = <Client<CurrentNetwork>>::MAXIMUM_NUMBER_OF_PEERS;
 
-/// The test node; it consists of a `Node` that handles networking and `State`
-/// that can be extended freely based on test requirements.
+/// The test node; it contains a `SynthNode` with some custom behavior.
 #[derive(Clone)]
 pub struct TestNode(SynthNode);
 
@@ -98,7 +97,7 @@ impl TestNode {
                 MESSAGE_VERSION,
                 MAXIMUM_FORK_DEPTH,
                 NodeType::Client,
-                State::Ready,
+                Status::Ready,
                 genesis.hash(),
                 Data::Object(genesis.header().clone()),
             );

--- a/.integration/tests/network/perf.rs
+++ b/.integration/tests/network/perf.rs
@@ -16,7 +16,7 @@
 
 use pea2pea::{protocols::Writing, Pea2Pea};
 use snarkos_environment::{
-    helpers::{NodeType, State},
+    helpers::{NodeType, Status},
     network::{Data, Message},
     Client,
     CurrentNetwork,
@@ -94,6 +94,7 @@ async fn measure_peer_request_time() {
             .send_direct_message(client_addr, Message::PeerRequest)
             .unwrap()
             .await
+            .unwrap()
             .unwrap();
         wait_until!(1, test_node.node().stats().received().0 as usize == init_recv_count + i + 1);
         avg_request_time += start.elapsed();
@@ -121,7 +122,7 @@ async fn measure_ping_time() {
         <Client<CurrentNetwork>>::MESSAGE_VERSION,
         CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH,
         NodeType::Client,
-        State::Ready,
+        Status::Ready,
         CurrentNetwork::genesis_block().hash(),
         Data::Object(CurrentNetwork::genesis_block().header().clone()),
     );
@@ -129,7 +130,12 @@ async fn measure_ping_time() {
     let init_recv_count = test_node.node().stats().received().0 as usize;
     for i in 0..NUM_ITERATIONS {
         let start = Instant::now();
-        test_node.send_direct_message(client_addr, ping.clone()).unwrap().await.unwrap();
+        test_node
+            .send_direct_message(client_addr, ping.clone())
+            .unwrap()
+            .await
+            .unwrap()
+            .unwrap();
         wait_until!(1, test_node.node().stats().received().0 as usize == init_recv_count + i + 1);
         avg_request_time += start.elapsed();
     }

--- a/.synthetic_node/src/lib.rs
+++ b/.synthetic_node/src/lib.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkos_environment::{
-    helpers::{NodeType, State},
+    helpers::{NodeType, Status},
     network::{Data, DisconnectReason, Message, MessageCodec},
     Client,
     CurrentNetwork,
@@ -45,7 +45,7 @@ pub const MAXIMUM_FORK_DEPTH: u32 = CurrentNetwork::ALEO_MAXIMUM_FORK_DEPTH;
 pub type ClientMessage = Message<CurrentNetwork, Client<CurrentNetwork>>;
 pub type ClientNonce = u64;
 
-/// The test node; it consists of a `Pea2PeaNode` that handles networking and `State`
+/// The test node; it consists of a `Pea2PeaNode` that handles networking and state
 /// that can be extended freely based on test requirements.
 #[derive(Clone)]
 pub struct SynthNode {
@@ -93,7 +93,7 @@ impl Pea2Pea for SynthNode {
 }
 
 impl SynthNode {
-    /// Creates a test node using the given `Pea2Pea` node and with the given `State`.
+    /// Creates a test node using the given `Pea2Pea` node and with the given `ClientState`.
     pub fn new(node: Pea2PeaNode, state: ClientState) -> Self {
         Self { node, state }
     }
@@ -138,7 +138,7 @@ impl Handshake for SynthNode {
             MESSAGE_VERSION,
             MAXIMUM_FORK_DEPTH,
             NodeType::Client,
-            State::Ready,
+            Status::Ready,
             own_ip.port(),
             self.state.local_nonce,
             0,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "bytes",
  "circular-queue",
  "futures",
+ "once_cell",
  "rand",
  "serde",
  "snarkos-environment",

--- a/environment/src/helpers/mod.rs
+++ b/environment/src/helpers/mod.rs
@@ -24,4 +24,4 @@ mod resources;
 pub use resources::{Resource, Resources};
 
 mod status;
-pub use status::{State, Status};
+pub use status::{RawStatus, Status};

--- a/environment/src/helpers/status.rs
+++ b/environment/src/helpers/status.rs
@@ -25,7 +25,7 @@ use std::{
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[repr(u8)]
-pub enum State {
+pub enum Status {
     /// The ledger is ready to handle requests.
     Ready = 0,
     /// The ledger is mining the next block.
@@ -38,66 +38,66 @@ pub enum State {
     ShuttingDown,
 }
 
-impl fmt::Display for State {
+impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct Status(Arc<AtomicU8>);
+pub struct RawStatus(Arc<AtomicU8>);
 
-impl Status {
-    /// Initializes a new instance of `Status`.
+impl RawStatus {
+    /// Initializes a new instance of `RawStatus`.
     pub fn new() -> Self {
-        Self(Arc::new(AtomicU8::new(State::Peering as u8)))
+        Self(Arc::new(AtomicU8::new(Status::Peering as u8)))
     }
 
-    /// Updates the status to the given state.
-    pub fn update(&self, state: State) {
-        self.0.store(state as u8, Ordering::SeqCst);
+    /// Updates the status to the given value.
+    pub fn update(&self, status: Status) {
+        self.0.store(status as u8, Ordering::SeqCst);
     }
 
-    /// Returns the state of the node.
-    pub fn get(&self) -> State {
+    /// Returns the status of the node.
+    pub fn get(&self) -> Status {
         match self.0.load(Ordering::SeqCst) {
-            0 => State::Ready,
-            1 => State::Mining,
-            2 => State::Peering,
-            3 => State::Syncing,
-            4 => State::ShuttingDown,
+            0 => Status::Ready,
+            1 => Status::Mining,
+            2 => Status::Peering,
+            3 => Status::Syncing,
+            4 => Status::ShuttingDown,
             _ => unreachable!("Invalid status code"),
         }
     }
 
     /// Returns `true` if the node is ready to handle requests.
     pub fn is_ready(&self) -> bool {
-        self.get() == State::Ready
+        self.get() == Status::Ready
     }
 
     /// Returns `true` if the node is currently mining.
     pub fn is_mining(&self) -> bool {
-        self.get() == State::Mining
+        self.get() == Status::Mining
     }
 
     /// Returns `true` if the node is currently peering.
     pub fn is_peering(&self) -> bool {
-        self.get() == State::Peering
+        self.get() == Status::Peering
     }
 
     /// Returns `true` if the node is currently syncing.
     pub fn is_syncing(&self) -> bool {
-        self.get() == State::Syncing
+        self.get() == Status::Syncing
     }
 }
 
-impl fmt::Display for Status {
+impl fmt::Display for RawStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.get())
     }
 }
 
-impl Default for Status {
+impl Default for RawStatus {
     fn default() -> Self {
         Self::new()
     }

--- a/environment/src/lib.rs
+++ b/environment/src/lib.rs
@@ -23,7 +23,7 @@ pub mod helpers;
 #[cfg(feature = "network")]
 pub mod network;
 
-use crate::helpers::{NodeType, Resources, Status};
+use crate::helpers::{NodeType, RawStatus, Resources};
 use snarkvm::dpc::Network;
 
 use once_cell::sync::OnceCell;
@@ -115,9 +115,9 @@ pub trait Environment: 'static + Clone + Debug + Default + Send + Sync {
     }
 
     /// Returns the status of the node.
-    fn status() -> &'static Status {
-        static STATUS: OnceCell<Status> = OnceCell::new();
-        STATUS.get_or_init(Status::new)
+    fn status() -> &'static RawStatus {
+        static STATUS: OnceCell<RawStatus> = OnceCell::new();
+        STATUS.get_or_init(RawStatus::default)
     }
 
     /// Returns the terminator bit for the prover.

--- a/environment/src/network/message.rs
+++ b/environment/src/network/message.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    helpers::{BlockLocators, NodeType, State},
+    helpers::{BlockLocators, NodeType, Status},
     Environment,
 };
 use snarkvm::{dpc::posw::PoSWProof, prelude::*};
@@ -113,7 +113,7 @@ pub enum Message<N: Network, E: Environment> {
     /// BlockResponse := (block)
     BlockResponse(Data<Block<N>>),
     /// ChallengeRequest := (version, fork_depth, node_type, status, listener_port, nonce, cumulative_weight)
-    ChallengeRequest(u32, u32, NodeType, State, u16, u64, u128),
+    ChallengeRequest(u32, u32, NodeType, Status, u16, u64, u128),
     /// ChallengeResponse := (block_header)
     ChallengeResponse(Data<BlockHeader<N>>),
     /// Disconnect := ()
@@ -123,7 +123,7 @@ pub enum Message<N: Network, E: Environment> {
     /// PeerResponse := (\[peer_ip\])
     PeerResponse(Vec<SocketAddr>, Option<Instant>),
     /// Ping := (version, fork_depth, node_type, status, block_hash, block_header)
-    Ping(u32, u32, NodeType, State, N::BlockHash, Data<BlockHeader<N>>),
+    Ping(u32, u32, NodeType, Status, N::BlockHash, Data<BlockHeader<N>>),
     /// Pong := (is_fork, block_locators)
     Pong(Option<bool>, Data<BlockLocators<N>>),
     /// UnconfirmedBlock := (block_height, block_hash, block)

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -32,6 +32,9 @@ version = "0.2"
 version = "0.3.21"
 features = [ "thread-pool" ]
 
+[dependencies.once_cell]
+version = "1"
+
 [dependencies.rand]
 version = "0.8"
 

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -169,7 +169,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Performs the given `request` to the ledger.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub async fn update(&self, request: LedgerRequest<N>) {
+    pub(super) async fn update(&self, request: LedgerRequest<N>) {
         match request {
             LedgerRequest::BlockResponse(peer_ip, block) => {
                 // Remove the block request from the ledger.

--- a/network/src/ledger.rs
+++ b/network/src/ledger.rs
@@ -17,9 +17,8 @@
 use crate::{
     helpers::{block_requests::*, BlockRequest, CircularMap},
     PeersRequest,
-    PeersRouter,
     ProverRequest,
-    ProverRouter,
+    State,
 };
 use snarkos_environment::{
     helpers::{block_locators::*, NodeType, Status},
@@ -41,10 +40,7 @@ use std::{
     time::{Duration, Instant},
 };
 use time::OffsetDateTime;
-use tokio::{
-    sync::{mpsc, oneshot, Mutex, RwLock},
-    task,
-};
+use tokio::sync::{mpsc, Mutex, RwLock};
 
 /// The maximum number of unconfirmed blocks that can be held by the ledger.
 const MAXIMUM_UNCONFIRMED_BLOCKS: u32 = 250;
@@ -53,27 +49,26 @@ pub type LedgerReader<N> = std::sync::Arc<snarkos_storage::LedgerState<N>>;
 
 /// Shorthand for the parent half of the `Ledger` message channel.
 pub type LedgerRouter<N> = mpsc::Sender<LedgerRequest<N>>;
-#[allow(unused)]
 /// Shorthand for the child half of the `Ledger` message channel.
-type LedgerHandler<N> = mpsc::Receiver<LedgerRequest<N>>;
+pub type LedgerHandler<N> = mpsc::Receiver<LedgerRequest<N>>;
 
 ///
 /// An enum of requests that the `Ledger` struct processes.
 ///
 #[derive(Debug)]
 pub enum LedgerRequest<N: Network> {
-    /// BlockResponse := (peer_ip, block, prover_router)
-    BlockResponse(SocketAddr, Block<N>, ProverRouter<N>),
+    /// BlockResponse := (peer_ip, block)
+    BlockResponse(SocketAddr, Block<N>),
     /// Disconnect := (peer_ip, reason)
     Disconnect(SocketAddr, DisconnectReason),
     /// Failure := (peer_ip, failure)
     Failure(SocketAddr, String),
-    /// Heartbeat := (prover_router)
-    Heartbeat(ProverRouter<N>),
+    /// Heartbeat
+    Heartbeat,
     /// Pong := (peer_ip, node_type, status, is_fork, block_locators)
     Pong(SocketAddr, NodeType, Status, Option<bool>, BlockLocators<N>, Option<Instant>),
     /// UnconfirmedBlock := (peer_ip, block, prover_router)
-    UnconfirmedBlock(SocketAddr, Block<N>, ProverRouter<N>),
+    UnconfirmedBlock(SocketAddr, Block<N>),
 }
 
 pub type PeersState<N> = HashMap<SocketAddr, Option<(NodeType, Status, Option<bool>, u32, BlockLocators<N>)>>;
@@ -81,18 +76,17 @@ pub type PeersState<N> = HashMap<SocketAddr, Option<(NodeType, Status, Option<bo
 ///
 /// A ledger for a specific network on the node server.
 ///
-#[derive(Debug)]
 #[allow(clippy::type_complexity)]
 pub struct Ledger<N: Network, E: Environment> {
     /// The ledger router of the node.
     ledger_router: LedgerRouter<N>,
     /// The canonical chain of blocks.
-    canon: Arc<LedgerState<N>>,
+    canon: LedgerState<N>,
     /// The canonical chain of blocks in read-only mode.
     canon_reader: Arc<LedgerState<N>>,
     /// A lock to ensure methods that need to be mutually-exclusive are enforced.
     /// In this context, `add_block`, and `revert_to_block_height` must be mutually-exclusive.
-    canon_lock: Arc<Mutex<()>>,
+    canon_lock: Mutex<()>,
     /// A map of previous block hashes to unconfirmed blocks.
     unconfirmed_blocks: RwLock<CircularMap<N::BlockHash, Block<N>, { MAXIMUM_UNCONFIRMED_BLOCKS }>>,
     /// The map of each peer to their ledger state := (node_type, status, is_fork, latest_block_height, block_locators).
@@ -101,75 +95,55 @@ pub struct Ledger<N: Network, E: Environment> {
     block_requests: RwLock<HashMap<SocketAddr, HashMap<BlockRequest<N>, i64>>>,
     /// A lock to ensure methods that need to be mutually-exclusive are enforced.
     /// In this context, `update_ledger`, `add_block`, and `update_block_requests` must be mutually-exclusive.
-    block_requests_lock: Arc<Mutex<()>>,
+    block_requests_lock: Mutex<()>,
     /// The timestamp of the last successful block update.
     last_block_update_timestamp: RwLock<Instant>,
     /// The map of each peer to their failure messages := (failure_message, timestamp).
     failures: RwLock<HashMap<SocketAddr, Vec<(String, i64)>>>,
-    /// The peers router of the node.
-    peers_router: PeersRouter<N, E>,
+    /// The shared state of the owning node.
+    state: Arc<State<N, E>>,
 }
 
 impl<N: Network, E: Environment> Ledger<N, E> {
-    /// Initializes a new instance of the ledger.
-    pub async fn open<S: Storage, P: AsRef<Path> + Copy>(path: P, peers_router: PeersRouter<N, E>) -> Result<Arc<Self>> {
+    /// Initializes a new instance of the ledger, paired with its handler.
+    pub async fn open<S: Storage, P: AsRef<Path> + Copy>(
+        path: P,
+        state: Arc<State<N, E>>,
+    ) -> Result<(Self, mpsc::Receiver<LedgerRequest<N>>)> {
         // Initialize an mpsc channel for sending requests to the `Ledger` struct.
-        let (ledger_router, mut ledger_handler) = mpsc::channel(1024);
+        let (ledger_router, ledger_handler) = mpsc::channel(1024);
 
-        let canon = Arc::new(LedgerState::open_writer::<S, P>(path)?);
+        let canon = LedgerState::open_writer::<S, P>(path)?;
         let (canon_reader, reader_resource) = LedgerState::open_reader::<S, P>(path)?;
         // Register the thread; no need to provide an id, as it will run indefinitely.
         E::resources().register(reader_resource, None);
 
         // Initialize the ledger.
-        let ledger = Arc::new(Self {
+        let ledger = Self {
             ledger_router,
             canon,
             canon_reader,
-            canon_lock: Arc::new(Mutex::new(())),
+            canon_lock: Default::default(),
             unconfirmed_blocks: Default::default(),
             peers_state: Default::default(),
             block_requests: Default::default(),
-            block_requests_lock: Arc::new(Mutex::new(())),
+            block_requests_lock: Default::default(),
             last_block_update_timestamp: RwLock::new(Instant::now()),
             failures: Default::default(),
-            peers_router,
-        });
+            state,
+        };
 
-        // Initialize the handler for the ledger.
-        {
-            let ledger = ledger.clone();
-            let (router, handler) = oneshot::channel();
-            E::resources().register_task(
-                None, // No need to provide an id, as the task will run indefinitely.
-                task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    // Asynchronously wait for a ledger request.
-                    while let Some(request) = ledger_handler.recv().await {
-                        // Update the state of the ledger.
-                        // Note: Do not wrap this call in a `task::spawn` as `BlockResponse` messages
-                        // will end up being processed out of order.
-                        ledger.update(request).await;
-                    }
-                }),
-            );
-
-            // Wait until the ledger handler is ready.
-            let _ = handler.await;
-        }
-
-        Ok(ledger)
+        Ok((ledger, ledger_handler))
     }
 
     /// Returns an instance of the ledger reader.
-    pub fn reader(&self) -> LedgerReader<N> {
-        self.canon_reader.clone()
+    pub fn reader(&self) -> &LedgerReader<N> {
+        &self.canon_reader
     }
 
     /// Returns an instance of the ledger router.
-    pub fn router(&self) -> LedgerRouter<N> {
-        self.ledger_router.clone()
+    pub fn router(&self) -> &LedgerRouter<N> {
+        &self.ledger_router
     }
 
     pub async fn shut_down(&self) {
@@ -195,13 +169,13 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Performs the given `request` to the ledger.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(&self, request: LedgerRequest<N>) {
+    pub async fn update(&self, request: LedgerRequest<N>) {
         match request {
-            LedgerRequest::BlockResponse(peer_ip, block, prover_router) => {
+            LedgerRequest::BlockResponse(peer_ip, block) => {
                 // Remove the block request from the ledger.
                 if self.remove_block_request(peer_ip, block.height()).await {
                     // On success, process the block response.
-                    self.add_block(block, &prover_router).await;
+                    self.add_block(block).await;
                     // Check if syncing with this peer is complete.
                     if self
                         .block_requests
@@ -222,11 +196,11 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             LedgerRequest::Failure(peer_ip, failure) => {
                 self.add_failure(peer_ip, failure).await;
             }
-            LedgerRequest::Heartbeat(prover_router) => {
+            LedgerRequest::Heartbeat => {
                 // Update for sync nodes.
                 self.update_sync_nodes().await;
                 // Update the ledger.
-                self.update_ledger(&prover_router).await;
+                self.update_ledger().await;
                 // Update the status of the ledger.
                 self.update_status().await;
                 // Remove expired block requests.
@@ -264,15 +238,15 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     _rtt_start.expect("rtt should be present with metrics enabled").elapsed()
                 );
             }
-            LedgerRequest::UnconfirmedBlock(peer_ip, block, prover_router) => {
+            LedgerRequest::UnconfirmedBlock(peer_ip, block) => {
                 // Ensure the node is not peering.
                 if !E::status().is_peering() {
                     // Process the unconfirmed block.
-                    self.add_block(block.clone(), &prover_router).await;
+                    self.add_block(block.clone()).await;
                     // Propagate the unconfirmed block to the connected peers.
                     let message = Message::UnconfirmedBlock(block.height(), block.hash(), Data::Object(block));
                     let request = PeersRequest::MessagePropagate(peer_ip, message);
-                    if let Err(error) = self.peers_router.send(request).await {
+                    if let Err(error) = self.state.peers().router().send(request).await {
                         warn!("[UnconfirmedBlock] {}", error);
                     }
                 }
@@ -291,14 +265,16 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.update_status().await;
         // Send a `Disconnect` message to the peer.
         if let Err(error) = self
-            .peers_router
+            .state
+            .peers()
+            .router()
             .send(PeersRequest::MessageSend(peer_ip, Message::Disconnect(reason)))
             .await
         {
             warn!("[Disconnect] {}", error);
         }
         // Route a `PeerDisconnected` to the peers.
-        if let Err(error) = self.peers_router.send(PeersRequest::PeerDisconnected(peer_ip)).await {
+        if let Err(error) = self.state.peers().router().send(PeersRequest::PeerDisconnected(peer_ip)).await {
             warn!("[PeerDisconnected] {}", error);
         }
     }
@@ -314,14 +290,16 @@ impl<N: Network, E: Environment> Ledger<N, E> {
         self.update_status().await;
         // Send a `Disconnect` message to the peer.
         if let Err(error) = self
-            .peers_router
+            .state
+            .peers()
+            .router()
             .send(PeersRequest::MessageSend(peer_ip, Message::Disconnect(reason)))
             .await
         {
             warn!("[Disconnect] {}", error);
         }
         // Route a `PeerRestricted` to the peers.
-        if let Err(error) = self.peers_router.send(PeersRequest::PeerRestricted(peer_ip)).await {
+        if let Err(error) = self.state.peers().router().send(PeersRequest::PeerRestricted(peer_ip)).await {
             warn!("[PeerRestricted] {}", error);
         }
     }
@@ -372,13 +350,13 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     /// Attempt to fast-forward the ledger with unconfirmed blocks.
     ///
-    async fn update_ledger(&self, prover_router: &ProverRouter<N>) {
+    async fn update_ledger(&self) {
         // Check for candidate blocks to fast forward the ledger.
         let mut block_hash = self.canon.latest_block_hash();
         let unconfirmed_blocks_snapshot = self.unconfirmed_blocks.read().await.clone();
         while let Some(unconfirmed_block) = unconfirmed_blocks_snapshot.get(&block_hash) {
             // Attempt to add the unconfirmed block.
-            match self.add_block(unconfirmed_block.clone(), prover_router).await {
+            match self.add_block(unconfirmed_block.clone()).await {
                 // Upon success, update the block hash iterator.
                 true => block_hash = unconfirmed_block.hash(),
                 false => break,
@@ -397,7 +375,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             self.unconfirmed_blocks.write().await.clear();
 
             // Reset the memory pool of its transactions.
-            if let Err(error) = prover_router.send(ProverRequest::MemoryPoolClear(None)).await {
+            if let Err(error) = self.state.prover().router().send(ProverRequest::MemoryPoolClear(None)).await {
                 error!("[MemoryPoolClear]: {}", error);
             }
 
@@ -477,7 +455,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     /// Returns `true` if the given block is successfully added to the *canon* chain.
     ///
-    async fn add_block(&self, unconfirmed_block: Block<N>, prover_router: &ProverRouter<N>) -> bool {
+    async fn add_block(&self, unconfirmed_block: Block<N>) -> bool {
         // Retrieve the unconfirmed block height.
         let unconfirmed_block_height = unconfirmed_block.height();
         // Retrieve the unconfirmed block hash.
@@ -541,7 +519,13 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                         self.unconfirmed_blocks.write().await.remove(&unconfirmed_previous_block_hash);
 
                         // On success, filter the memory pool of its transactions, if they exist.
-                        if let Err(error) = prover_router.send(ProverRequest::MemoryPoolClear(Some(unconfirmed_block))).await {
+                        if let Err(error) = self
+                            .state
+                            .prover()
+                            .router()
+                            .send(ProverRequest::MemoryPoolClear(Some(unconfirmed_block)))
+                            .await
+                        {
                             error!("[MemoryPoolClear]: {}", error);
                         }
 
@@ -805,7 +789,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
             // Send a `BlockRequest` message to the peer.
             debug!("Requesting blocks {} to {} from {}", start_block_height, end_block_height, peer_ip);
             let request = PeersRequest::MessageSend(peer_ip, Message::BlockRequest(start_block_height, end_block_height));
-            if let Err(error) = self.peers_router.send(request).await {
+            if let Err(error) = self.state.peers().router().send(request).await {
                 warn!("[BlockRequest] {}", error);
                 return;
             }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -38,3 +38,6 @@ pub use peers::*;
 
 pub mod prover;
 pub use prover::*;
+
+pub mod state;
+pub use state::*;

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -69,7 +69,7 @@ pub struct Operator<N: Network, E: Environment> {
     /// The operator router of the node.
     operator_router: OperatorRouter<N>,
     /// The shared state of the owning node.
-    pub state: Arc<State<N, E>>,
+    state: Arc<State<N, E>>,
 }
 
 impl<N: Network, E: Environment> Operator<N, E> {
@@ -194,7 +194,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
     /// Performs the given `request` to the operator.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub async fn update(&self, request: OperatorRequest<N>) {
+    pub(super) async fn update(&self, request: OperatorRequest<N>) {
         match request {
             OperatorRequest::PoolRegister(peer_ip, address) => {
                 if let Some(block_template) = self.block_template.read().await.clone() {

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerReader, LedgerRequest, LedgerRouter, PeersRequest, PeersRouter, ProverRouter};
+use crate::{LedgerRequest, PeersRequest, State};
 use snarkos_environment::{
     helpers::NodeType,
     network::{Data, Message},
@@ -24,7 +24,6 @@ use snarkos_storage::{storage::Storage, OperatorState};
 use snarkvm::dpc::{prelude::*, PoSWProof};
 
 use anyhow::Result;
-use rand::thread_rng;
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
@@ -32,16 +31,12 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use tokio::{
-    sync::{mpsc, oneshot, RwLock},
-    task,
-};
+use tokio::sync::{mpsc, oneshot, RwLock};
 
 /// Shorthand for the parent half of the `Operator` message channel.
 pub type OperatorRouter<N> = mpsc::Sender<OperatorRequest<N>>;
-#[allow(unused)]
 /// Shorthand for the child half of the `Operator` message channel.
-type OperatorHandler<N> = mpsc::Receiver<OperatorRequest<N>>;
+pub type OperatorHandler<N> = mpsc::Receiver<OperatorRequest<N>>;
 
 ///
 /// An enum of requests that the `Operator` struct processes.
@@ -62,14 +57,9 @@ const HEARTBEAT_IN_SECONDS: Duration = Duration::from_secs(1);
 ///
 /// An operator for a program on a specific network in the node server.
 ///
-#[derive(Debug)]
 pub struct Operator<N: Network, E: Environment> {
-    /// The address of the operator.
-    address: Option<Address<N>>,
-    /// The local address of this node.
-    local_ip: SocketAddr,
     /// The state storage of the operator.
-    state: Arc<OperatorState<N>>,
+    operator_state: Arc<OperatorState<N>>,
     /// The current block template that is being mined on by the operator.
     block_template: RwLock<Option<BlockTemplate<N>>>,
     /// A list of provers and their associated state := (last_submitted, share_difficulty)
@@ -78,99 +68,66 @@ pub struct Operator<N: Network, E: Environment> {
     known_nonces: RwLock<HashSet<N::PoSWNonce>>,
     /// The operator router of the node.
     operator_router: OperatorRouter<N>,
-    /// The pool of unconfirmed transactions.
-    memory_pool: Arc<RwLock<MemoryPool<N>>>,
-    /// The peers router of the node.
-    peers_router: PeersRouter<N, E>,
-    /// The ledger state of the node.
-    ledger_reader: LedgerReader<N>,
-    /// The ledger router of the node.
-    ledger_router: LedgerRouter<N>,
-    /// The prover router of the node.
-    prover_router: ProverRouter<N>,
+    /// The shared state of the owning node.
+    pub state: Arc<State<N, E>>,
 }
 
 impl<N: Network, E: Environment> Operator<N, E> {
-    /// Initializes a new instance of the operator.
+    /// Initializes a new instance of the operator, paired with its handler.
     #[allow(clippy::too_many_arguments)]
     pub async fn open<S: Storage, P: AsRef<Path> + Copy>(
         path: P,
-        address: Option<Address<N>>,
-        local_ip: SocketAddr,
-        memory_pool: Arc<RwLock<MemoryPool<N>>>,
-        peers_router: PeersRouter<N, E>,
-        ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
-        prover_router: ProverRouter<N>,
-    ) -> Result<Arc<Self>> {
+        state: Arc<State<N, E>>,
+    ) -> Result<(Self, mpsc::Receiver<OperatorRequest<N>>)> {
         // Initialize an mpsc channel for sending requests to the `Operator` struct.
-        let (operator_router, mut operator_handler) = mpsc::channel(1024);
+        let (operator_router, operator_handler) = mpsc::channel(1024);
         // Initialize the operator.
-        let operator = Arc::new(Self {
-            address,
-            local_ip,
-            state: Arc::new(OperatorState::open_writer::<S, P>(path)?),
+        let operator = Self {
+            operator_state: Arc::new(OperatorState::open_writer::<S, P>(path)?),
             block_template: RwLock::new(None),
             provers: Default::default(),
             known_nonces: Default::default(),
             operator_router,
-            memory_pool,
-            peers_router,
-            ledger_reader,
-            ledger_router,
-            prover_router,
-        });
+            state,
+        };
 
+        Ok((operator, operator_handler))
+    }
+
+    pub async fn initialize(&self) {
         if E::NODE_TYPE == NodeType::Operator {
-            // Initialize the handler for the operator.
-            let operator_clone = operator.clone();
-            let (router, handler) = oneshot::channel();
-            E::resources().register_task(
-                None, // No need to provide an id, as the task will run indefinitely.
-                task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    // Asynchronously wait for a operator request.
-                    while let Some(request) = operator_handler.recv().await {
-                        operator_clone.update(request).await;
-                    }
-                }),
-            );
-
-            // Wait until the operator handler is ready.
-            let _ = handler.await;
-        }
-
-        if E::NODE_TYPE == NodeType::Operator {
-            if let Some(recipient) = operator.address {
+            if let Some(recipient) = self.state.prover().address {
                 // Initialize an update loop for the block template.
-                let operator = operator.clone();
+                let state = self.state.clone();
                 let (router, handler) = oneshot::channel();
                 E::resources().register_task(
                     None, // No need to provide an id, as the task will run indefinitely.
-                    task::spawn(async move {
+                    tokio::spawn(async move {
+                        let operator = &state.operator();
                         // Notify the outer function that the task is ready.
                         let _ = router.send(());
                         // TODO (julesdesmit): Add logic to the loop to retarget share difficulty.
                         loop {
                             // Determine if the current block template is stale.
                             let is_block_template_stale = match &*operator.block_template.read().await {
-                                Some(template) => operator.ledger_reader.latest_block_height().saturating_add(1) != template.block_height(),
+                                Some(template) => {
+                                    operator.state.ledger().reader().latest_block_height().saturating_add(1) != template.block_height()
+                                }
                                 None => true,
                             };
 
                             // Update the block template if it is stale.
                             if is_block_template_stale {
                                 // Construct a new block template.
-                                let transactions = operator.memory_pool.read().await.transactions();
-                                let ledger_reader = operator.ledger_reader.clone();
-                                let result = task::spawn_blocking(move || {
+                                let transactions = operator.state.prover().memory_pool().read().await.transactions();
+                                let ledger_reader = operator.state.ledger().reader().clone();
+                                let result = tokio::task::spawn_blocking(move || {
                                     E::thread_pool().install(move || {
                                         match ledger_reader.get_block_template(
                                             recipient,
                                             E::COINBASE_IS_PUBLIC,
                                             &transactions,
-                                            &mut thread_rng(),
+                                            &mut rand::thread_rng(),
                                         ) {
                                             Ok(block_template) => Ok(block_template),
                                             Err(error) => Err(format!("Failed to produce a new block template: {}", error)),
@@ -204,42 +161,40 @@ impl<N: Network, E: Environment> Operator<N, E> {
                 error!("Missing operator address. Please specify an Aleo address in order to operate a pool");
             }
         }
-
-        Ok(operator)
     }
 
     /// Returns an instance of the operator router.
-    pub fn router(&self) -> OperatorRouter<N> {
-        self.operator_router.clone()
+    pub fn router(&self) -> &OperatorRouter<N> {
+        &self.operator_router
     }
 
     /// Returns all the shares in storage.
     pub fn to_shares(&self) -> Vec<((u32, Record<N>), HashMap<Address<N>, u64>)> {
-        self.state.to_shares()
+        self.operator_state.to_shares()
     }
 
     /// Returns the shares for a specific block, given the block height and coinbase record commitment.
     pub fn get_shares_for_block(&self, block_height: u32, coinbase_record: Record<N>) -> Result<HashMap<Address<N>, u64>> {
-        self.state.get_shares_for_block(block_height, coinbase_record)
+        self.operator_state.get_shares_for_block(block_height, coinbase_record)
     }
 
     /// Returns the shares for a specific prover, given the prover address.
     pub fn get_shares_for_prover(&self, prover: &Address<N>) -> u64 {
-        self.state.get_shares_for_prover(prover)
+        self.operator_state.get_shares_for_prover(prover)
     }
 
     ///
     /// Returns a list of all provers which have submitted shares to this operator.
     ///
     pub fn get_provers(&self) -> Vec<Address<N>> {
-        self.state.get_provers()
+        self.operator_state.get_provers()
     }
 
     ///
     /// Performs the given `request` to the operator.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(&self, request: OperatorRequest<N>) {
+    pub async fn update(&self, request: OperatorRequest<N>) {
         match request {
             OperatorRequest::PoolRegister(peer_ip, address) => {
                 if let Some(block_template) = self.block_template.read().await.clone() {
@@ -254,7 +209,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
 
                     // Route a `PoolRequest` to the peer.
                     let message = Message::PoolRequest(share_difficulty, Data::Object(block_template));
-                    if let Err(error) = self.peers_router.send(PeersRequest::MessageSend(peer_ip, message)).await {
+                    if let Err(error) = self.state.peers().router().send(PeersRequest::MessageSend(peer_ip, message)).await {
                         warn!("[PoolRequest] {}", error);
                     }
                 } else {
@@ -307,7 +262,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
 
                     // Increment the share count for the prover.
                     let coinbase_record = block_template.coinbase_record().clone();
-                    match self.state.increment_share(block_height, coinbase_record, &prover) {
+                    match self.operator_state.increment_share(block_height, coinbase_record, &prover) {
                         Ok(..) => info!(
                             "Operator has received a valid share from {} ({}) for block {}",
                             prover, peer_ip, block_height,
@@ -327,8 +282,8 @@ impl<N: Network, E: Environment> Operator<N, E> {
                     ) {
                         if let Ok(block) = Block::from(previous_block_hash, block_header, transactions) {
                             info!("Operator has found unconfirmed block {} ({})", block.height(), block.hash());
-                            let request = LedgerRequest::UnconfirmedBlock(self.local_ip, block, self.prover_router.clone());
-                            if let Err(error) = self.ledger_router.send(request).await {
+                            let request = LedgerRequest::UnconfirmedBlock(self.state.local_ip, block);
+                            if let Err(error) = self.state.ledger().router().send(request).await {
                                 warn!("Failed to broadcast mined block - {}", error);
                             }
                         }

--- a/network/src/operator.rs
+++ b/network/src/operator.rs
@@ -96,7 +96,7 @@ impl<N: Network, E: Environment> Operator<N, E> {
 
     pub async fn initialize(&self) {
         if E::NODE_TYPE == NodeType::Operator {
-            if let Some(recipient) = self.state.prover().address {
+            if let Some(recipient) = self.state.address {
                 // Initialize an update loop for the block template.
                 let state = self.state.clone();
                 let (router, handler) = oneshot::channel();

--- a/network/src/peers.rs
+++ b/network/src/peers.rs
@@ -226,7 +226,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     /// Performs the given `request` to the peers.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub async fn update(&self, request: PeersRequest<N, E>) {
+    pub(super) async fn update(&self, request: PeersRequest<N, E>) {
         match request {
             PeersRequest::Connect(peer_ip, connection_result) => {
                 // Ensure the peer IP is not this node.

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{LedgerReader, LedgerRequest, LedgerRouter, PeersRequest, PeersRouter};
+use crate::{LedgerRequest, PeersRequest, State};
 use snarkos_environment::{
     helpers::{NodeType, Status},
     network::{Data, Message},
@@ -38,9 +38,8 @@ use tokio::{
 
 /// Shorthand for the parent half of the `Prover` message channel.
 pub type ProverRouter<N> = mpsc::Sender<ProverRequest<N>>;
-#[allow(unused)]
 /// Shorthand for the child half of the `Prover` message channel.
-type ProverHandler<N> = mpsc::Receiver<ProverRequest<N>>;
+pub type ProverHandler<N> = mpsc::Receiver<ProverRequest<N>>;
 
 /// The miner heartbeat in seconds.
 const MINER_HEARTBEAT_IN_SECONDS: Duration = Duration::from_secs(2);
@@ -61,80 +60,55 @@ pub enum ProverRequest<N: Network> {
 ///
 /// A prover for a specific network on the node server.
 ///
-#[derive(Debug)]
 pub struct Prover<N: Network, E: Environment> {
     /// The state storage of the prover.
-    state: Arc<ProverState<N>>,
+    prover_state: Arc<ProverState<N>>,
     /// The Aleo address of the prover.
-    address: Option<Address<N>>,
+    pub address: Option<Address<N>>,
     /// The IP address of the connected pool.
     pool: Option<SocketAddr>,
     /// The prover router of the node.
     prover_router: ProverRouter<N>,
     /// The pool of unconfirmed transactions.
     memory_pool: Arc<RwLock<MemoryPool<N>>>,
-    /// The peers router of the node.
-    peers_router: PeersRouter<N, E>,
-    /// The ledger state of the node.
-    ledger_reader: LedgerReader<N>,
-    /// The ledger router of the node.
-    ledger_router: LedgerRouter<N>,
+    /// The shared state of the owning node.
+    pub state: Arc<State<N, E>>,
 }
 
 impl<N: Network, E: Environment> Prover<N, E> {
-    /// Initializes a new instance of the prover.
+    /// Initializes a new instance of the prover, paired with its handler.
     pub async fn open<S: Storage, P: AsRef<Path> + Copy>(
         path: P,
         address: Option<Address<N>>,
-        local_ip: SocketAddr,
         pool_ip: Option<SocketAddr>,
-        peers_router: PeersRouter<N, E>,
-        ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
-    ) -> Result<Arc<Self>> {
+        state: Arc<State<N, E>>,
+    ) -> Result<(Self, mpsc::Receiver<ProverRequest<N>>)> {
         // Initialize an mpsc channel for sending requests to the `Prover` struct.
-        let (prover_router, mut prover_handler) = mpsc::channel(1024);
+        let (prover_router, prover_handler) = mpsc::channel(1024);
         // Initialize the prover.
-        let prover = Arc::new(Self {
-            state: Arc::new(ProverState::open::<S, P>(path, false)?),
+        let prover = Self {
+            prover_state: Arc::new(ProverState::open::<S, P>(path, false)?),
             address,
             pool: pool_ip,
             prover_router,
             memory_pool: Arc::new(RwLock::new(MemoryPool::new())),
-            peers_router,
-            ledger_reader,
-            ledger_router,
-        });
+            state,
+        };
 
-        // Initialize the handler for the prover.
-        {
-            let prover = prover.clone();
-            let (router, handler) = oneshot::channel();
-            E::resources().register_task(
-                None, // No need to provide an id, as the task will run indefinitely.
-                task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    // Asynchronously wait for a prover request.
-                    while let Some(request) = prover_handler.recv().await {
-                        // Update the state of the prover.
-                        prover.update(request).await;
-                    }
-                }),
-            );
+        Ok((prover, prover_handler))
+    }
 
-            // Wait until the prover handler is ready.
-            let _ = handler.await;
-        }
-
+    pub async fn initialize_miner(&self) {
         // Initialize the miner, if the node type is a miner.
-        if E::NODE_TYPE == NodeType::Miner && prover.pool.is_none() {
-            Self::start_miner(prover.clone(), local_ip).await;
+        if E::NODE_TYPE == NodeType::Miner && self.pool.is_none() {
+            self.state.prover().start_miner().await;
         }
+    }
 
+    pub async fn initialize_pooling(&self) {
         // Initialize the prover, if the node type is a prover.
-        if E::NODE_TYPE == NodeType::Prover && prover.pool.is_some() {
-            let prover = prover.clone();
+        if E::NODE_TYPE == NodeType::Prover && self.pool.is_some() {
+            let state = self.state.clone();
             let (router, handler) = oneshot::channel();
             E::resources().register_task(
                 None, // No need to provide an id, as the task will run indefinitely.
@@ -148,7 +122,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
                         // TODO (howardwu): Check that the prover is connected to the pool before proceeding.
                         //  Currently we use a sleep function to probabilistically ensure the peer is connected.
                         if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
-                            prover.send_pool_register().await;
+                            state.prover().send_pool_register().await;
                         }
                     }
                 }),
@@ -157,13 +131,43 @@ impl<N: Network, E: Environment> Prover<N, E> {
             // Wait until the operator handler is ready.
             let _ = handler.await;
         }
+    }
 
-        Ok(prover)
+    pub async fn initialize_pool_connection_loop(&self, pool_ip: Option<SocketAddr>) {
+        // TODO (howardwu): This is a hack for the prover.
+        // Check that the prover is connected to the pool before sending a PoolRegister message.
+        if let Some(pool_ip) = pool_ip {
+            let peers_router = self.state.peers().router().clone();
+            let (router, handler) = oneshot::channel();
+            E::resources().register_task(
+                None, // No need to provide an id, as the task will run indefinitely.
+                task::spawn(async move {
+                    // Notify the outer function that the task is ready.
+                    let _ = router.send(());
+                    loop {
+                        // Initialize the connection process.
+                        let (router, handler) = oneshot::channel();
+                        // Route a `Connect` request to the pool.
+                        if let Err(error) = peers_router.send(PeersRequest::Connect(pool_ip, router)).await {
+                            trace!("[Connect] {}", error);
+                        }
+                        // Wait until the connection task is initialized.
+                        let _ = handler.await;
+
+                        // Sleep for `30` seconds.
+                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    }
+                }),
+            );
+
+            // Wait until the prover handler is ready.
+            let _ = handler.await;
+        }
     }
 
     /// Returns an instance of the prover router.
-    pub fn router(&self) -> ProverRouter<N> {
-        self.prover_router.clone()
+    pub fn router(&self) -> &ProverRouter<N> {
+        &self.prover_router
     }
 
     /// Returns an instance of the memory pool.
@@ -173,14 +177,14 @@ impl<N: Network, E: Environment> Prover<N, E> {
 
     /// Returns all coinbase records in storage.
     pub fn to_coinbase_records(&self) -> Vec<(u32, Record<N>)> {
-        self.state.to_coinbase_records()
+        self.prover_state.to_coinbase_records()
     }
 
     ///
     /// Performs the given `request` to the prover.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(&self, request: ProverRequest<N>) {
+    pub async fn update(&self, request: ProverRequest<N>) {
         match request {
             ProverRequest::PoolRequest(operator_ip, share_difficulty, block_template) => {
                 // Process the pool request message.
@@ -203,13 +207,13 @@ impl<N: Network, E: Environment> Prover<N, E> {
     ///
     /// Sends a `PoolRegister` message to the pool IP address.
     ///
-    async fn send_pool_register(&self) {
+    pub async fn send_pool_register(&self) {
         if E::NODE_TYPE == NodeType::Prover {
             if let Some(recipient) = self.address {
                 if let Some(pool_ip) = self.pool {
                     // Proceed to register the prover to receive a block template.
                     let request = PeersRequest::MessageSend(pool_ip, Message::PoolRegister(recipient));
-                    if let Err(error) = self.peers_router.send(request).await {
+                    if let Err(error) = self.state.peers().router().send(request).await {
                         warn!("[PoolRegister] {}", error);
                     }
                 } else {
@@ -274,7 +278,13 @@ impl<N: Network, E: Environment> Prover<N, E> {
 
                                     // Send a `PoolResponse` to the operator.
                                     let message = Message::PoolResponse(recipient, nonce, Data::Object(proof));
-                                    if let Err(error) = self.peers_router.send(PeersRequest::MessageSend(operator_ip, message)).await {
+                                    if let Err(error) = self
+                                        .state
+                                        .peers()
+                                        .router()
+                                        .send(PeersRequest::MessageSend(operator_ip, message))
+                                        .await
+                                    {
                                         warn!("[PoolResponse] {}", error);
                                     }
                                 }
@@ -299,14 +309,14 @@ impl<N: Network, E: Environment> Prover<N, E> {
         // Process the unconfirmed transaction.
         trace!("Received unconfirmed transaction {} from {}", transaction.transaction_id(), peer_ip);
         // Ensure the unconfirmed transaction is new.
-        if let Ok(false) = self.ledger_reader.contains_transaction(&transaction.transaction_id()) {
+        if let Ok(false) = self.state.ledger().reader().contains_transaction(&transaction.transaction_id()) {
             debug!("Adding unconfirmed transaction {} to memory pool", transaction.transaction_id());
             // Attempt to add the unconfirmed transaction to the memory pool.
             match self.memory_pool.write().await.add_transaction(&transaction) {
                 Ok(()) => {
                     // Upon success, propagate the unconfirmed transaction to the connected peers.
                     let request = PeersRequest::MessagePropagate(peer_ip, Message::UnconfirmedTransaction(Data::Object(transaction)));
-                    if let Err(error) = self.peers_router.send(request).await {
+                    if let Err(error) = self.state.peers().router().send(request).await {
                         warn!("[UnconfirmedTransaction] {}", error);
                     }
                 }
@@ -318,13 +328,15 @@ impl<N: Network, E: Environment> Prover<N, E> {
     ///
     /// Initialize the miner, if the node type is a miner.
     ///
-    async fn start_miner(prover: Arc<Self>, local_ip: SocketAddr) {
+    pub async fn start_miner(&self) {
         // Initialize a new instance of the miner.
-        if E::NODE_TYPE == NodeType::Miner && prover.pool.is_none() {
-            if let Some(recipient) = prover.address {
+        if E::NODE_TYPE == NodeType::Miner && self.pool.is_none() {
+            if let Some(recipient) = self.address {
                 // Initialize the prover process.
-                let prover = prover.clone();
                 let (router, handler) = oneshot::channel();
+                let state = self.state.clone();
+                let prover_state = self.prover_state.clone();
+                let local_ip = state.local_ip;
                 E::resources().register_task(
                     None, // No need to provide an id, as the task will run indefinitely.
                     task::spawn(async move {
@@ -337,11 +349,10 @@ impl<N: Network, E: Environment> Prover<N, E> {
                                 E::status().update(Status::Mining);
 
                                 // Prepare the unconfirmed transactions and dependent objects.
-                                let state = prover.state.clone();
-                                let canon = prover.ledger_reader.clone(); // This is *safe* as the ledger only reads.
-                                let unconfirmed_transactions = prover.memory_pool.read().await.transactions();
-                                let ledger_router = prover.ledger_router.clone();
-                                let prover_router = prover.prover_router.clone();
+                                let prover_state = prover_state.clone();
+                                let canon = state.ledger().reader().clone(); // This is *safe* as the ledger only reads.
+                                let unconfirmed_transactions = state.prover().memory_pool.read().await.transactions();
+                                let ledger_router = state.ledger().router().clone();
 
                                 // Procure a resource id to register the task with, as it might be terminated at any point in time.
                                 let mining_task_id = E::resources().procure_id();
@@ -370,12 +381,12 @@ impl<N: Network, E: Environment> Prover<N, E> {
                                             Ok(Ok((block, coinbase_record))) => {
                                                 debug!("Miner has found unconfirmed block {} ({})", block.height(), block.hash());
                                                 // Store the coinbase record.
-                                                if let Err(error) = state.add_coinbase_record(block.height(), coinbase_record) {
+                                                if let Err(error) = prover_state.add_coinbase_record(block.height(), coinbase_record) {
                                                     warn!("[Miner] Failed to store coinbase record - {}", error);
                                                 }
 
                                                 // Broadcast the next block.
-                                                let request = LedgerRequest::UnconfirmedBlock(local_ip, block, prover_router.clone());
+                                                let request = LedgerRequest::UnconfirmedBlock(local_ip, block);
                                                 if let Err(error) = ledger_router.send(request).await {
                                                     warn!("Failed to broadcast mined block - {}", error);
                                                 }

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -72,7 +72,7 @@ pub struct Prover<N: Network, E: Environment> {
     /// The pool of unconfirmed transactions.
     memory_pool: Arc<RwLock<MemoryPool<N>>>,
     /// The shared state of the owning node.
-    pub state: Arc<State<N, E>>,
+    state: Arc<State<N, E>>,
 }
 
 impl<N: Network, E: Environment> Prover<N, E> {
@@ -184,7 +184,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
     /// Performs the given `request` to the prover.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub async fn update(&self, request: ProverRequest<N>) {
+    pub(super) async fn update(&self, request: ProverRequest<N>) {
         match request {
             ProverRequest::PoolRequest(operator_ip, share_difficulty, block_template) => {
                 // Process the pool request message.
@@ -207,7 +207,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
     ///
     /// Sends a `PoolRegister` message to the pool IP address.
     ///
-    pub async fn send_pool_register(&self) {
+    async fn send_pool_register(&self) {
         if E::NODE_TYPE == NodeType::Prover {
             if let Some(recipient) = self.address {
                 if let Some(pool_ip) = self.pool {
@@ -328,7 +328,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
     ///
     /// Initialize the miner, if the node type is a miner.
     ///
-    pub async fn start_miner(&self) {
+    async fn start_miner(&self) {
         // Initialize a new instance of the miner.
         if E::NODE_TYPE == NodeType::Miner && self.pool.is_none() {
             if let Some(recipient) = self.address {

--- a/network/src/prover.rs
+++ b/network/src/prover.rs
@@ -16,7 +16,7 @@
 
 use crate::{LedgerReader, LedgerRequest, LedgerRouter, PeersRequest, PeersRouter};
 use snarkos_environment::{
-    helpers::{NodeType, State},
+    helpers::{NodeType, Status},
     network::{Data, Message},
     Environment,
 };
@@ -234,7 +234,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
                         // already, mine the next block.
                         if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
                             // Set the status to `Mining`.
-                            E::status().update(State::Mining);
+                            E::status().update(Status::Mining);
 
                             let block_height = block_template.block_height();
                             let block_template = block_template.clone();
@@ -263,7 +263,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
                             })
                             .await;
 
-                            E::status().update(State::Ready);
+                            E::status().update(Status::Ready);
 
                             match result {
                                 Ok(Ok((nonce, proof, proof_difficulty))) => {
@@ -334,7 +334,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
                             // If `terminator` is `false` and the status is not `Peering` or `Mining` already, mine the next block.
                             if !E::terminator().load(Ordering::SeqCst) && !E::status().is_peering() && !E::status().is_mining() {
                                 // Set the status to `Mining`.
-                                E::status().update(State::Mining);
+                                E::status().update(Status::Mining);
 
                                 // Prepare the unconfirmed transactions and dependent objects.
                                 let state = prover.state.clone();
@@ -364,7 +364,7 @@ impl<N: Network, E: Environment> Prover<N, E> {
                                         .map_err(|e| e.into());
 
                                         // Set the status to `Ready`.
-                                        E::status().update(State::Ready);
+                                        E::status().update(Status::Ready);
 
                                         match result {
                                             Ok(Ok((block, coinbase_record))) => {

--- a/network/src/state.rs
+++ b/network/src/state.rs
@@ -1,0 +1,173 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use once_cell::race::OnceBox;
+use snarkos_environment::{helpers::NodeType, Environment};
+use snarkvm::prelude::*;
+use tokio::sync::oneshot;
+
+use crate::{
+    ledger::{Ledger, LedgerHandler},
+    operator::{Operator, OperatorHandler},
+    peers::{Peers, PeersHandler},
+    prover::{Prover, ProverHandler},
+};
+
+pub struct State<N: Network, E: Environment> {
+    /// The local address of the node.
+    pub local_ip: SocketAddr,
+    /// The list of peers for the node.
+    peers: OnceBox<Peers<N, E>>,
+    /// The ledger of the node.
+    ledger: OnceBox<Ledger<N, E>>,
+    /// The prover of the node.
+    prover: OnceBox<Prover<N, E>>,
+    /// The operator of the node.
+    operator: OnceBox<Operator<N, E>>,
+}
+
+impl<N: Network, E: Environment> State<N, E> {
+    pub fn new(local_ip: SocketAddr) -> Self {
+        Self {
+            local_ip,
+            peers: Default::default(),
+            ledger: Default::default(),
+            operator: Default::default(),
+            prover: Default::default(),
+        }
+    }
+
+    pub async fn initialize_peers(self: &Arc<Self>, peers: Peers<N, E>, mut peers_handler: PeersHandler<N, E>) {
+        self.peers.set(peers.into()).map_err(|_| ()).unwrap();
+
+        let state = self.clone();
+        let (router, handler) = oneshot::channel();
+        E::resources().register_task(
+            None, // No need to provide an id, as the task will run indefinitely.
+            tokio::spawn(async move {
+                // Notify the outer function that the task is ready.
+                let _ = router.send(());
+                // Asynchronously wait for a peers request.
+                while let Some(request) = peers_handler.recv().await {
+                    let state = state.clone();
+                    // Procure a resource id to register the task with, as it might be terminated at any point in time.
+                    let resource_id = E::resources().procure_id();
+                    // Asynchronously process a peers request.
+                    E::resources().register_task(
+                        Some(resource_id),
+                        tokio::spawn(async move {
+                            // Update the state of the peers.
+                            state.peers().update(request).await;
+
+                            E::resources().deregister(resource_id);
+                        }),
+                    );
+                }
+            }),
+        );
+
+        // Wait until the peers router task is ready.
+        let _ = handler.await;
+    }
+
+    pub async fn initialize_ledger(self: &Arc<Self>, ledger: Ledger<N, E>, mut ledger_handler: LedgerHandler<N>) {
+        self.ledger.set(ledger.into()).map_err(|_| ()).unwrap();
+
+        let state = self.clone();
+        let (router, handler) = oneshot::channel();
+        E::resources().register_task(
+            None, // No need to provide an id, as the task will run indefinitely.
+            tokio::spawn(async move {
+                // Notify the outer function that the task is ready.
+                let _ = router.send(());
+                // Asynchronously wait for a ledger request.
+                while let Some(request) = ledger_handler.recv().await {
+                    // Update the state of the ledger.
+                    // Note: Do not wrap this call in a `tokio::spawn` as `BlockResponse` messages
+                    // will end up being processed out of order.
+                    state.ledger().update(request).await;
+                }
+            }),
+        );
+
+        // Wait until the ledger handler is ready.
+        let _ = handler.await;
+    }
+
+    pub async fn initialize_prover(self: &Arc<Self>, prover: Prover<N, E>, mut prover_handler: ProverHandler<N>) {
+        self.prover.set(prover.into()).map_err(|_| ()).unwrap();
+
+        let state = self.clone();
+        let (router, handler) = oneshot::channel();
+        E::resources().register_task(
+            None, // No need to provide an id, as the task will run indefinitely.
+            tokio::spawn(async move {
+                // Notify the outer function that the task is ready.
+                let _ = router.send(());
+                // Asynchronously wait for a prover request.
+                while let Some(request) = prover_handler.recv().await {
+                    // Update the state of the prover.
+                    state.prover().update(request).await;
+                }
+            }),
+        );
+
+        // Wait until the prover handler is ready.
+        let _ = handler.await;
+    }
+
+    pub async fn initialize_operator(self: &Arc<Self>, operator: Operator<N, E>, mut operator_handler: OperatorHandler<N>) {
+        self.operator.set(operator.into()).map_err(|_| ()).unwrap();
+
+        if E::NODE_TYPE == NodeType::Operator {
+            // Initialize the handler for the operator.
+            let state = self.clone();
+            let (router, handler) = oneshot::channel();
+            E::resources().register_task(
+                None, // No need to provide an id, as the task will run indefinitely.
+                tokio::spawn(async move {
+                    // Notify the outer function that the task is ready.
+                    let _ = router.send(());
+                    // Asynchronously wait for a operator request.
+                    while let Some(request) = operator_handler.recv().await {
+                        state.operator().update(request).await;
+                    }
+                }),
+            );
+
+            // Wait until the operator handler is ready.
+            let _ = handler.await;
+        }
+    }
+
+    pub fn peers(&self) -> &Peers<N, E> {
+        self.peers.get().unwrap()
+    }
+
+    pub fn ledger(&self) -> &Ledger<N, E> {
+        self.ledger.get().unwrap()
+    }
+
+    pub fn prover(&self) -> &Prover<N, E> {
+        self.prover.get().unwrap()
+    }
+
+    pub fn operator(&self) -> &Operator<N, E> {
+        self.operator.get().unwrap()
+    }
+}

--- a/network/src/state.rs
+++ b/network/src/state.rs
@@ -31,6 +31,8 @@ use crate::{
 pub struct State<N: Network, E: Environment> {
     /// The local address of the node.
     pub local_ip: SocketAddr,
+    /// The Aleo address corresponding to the Node's prover and/or operator.
+    pub address: Option<Address<N>>,
     /// The list of peers for the node.
     peers: OnceBox<Peers<N, E>>,
     /// The ledger of the node.
@@ -42,9 +44,10 @@ pub struct State<N: Network, E: Environment> {
 }
 
 impl<N: Network, E: Environment> State<N, E> {
-    pub fn new(local_ip: SocketAddr) -> Self {
+    pub fn new(local_ip: SocketAddr, address: Option<Address<N>>) -> Self {
         Self {
             local_ip,
+            address,
             peers: Default::default(),
             ledger: Default::default(),
             operator: Default::default(),

--- a/rpc/src/context.rs
+++ b/rpc/src/context.rs
@@ -18,8 +18,8 @@
 
 use crate::RpcFunctions;
 use snarkos_environment::Environment;
-use snarkos_network::{LedgerReader, Operator, Peers, ProverRouter};
-use snarkvm::dpc::{Address, MemoryPool, Network};
+use snarkos_network::{LedgerReader, State};
+use snarkvm::dpc::{Address, Network};
 
 use futures::TryFutureExt;
 use jsonrpsee::{
@@ -28,7 +28,7 @@ use jsonrpsee::{
 };
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::oneshot;
 
 // The details on resource-limiting can be found at https://github.com/paritytech/jsonrpsee/blob/master/core/src/server/resource_limiting.rs
 // note: jsonrpsee expects string literals as resource names; we'll be distinguishing
@@ -42,11 +42,7 @@ const ALL_CONCURRENT_REQUESTS_LIMIT: u16 = 10;
 #[doc(hidden)]
 pub struct RpcInner<N: Network, E: Environment> {
     pub(crate) address: Option<Address<N>>,
-    pub(crate) peers: Arc<Peers<N, E>>,
-    pub(crate) ledger: LedgerReader<N>,
-    pub(crate) operator: Arc<Operator<N, E>>,
-    pub(crate) prover_router: ProverRouter<N>,
-    pub(crate) memory_pool: Arc<RwLock<MemoryPool<N>>>,
+    pub(crate) state: Arc<State<N, E>>,
     /// RPC credentials for accessing guarded endpoints
     #[allow(unused)]
     pub(crate) credentials: RpcCredentials,
@@ -68,26 +64,17 @@ impl<N: Network, E: Environment> Deref for RpcContext<N, E> {
 impl<N: Network, E: Environment> RpcContext<N, E> {
     /// Creates a new struct for calling public and private RPC endpoints.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        username: String,
-        password: String,
-        address: Option<Address<N>>,
-        peers: Arc<Peers<N, E>>,
-        ledger: LedgerReader<N>,
-        operator: Arc<Operator<N, E>>,
-        prover_router: ProverRouter<N>,
-        memory_pool: Arc<RwLock<MemoryPool<N>>>,
-    ) -> Self {
+    pub fn new(username: String, password: String, address: Option<Address<N>>, state: Arc<State<N, E>>) -> Self {
         Self(Arc::new(RpcInner {
             address,
-            peers,
-            ledger,
-            operator,
-            prover_router,
-            memory_pool,
+            state,
             credentials: RpcCredentials { username, password },
             launched: Instant::now(),
         }))
+    }
+
+    pub(crate) fn ledger(&self) -> &LedgerReader<N> {
+        self.state.ledger().reader()
     }
 }
 

--- a/rpc/src/rpc_impl.rs
+++ b/rpc/src/rpc_impl.rs
@@ -35,87 +35,87 @@ use std::{cmp::max, net::SocketAddr};
 impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
     /// Returns the latest block from the canonical chain.
     async fn latest_block(&self) -> Result<Block<N>, RpcError> {
-        Ok(self.ledger.latest_block())
+        Ok(self.ledger().latest_block())
     }
 
     /// Returns the latest block height from the canonical chain.
     async fn latest_block_height(&self) -> Result<u32, RpcError> {
-        Ok(self.ledger.latest_block_height())
+        Ok(self.ledger().latest_block_height())
     }
 
     /// Returns the latest cumulative weight from the canonical chain.
     async fn latest_cumulative_weight(&self) -> Result<u128, RpcError> {
-        Ok(self.ledger.latest_cumulative_weight())
+        Ok(self.ledger().latest_cumulative_weight())
     }
 
     /// Returns the latest block hash from the canonical chain.
     async fn latest_block_hash(&self) -> Result<N::BlockHash, RpcError> {
-        Ok(self.ledger.latest_block_hash())
+        Ok(self.ledger().latest_block_hash())
     }
 
     /// Returns the latest block header from the canonical chain.
     async fn latest_block_header(&self) -> Result<BlockHeader<N>, RpcError> {
-        Ok(self.ledger.latest_block_header())
+        Ok(self.ledger().latest_block_header())
     }
 
     /// Returns the latest block transactions from the canonical chain.
     async fn latest_block_transactions(&self) -> Result<Transactions<N>, RpcError> {
-        Ok(self.ledger.latest_block_transactions())
+        Ok(self.ledger().latest_block_transactions())
     }
 
     /// Returns the latest ledger root from the canonical chain.
     async fn latest_ledger_root(&self) -> Result<N::LedgerRoot, RpcError> {
-        Ok(self.ledger.latest_ledger_root())
+        Ok(self.ledger().latest_ledger_root())
     }
 
     /// Returns the block given the block height.
     async fn get_block(&self, block_height: u32) -> Result<Block<N>, RpcError> {
-        Ok(self.ledger.get_block(block_height)?)
+        Ok(self.ledger().get_block(block_height)?)
     }
 
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` blocks from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        Ok(self.ledger.get_blocks(safe_start_height, end_block_height)?)
+        Ok(self.ledger().get_blocks(safe_start_height, end_block_height)?)
     }
 
     /// Returns the block height for the given the block hash.
     async fn get_block_height(&self, block_hash: N::BlockHash) -> Result<u32, RpcError> {
-        Ok(self.ledger.get_block_height(&block_hash)?)
+        Ok(self.ledger().get_block_height(&block_hash)?)
     }
 
     /// Returns the block hash for the given block height, if it exists in the canonical chain.
     async fn get_block_hash(&self, block_height: u32) -> Result<N::BlockHash, RpcError> {
-        Ok(self.ledger.get_block_hash(block_height)?)
+        Ok(self.ledger().get_block_hash(block_height)?)
     }
 
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` block hashes from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_block_hashes(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<N::BlockHash>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        Ok(self.ledger.get_block_hashes(safe_start_height, end_block_height)?)
+        Ok(self.ledger().get_block_hashes(safe_start_height, end_block_height)?)
     }
 
     /// Returns the block header for the given the block height.
     async fn get_block_header(&self, block_height: u32) -> Result<BlockHeader<N>, RpcError> {
-        Ok(self.ledger.get_block_header(block_height)?)
+        Ok(self.ledger().get_block_header(block_height)?)
     }
 
     /// Returns the block template for the next mined block
     async fn get_block_template(&self) -> Result<Value, RpcError> {
         // Fetch the latest state from the ledger.
-        let latest_block = self.ledger.latest_block();
-        let ledger_root = self.ledger.latest_ledger_root();
+        let latest_block = self.ledger().latest_block();
+        let ledger_root = self.ledger().latest_ledger_root();
 
         // Prepare the new block.
         let previous_block_hash = latest_block.hash();
-        let block_height = self.ledger.latest_block_height() + 1;
+        let block_height = self.ledger().latest_block_height() + 1;
         let block_timestamp = OffsetDateTime::now_utc().unix_timestamp();
 
         // Compute the block difficulty target.
         let difficulty_target = if N::NETWORK_ID == 2 && block_height <= snarkvm::dpc::testnet2::V12_UPGRADE_BLOCK_HEIGHT {
             Blocks::<N>::compute_difficulty_target(latest_block.header(), block_timestamp, block_height)
         } else if N::NETWORK_ID == 2 {
-            let anchor_block_header = self.ledger.get_block_header(snarkvm::dpc::testnet2::V12_UPGRADE_BLOCK_HEIGHT)?;
+            let anchor_block_header = self.ledger().get_block_header(snarkvm::dpc::testnet2::V12_UPGRADE_BLOCK_HEIGHT)?;
             Blocks::<N>::compute_difficulty_target(&anchor_block_header, block_timestamp, block_height)
         } else {
             Blocks::<N>::compute_difficulty_target(N::genesis_block().header(), block_timestamp, block_height)
@@ -132,20 +132,22 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
 
         // Get and filter the transactions from the mempool.
         let transactions: Vec<String> = self
-            .memory_pool
+            .state
+            .prover()
+            .memory_pool()
             .read()
             .await
             .transactions()
             .iter()
             .filter(|transaction| {
                 for serial_number in transaction.serial_numbers() {
-                    if let Ok(true) = self.ledger.contains_serial_number(serial_number) {
+                    if let Ok(true) = self.ledger().contains_serial_number(serial_number) {
                         return false;
                     }
                 }
 
                 for commitment in transaction.commitments() {
-                    if let Ok(true) = self.ledger.contains_commitment(commitment) {
+                    if let Ok(true) = self.ledger().contains_commitment(commitment) {
                         return false;
                     }
                 }
@@ -178,54 +180,54 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
 
     /// Returns the transactions from the block of the given block height.
     async fn get_block_transactions(&self, block_height: u32) -> Result<Transactions<N>, RpcError> {
-        Ok(self.ledger.get_block_transactions(block_height)?)
+        Ok(self.ledger().get_block_transactions(block_height)?)
     }
 
     /// Returns the ciphertext given the commitment.
     async fn get_ciphertext(&self, commitment: N::Commitment) -> Result<N::RecordCiphertext, RpcError> {
-        Ok(self.ledger.get_ciphertext(&commitment)?)
+        Ok(self.ledger().get_ciphertext(&commitment)?)
     }
 
     /// Returns the ledger proof for a given record commitment.
     async fn get_ledger_proof(&self, record_commitment: N::Commitment) -> Result<String, RpcError> {
-        let ledger_proof = self.ledger.get_ledger_inclusion_proof(record_commitment)?;
+        let ledger_proof = self.ledger().get_ledger_inclusion_proof(record_commitment)?;
         Ok(hex::encode(ledger_proof.to_bytes_le().expect("Failed to serialize ledger proof")))
     }
 
     /// Returns transactions in the node's memory pool.
     async fn get_memory_pool(&self) -> Result<Vec<Transaction<N>>, RpcError> {
-        Ok(self.memory_pool.read().await.transactions())
+        Ok(self.state.prover().memory_pool().read().await.transactions())
     }
 
     /// Returns a transaction with metadata and decrypted records given the transaction ID.
     async fn get_transaction(&self, transaction_id: N::TransactionID) -> Result<Value, RpcError> {
-        let transaction: Transaction<N> = self.ledger.get_transaction(&transaction_id)?;
-        let metadata = self.ledger.get_transaction_metadata(&transaction_id)?;
+        let transaction: Transaction<N> = self.ledger().get_transaction(&transaction_id)?;
+        let metadata = self.ledger().get_transaction_metadata(&transaction_id)?;
         let decrypted_records: Vec<Record<N>> = transaction.to_records().collect();
         Ok(serde_json::json!({ "transaction": transaction, "metadata": metadata, "decrypted_records": decrypted_records }))
     }
 
     /// Returns a transition given the transition ID.
     async fn get_transition(&self, transition_id: N::TransitionID) -> Result<Transition<N>, RpcError> {
-        Ok(self.ledger.get_transition(&transition_id)?)
+        Ok(self.ledger().get_transition(&transition_id)?)
     }
 
     /// Returns the peers currently connected to this node.
     async fn get_connected_peers(&self) -> Result<Vec<SocketAddr>, RpcError> {
-        Ok(self.peers.connected_peers().await)
+        Ok(self.state.peers().connected_peers().await)
     }
 
     /// Returns the current state of this node.
     async fn get_node_state(&self) -> Result<Value, RpcError> {
-        let candidate_peers = self.peers.candidate_peers().await;
-        let connected_peers = self.peers.connected_peers().await;
+        let candidate_peers = self.state.peers().candidate_peers().await;
+        let connected_peers = self.state.peers().connected_peers().await;
         let number_of_candidate_peers = candidate_peers.len();
         let number_of_connected_peers = connected_peers.len();
-        let number_of_connected_sync_nodes = self.peers.number_of_connected_sync_nodes().await;
+        let number_of_connected_sync_nodes = self.state.peers().number_of_connected_sync_nodes().await;
 
-        let latest_block_hash = self.ledger.latest_block_hash();
-        let latest_block_height = self.ledger.latest_block_height();
-        let latest_cumulative_weight = self.ledger.latest_cumulative_weight();
+        let latest_block_hash = self.ledger().latest_block_hash();
+        let latest_block_height = self.ledger().latest_block_height();
+        let latest_cumulative_weight = self.ledger().latest_cumulative_weight();
 
         Ok(serde_json::json!({
             "address": self.address,
@@ -250,7 +252,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
         let transaction: Transaction<N> = FromBytes::from_bytes_le(&hex::decode(transaction_hex)?)?;
         // Route an `UnconfirmedTransaction` to the prover.
         let request = ProverRequest::UnconfirmedTransaction("0.0.0.0:3032".parse().unwrap(), transaction.clone());
-        if let Err(error) = self.prover_router.send(request).await {
+        if let Err(error) = self.state.prover().router().send(request).await {
             warn!("[UnconfirmedTransaction] {}", error);
         }
         Ok(transaction.transaction_id())
@@ -258,18 +260,18 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
 
     /// Returns the amount of shares submitted by a given prover.
     async fn get_shares_for_prover(&self, prover: Address<N>) -> Result<u64, RpcError> {
-        Ok(self.operator.get_shares_for_prover(&prover))
+        Ok(self.state.operator().get_shares_for_prover(&prover))
     }
 
     /// Returns the amount of shares submitted to the operator in total.
     async fn get_shares(&self) -> u64 {
-        let shares = self.operator.to_shares();
+        let shares = self.state.operator().to_shares();
         shares.iter().map(|(_, share)| share.values().sum::<u64>()).sum()
     }
 
     /// Returns a list of all provers that have submitted shares to the operator.
     async fn get_provers(&self) -> Value {
-        let provers = self.operator.get_provers();
+        let provers = self.state.operator().get_provers();
         serde_json::json!(provers)
     }
 }

--- a/rpc/src/tests.rs
+++ b/rpc/src/tests.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{initialize_rpc_server, rpc_trait::RpcFunctions, RpcContext};
-use snarkos_environment::{helpers::State, Client, CurrentNetwork, Environment};
+use snarkos_environment::{helpers::Status, Client, CurrentNetwork, Environment};
 use snarkos_network::{ledger::Ledger, Operator, Peers, Prover};
 use snarkos_storage::{
     storage::{rocksdb::RocksDB, Storage},
@@ -78,7 +78,7 @@ async fn new_rpc_context<N: Network, E: Environment, S: Storage, P: AsRef<Path>>
     let node_addr: SocketAddr = "127.0.0.1:8888".parse().expect("Failed to parse ip");
 
     // Initialize the status indicator.
-    E::status().update(State::Ready);
+    E::status().update(Status::Ready);
 
     // Derive the storage paths.
     let (ledger_path, prover_path, operator_storage_path) = (path.as_ref().to_path_buf(), temp_dir(), temp_dir());

--- a/rpc/src/tests.rs
+++ b/rpc/src/tests.rs
@@ -84,7 +84,7 @@ async fn new_rpc_context<N: Network, E: Environment, S: Storage, P: AsRef<Path>>
     // Derive the storage paths.
     let (ledger_path, prover_path, operator_storage_path) = (path.as_ref().to_path_buf(), temp_dir(), temp_dir());
 
-    let state = Arc::new(State::new(node_addr));
+    let state = Arc::new(State::new(node_addr, None));
 
     // Initialize a new instance for managing peers.
     let (peers, peers_handler) = Peers::new(None, state.clone()).await;
@@ -95,7 +95,7 @@ async fn new_rpc_context<N: Network, E: Environment, S: Storage, P: AsRef<Path>>
         .expect("Failed to initialize ledger");
 
     // Initialize a new instance for managing the prover.
-    let (prover, prover_handler) = Prover::open::<S, _>(&prover_path, None, Some(node_addr), state.clone())
+    let (prover, prover_handler) = Prover::open::<S, _>(&prover_path, Some(node_addr), state.clone())
         .await
         .expect("Failed to initialize prover");
 

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -128,7 +128,7 @@ impl<N: Network, E: Environment> Server<N, E> {
 
     #[inline]
     pub async fn disconnect_from(&self, peer_ip: SocketAddr, reason: DisconnectReason) {
-        self.ledger.disconnect(peer_ip, reason).await
+        self.state.ledger().disconnect(peer_ip, reason).await
     }
 
     ///

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -21,10 +21,11 @@ use snarkos_environment::{
     Environment,
 };
 use snarkos_network::{
-    ledger::{Ledger, LedgerReader, LedgerRequest, LedgerRouter},
-    operator::{Operator, OperatorRouter},
-    peers::{Peers, PeersRequest, PeersRouter},
-    prover::{Prover, ProverRouter},
+    ledger::{Ledger, LedgerRequest},
+    operator::Operator,
+    peers::{Peers, PeersRequest},
+    prover::Prover,
+    State,
 };
 use snarkos_storage::storage::rocksdb::RocksDB;
 use snarkvm::prelude::*;
@@ -34,9 +35,8 @@ use snarkos_rpc::{initialize_rpc_server, RpcContext};
 
 #[cfg(any(feature = "test", feature = "prometheus"))]
 use snarkos_metrics as metrics;
-
-#[cfg(feature = "rpc")]
-use tokio::sync::RwLock;
+#[cfg(any(feature = "test", feature = "prometheus"))]
+use snarkos_network::LedgerReader;
 
 use anyhow::Result;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
@@ -47,23 +47,13 @@ use tokio::{net::TcpListener, sync::oneshot, task};
 ///
 #[derive(Clone)]
 pub struct Server<N: Network, E: Environment> {
-    /// The local address of the node.
-    local_ip: SocketAddr,
-    /// The list of peers for the node.
-    peers: Arc<Peers<N, E>>,
-    /// The ledger of the node.
-    ledger: Arc<Ledger<N, E>>,
-    /// The operator of the node.
-    operator: Arc<Operator<N, E>>,
-    /// The prover of the node.
-    prover: Arc<Prover<N, E>>,
+    pub state: Arc<State<N, E>>,
 }
 
 impl<N: Network, E: Environment> Server<N, E> {
     ///
     /// Starts the connection listener for peers.
     ///
-    #[inline]
     pub async fn initialize(node: &Node, address: Option<Address<N>>, pool_ip: Option<SocketAddr>) -> Result<Self> {
         // Initialize a new TCP listener at the given IP.
         let (local_ip, listener) = match TcpListener::bind(node.node).await {
@@ -78,158 +68,59 @@ impl<N: Network, E: Environment> Server<N, E> {
         // Initialize the prover storage path.
         let prover_storage_path = node.prover_storage_path(local_ip);
 
+        // Initialize the shared state.
+        let state = Arc::new(State::new(local_ip));
+
         // Initialize a new instance for managing peers.
-        let peers = Peers::new(local_ip, None).await;
+        let (peers, peers_handler) = Peers::new(None, state.clone()).await;
+
         // Initialize a new instance for managing the ledger.
-        let ledger = Ledger::<N, E>::open::<RocksDB, _>(&ledger_storage_path, peers.router()).await?;
+        let (ledger, ledger_handler) = Ledger::<N, E>::open::<RocksDB, _>(&ledger_storage_path, state.clone()).await?;
+
         // Initialize a new instance for managing the prover.
-        let prover = Prover::open::<RocksDB, _>(
-            &prover_storage_path,
-            address,
-            local_ip,
-            pool_ip,
-            peers.router(),
-            ledger.reader(),
-            ledger.router(),
-        )
-        .await?;
+        let (prover, prover_handler) = Prover::open::<RocksDB, _>(&prover_storage_path, address, pool_ip, state.clone()).await?;
+
         // Initialize a new instance for managing the operator.
-        let operator = Operator::open::<RocksDB, _>(
-            &operator_storage_path,
-            address,
-            local_ip,
-            prover.memory_pool(),
-            peers.router(),
-            ledger.reader(),
-            ledger.router(),
-            prover.router(),
-        )
-        .await?;
-
-        // TODO (howardwu): This is a hack for the prover.
-        //  Check that the prover is connected to the pool before sending a PoolRegister message.
-        if let Some(pool_ip) = pool_ip {
-            let peers_router = peers.router();
-            let ledger_reader = ledger.reader();
-            let ledger_router = ledger.router();
-            let operator_router = operator.router();
-            let prover_router = prover.router();
-
-            let (router, handler) = oneshot::channel();
-            E::resources().register_task(
-                None, // No need to provide an id, as the task will run indefinitely.
-                task::spawn(async move {
-                    // Notify the outer function that the task is ready.
-                    let _ = router.send(());
-                    loop {
-                        // Initialize the connection process.
-                        let (router, handler) = oneshot::channel();
-                        // Route a `Connect` request to the pool.
-                        if let Err(error) = peers_router
-                            .send(PeersRequest::Connect(
-                                pool_ip,
-                                ledger_reader.clone(),
-                                ledger_router.clone(),
-                                operator_router.clone(),
-                                prover_router.clone(),
-                                router,
-                            ))
-                            .await
-                        {
-                            trace!("[Connect] {}", error);
-                        }
-                        // Wait until the connection task is initialized.
-                        let _ = handler.await;
-
-                        // Sleep for `30` seconds.
-                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                    }
-                }),
-            );
-
-            // Wait until the prover handler is ready.
-            let _ = handler.await;
-        }
-
-        // Initialize the connection listener for new peers.
-        Self::initialize_listener(
-            local_ip,
-            listener,
-            peers.clone(),
-            ledger.reader(),
-            ledger.router(),
-            operator.router(),
-            prover.router(),
-        )
-        .await;
-
-        // Initialize a new instance of the heartbeat.
-        Self::initialize_heartbeat(peers.router(), ledger.reader(), ledger.router(), operator.router(), prover.router()).await;
-
-        #[cfg(feature = "rpc")]
-        // Initialize a new instance of the RPC server.
-        Self::initialize_rpc(
-            node,
-            address,
-            peers.clone(),
-            ledger.reader(),
-            operator.clone(),
-            prover.router(),
-            prover.memory_pool(),
-        )
-        .await;
-
-        // Initialize a new instance of the notification.
-        Self::initialize_notification(ledger.reader(), prover.clone(), address).await;
+        let (operator, operator_handler) = Operator::open::<RocksDB, _>(&operator_storage_path, state.clone()).await?;
 
         // Initialise the metrics exporter.
         #[cfg(any(feature = "test", feature = "prometheus"))]
-        Self::initialize_metrics(ledger.reader());
+        Self::initialize_metrics(ledger.reader().clone());
 
-        Ok(Self {
-            local_ip,
-            peers,
-            ledger,
-            operator,
-            prover,
-        })
+        let server = Self { state };
+
+        server.state.initialize_peers(peers, peers_handler).await;
+        server.state.initialize_ledger(ledger, ledger_handler).await;
+        server.state.initialize_prover(prover, prover_handler).await;
+        server.state.initialize_operator(operator, operator_handler).await;
+
+        server.state.prover().initialize_miner().await;
+        server.state.prover().initialize_pooling().await;
+        server.state.prover().initialize_pool_connection_loop(pool_ip).await;
+        server.state.operator().initialize().await;
+
+        server.initialize_notification(address).await;
+        server.initialize_listener(listener).await;
+        server.initialize_heartbeat().await;
+        server.initialize_rpc(node, address).await;
+
+        Ok(server)
     }
 
     /// Returns the IP address of this node.
     pub fn local_ip(&self) -> SocketAddr {
-        self.local_ip
-    }
-
-    /// Returns the peer manager of this node.
-    pub fn peers(&self) -> Arc<Peers<N, E>> {
-        self.peers.clone()
-    }
-
-    /// Returns the ledger of this node.
-    pub fn ledger(&self) -> Arc<Ledger<N, E>> {
-        self.ledger.clone()
+        self.state.local_ip
     }
 
     ///
     /// Sends a connection request to the given IP address.
     ///
-    #[inline]
     pub async fn connect_to(&self, peer_ip: SocketAddr) -> Result<()> {
         // Initialize the connection process.
         let (router, handler) = oneshot::channel();
 
         // Route a `Connect` request to the peer manager.
-        self.peers
-            .router()
-            .send(PeersRequest::Connect(
-                peer_ip,
-                self.ledger.reader(),
-                self.ledger.router(),
-                self.operator.router(),
-                self.prover.router(),
-                router,
-            ))
-            .await?;
+        self.state.peers().router().send(PeersRequest::Connect(peer_ip, router)).await?;
 
         // Wait until the connection task is initialized.
         handler.await.map(|_| ()).map_err(|e| e.into())
@@ -243,7 +134,6 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     /// Disconnects from peers and proceeds to shut down the node.
     ///
-    #[inline]
     pub async fn shut_down(&self) {
         info!("Shutting down...");
         // Update the node status.
@@ -251,7 +141,7 @@ impl<N: Network, E: Environment> Server<N, E> {
 
         // Shut down the ledger.
         trace!("Proceeding to shut down the ledger...");
-        self.ledger.shut_down().await;
+        self.state.ledger().shut_down().await;
 
         // Flush the tasks.
         E::resources().shut_down();
@@ -261,40 +151,25 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     /// Initialize the connection listener for new peers.
     ///
-    #[inline]
-    async fn initialize_listener(
-        local_ip: SocketAddr,
-        listener: TcpListener,
-        peers: Arc<Peers<N, E>>,
-        ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
-        operator_router: OperatorRouter<N>,
-        prover_router: ProverRouter<N>,
-    ) {
+    async fn initialize_listener(&self, listener: TcpListener) {
         // Initialize the listener process.
         let (router, handler) = oneshot::channel();
+        let state = self.state.clone();
         E::resources().register_task(
             None, // No need to provide an id, as the task will run indefinitely.
             task::spawn(async move {
                 // Notify the outer function that the task is ready.
                 let _ = router.send(());
-                info!("Listening for peers at {}", local_ip);
+                info!("Listening for peers at {}", state.local_ip);
                 loop {
                     // Don't accept connections if the node is breaching the configured peer limit.
-                    if peers.number_of_connected_peers().await < E::MAXIMUM_NUMBER_OF_PEERS {
+                    if state.peers().number_of_connected_peers().await < E::MAXIMUM_NUMBER_OF_PEERS {
                         // Asynchronously wait for an inbound TcpStream.
                         match listener.accept().await {
                             // Process the inbound connection request.
                             Ok((stream, peer_ip)) => {
-                                let request = PeersRequest::PeerConnecting(
-                                    stream,
-                                    peer_ip,
-                                    ledger_reader.clone(),
-                                    ledger_router.clone(),
-                                    operator_router.clone(),
-                                    prover_router.clone(),
-                                );
-                                if let Err(error) = peers.router().send(request).await {
+                                let request = PeersRequest::PeerConnecting(stream, peer_ip);
+                                if let Err(error) = state.peers().router().send(request).await {
                                     error!("Failed to send request to peers: {}", error)
                                 }
                             }
@@ -317,16 +192,10 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     /// Initialize a new instance of the heartbeat.
     ///
-    #[inline]
-    async fn initialize_heartbeat(
-        peers_router: PeersRouter<N, E>,
-        ledger_reader: LedgerReader<N>,
-        ledger_router: LedgerRouter<N>,
-        operator_router: OperatorRouter<N>,
-        prover_router: ProverRouter<N>,
-    ) {
+    async fn initialize_heartbeat(&self) {
         // Initialize the heartbeat process.
         let (router, handler) = oneshot::channel();
+        let state = self.state.clone();
         E::resources().register_task(
             None, // No need to provide an id, as the task will run indefinitely.
             task::spawn(async move {
@@ -334,17 +203,12 @@ impl<N: Network, E: Environment> Server<N, E> {
                 let _ = router.send(());
                 loop {
                     // Transmit a heartbeat request to the ledger.
-                    if let Err(error) = ledger_router.send(LedgerRequest::Heartbeat(prover_router.clone())).await {
+                    if let Err(error) = state.ledger().router().send(LedgerRequest::Heartbeat).await {
                         error!("Failed to send heartbeat to ledger: {}", error)
                     }
                     // Transmit a heartbeat request to the peers.
-                    let request = PeersRequest::Heartbeat(
-                        ledger_reader.clone(),
-                        ledger_router.clone(),
-                        operator_router.clone(),
-                        prover_router.clone(),
-                    );
-                    if let Err(error) = peers_router.send(request).await {
+                    let request = PeersRequest::Heartbeat;
+                    if let Err(error) = state.peers().router().send(request).await {
                         error!("Failed to send heartbeat to peers: {}", error)
                     }
                     // Sleep for `E::HEARTBEAT_IN_SECS` seconds.
@@ -360,29 +224,11 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     /// Initialize a new instance of the RPC server.
     ///
-    #[inline]
     #[cfg(feature = "rpc")]
-    async fn initialize_rpc(
-        node: &Node,
-        address: Option<Address<N>>,
-        peers: Arc<Peers<N, E>>,
-        ledger_reader: LedgerReader<N>,
-        operator: Arc<Operator<N, E>>,
-        prover_router: ProverRouter<N>,
-        memory_pool: Arc<RwLock<MemoryPool<N>>>,
-    ) {
+    async fn initialize_rpc(&self, node: &Node, address: Option<Address<N>>) {
         if !node.norpc {
             // Initialize a new instance of the RPC server.
-            let rpc_context = RpcContext::new(
-                node.rpc_username.clone(),
-                node.rpc_password.clone(),
-                address,
-                peers,
-                ledger_reader,
-                operator,
-                prover_router,
-                memory_pool,
-            );
+            let rpc_context = RpcContext::new(node.rpc_username.clone(), node.rpc_password.clone(), address, self.state.clone());
             let (rpc_server_addr, rpc_server_handle) = initialize_rpc_server::<N, E>(node.rpc, rpc_context).await;
 
             debug!("JSON-RPC server listening on {}", rpc_server_addr);
@@ -395,10 +241,10 @@ impl<N: Network, E: Environment> Server<N, E> {
     ///
     /// Initialize a new instance of the notification.
     ///
-    #[inline]
-    async fn initialize_notification(ledger: LedgerReader<N>, prover: Arc<Prover<N, E>>, address: Option<Address<N>>) {
+    async fn initialize_notification(&self, address: Option<Address<N>>) {
         // Initialize the heartbeat process.
         let (router, handler) = oneshot::channel();
+        let state = self.state.clone();
         E::resources().register_task(
             None, // No need to provide an id, as the task will run indefinitely.
             task::spawn(async move {
@@ -410,16 +256,16 @@ impl<N: Network, E: Environment> Server<N, E> {
                     if E::NODE_TYPE == NodeType::Miner {
                         if let Some(miner_address) = address {
                             // Retrieve the latest block height.
-                            let latest_block_height = ledger.latest_block_height();
+                            let latest_block_height = state.ledger().reader().latest_block_height();
 
                             // Prepare a list of confirmed and pending coinbase records.
                             let mut confirmed = vec![];
                             let mut pending = vec![];
 
                             // Iterate through the coinbase records from storage.
-                            for (block_height, record) in prover.to_coinbase_records() {
+                            for (block_height, record) in state.prover().to_coinbase_records() {
                                 // Filter the coinbase records by determining if they exist on the canonical chain.
-                                if let Ok(true) = ledger.contains_commitment(&record.commitment()) {
+                                if let Ok(true) = state.ledger().reader().contains_commitment(&record.commitment()) {
                                     // Ensure the record owner matches.
                                     if record.owner() == miner_address {
                                         // Add the block to the appropriate list.

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -16,7 +16,7 @@
 
 use crate::{display::notification_message, Node};
 use snarkos_environment::{
-    helpers::{NodeType, State},
+    helpers::{NodeType, Status},
     network::DisconnectReason,
     Environment,
 };
@@ -247,7 +247,7 @@ impl<N: Network, E: Environment> Server<N, E> {
     pub async fn shut_down(&self) {
         info!("Shutting down...");
         // Update the node status.
-        E::status().update(State::ShuttingDown);
+        E::status().update(Status::ShuttingDown);
 
         // Shut down the ledger.
         trace!("Proceeding to shut down the ledger...");

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -69,7 +69,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         let prover_storage_path = node.prover_storage_path(local_ip);
 
         // Initialize the shared state.
-        let state = Arc::new(State::new(local_ip));
+        let state = Arc::new(State::new(local_ip, address));
 
         // Initialize a new instance for managing peers.
         let (peers, peers_handler) = Peers::new(None, state.clone()).await;
@@ -78,7 +78,7 @@ impl<N: Network, E: Environment> Server<N, E> {
         let (ledger, ledger_handler) = Ledger::<N, E>::open::<RocksDB, _>(&ledger_storage_path, state.clone()).await?;
 
         // Initialize a new instance for managing the prover.
-        let (prover, prover_handler) = Prover::open::<RocksDB, _>(&prover_storage_path, address, pool_ip, state.clone()).await?;
+        let (prover, prover_handler) = Prover::open::<RocksDB, _>(&prover_storage_path, pool_ip, state.clone()).await?;
 
         // Initialize a new instance for managing the operator.
         let (operator, operator_handler) = Operator::open::<RocksDB, _>(&operator_storage_path, state.clone()).await?;


### PR DESCRIPTION
This PR is purely a refactoring and despite the rather large diff, it introduces no changes to the current functionalities, other than the order of some operations when the node is started.

There are 2 main changes:
1. [rename `Status` to `RawStatus` and `State` to `Status`](https://github.com/AleoHQ/snarkOS/commit/0851bd0c10456a35234ad92e6d4d7b8ceda194db): both of these objects refer to the same thing, so their names should match as well; also, this allows the new combined state object to be named `State`
2. [introduce a `State` object](https://github.com/AleoHQ/snarkOS/commit/0ee6be33ec34c154b56fb5c112610950b5a9d70e): the current node structure involves a few actor-like objects that communicate with one another; this is fine, but the state of the actors overlaps, can't really be fully isolated, and adds plenty of extra complexity; this change proposes a combined `State` object shared between the main actors, allowing the communication between them to be much simpler, while not changing the way their channels are utilized or the scopes of their functionalities; this setup reduces code complexity and will enable further improvements to the overall structure