### PR TITLE
Retry on Block parse errors when syncing

### DIFF
--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -309,19 +309,21 @@ impl<N: Network> Ledger<N> {
                         let block_url = format!("{TARGET_URL}{height}.block");
 
                         // Fetch the bytes from the given url
-                        reqwest::get(block_url).await
+                        let block_bytes = reqwest::get(block_url).await?.bytes().await?;
+
+                        // Parse the block.
+                        let block = task::spawn_blocking(move || Block::from_bytes_le(&block_bytes)).await.unwrap()?;
+
+                        std::future::ready(Ok(block)).await
                     })
                 })
                 .buffered(CONCURRENT_REQUESTS)
-                .for_each(|response| async {
+                .for_each(|block| async {
+                    let block = block.unwrap();
                     // Use blocking tasks, as deserialization and adding blocks are expensive operations.
                     let self_clone = self.clone();
-                    let block_bytes = response.unwrap().bytes().await;
 
                     task::spawn_blocking(move || {
-                        // Parse the block.
-                        let block = Block::from_bytes_le(&block_bytes.unwrap()).unwrap();
-
                         // Add the block to the ledger.
                         self_clone.ledger.write().add_next_block(&block).unwrap();
 


### PR DESCRIPTION
A quick adjustment making the existing network retry setup apply to `Block` parse errors (during the initial sync); I haven't had a chance to test it a lot yet (though it did work when I ran it for a while), but in theory, this should do the trick.

Seems to fix https://github.com/AleoHQ/snarkOS/issues/1873, and likely https://github.com/AleoHQ/snarkOS/issues/1891 as well.