### PR TITLE
Improve Client node usability 

### DIFF
--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -44,6 +44,14 @@ pub struct CLI {
     /// Specify the IP address and port for the node server.
     #[clap(parse(try_from_str), default_value = "0.0.0.0:4133", long = "node")]
     pub node: SocketAddr,
+    /// Specify the IP address and port of a beacon node to connect to.
+    #[clap(
+        hide = true,
+        parse(try_from_str),
+        default_value = "159.203.77.113:4130",
+        long = "connect_to_beacon"
+    )]
+    pub beacon_addr: SocketAddr,
     /// Specify the IP address and port of a peer to connect to.
     #[clap(long = "connect")]
     pub connect: Option<String>,

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -25,7 +25,10 @@ use futures::StreamExt;
 use indexmap::IndexMap;
 use once_cell::race::OnceBox;
 use parking_lot::RwLock;
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 use tokio::task;
 
 pub(crate) type InternalLedger<N> = snarkvm::prelude::Ledger<N, BlockDB<N>, ProgramDB<N>>;
@@ -213,7 +216,7 @@ impl<N: Network> Ledger<N> {
 // Internal operations.
 impl<N: Network> Ledger<N> {
     /// Syncs the ledger with the network.
-    pub(crate) async fn initial_sync_with_network(self: &Arc<Self>, leader_ip: &str) -> Result<()> {
+    pub(crate) async fn initial_sync_with_network(self: &Arc<Self>, leader_ip: &IpAddr) -> Result<()> {
         /// The number of concurrent requests with the network.
         const CONCURRENT_REQUESTS: usize = 100;
         /// Url to fetch the blocks from.

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -121,15 +121,13 @@ impl<N: Network> Ledger<N> {
 
     /// Attempts to add the given block to the ledger.
     pub(crate) async fn add_next_block(self: &Arc<Self>, next_block: &Block<N>) -> Result<()> {
-        // Ensure the given block is a valid next block.
-        self.ledger.read().check_next_block(next_block)?;
-
         // Add the next block to the ledger.
         let self_clone = self.clone();
         let next_block_clone = next_block.clone();
         if let Err(error) = task::spawn_blocking(move || self_clone.ledger.write().add_next_block(&next_block_clone)).await? {
             // Log the error.
             warn!("{error}");
+            return Err(error);
         }
 
         Ok(())

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -182,7 +182,7 @@ impl<N: Network> Server<N> {
                     LedgerRequest::TransactionBroadcast(transaction) => {
                         let transaction_id = transaction.id();
                         match ledger.add_to_memory_pool(transaction) {
-                            Ok(()) => debug!("✉️ Added transaction '{transaction_id}' to the memory pool"),
+                            Ok(()) => trace!("✉️ Added transaction '{transaction_id}' to the memory pool"),
                             Err(error) => {
                                 warn!("⚠️ Failed to add transaction '{transaction_id}' to the memory pool: {error}")
                             }

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -119,7 +119,7 @@ pub(crate) async fn handle_peer<N: Network>(
                             // Check if the block can be added to the ledger.
                             if block.height() == ledger.ledger().read().latest_height() + 1 {
                                 // Attempt to add the block to the ledger.
-                                match ledger.ledger().write().add_next_block(&block) {
+                                match ledger.add_next_block(&block).await {
                                     Ok(_) => info!("Advanced to block {} ({})", block.height(), block.hash()),
                                     Err(err) => warn!("Failed to process block {} (height: {}): {:?}",block.hash(),block.header().height(), err)
                                 };
@@ -161,7 +161,7 @@ pub(crate) async fn handle_peer<N: Network>(
                             // Check if the block can be added to the ledger.
                             if block.height() == ledger.ledger().read().latest_height() + 1 {
                                 // Attempt to add the block to the ledger.
-                                match ledger.ledger().write().add_next_block(&block) {
+                                match ledger.add_next_block(&block).await {
                                     Ok(_) => {
                                         info!("Advanced to block {} ({})", block.height(), block.hash());
 

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -87,7 +87,7 @@ pub(crate) async fn handle_peer<N: Network>(
                 // A message was received from the current user, we should
                 // broadcast this message to the other users.
                 Some(Ok(message)) => {
-                    debug!("Received message {} from peer {:?}", message.name(), peer.ip);
+                    trace!("Received '{}' from {}", message.name(), peer.ip);
 
                     match message {
                         Message::Ping => {
@@ -107,7 +107,7 @@ pub(crate) async fn handle_peer<N: Network>(
                         Message::BlockRequest(height) => {
                             let latest_height = ledger.ledger().read().latest_height();
                             if height > latest_height {
-                                debug!("Peer requested block {height}, which is greater than the current height {latest_height}");
+                                trace!("Peer requested block {height}, which is greater than the current height {latest_height}");
                             } else {
                                 let block = ledger.ledger().read().get_block(height)?;
                                 let response = Message::BlockResponse(block);
@@ -260,7 +260,7 @@ pub async fn connect_to_leader<N: Network>(initial_peer: SocketAddr, ledger: Arc
             let ledger_clone = ledger.clone();
 
             if !ledger_clone.peers().read().contains_key(&initial_peer) {
-                debug!("Attempting to connect to peer {}", initial_peer);
+                trace!("Attempting to connect to peer {}", initial_peer);
                 match TcpStream::connect(initial_peer).await {
                     Ok(stream) => {
                         tokio::spawn(async move {

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -233,7 +233,7 @@ pub async fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledg
 }
 
 /// Send a ping to all peers every 10 seconds.
-pub async fn send_pings<N: Network>(ledger: Arc<Ledger<N>>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn send_pings<N: Network>(ledger: Arc<Ledger<N>>) -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(time::Duration::from_secs(10));
         loop {
@@ -242,7 +242,7 @@ pub async fn send_pings<N: Network>(ledger: Arc<Ledger<N>>) -> Result<(), Box<dy
             let peers = ledger.peers().read().clone();
 
             for (addr, outbound) in peers.iter() {
-                if let Err(err) = outbound.send(Message::<N>::Ping).await {
+                if let Err(err) = outbound.try_send(Message::<N>::Ping) {
                     warn!("Error sending ping {} to {}", err, addr);
                 }
             }

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -56,7 +56,7 @@ impl<N: Network, E: Environment> Node<N, E> {
         let _ = connect_to_leader::<N>(leader_addr, ledger.clone()).await;
 
         // Send pings to all peers every 10 seconds.
-        let _pings = send_pings::<N>(ledger.clone()).await;
+        let _pings = send_pings::<N>(ledger.clone());
 
         Ok(Self {
             ledger: ledger.clone(),

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -52,7 +52,7 @@ impl<N: Network, E: Environment> Node<N, E> {
 
         // Connect to the leader node and listen for new blocks.
         let leader_addr = cli.beacon_addr;
-        debug!("Connecting to '{}'...", leader_addr);
+        trace!("Connecting to '{}'...", leader_addr);
         let _ = connect_to_leader::<N>(leader_addr, ledger.clone()).await;
 
         // Send pings to all peers every 10 seconds.
@@ -66,7 +66,7 @@ impl<N: Network, E: Environment> Node<N, E> {
 
     /// Sends a connection request to the given IP address.
     pub async fn connect_to(&self, peer_ip: SocketAddr) -> Result<()> {
-        debug!("Attempting to connect to peer {}", peer_ip);
+        trace!("Attempting to connect to peer {}", peer_ip);
         match tokio::net::TcpStream::connect(peer_ip).await {
             Ok(stream) => {
                 let ledger = self.ledger.clone();

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -41,7 +41,7 @@ impl<N: Network, E: Environment> Node<N, E> {
         // If the node is not in development mode, perform fast sync with the network.
         if cli.dev.is_none() {
             // Sync the ledger with the network.
-            ledger.initial_sync_with_network(&cli.beacon_addr.ip().to_string()).await?;
+            ledger.initial_sync_with_network(&cli.beacon_addr.ip()).await?;
         }
 
         // Initialize the listener.

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -22,10 +22,7 @@ use snarkvm::prelude::Network;
 
 use anyhow::{bail, Result};
 use core::marker::PhantomData;
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
-
-// The IP of the leader node to connect to.
-const LEADER_IP: &str = "159.203.77.113:4130";
+use std::{net::SocketAddr, sync::Arc};
 
 #[derive(Clone)]
 pub struct Node<N: Network, E: Environment> {
@@ -41,6 +38,12 @@ impl<N: Network, E: Environment> Node<N, E> {
         // Initialize the ledger.
         let ledger = Ledger::<N>::load(account.private_key()).await?;
 
+        // If the node is not in development mode, perform fast sync with the network.
+        if cli.dev.is_none() {
+            // Sync the ledger with the network.
+            ledger.initial_sync_with_network(&cli.beacon_addr.ip().to_string()).await?;
+        }
+
         // Initialize the listener.
         let listener = tokio::net::TcpListener::bind(cli.node).await?;
 
@@ -48,7 +51,7 @@ impl<N: Network, E: Environment> Node<N, E> {
         let _handle_listener = handle_listener::<N>(listener, ledger.clone()).await;
 
         // Connect to the leader node and listen for new blocks.
-        let leader_addr = SocketAddr::from_str(LEADER_IP)?;
+        let leader_addr = cli.beacon_addr;
         let _ = connect_to_leader::<N>(leader_addr, ledger.clone()).await;
 
         debug!("Connecting to '{}'...", leader_addr);

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -52,11 +52,9 @@ impl<N: Network, E: Environment> Node<N, E> {
 
         // Connect to the leader node and listen for new blocks.
         let leader_addr = cli.beacon_addr;
+        debug!("Connecting to '{}'...", leader_addr);
         let _ = connect_to_leader::<N>(leader_addr, ledger.clone()).await;
 
-        debug!("Connecting to '{}'...", leader_addr);
-
-        // This will prevent the node from generating blocks and will maintain a connection with the leader.
         // Send pings to all peers every 10 seconds.
         let _pings = send_pings::<N>(ledger.clone()).await;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR removes the two hard-coded instances of `LEADER_IP` and instead replaces it with a CLI based declaration. This gives the ability to choose a specified beacon/leader nodes in custom testnets.

Additional (minor) fixes:

- Uses `Ledger` interface instead of directly accessing the `InternalLedger` functions. This should also address - https://github.com/AleoHQ/snarkOS/pull/1876
- Disable fast-syncing `initial_sync_with_network`  in development mode.
- Handle thread loops properly with tokio `Interval`s
- Update incorrect comments.

