### PR TITLE
Feature: iterator for get_blocks function

### DIFF
--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -480,16 +480,8 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                         continue;
                                     }
                                     // Retrieve the requested blocks.
-                                    let blocks: Vec<Block<N>> = match ledger_reader.get_blocks(start_block_height, end_block_height) {
-                                        Ok(blocks) => match blocks.collect() {
-                                            Ok(blocks) => blocks,
-                                            Err(error) => {
-                                                if let Err(error) = ledger_router.send(LedgerRequest::Failure(peer_ip, format!("{}", error))).await {
-                                                    warn!("[Failure] {}", error);
-                                                }
-                                                continue;
-                                            }
-                                        },
+                                    let blocks: Vec<Block<N>> = match ledger_reader.get_blocks(start_block_height, end_block_height).and_then(|blocks| blocks.collect()) {
+                                        Ok(blocks) => blocks,
                                         Err(error) => {
                                             // Route a `Failure` to the ledger.
                                             if let Err(error) = ledger_router.send(LedgerRequest::Failure(peer_ip, format!("{}", error))).await {

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -480,7 +480,7 @@ impl<N: Network, E: Environment> Peer<N, E> {
                                     }
                                     // Retrieve the requested blocks.
                                     let blocks = match ledger_reader.get_blocks(start_block_height, end_block_height) {
-                                        Ok(blocks) => blocks,
+                                        Ok(blocks) => blocks.filter_map(|block_result| block_result.ok()),
                                         Err(error) => {
                                             // Route a `Failure` to the ledger.
                                             if let Err(error) = ledger_router.send(LedgerRequest::Failure(peer_ip, format!("{}", error))).await {

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -76,13 +76,11 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` blocks from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        let blocks: Result<Vec<Block<N>>, _> = self
+        Ok(self
             .ledger
             .get_blocks(safe_start_height, end_block_height)?
             .map(|block_result| block_result)
-            .collect();
-
-        Ok(blocks?)
+            .collect::<Result<Vec<Block<N>>, _>>()?)
     }
 
     /// Returns the block height for the given the block hash.

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -29,7 +29,7 @@ use snarkvm::{
     utilities::{FromBytes, ToBytes},
 };
 
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use serde_json::Value;
 use time::OffsetDateTime;
 
@@ -81,7 +81,7 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
         match self.ledger.get_blocks(safe_start_height, end_block_height) {
-            Ok(blocks_iter) => Ok(blocks_iter.par_bridge().filter_map(|block_result| block_result.ok()).collect()),
+            Ok(blocks_iter) => Ok(blocks_iter.filter_map(|block_result| block_result.ok()).collect()),
             Err(error) => Err(AnyhowError(error)),
         }
     }

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -18,11 +18,7 @@
 //!
 //! See [RpcFunctions](../trait.RpcFunctions.html) for documentation of public endpoints.
 
-use crate::{
-    rpc::{RpcError::AnyhowError, *},
-    Environment,
-    ProverRequest,
-};
+use crate::{rpc::*, Environment, ProverRequest};
 use snarkos_storage::Metadata;
 use snarkvm::{
     dpc::{Address, AleoAmount, Block, BlockHeader, Blocks, Network, Record, Transaction, Transactions, Transition},
@@ -80,10 +76,13 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
     /// Returns up to `MAXIMUM_BLOCK_REQUEST` blocks from the given `start_block_height` to `end_block_height` (inclusive).
     async fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<Vec<Block<N>>, RpcError> {
         let safe_start_height = max(start_block_height, end_block_height.saturating_sub(E::MAXIMUM_BLOCK_REQUEST - 1));
-        match self.ledger.get_blocks(safe_start_height, end_block_height) {
-            Ok(blocks_iter) => Ok(blocks_iter.filter_map(|block_result| block_result.ok()).collect()),
-            Err(error) => Err(AnyhowError(error)),
-        }
+        let blocks: Result<Vec<Block<N>>, _> = self
+            .ledger
+            .get_blocks(safe_start_height, end_block_height)?
+            .map(|block_result| block_result)
+            .collect();
+
+        Ok(blocks?)
     }
 
     /// Returns the block height for the given the block hash.

--- a/src/rpc/rpc_impl.rs
+++ b/src/rpc/rpc_impl.rs
@@ -79,7 +79,6 @@ impl<N: Network, E: Environment> RpcFunctions<N> for RpcContext<N, E> {
         Ok(self
             .ledger
             .get_blocks(safe_start_height, end_block_height)?
-            .map(|block_result| block_result)
             .collect::<Result<Vec<Block<N>>, _>>()?)
     }
 

--- a/src/rpc/tests.rs
+++ b/src/rpc/tests.rs
@@ -259,7 +259,6 @@ async fn test_get_block() {
     assert_eq!(response, *Testnet2::genesis_block());
 }
 
-// This test Fails or Pass randomly because par_bridge does not guarantees the order of the iterator.
 #[tokio::test]
 async fn test_get_blocks() {
     // Initialize a new temporary directory.

--- a/src/rpc/tests.rs
+++ b/src/rpc/tests.rs
@@ -259,6 +259,7 @@ async fn test_get_block() {
     assert_eq!(response, *Testnet2::genesis_block());
 }
 
+// This test Fails or Pass randomly because par_bridge does not guarantees the order of the iterator.
 #[tokio::test]
 async fn test_get_blocks() {
     // Initialize a new temporary directory.

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -881,12 +881,11 @@ impl<N: Network> LedgerState<N> {
         // Fetch the blocks to be removed. This ensures the blocks to be removed exist in the ledger,
         // and is used during the removal process to expedite the procedure.
         let start_block_height = latest_block_height.saturating_sub(number_of_blocks);
-        let blocks: Result<BTreeMap<u32, Block<N>>> = self
+        let blocks: BTreeMap<u32, Block<N>> = self
             .get_blocks(start_block_height, latest_block_height)?
             .map(|block| block.map(|block| (block.height(), block)))
-            .collect();
+            .collect::<Result<BTreeMap<u32, Block<N>>>>()?;
 
-        let blocks = blocks?;
         // Acquire the map lock to ensure the following operations aren't interrupted by a shutdown.
         let _map_lock = self.map_lock.read();
 

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -1422,7 +1422,7 @@ impl<N: Network> BlockState<N> {
     /// Returns the blocks from the given `start_block_height` to `end_block_height` (inclusive).
     fn get_blocks(&self, start_block_height: u32, end_block_height: u32) -> Result<impl ParallelIterator<Item = Result<Block<N>>> + '_> {
         // Ensure the starting block height is less than the ending block height.
-        ensure!(start_block_height > end_block_height, "Invalid starting and ending block heights");
+        ensure!(start_block_height <= end_block_height, "Invalid starting and ending block heights");
 
         Ok((start_block_height..=end_block_height)
             .into_par_iter()

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -878,10 +878,7 @@ impl<N: Network> LedgerState<N> {
         let start_block_height = latest_block_height.saturating_sub(number_of_blocks);
         let blocks: Result<BTreeMap<u32, Block<N>>> = self
             .get_blocks(start_block_height, latest_block_height)?
-            .map(|block| match block {
-                Ok(block) => Ok((block.height(), block)),
-                Err(err) => Err(err),
-            })
+            .map(|block| block.map(|block| (block.height(), block)))
             .collect();
 
         let blocks = blocks?;

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -881,7 +881,7 @@ impl<N: Network> LedgerState<N> {
         // Fetch the blocks to be removed. This ensures the blocks to be removed exist in the ledger,
         // and is used during the removal process to expedite the procedure.
         let start_block_height = latest_block_height.saturating_sub(number_of_blocks);
-        let blocks: BTreeMap<u32, Block<N>> = self
+        let blocks = self
             .get_blocks(start_block_height, latest_block_height)?
             .map(|block| block.map(|block| (block.height(), block)))
             .collect::<Result<BTreeMap<u32, Block<N>>>>()?;

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -369,8 +369,6 @@ fn test_get_blocks_iterator() {
         .filter_map(|block_result| block_result.ok())
         .collect();
 
-    drop(ledger_state);
-
     assert_eq!(blocks_result, vec![Testnet2::genesis_block().clone(), blocks[0].clone()]);
 }
 

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -356,8 +356,8 @@ fn test_get_blocks_iterator() {
     // Initialize an empty ledger.
     let ledger_state = LedgerState::open_writer::<RocksDB, _>(directory.clone()).expect("Failed to initialize ledger");
 
-    // Read the test blocks; note: they don't include the genesis block, as it's always available when creating a ledger.
-    // note: the `blocks_100` file was generated on a testnet2 storage using `LedgerState::dump_blocks`.
+    // Read the test blocks;
+    // note: they don't include the genesis block, as it's always available when creating a ledger.
     let test_blocks = fs::read("benches/blocks_1").unwrap_or_else(|_| panic!("Missing the test blocks file"));
     let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&test_blocks).expect("Failed to deserialize a block dump");
 

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -18,7 +18,7 @@ use crate::{
     storage::{rocksdb::RocksDB, Storage},
     LedgerState,
 };
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
@@ -348,7 +348,6 @@ fn test_transaction_fees() {
     assert_eq!(output_record.value(), amount);
 }
 
-// This test Fails or Pass randomly because par_bridge does not garantee the order of the iterator.
 #[test]
 fn test_get_blocks_iterator() {
     // Initialize a new temporary directory.
@@ -367,7 +366,6 @@ fn test_get_blocks_iterator() {
     let blocks_result: Vec<_> = ledger_state
         .get_blocks(0, ledger_state.latest_block_height() + 1)
         .unwrap()
-        .par_bridge()
         .filter_map(|block_result| block_result.ok())
         .collect();
 

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -358,7 +358,7 @@ fn test_get_blocks_iterator() {
 
     // Read the test blocks;
     // note: they don't include the genesis block, as it's always available when creating a ledger.
-    let test_blocks = fs::read("benches/blocks_1").unwrap_or_else(|_| panic!("Missing the test blocks file"));
+    let test_blocks = fs::read("benches/blocks_1").expect("Missing the test blocks file");
     let blocks: Vec<Block<Testnet2>> = bincode::deserialize(&test_blocks).expect("Failed to deserialize a block dump");
 
     // Load a test block into the ledger.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -22,8 +22,7 @@ use rayon::iter::ParallelIterator;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
-use std::{fs, sync::atomic::AtomicBool};
-use std::{collections::HashSet, sync::atomic::AtomicBool};
+use std::{collections::HashSet, fs, sync::atomic::AtomicBool};
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir().expect("Failed to open temporary directory").into_path()


### PR DESCRIPTION
## Motivation

Optimize the `get_blocks` function to be faster and avoid using `collect` because of future memory issues with a great number of blocks. I did some benchmarking with Criterion, trying different scenarios and implementations of this function and these were the results.

|                           | 1 Block         | 143 Blocks        | 203 Blocks        | 400 Blocks       |
|:---------------|:------------ | --------------- |:--------------- |:--------------- |
| std-iterator       |  620 ms       | 19.5 s                 | 28 s                  | 54 s                    |
| std-iterator + par_bridge (std + rayon) | 760 ms (+22%) | 21 s (+5%)   | 30.6 s (+10%) | 58.5 s(+9%) |
| Parallel-iterator (rayon)        | 244 ms (-60%) | 5.6 s (-70%) | 8 s (-71%)   | 15 s (-72%)   |

These results are approximations of the real values.
The first implementation returns an Iterator from the std library.
The second returns an iterator from the std library and uses the `par_bridge` function to transform it into a parallel one whenever it's possible (this `par_bridge` function doesn't guarantee to keep the same order of the original iterator as it says in the [documentation](https://docs.rs/rayon/1.0.3/rayon/iter/trait.ParallelBridge.html)).
The third implementation returns a `ParallelIterator` from rayon and uses that directly.
I had the best results using the third implementation, so I went with that.

I encountered a little problem in the `src/network/peer.rs` file, there was a `for` loop and some `async/await` code and I used a `collect` right now to make it work, that is a work in progress and I want to find a way to avoid that and use the `ParallelIterator` without the `collect` and the `for` loop.

Here are the reports and graphics made by Criterion for you to check the results in more detail 
[report.zip](https://github.com/IAvecilla/snarkOS/files/8612334/report.zip)
The report has three directories:
- Get Blocks ParallelIterator Benches
- Get Blocks std-iter + par_bridge Benches
- Get Blocks std-iter Benches

Each one has a directory for each case of benchmarking (1 block, 143 blocks, 203 blocks and 403 blocks).
The report folder inside each case has all the graphics of interest.

## Test Plan

There is a new test `storage/src/tests.rs` named `test_get_blocks_iterator` that checks that this function works properly with a couple of blocks.
