### PR TITLE
Rename RPC args to HTTP, use those values for the warp server

### DIFF
--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -57,7 +57,7 @@ pub struct CLI {
     pub connect: Option<String>,
 
     /// Specify the IP address and port for the HTTP server.
-    #[clap(parse(try_from_str), default_value = "127.0.0.1:3033")]
+    #[clap(parse(try_from_str), default_value = "0.0.0.0:3033")]
     pub rest: SocketAddr,
     /// If the flag is set, the node will not initialize the HTTP server.
     #[clap(long)]

--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -56,18 +56,12 @@ pub struct CLI {
     #[clap(long = "connect")]
     pub connect: Option<String>,
 
-    /// Specify the IP address and port for the RPC server.
-    #[clap(parse(try_from_str), default_value = "0.0.0.0:3033", long = "rpc")]
-    pub rpc: SocketAddr,
-    /// Specify the username for the RPC server.
-    #[clap(default_value = "root", long = "username")]
-    pub rpc_username: String,
-    /// Specify the password for the RPC server.
-    #[clap(default_value = "pass", long = "password")]
-    pub rpc_password: String,
-    /// If the flag is set, the node will not initialize the RPC server.
+    /// Specify the IP address and port for the HTTP server.
+    #[clap(parse(try_from_str), default_value = "127.0.0.1:3033")]
+    pub rest: SocketAddr,
+    /// If the flag is set, the node will not initialize the HTTP server.
     #[clap(long)]
-    pub norpc: bool,
+    pub norest: bool,
 
     /// Specify the verbosity of the node [options: 0, 1, 2, 3]
     #[clap(default_value = "2", long = "verbosity")]

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -20,7 +20,7 @@ use snarkvm::prelude::{Field, Network, RecordsFilter, Transaction, ViewKey};
 use anyhow::Result;
 use core::marker::PhantomData;
 use indexmap::IndexMap;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 use tokio::{sync::mpsc, task::JoinHandle};
 use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};
 
@@ -76,7 +76,7 @@ pub struct Server<N: Network> {
 
 impl<N: Network> Server<N> {
     /// Initializes a new instance of the server.
-    pub fn start(ledger: Arc<Ledger<N>>) -> Result<Self> {
+    pub fn start(ledger: Arc<Ledger<N>>, server_addr: SocketAddr) -> Result<Self> {
         // Initialize a channel to send requests to the ledger.
         let (ledger_sender, ledger_receiver) = mpsc::channel(64);
 
@@ -160,7 +160,7 @@ impl<N: Network> Server<N> {
                 .or(records_unspent)
                 .or(transaction_broadcast);
             // Start the server.
-            warp::serve(routes).run(([0, 0, 0, 0], 80)).await;
+            warp::serve(routes).run(server_addr).await;
         }));
 
         // Spawn the ledger handler.

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -39,7 +39,7 @@ impl<N: Network, E: Environment> Node<N, E> {
         let ledger = match cli.dev {
             None => {
                 // Initialize the ledger.
-                let ledger = Ledger::<N>::load(*account.private_key())?;
+                let ledger = Ledger::<N>::load(*account.private_key(), cli)?;
                 // Sync the ledger with the network.
                 ledger.initial_sync_with_network(&cli.beacon_addr.ip()).await?;
 
@@ -52,7 +52,7 @@ impl<N: Network, E: Environment> Node<N, E> {
                 let genesis_block = request_genesis_block::<N>(cli.beacon_addr.ip()).await?;
 
                 // Initialize the ledger from the provided genesis block.
-                Ledger::<N>::new_with_genesis(*account.private_key(), genesis_block)?
+                Ledger::<N>::new_with_genesis(*account.private_key(), genesis_block, cli)?
             }
         };
 


### PR DESCRIPTION
This fixes the initial panic if port 80 is in use (which is extremely likely), adjusts the settings to the current server setup and allows the user to specify the address or disable it.

Closes https://github.com/AleoHQ/snarkOS/issues/1875.