### PR TITLE
Add a block dump utility test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,6 +2951,7 @@ dependencies = [
 name = "snarkos-storage"
 version = "2.0.2"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "bincode",
  "circular-queue",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -76,6 +76,9 @@ features = [ "sync" ]
 [dependencies.tracing]
 version = "0.1"
 
+[dev-dependencies.aleo-std]
+version = "0.1.12"
+
 [dev-dependencies.criterion]
 version = "0.3"
 

--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -1278,9 +1278,9 @@ impl<N: Network> LedgerState<N> {
     ///
     /// Dump the specified number of blocks - excluding the genesis - to the given location.
     ///
-    #[cfg(test)]
+    #[cfg(feature = "test")]
     #[allow(dead_code)]
-    fn dump_blocks<P: AsRef<Path>>(&self, path: P, count: u32) -> Result<()> {
+    pub fn dump_blocks<P: AsRef<Path>>(&self, path: P, count: u32) -> Result<()> {
         let mut file = std::fs::File::create(path)?;
         let mut blocks = Vec::with_capacity(count as usize);
 

--- a/storage/tests/dump_blocks.rs
+++ b/storage/tests/dump_blocks.rs
@@ -16,12 +16,16 @@
 
 use snarkos_environment::CurrentNetwork;
 use snarkos_storage::{storage::rocksdb::RocksDB, LedgerState};
+use snarkvm::dpc::traits::network::Network;
 
 #[test]
 #[ignore = "This can be run whenever a block dump is needed."]
 fn dump_blocks() {
-    // The path containing the ledger to dump from.
-    let source_path = "/home/<user>/.aleo/storage/ledger-2";
+    // Compose the correct file path for the parameter file.
+    let mut source_path = aleo_std::aleo_dir();
+    source_path.push("storage");
+    source_path.push(format!("ledger-{}", CurrentNetwork::NETWORK_ID));
+
     // The path to dump the blocks to.
     let target_path = "./blocks.dump";
     // The number of blocks to dump.

--- a/storage/tests/dump_blocks.rs
+++ b/storage/tests/dump_blocks.rs
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use snarkos_environment::CurrentNetwork;
+use snarkos_storage::{storage::rocksdb::RocksDB, LedgerState};
+
+#[test]
+#[ignore = "This can be run whenever a block dump is needed."]
+fn dump_blocks() {
+    // The path containing the ledger to dump from.
+    let source_path = "/home/<user>/.aleo/storage/ledger-2";
+    // The path to dump the blocks to.
+    let target_path = "./blocks.dump";
+    // The number of blocks to dump.
+    let num_blocks = 10;
+
+    let (ledger, _) = LedgerState::<CurrentNetwork>::open_reader::<RocksDB, _>(source_path).unwrap();
+    ledger.dump_blocks(target_path, num_blocks).unwrap();
+}


### PR DESCRIPTION
This utility test allows the blocks of a given ledger to be dumped easily.

To execute it, go to the location of `snarkos-storage`, adjust the paths and number of blocks and run `cargo test --release -- --ignored dump_blocks`.

Note: the dumped blocks don't contain the genesis block, as it's always created with the ledger.