### PR TITLE
Feature: get all the ciphertexts from the LedgerState

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -283,6 +283,11 @@ impl<N: Network, A: StorageAccess> LedgerState<N, A> {
         self.blocks.get_previous_ledger_root(block_height)
     }
 
+    /// Returns all the records ciphertexts in the ledger.
+    pub fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.blocks.get_ciphertexts()
+    }
+
     /// Returns the block locators of the current ledger, from the given block height.
     pub fn get_block_locators(&self, block_height: u32) -> Result<BlockLocators<N>> {
         // Initialize the current block height that a block locator is obtained from.
@@ -1306,6 +1311,11 @@ impl<N: Network, A: StorageAccess> BlockState<N, A> {
         self.transactions.get_ciphertext(commitment)
     }
 
+    /// Returns all the records ciphertexts in the ledger.
+    fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.transactions.get_ciphertexts()
+    }
+
     /// Returns the transition for a given transition ID.
     fn get_transition(&self, transition_id: &N::TransitionID) -> Result<Transition<N>> {
         self.transactions.get_transition(transition_id)
@@ -1581,6 +1591,13 @@ impl<N: Network, A: StorageAccess> TransactionState<N, A> {
         }
 
         Err(anyhow!("Commitment {} is missing in storage", commitment))
+    }
+
+    /// Returns all the records ciphertexts in the ledger.
+    fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.transitions
+            .values()
+            .flat_map(|(_, _, transition)| transition.ciphertexts().cloned().collect::<Vec<N::RecordCiphertext>>())
     }
 
     /// Returns the transition for a given transition ID.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -290,7 +290,7 @@ fn test_transaction_fees() {
 #[test]
 fn test_get_all_ciphertexts() {
     // Initialize a new ledger.
-    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+    let ledger = create_new_ledger::<CurrentNetwork, RocksDB>();
 
     let expected_ciphertexts: Vec<_> = ledger
         .get_block(0)

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -19,7 +19,7 @@ use crate::{
     LedgerState,
 };
 use snarkos_environment::CurrentNetwork;
-use snarkvm::dpc::prelude::*;
+use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
 use std::{fs, path::PathBuf, sync::atomic::AtomicBool};
@@ -285,4 +285,21 @@ fn test_transaction_fees() {
     // Check that the output record balances are correct.
     assert_eq!(new_coinbase_record.value(), expected_block_reward);
     assert_eq!(output_record.value(), amount);
+}
+
+#[test]
+fn test_get_all_ciphertexts() {
+    // Initialize a new ledger.
+    let ledger = create_new_ledger::<Testnet2, RocksDB>();
+
+    let expected_ciphertexts: Vec<_> = ledger
+        .get_block(0)
+        .unwrap()
+        .commitments()
+        .map(|commitment| ledger.get_ciphertext(commitment).unwrap())
+        .collect();
+
+    let ciphertexts: Vec<_> = ledger.get_ciphertexts().collect();
+
+    assert_eq!(expected_ciphertexts, ciphertexts);
 }

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -19,7 +19,7 @@ use crate::{
     LedgerState,
 };
 use snarkos_environment::CurrentNetwork;
-use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
+use snarkvm::dpc::prelude::*;
 
 use rand::{thread_rng, Rng};
 use std::{fs, path::PathBuf, sync::atomic::AtomicBool};


### PR DESCRIPTION
## Motivation

This PR is related to #1725. It has some improvements in performance and now it returns all ciphertexts in the correct order.
The motivation is to get all the ciphertexts directly from LedgerState to avoid iterating over all the transactions and commitments to get them.

## Test Plan

There is a new test created in `storage/src/state/tests.rs`
- `test_get_all_ciphertexts` - This test asserts that this function gets all the ciphertexts in the ledger without a specific order.
