### PR TITLE
Feature: get ciphertexts improvement

### DIFF
--- a/storage/src/state/ledger.rs
+++ b/storage/src/state/ledger.rs
@@ -471,7 +471,7 @@ impl<N: Network> LedgerState<N> {
     }
 
     // Returns all the ciphertexts in ledger.
-    pub fn get_ciphertexts(&self) -> impl Iterator<Item = Result<N::RecordCiphertext>> + '_ {
+    pub fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
         self.blocks.get_ciphertexts()
     }
 
@@ -1301,7 +1301,7 @@ impl<N: Network> BlockState<N> {
     }
 
     // Returns all the record ciphertexts.
-    fn get_ciphertexts(&self) -> impl Iterator<Item = Result<N::RecordCiphertext>> + '_ {
+    fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
         self.transactions.get_ciphertexts()
     }
 
@@ -1578,8 +1578,10 @@ impl<N: Network> TransactionState<N> {
     }
 
     // Returns all the record ciphertexts.
-    fn get_ciphertexts(&self) -> impl Iterator<Item = Result<N::RecordCiphertext>> + '_ {
-        self.commitments.keys().map(move |commitment| self.get_ciphertext(&commitment))
+    fn get_ciphertexts(&self) -> impl Iterator<Item = N::RecordCiphertext> + '_ {
+        self.transitions
+            .values()
+            .flat_map(|(_, _, transition)| transition.ciphertexts().cloned().collect::<Vec<N::RecordCiphertext>>())
     }
 
     /// Returns the transition for a given transition ID.

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -22,7 +22,7 @@ use rayon::iter::ParallelIterator;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
-use std::{sync::atomic::AtomicBool, fs};
+use std::{fs, sync::atomic::AtomicBool};
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir().expect("Failed to open temporary directory").into_path()
 }

--- a/storage/src/state/tests.rs
+++ b/storage/src/state/tests.rs
@@ -22,8 +22,7 @@ use rayon::iter::ParallelIterator;
 use snarkvm::dpc::{prelude::*, testnet2::Testnet2};
 
 use rand::{thread_rng, Rng};
-use std::{collections::HashSet, fs, sync::atomic::AtomicBool};
-
+use std::{sync::atomic::AtomicBool, fs};
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir().expect("Failed to open temporary directory").into_path()
 }
@@ -377,17 +376,14 @@ fn test_get_all_ciphertexts() {
     // Initialize a new ledger.
     let ledger = create_new_ledger::<Testnet2, RocksDB>();
 
-    let expected_ciphertexts_set = ledger
+    let expected_ciphertexts: Vec<_> = ledger
         .get_block(0)
         .unwrap()
         .commitments()
         .map(|commitment| ledger.get_ciphertext(commitment).unwrap())
-        .collect::<HashSet<_>>();
-
-    let ciphertexts_set = ledger
-        .get_ciphertexts()
-        .filter_map(|ciphertext_result| ciphertext_result.ok())
         .collect();
 
-    assert_eq!(expected_ciphertexts_set, ciphertexts_set);
+    let ciphertexts: Vec<_> = ledger.get_ciphertexts().collect();
+
+    assert_eq!(expected_ciphertexts, ciphertexts);
 }


### PR DESCRIPTION
## Motivation

Improve performance in `get_ciphertexts` method of `LedgerState`. This improvement was added in another PR to Testnet 3 #1759.

## Test Plan

There are no new tests but the `test_get_all_ciphertexts` has been modified because the use of HashSet is no longer needed.
