### PR TITLE
Modularize and update `Server` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,6 +2264,7 @@ dependencies = [
  "snarkvm",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tokio-util 0.7.3",
  "tracing",
@@ -2292,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "clap",
@@ -2318,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2352,7 +2353,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2366,7 +2367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2377,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2387,7 +2388,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2397,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2415,12 +2416,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2431,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2443,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2458,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2471,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2480,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2490,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2502,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2513,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2524,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2536,7 +2537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "colored",
@@ -2562,7 +2563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2575,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2585,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2597,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2608,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2627,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2645,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2662,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2677,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2688,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2696,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2705,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2716,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2726,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2736,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2747,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2760,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2777,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2800,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2816,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2834,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.7.5"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e866f2d#e866f2d2ce5afcac9a0e6ff10a4ac7ea73f2ec40"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1db1f75#1db1f757939aef9b2f58c1f382d8d66cd81f9232"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2983,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "e866f2d"
+rev = "1db1f75"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]
@@ -108,6 +108,9 @@ version = "1"
 
 [dependencies.thiserror]
 version = "1.0"
+
+[dependencies.time]
+version = "0.3.14"
 
 [dependencies.tokio]
 version = "1"

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "e866f2d"
+rev = "1db1f75"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -307,7 +307,7 @@ impl<N: Network> Server<N> {
     /// Returns the peers connected to the node.
     async fn peers_all(ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(
-            &ledger.peers.read().keys().map(|addr| addr.ip()).collect::<Vec<std::net::IpAddr>>(),
+            &ledger.peers.read().keys().cloned().collect::<Vec<std::net::SocketAddr>>(),
         ))
     }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the snarkVM rev to [1db1f75](https://github.com/AleoHQ/snarkVM/commit/1db1f757939aef9b2f58c1f382d8d66cd81f9232) and updates the `Server`. 

The Server routes are now constructed with a dedicated function. Additionally, a few new endpoints have been added:
 - GET /testnet3/peers/count
 - GET /testnet3/peers/all
 - GET /testnet3/transactions/{height}
 - GET /testnet3/transaction/{id}




