### PR TITLE
Dependency updates

### DIFF
--- a/.integration/tests/network/perf.rs
+++ b/.integration/tests/network/perf.rs
@@ -90,7 +90,7 @@ async fn measure_peer_request_time() {
     let init_recv_count = test_node.node().stats().received().0 as usize;
     for i in 0..NUM_ITERATIONS {
         let start = Instant::now();
-        test_node
+        let _ = test_node
             .send_direct_message(client_addr, Message::PeerRequest)
             .unwrap()
             .await
@@ -129,7 +129,7 @@ async fn measure_ping_time() {
     let init_recv_count = test_node.node().stats().received().0 as usize;
     for i in 0..NUM_ITERATIONS {
         let start = Instant::now();
-        test_node.send_direct_message(client_addr, ping.clone()).unwrap().await.unwrap();
+        let _ = test_node.send_direct_message(client_addr, ping.clone()).unwrap().await.unwrap();
         wait_until!(1, test_node.node().stats().received().0 as usize == init_recv_count + i + 1);
         avg_request_time += start.elapsed();
     }

--- a/.integration/tests/network/perf.rs
+++ b/.integration/tests/network/perf.rs
@@ -90,10 +90,11 @@ async fn measure_peer_request_time() {
     let init_recv_count = test_node.node().stats().received().0 as usize;
     for i in 0..NUM_ITERATIONS {
         let start = Instant::now();
-        let _ = test_node
+        test_node
             .send_direct_message(client_addr, Message::PeerRequest)
             .unwrap()
             .await
+            .unwrap()
             .unwrap();
         wait_until!(1, test_node.node().stats().received().0 as usize == init_recv_count + i + 1);
         avg_request_time += start.elapsed();
@@ -129,7 +130,12 @@ async fn measure_ping_time() {
     let init_recv_count = test_node.node().stats().received().0 as usize;
     for i in 0..NUM_ITERATIONS {
         let start = Instant::now();
-        let _ = test_node.send_direct_message(client_addr, ping.clone()).unwrap().await.unwrap();
+        test_node
+            .send_direct_message(client_addr, ping.clone())
+            .unwrap()
+            .await
+            .unwrap()
+            .unwrap();
         wait_until!(1, test_node.node().stats().received().0 as usize == init_recv_count + i + 1);
         avg_request_time += start.elapsed();
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b85aed1b7ca965b6613d14ab243c746316180401cbb9ba3b2cb22bff16fc08f"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -136,9 +136,9 @@ version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
  "regex",
  "rustc-hash",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.16"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
@@ -479,15 +479,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -765,9 +765,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -1003,9 +1003,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -1637,9 +1637,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -1686,25 +1686,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1729,9 +1718,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -1775,15 +1764,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1848,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
@@ -1900,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.39"
+version = "0.10.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f3916d46d9d813a62d7b7d2724d7b14785ac999fb623d990ee4603f9122742"
+checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1919,9 +1899,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -2184,9 +2164,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
  "version_check",
 ]
 
@@ -2196,7 +2176,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
  "version_check",
 ]
@@ -2212,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 dependencies = [
  "unicode-xid 0.2.3",
 ]
@@ -2259,7 +2239,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
 ]
 
 [[package]]
@@ -2496,9 +2476,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -2703,9 +2683,9 @@ version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -2842,7 +2822,7 @@ version = "2.0.2"
 dependencies = [
  "aleo-std",
  "anyhow",
- "clap 3.1.16",
+ "clap 3.1.18",
  "colored",
  "crossterm",
  "num_cpus",
@@ -2872,7 +2852,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
- "clap 3.1.16",
+ "clap 3.1.18",
  "nalgebra",
  "native-tls",
  "parking_lot 0.12.0",
@@ -2918,7 +2898,7 @@ version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 3.1.16",
+ "clap 3.1.18",
  "pea2pea",
  "peak_alloc",
  "snarkos",
@@ -3098,9 +3078,9 @@ checksum = "ac5370287d7a59a916b66cb4c5d3fc83884834930cc4dbf066e9741e276f2fd6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -3332,11 +3312,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
  "unicode-xid 0.2.3",
 ]
@@ -3413,9 +3393,9 @@ version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -3472,9 +3452,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.1"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes",
  "libc",
@@ -3496,9 +3476,9 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -3547,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
  "tokio",
@@ -3614,9 +3594,9 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -3826,9 +3806,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
  "wasm-bindgen-shared",
 ]
 
@@ -3860,9 +3840,9 @@ version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
- "syn 1.0.92",
+ "syn 1.0.93",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,10 +1349,20 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d02a921aa22006ed979c2e1c407fd21302ac6049e5b544634ec5ec41516363d"
 dependencies = [
- "jsonrpsee-core",
+ "jsonrpsee-core 0.11.0",
  "jsonrpsee-http-client",
+ "jsonrpsee-types 0.11.0",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae63f7fdeb51700b35e9b28bf92e8d233951590968c186ed79510b6c12fa3d9"
+dependencies = [
+ "jsonrpsee-core 0.13.0",
  "jsonrpsee-http-server",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.13.0",
 ]
 
 [[package]]
@@ -1362,13 +1372,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8066473754794e7784c61808d25d60dfb68e1025a625792a6a1bc680d1ab700a"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types 0.11.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6b13067b615dd050ced7c19517a52cde490eee2c754d5447ce513f2275f7d"
+dependencies = [
+ "anyhow",
  "arrayvec",
  "async-trait",
  "beef",
  "futures-channel",
  "futures-util",
  "hyper",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.13.0",
  "parking_lot 0.12.0",
  "rand",
  "rustc-hash",
@@ -1388,8 +1416,8 @@ dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.11.0",
+ "jsonrpsee-types 0.11.0",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1400,16 +1428,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-server"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee81d83b686966d6ba3b79f21bc71beedad9ec7e31c201fccff31ef0dd212e17"
+checksum = "b34f1090bdc8f7f14ad8811fc84501867c23a9046ce79d49c0cd929a256c501e"
 dependencies = [
  "futures-channel",
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.13.0",
+ "jsonrpsee-types 0.13.0",
  "lazy_static",
  "serde_json",
  "tokio",
@@ -1422,6 +1450,20 @@ name = "jsonrpsee-types"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd42e08ae7f0de7b00319f723f7b06e2d461ab69bfa615a611fab5dec00b192e"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f1835f131e77cd766b4dcb025873944cb1e479cd5debb639e2dc11f90df24a"
 dependencies = [
  "anyhow",
  "beef",
@@ -2931,7 +2973,8 @@ dependencies = [
  "bincode",
  "futures",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.11.0",
+ "jsonrpsee 0.13.0",
  "rand",
  "rand_chacha",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,42 +1345,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d02a921aa22006ed979c2e1c407fd21302ac6049e5b544634ec5ec41516363d"
-dependencies = [
- "jsonrpsee-core 0.11.0",
- "jsonrpsee-http-client",
- "jsonrpsee-types 0.11.0",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae63f7fdeb51700b35e9b28bf92e8d233951590968c186ed79510b6c12fa3d9"
 dependencies = [
- "jsonrpsee-core 0.13.0",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
  "jsonrpsee-http-server",
- "jsonrpsee-types 0.13.0",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8066473754794e7784c61808d25d60dfb68e1025a625792a6a1bc680d1ab700a"
-dependencies = [
- "anyhow",
- "async-trait",
- "beef",
- "futures-channel",
- "futures-util",
- "hyper",
- "jsonrpsee-types 0.11.0",
- "serde",
- "serde_json",
- "thiserror",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -1396,7 +1368,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hyper",
- "jsonrpsee-types 0.13.0",
+ "jsonrpsee-types",
  "parking_lot 0.12.0",
  "rand",
  "rustc-hash",
@@ -1409,15 +1381,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157df2774b82fddf37a297fd5c8f711601b158176608f86d2adb5d227c524506"
+checksum = "c75812b0f7982c664b10c8779a774390d138fdb32f080560ea972c1a094c9407"
 dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
- "jsonrpsee-core 0.11.0",
- "jsonrpsee-types 0.11.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1436,27 +1408,13 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-core 0.13.0",
- "jsonrpsee-types 0.13.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "lazy_static",
  "serde_json",
  "tokio",
  "tracing",
  "unicase",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd42e08ae7f0de7b00319f723f7b06e2d461ab69bfa615a611fab5dec00b192e"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -2953,8 +2911,7 @@ dependencies = [
  "bincode",
  "futures",
  "hex",
- "jsonrpsee 0.11.0",
- "jsonrpsee 0.13.0",
+ "jsonrpsee",
  "rand",
  "rand_chacha",
  "serde",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -30,7 +30,7 @@ features = [ "thread-pool" ]
 version = "0.4"
 
 [dependencies.jsonrpsee]
-version = "0.11"
+version = "0.13"
 features = [ "http-server" ]
 
 [dependencies.serde]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -71,7 +71,7 @@ version = "0.1"
 version = "1.0"
 
 [dev-dependencies.jsonrpsee]
-version = "0.11"
+version = "0.13"
 features = [ "http-client" ]
 
 [dev-dependencies.rand]


### PR DESCRIPTION
Bumps `jsonrpsee` to `0.13` and updates the lock file. 

```
 Updating clap v3.1.16 -> v3.1.18
 Updating clap_derive v3.1.7 -> v3.1.18
 Updating mio v0.8.2 -> v0.8.3
 Removing miow v0.3.7
 Removing ntapi v0.3.7
 Updating num_threads v0.1.5 -> v0.1.6
 Updating openssl v0.10.39 -> v0.10.40
 Updating proc-macro2 v1.0.37 -> v1.0.38
 Updating syn v1.0.92 -> v1.0.93
 Updating tokio v1.18.1 -> v1.18.2
 Updating tokio-rustls v0.23.3 -> v0.23.4
```

Obviates #1765, #1766. 