### PR TITLE
Api: re-export snarkVM's Testnet3 struct

### DIFF
--- a/snarkos/lib.rs
+++ b/snarkos/lib.rs
@@ -52,7 +52,7 @@ pub use snarkos_environment as environment;
 #[cfg(feature = "rpc")]
 pub use snarkos_rpc as rpc;
 
-pub use snarkvm::prelude::{Address, Network};
+pub use snarkvm::prelude::{Address, Network, Testnet3};
 
 pub mod prelude {
     pub use crate::environment::*;
@@ -60,7 +60,7 @@ pub mod prelude {
     #[cfg(feature = "rpc")]
     pub use crate::rpc::*;
 
-    pub use snarkvm::prelude::{Address, Network};
+    pub use snarkvm::prelude::{Address, Network, Testnet3};
 }
 
 use backoff::{future::retry, ExponentialBackoff};

--- a/snarkos/network/message.rs
+++ b/snarkos/network/message.rs
@@ -20,6 +20,7 @@ use ::bytes::{Buf, BufMut, BytesMut};
 use std::marker::PhantomData;
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
+#[derive(Clone)]
 pub enum Message<N: Network> {
     /// Ping with the current block height.
     Ping,


### PR DESCRIPTION
External callers of snarkOS' `Message` won't be able to satisfy the associated trait bounds unless `Testnet3` is also re-exported (snarkVM's won't do, unfortunately). In addition, all fields in `Message` are `Clone` so I've added the `derive` for the type as well.