### PR TITLE
Add custom testnet support for client nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,18 +2082,18 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "anyhow",
  "clap",
@@ -2318,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2352,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2415,12 +2415,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2502,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "anyhow",
  "colored",
@@ -2562,7 +2562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "anyhow",
  "clap",
@@ -2318,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2352,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2377,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2415,12 +2415,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2480,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2502,7 +2502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "anyhow",
  "colored",
@@ -2562,7 +2562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2608,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2662,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7555dc0#7555dc036d19b41d3e06ca4934ee12b931cdde43"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=a6c838a#a6c838aa19a1b9c677a20f548e65574b8879cf0e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "7555dc0"
+rev = "a6c838a"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "a6c838a"
+rev = "e866f2d"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "7555dc0"
+rev = "a6c838a"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -29,14 +29,14 @@ version = "1"
 version = "1"
 
 [dependencies.serde]
-version = "1"
+version = "1.0.144"
 
 [dependencies.serde_json]
 version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "a6c838a"
+rev = "e866f2d"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -230,7 +230,7 @@ impl Clean {
     }
 
     /// Removes the specified ledger from storage.
-    fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
+    pub(super) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
         let path = aleo_std::aleo_ledger_dir(network, dev);
         // Check if the path to the ledger exists in storage.

--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -230,7 +230,7 @@ impl Clean {
     }
 
     /// Removes the specified ledger from storage.
-    pub(super) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
+    fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
         let path = aleo_std::aleo_ledger_dir(network, dev);
         // Check if the path to the ledger exists in storage.

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -60,7 +60,7 @@ impl<N: Network> Ledger<N> {
         // Initialize the ledger.
         let ledger = Arc::new(Self {
             ledger: RwLock::new(InternalLedger::open()?),
-            peers: RwLock::new(IndexMap::new()),
+            peers: Default::default(),
             server: OnceBox::new(),
             private_key: *private_key,
             view_key,
@@ -102,7 +102,7 @@ impl<N: Network> Ledger<N> {
         // Initialize the ledger.
         let ledger = Arc::new(Self {
             ledger: RwLock::new(internal_ledger),
-            peers: RwLock::new(IndexMap::new()),
+            peers: Default::default(),
             server: OnceBox::new(),
             private_key: *private_key,
             view_key,

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -52,7 +52,7 @@ pub struct Ledger<N: Network> {
 
 impl<N: Network> Ledger<N> {
     /// Initializes a new instance of the ledger.
-    pub async fn load(private_key: &PrivateKey<N>) -> Result<Arc<Self>> {
+    pub fn load(private_key: PrivateKey<N>) -> Result<Arc<Self>> {
         // Derive the view key and address.
         let view_key = ViewKey::try_from(private_key)?;
         let address = Address::try_from(&view_key)?;
@@ -62,7 +62,7 @@ impl<N: Network> Ledger<N> {
             ledger: RwLock::new(InternalLedger::open()?),
             peers: Default::default(),
             server: OnceBox::new(),
-            private_key: *private_key,
+            private_key,
             view_key,
             address,
         });
@@ -79,7 +79,7 @@ impl<N: Network> Ledger<N> {
     }
 
     /// Initializes a new instance of the ledger.
-    pub(super) async fn new_with_genesis(private_key: &PrivateKey<N>, genesis_block: Block<N>) -> Result<Arc<Self>> {
+    pub(super) fn new_with_genesis(private_key: PrivateKey<N>, genesis_block: Block<N>) -> Result<Arc<Self>> {
         // Derive the view key and address.
         let view_key = ViewKey::try_from(private_key)?;
         let address = Address::try_from(&view_key)?;
@@ -104,7 +104,7 @@ impl<N: Network> Ledger<N> {
             ledger: RwLock::new(internal_ledger),
             peers: Default::default(),
             server: OnceBox::new(),
-            private_key: *private_key,
+            private_key,
             view_key,
             address,
         });

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -79,7 +79,7 @@ impl<N: Network> Ledger<N> {
     }
 
     /// Initializes a new instance of the ledger.
-    pub(super) async fn new_from_genesis(private_key: &PrivateKey<N>, genesis_block: Block<N>) -> Result<Arc<Self>> {
+    pub(super) async fn new_with_genesis(private_key: &PrivateKey<N>, genesis_block: Block<N>) -> Result<Arc<Self>> {
         // Derive the view key and address.
         let view_key = ViewKey::try_from(private_key)?;
         let address = Address::try_from(&view_key)?;

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -22,7 +22,10 @@ use crate::Ledger;
 use snarkvm::prelude::*;
 
 use futures::{SinkExt, StreamExt};
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::mpsc,
@@ -235,10 +238,9 @@ pub async fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledg
 // TODO (raychu86): Handle this request via `Message::BlockRequest`. This is currently not done,
 //  because the node has not established the leader as a peer.
 /// Request the genesis block from the leader.
-pub(super) async fn request_genesis_block<N: Network>(leader_ip: &SocketAddr) -> Result<Block<N>> {
+pub(super) async fn request_genesis_block<N: Network>(leader_ip: IpAddr) -> Result<Block<N>> {
     info!("Requesting genesis block from {}", leader_ip);
-    let ip = leader_ip.ip();
-    let block_string = reqwest::get(format!("http://{ip}/testnet3/block/0")).await?.text().await?;
+    let block_string = reqwest::get(format!("http://{leader_ip}/testnet3/block/0")).await?.text().await?;
 
     Block::from_str(&block_string)
 }

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -237,9 +237,9 @@ pub async fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledg
 /// Request the genesis block from the leader.
 pub(super) async fn request_genesis_block<N: Network>(leader_ip: &SocketAddr) -> Result<Block<N>> {
     let ip = leader_ip.ip();
-    let bytes = reqwest::get(format!("http://{ip}/testnet3/block/0")).await?.bytes().await?;
+    let block_string = reqwest::get(format!("http://{ip}/testnet3/block/0")).await?.text().await?;
 
-    Block::from_bytes_le(&bytes)
+    Block::from_str(&block_string)
 }
 
 /// Send a ping to all peers every 10 seconds.

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -236,6 +236,7 @@ pub async fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledg
 //  because the node has not established the leader as a peer.
 /// Request the genesis block from the leader.
 pub(super) async fn request_genesis_block<N: Network>(leader_ip: &SocketAddr) -> Result<Block<N>> {
+    info!("Requesting genesis block from {}", leader_ip);
     let ip = leader_ip.ip();
     let block_string = reqwest::get(format!("http://{ip}/testnet3/block/0")).await?.text().await?;
 

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -232,6 +232,16 @@ pub async fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledg
     Ok(())
 }
 
+// TODO (raychu86): Handle this request via `Message::BlockRequest`. This is currently not done,
+//  because the node has not established the leader as a peer.
+/// Request the genesis block from the leader.
+pub(super) async fn request_genesis_block<N: Network>(leader_ip: &SocketAddr) -> Result<Block<N>> {
+    let ip = leader_ip.ip();
+    let bytes = reqwest::get(format!("http://{ip}/testnet3/block/0")).await?.bytes().await?;
+
+    Block::from_bytes_le(&bytes)
+}
+
 /// Send a ping to all peers every 10 seconds.
 pub fn send_pings<N: Network>(ledger: Arc<Ledger<N>>) -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -49,7 +49,7 @@ impl<N: Network, E: Environment> Node<N, E> {
                 // TODO (raychu86): Formalize this process via network messages.
                 //  Currently this operations pulls from the leader's server.
                 // Request genesis block from the beacon leader.
-                let genesis_block = request_genesis_block::<N>(&cli.beacon_addr).await?;
+                let genesis_block = request_genesis_block::<N>(cli.beacon_addr.ip()).await?;
 
                 // Initialize the ledger from the provided genesis block.
                 Ledger::<N>::new_with_genesis(account.private_key(), genesis_block).await?

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -52,7 +52,7 @@ impl<N: Network, E: Environment> Node<N, E> {
                 let genesis_block = request_genesis_block::<N>(&cli.beacon_addr).await?;
 
                 // Initialize the ledger from the provided genesis block.
-                Ledger::<N>::new_from_genesis(account.private_key(), genesis_block).await?
+                Ledger::<N>::new_with_genesis(account.private_key(), genesis_block).await?
             }
         };
 

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -16,7 +16,7 @@
 
 use crate::CLI;
 
-use crate::{connect_to_leader, handle_listener, handle_peer, request_genesis_block, send_pings, Account, Ledger};
+use crate::{connect_to_leader, handle_listener, handle_peer, request_genesis_block, send_pings, Account, Clean, Ledger};
 use snarkos_environment::{helpers::Status, Environment};
 use snarkvm::prelude::Network;
 
@@ -51,8 +51,24 @@ impl<N: Network, E: Environment> Node<N, E> {
                 // Request genesis block from the beacon leader.
                 let genesis_block = request_genesis_block::<N>(&cli.beacon_addr).await?;
 
-                // Initialize the ledger from the provided genesis block.
-                Ledger::<N>::new_with_genesis(account.private_key(), genesis_block).await?
+                // Initialize the development ledger. This will clear the existing ledger if the
+                // genesis block does not match the one in the existing ledger.
+                // Initialize the ledger.
+                let existing_ledger = Ledger::<N>::load(account.private_key()).await?;
+
+                // Check if the existing ledger shares the same genesis block as the beacon node.
+                let genesis_block_exists = existing_ledger.ledger().read().contains_block_hash(&genesis_block.hash())?;
+                match genesis_block_exists {
+                    true => existing_ledger.clone(),
+                    false => {
+                        // Remove the existing ledger if the genesis block is not found.
+                        drop(existing_ledger);
+                        Clean::remove_ledger(N::ID, cli.dev)?;
+
+                        // Initialize a new ledger from the provided genesis block.
+                        Ledger::<N>::new_with_genesis(account.private_key(), genesis_block).await?
+                    }
+                }
             }
         };
 

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -39,7 +39,7 @@ impl<N: Network, E: Environment> Node<N, E> {
         let ledger = match cli.dev {
             None => {
                 // Initialize the ledger.
-                let ledger = Ledger::<N>::load(account.private_key()).await?;
+                let ledger = Ledger::<N>::load(*account.private_key())?;
                 // Sync the ledger with the network.
                 ledger.initial_sync_with_network(&cli.beacon_addr.ip()).await?;
 
@@ -52,7 +52,7 @@ impl<N: Network, E: Environment> Node<N, E> {
                 let genesis_block = request_genesis_block::<N>(cli.beacon_addr.ip()).await?;
 
                 // Initialize the ledger from the provided genesis block.
-                Ledger::<N>::new_with_genesis(account.private_key(), genesis_block).await?
+                Ledger::<N>::new_with_genesis(*account.private_key(), genesis_block)?
             }
         };
 


### PR DESCRIPTION
## Motivation

This PR enables support for client nodes to connect to custom testnets. This is done by requesting the specific genesis block (via the beacon server) for the custom testnet and 

You can specify the specific beacon node using the flags `--dev <id> --connect_to_beacon <IP>`.

Note: There are a few additional things that should be addressed:

 - New Network ID for blocks in custom testnets.
 - Formalized genesis block request and go through Message::BlockRequest instead of the server.
 - Update the storage location. 
   - Currently all networks store blocks in the same `.aleo` database. You will need to run `cargo run --release clean` before spinning up clients for custom networks.

