### PR TITLE
Update pea2pea to 0.37, run cargo update

### DIFF
--- a/.crawler/Cargo.toml
+++ b/.crawler/Cargo.toml
@@ -49,7 +49,7 @@ optional = true
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.36"
+version = "0.37"
 
 [dependencies.postgres-native-tls]
 version = "0.5"

--- a/.crawler/src/constants.rs
+++ b/.crawler/src/constants.rs
@@ -42,11 +42,6 @@ pub const STALE_CONNECTION_CUTOFF_TIME_HRS: i64 = 4;
 pub const DESIRED_PEER_SET_COUNT: u8 = 3;
 /// The maximum number of connections to attempt to initiate when updating peers.
 pub const NUM_CONCURRENT_CONNECTION_ATTEMPTS: u8 = 50;
-/// The maximum time (in milliseconds) a handshake can take; doesn't have to match the one in the snarkOS node.
-pub const MAX_HANDSHAKE_TIME_MS: u64 = 10_000;
-/// The size of the per-connection read buffer.
-// TODO: double-check maximum message length
-pub const READ_BUFFER_SIZE: usize = 16 * 1024;
 /// The number of peers shared with the crawled nodes when requested.
 pub const SHARED_PEER_COUNT: usize = 15;
 /// The number of connection failures after which a node is removed from the list of known nodes.

--- a/.crawler/src/crawler.rs
+++ b/.crawler/src/crawler.rs
@@ -88,7 +88,6 @@ impl Crawler {
             listener_ip: Some(opts.addr.ip()),
             desired_listening_port: Some(opts.addr.port()),
             max_connections: MAXIMUM_NUMBER_OF_PEERS as u16,
-            max_handshake_time_ms: MAX_HANDSHAKE_TIME_MS,
             ..Default::default()
         };
 

--- a/.integration/Cargo.toml
+++ b/.integration/Cargo.toml
@@ -27,7 +27,7 @@ optional = true
 version = "0.1"
 
 [dependencies.pea2pea]
-version = "0.36"
+version = "0.37"
 
 [dependencies.peak_alloc]
 version = "0.1"

--- a/.synthetic_node/Cargo.toml
+++ b/.synthetic_node/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.3"
 version = "0.12"
 
 [dependencies.pea2pea]
-version = "0.36"
+version = "0.37"
 
 [dependencies.rand]
 version = "0.8"

--- a/.synthetic_node/src/lib.rs
+++ b/.synthetic_node/src/lib.rs
@@ -116,6 +116,8 @@ impl SynthNode {
 /// Automated handshake handling for the test nodes.
 #[async_trait::async_trait]
 impl Handshake for SynthNode {
+    const TIMEOUT_MS: u64 = 10_000;
+
     async fn perform_handshake(&self, mut connection: Connection) -> io::Result<Connection> {
         let own_ip = self.node().listening_addr()?;
         let peer_addr = connection.addr();

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -1858,16 +1858,28 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "28f3916d46d9d813a62d7b7d2724d7b14785ac999fb623d990ee4603f9122742"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.92",
 ]
 
 [[package]]
@@ -1878,9 +1890,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.72"
+version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
 dependencies = [
  "autocfg",
  "cc",
@@ -1960,9 +1972,9 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pea2pea"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf32fca091ab99495605b95bed44fe3f6374780c431cd125bf575164494a63a"
+checksum = "50d95939323d3da9bc0493c660e045a80d3960b82b1a5de99b73cf1d5cd6a511"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2656,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa 1.0.1",
  "ryu",


### PR DESCRIPTION
While the `pea2pea` update required minor tweaks, `cargo update` is a drive-by to preemptively prune out any upcoming dependabot entries.