### PR TITLE
Safer storage traits

### DIFF
--- a/network/src/helpers/block_requests.rs
+++ b/network/src/helpers/block_requests.rs
@@ -16,7 +16,7 @@
 
 use crate::ledger::PeersState;
 use snarkos_environment::{helpers::BlockLocators, network::DisconnectReason, Environment};
-use snarkos_storage::LedgerState;
+use snarkos_storage::{storage::StorageAccess, LedgerState};
 use snarkvm::dpc::prelude::*;
 
 use std::net::SocketAddr;
@@ -63,7 +63,10 @@ pub fn find_maximal_peer<N: Network, E: Environment>(
 
 /// Returns the common ancestor and the first deviating locator (if it exists),
 /// given the block locators of a peer. If the peer has invalid block locators, returns an error.
-pub fn find_common_ancestor<N: Network>(canon: &LedgerState<N>, block_locators: &BlockLocators<N>) -> Result<(u32, Option<u32>), String> {
+pub fn find_common_ancestor<N: Network, A: StorageAccess>(
+    canon: &LedgerState<N, A>,
+    block_locators: &BlockLocators<N>,
+) -> Result<(u32, Option<u32>), String> {
     // Determine the common ancestor block height between this ledger and the peer.
     let mut maximum_common_ancestor = 0;
     // Determine the first locator (smallest height) that does not exist in this ledger.

--- a/snarkos/server.rs
+++ b/snarkos/server.rs
@@ -27,7 +27,6 @@ use snarkos_network::{
     prover::Prover,
     State,
 };
-use snarkos_storage::storage::rocksdb::RocksDB;
 use snarkvm::prelude::*;
 
 #[cfg(feature = "rpc")]
@@ -75,13 +74,13 @@ impl<N: Network, E: Environment> Server<N, E> {
         let (peers, peers_handler) = Peers::new(None, state.clone()).await;
 
         // Initialize a new instance for managing the ledger.
-        let (ledger, ledger_handler) = Ledger::<N, E>::open::<RocksDB, _>(&ledger_storage_path, state.clone()).await?;
+        let (ledger, ledger_handler) = Ledger::<N, E>::open::<_>(&ledger_storage_path, state.clone()).await?;
 
         // Initialize a new instance for managing the prover.
-        let (prover, prover_handler) = Prover::open::<RocksDB, _>(&prover_storage_path, pool_ip, state.clone()).await?;
+        let (prover, prover_handler) = Prover::open::<_>(&prover_storage_path, pool_ip, state.clone()).await?;
 
         // Initialize a new instance for managing the operator.
-        let (operator, operator_handler) = Operator::open::<RocksDB, _>(&operator_storage_path, state.clone()).await?;
+        let (operator, operator_handler) = Operator::open::<_>(&operator_storage_path, state.clone()).await?;
 
         // Initialise the metrics exporter.
         #[cfg(any(feature = "test", feature = "prometheus"))]

--- a/storage/benches/insertion.rs
+++ b/storage/benches/insertion.rs
@@ -16,7 +16,7 @@
 
 use snarkos_environment::CurrentNetwork;
 use snarkos_storage::{
-    storage::{rocksdb::RocksDB, Storage},
+    storage::{rocksdb::RocksDB, ReadWrite, Storage},
     LedgerState,
 };
 
@@ -30,7 +30,7 @@ const NUM_BLOCKS: u32 = 1_000;
 fn insertion(c: &mut Criterion) {
     let temp_dir1 = tempfile::tempdir().expect("Failed to open temporary directory").into_path();
     // Create an empty ledger.
-    let ledger1: LedgerState<CurrentNetwork> =
+    let ledger1: LedgerState<CurrentNetwork, ReadWrite> =
         LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir1, 1).expect("Failed to initialize ledger");
     // Import a dump of a ledger containing 1k blocks.
     ledger1
@@ -39,7 +39,7 @@ fn insertion(c: &mut Criterion) {
         .expect("Couldn't import the test ledger");
     // Reopen the ledger so that it applies the storage changes to its in-memory components.
     drop(ledger1);
-    let ledger1: LedgerState<CurrentNetwork> =
+    let ledger1: LedgerState<CurrentNetwork, ReadWrite> =
         LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir1, NUM_BLOCKS).expect("Failed to initialize ledger");
 
     // Prepare a second test ledger that will be importing blocks belonging to the first one.

--- a/storage/benches/lookups.rs
+++ b/storage/benches/lookups.rs
@@ -16,7 +16,7 @@
 
 use snarkos_environment::CurrentNetwork;
 use snarkos_storage::{
-    storage::{rocksdb::RocksDB, Map, MapId, Storage},
+    storage::{rocksdb::RocksDB, MapId, MapRead, ReadWrite, Storage},
     LedgerState,
     Metadata,
 };
@@ -32,7 +32,7 @@ const NUM_BLOCKS: u32 = 1_000;
 fn lookups(c: &mut Criterion) {
     let temp_dir = tempfile::tempdir().expect("Failed to open temporary directory").into_path();
     // Create an empty ledger.
-    let ledger: LedgerState<CurrentNetwork> =
+    let ledger: LedgerState<CurrentNetwork, ReadWrite> =
         LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir, 1).expect("Failed to initialize ledger");
     // Import a dump of a ledger containing 1k blocks.
     ledger

--- a/storage/benches/opening.rs
+++ b/storage/benches/opening.rs
@@ -16,7 +16,7 @@
 
 use snarkos_environment::CurrentNetwork;
 use snarkos_storage::{
-    storage::{rocksdb::RocksDB, Storage},
+    storage::{rocksdb::RocksDB, ReadWrite, Storage},
     LedgerState,
 };
 
@@ -30,7 +30,7 @@ const NUM_BLOCKS: u32 = 1_000;
 fn opening(c: &mut Criterion) {
     let temp_dir = tempfile::tempdir().expect("Failed to open temporary directory").into_path();
     // Create an empty ledger.
-    let ledger: LedgerState<CurrentNetwork> =
+    let ledger: LedgerState<CurrentNetwork, ReadWrite> =
         LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir, 1).expect("Failed to initialize ledger");
     // Import a dump of a ledger containing 1k blocks.
     ledger
@@ -42,7 +42,7 @@ fn opening(c: &mut Criterion) {
 
     c.bench_function("Ledger::open_writer", |b| {
         b.iter(|| {
-            let _ledger: LedgerState<CurrentNetwork> =
+            let _ledger: LedgerState<CurrentNetwork, ReadWrite> =
                 LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir, NUM_BLOCKS).expect("Failed to initialize ledger");
         })
     });

--- a/storage/src/state/prover.rs
+++ b/storage/src/state/prover.rs
@@ -14,26 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::storage::{DataMap, Map, MapId, Storage};
+use crate::storage::{DataMap, MapId, MapRead, MapReadWrite, Storage, StorageAccess, StorageReadWrite};
 use snarkvm::dpc::prelude::*;
 
 use anyhow::{anyhow, Result};
 use std::path::Path;
 
 #[derive(Debug)]
-pub struct ProverState<N: Network> {
+pub struct ProverState<N: Network, A: StorageAccess> {
     /// The coinbase records of the prover in storage.
-    coinbase: CoinbaseState<N>,
+    coinbase: CoinbaseState<N, A>,
 }
 
-impl<N: Network> ProverState<N> {
-    ///
+impl<N: Network, A: StorageAccess> ProverState<N, A> {
     /// Opens a new instance of `ProverState` from the given storage path.
-    ///
-    pub fn open<S: Storage, P: AsRef<Path>>(path: P, is_read_only: bool) -> Result<Self> {
+    pub fn open<S: Storage<Access = A>, P: AsRef<Path>>(path: P) -> Result<Self> {
         // Open storage.
         let context = N::NETWORK_ID;
-        let storage = S::open(path, context, is_read_only)?;
+        let storage = S::open(path, context)?;
 
         // Initialize the prover.
         let prover = Self {
@@ -58,7 +56,9 @@ impl<N: Network> ProverState<N> {
     pub fn get_coinbase_record(&self, commitment: &N::Commitment) -> Result<(u32, Record<N>)> {
         self.coinbase.get_record(commitment)
     }
+}
 
+impl<N: Network, A: StorageReadWrite> ProverState<N, A> {
     /// Adds the given coinbase record to storage.
     pub fn add_coinbase_record(&self, block_height: u32, record: Record<N>) -> Result<()> {
         self.coinbase.add_record(block_height, record)
@@ -72,13 +72,13 @@ impl<N: Network> ProverState<N> {
 
 #[derive(Clone, Debug)]
 #[allow(clippy::type_complexity)]
-struct CoinbaseState<N: Network> {
-    records: DataMap<N::Commitment, (u32, Record<N>)>,
+struct CoinbaseState<N: Network, A: StorageAccess> {
+    records: DataMap<N::Commitment, (u32, Record<N>), A>,
 }
 
-impl<N: Network> CoinbaseState<N> {
+impl<N: Network, A: StorageAccess> CoinbaseState<N, A> {
     /// Initializes a new instance of `CoinbaseState`.
-    fn open<S: Storage>(storage: S) -> Result<Self> {
+    fn open<S: Storage<Access = A>>(storage: S) -> Result<Self> {
         Ok(Self {
             records: storage.open_map(MapId::Records)?,
         })
@@ -101,7 +101,9 @@ impl<N: Network> CoinbaseState<N> {
             None => return Err(anyhow!("Record with commitment {} does not exist in storage", commitment)),
         }
     }
+}
 
+impl<N: Network, A: StorageReadWrite> CoinbaseState<N, A> {
     /// Adds the given block height and record to storage.
     fn add_record(&self, block_height: u32, record: Record<N>) -> Result<()> {
         // Ensure the record does not exist.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    storage::{rocksdb::RocksDB, Storage},
+    storage::{rocksdb::RocksDB, ReadWrite, Storage},
     LedgerState,
 };
 use snarkos_environment::CurrentNetwork;
@@ -40,7 +40,7 @@ fn test_blocks_3() -> Vec<Block<CurrentNetwork>> {
 }
 
 /// Initializes a new instance of the ledger.
-fn create_new_ledger<N: Network, S: Storage>() -> LedgerState<N> {
+fn create_new_ledger<N: Network, S: Storage<Access = ReadWrite>>() -> LedgerState<N, ReadWrite> {
     LedgerState::open_writer_with_increment::<S, _>(temp_dir(), 1).expect("Failed to initialize ledger")
 }
 

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -17,7 +17,7 @@
 #[cfg(feature = "rocks")]
 pub mod rocksdb;
 #[cfg(feature = "rocks")]
-pub type DataMap<K, V> = crate::storage::rocksdb::DataMap<K, V>;
+pub type DataMap<K, V, A> = crate::storage::rocksdb::DataMap<K, V, A>;
 #[cfg(feature = "rocks")]
 pub use crate::storage::rocksdb::MapId;
 

--- a/storage/src/storage/rocksdb/tests.rs
+++ b/storage/src/storage/rocksdb/tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::storage::{rocksdb::RocksDB, Map, MapId, Storage};
+use crate::storage::{rocksdb::RocksDB, MapId, MapRead, MapReadWrite, ReadWrite, Storage};
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir().expect("Failed to open temporary directory").into_path()
@@ -29,18 +29,18 @@ fn temp_file() -> std::path::PathBuf {
 
 #[test]
 fn test_open() {
-    let _storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let _storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
 }
 
 #[test]
 fn test_open_map() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 }
 
 #[test]
 fn test_insert_and_contains_key() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
@@ -50,7 +50,7 @@ fn test_insert_and_contains_key() {
 
 #[test]
 fn test_insert_and_get() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
@@ -60,7 +60,7 @@ fn test_insert_and_get() {
 
 #[test]
 fn test_insert_and_remove() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
@@ -72,7 +72,7 @@ fn test_insert_and_remove() {
 
 #[test]
 fn test_insert_and_iter() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
     map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
 
@@ -83,7 +83,7 @@ fn test_insert_and_iter() {
 
 #[test]
 fn test_insert_and_keys() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
     map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
 
@@ -94,7 +94,7 @@ fn test_insert_and_keys() {
 
 #[test]
 fn test_insert_and_values() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
     map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
 
@@ -107,12 +107,12 @@ fn test_insert_and_values() {
 fn test_reopen() {
     let directory = temp_dir();
     {
-        let storage = RocksDB::open(directory.clone(), 0, false).expect("Failed to open storage");
+        let storage = RocksDB::<ReadWrite>::open(directory.clone(), 0).expect("Failed to open storage");
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         map.insert(&123456789, &"123456789".to_string(), None).expect("Failed to insert");
     }
     {
-        let storage = RocksDB::open(directory, 0, false).expect("Failed to open storage");
+        let storage = RocksDB::<ReadWrite>::open(directory, 0).expect("Failed to open storage");
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
         assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get"));
     }
@@ -120,7 +120,7 @@ fn test_reopen() {
 
 #[test]
 fn test_batch_insert_and_remove() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     let batch = map.prepare_batch();
@@ -151,7 +151,7 @@ fn test_batch_insert_and_remove() {
 
 #[test]
 fn test_multiple_batches() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     let batch1 = map.prepare_batch();
@@ -191,7 +191,7 @@ fn test_multiple_batches() {
 
 #[test]
 fn test_discard_batch() {
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
     let batch = map.prepare_batch();
@@ -214,7 +214,7 @@ fn test_export_import() {
     let file = temp_file();
 
     {
-        let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+        let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
         let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");
 
         for i in 0..100 {
@@ -224,7 +224,7 @@ fn test_export_import() {
         storage.export(&file).expect("Failed to export storage");
     }
 
-    let storage = RocksDB::open(temp_dir(), 0, false).expect("Failed to open storage");
+    let storage = RocksDB::<ReadWrite>::open(temp_dir(), 0).expect("Failed to open storage");
     storage.import(&file).expect("Failed to import storage");
 
     let map = storage.open_map::<u32, String>(MapId::Test).expect("Failed to open data map");

--- a/storage/tests/dump_blocks.rs
+++ b/storage/tests/dump_blocks.rs
@@ -15,7 +15,10 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkos_environment::CurrentNetwork;
-use snarkos_storage::{storage::rocksdb::RocksDB, LedgerState};
+use snarkos_storage::{
+    storage::{rocksdb::RocksDB, ReadOnly},
+    LedgerState,
+};
 use snarkvm::dpc::traits::network::Network;
 
 #[test]
@@ -31,6 +34,6 @@ fn dump_blocks() {
     // The number of blocks to dump.
     let num_blocks = 10;
 
-    let (ledger, _) = LedgerState::<CurrentNetwork>::open_reader::<RocksDB, _>(source_path).unwrap();
+    let (ledger, _) = LedgerState::<CurrentNetwork, _>::open_reader::<RocksDB<ReadOnly>, _>(source_path).unwrap();
     ledger.dump_blocks(target_path, num_blocks).unwrap();
 }

--- a/storage/tests/ledger_breakdown.rs
+++ b/storage/tests/ledger_breakdown.rs
@@ -75,7 +75,7 @@ impl fmt::Display for PrefixInfo {
 fn show_ledger_breakdown() {
     let temp_dir = tempfile::tempdir().expect("Failed to open temporary directory").into_path();
     // Create an empty ledger.
-    let ledger: LedgerState<CurrentNetwork> =
+    let ledger: LedgerState<CurrentNetwork, _> =
         LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir, 1).expect("Failed to initialize ledger");
     // Import a dump of a ledger containing 1k blocks.
     ledger

--- a/storage/tests/ledger_validation.rs
+++ b/storage/tests/ledger_validation.rs
@@ -16,7 +16,7 @@
 
 use snarkos_environment::CurrentNetwork;
 use snarkos_storage::{
-    storage::{rocksdb::RocksDB, Storage},
+    storage::{rocksdb::RocksDB, ReadWrite, Storage},
     LedgerState,
 };
 
@@ -33,7 +33,7 @@ fn test_ledger_validation() {
     // Prepare a test ledger and an iterator of blocks to insert.
     let temp_dir = tempfile::tempdir().expect("Failed to open temporary directory").into_path();
     {
-        let ledger: LedgerState<CurrentNetwork> =
+        let ledger: LedgerState<CurrentNetwork, ReadWrite> =
             LedgerState::open_writer_with_increment::<RocksDB, _>(&temp_dir, 1).expect("Failed to initialize ledger");
         ledger
             .storage()
@@ -47,7 +47,7 @@ fn test_ledger_validation() {
     for _ in 0..NUM_CHECKS {
         let increment: u32 = rng.gen_range(1..=NUM_BLOCKS as u32);
         println!("Validating with an increment = {}", increment);
-        let _ledger: LedgerState<CurrentNetwork> =
+        let _ledger: LedgerState<CurrentNetwork, ReadWrite> =
             LedgerState::open_writer_with_increment::<RocksDB, &Path>(&temp_dir, increment).expect("Failed to initialize ledger");
     }
 }


### PR DESCRIPTION
The ledger currently accesses storage via a single abstraction (`LedgerState`) with a `read_only` flag that determines what operations can/should be run using it. However, this applies only to the top layer and one could still perform writes in the read-only instance using the more low-level objects or in the top layer if the flag is not checked or ignored; in fact, storage is currently written to in `LedgerState::open_reader`.

This PR introduces new traits and marker types that ensure that neither the lowest-level objects related to storage, nor any abstraction built on top of them, can perform any writes if it's created in read-only mode. This is checked at compile time.

The most notable changes are:
- traits `StorageAccess` and `StorageReadWrite` are added
- marker types `ReadOnly` and `ReadWrite` are added
- the `Storage` trait now has an associated `Access` type
- the `Map` trait is split into `MapRead` and `MapWrite`
- `LedgerState::open_reader` no longer performs any storage writes (only uses `MapRead::refresh`)
- the storage-related objects have an additional `T: StorageAccess` bound (some with the default set to `ReadWrite`)
- `LedgerState` no longer has (or needs) the `read_only` member