### PR TITLE
Add get program and execution endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2354,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2417,12 +2417,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2690,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2707,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2718,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2728,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "b15f2ea93df33549dbe2e8eecd1ca55269d63ae0b3ba1f55db030817d1c2867f"
 dependencies = [
  "atty",
  "bitflags",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -458,9 +458,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1079fb8528d9f9c888b1e8aa651e6e079ade467323d58f75faf1d30b1808f540"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -792,9 +792,9 @@ checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -817,15 +817,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -834,15 +834,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -851,21 +851,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1081,13 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1231,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2162,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2293,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "anyhow",
  "clap",
@@ -2319,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2340,7 +2341,7 @@ dependencies = [
  "rand_core",
  "rayon",
  "serde",
- "sha2 0.10.2",
+ "sha2 0.10.3",
  "smallvec",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -2353,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2367,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2378,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2388,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2398,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2416,12 +2417,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2432,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2444,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2459,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2472,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2481,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2491,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2503,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2514,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2525,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2537,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "anyhow",
  "colored",
@@ -2563,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2576,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2586,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2598,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2609,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2628,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2646,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2663,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2678,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2689,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2697,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2706,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2717,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2727,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2737,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2748,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2761,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2778,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2792,7 +2793,7 @@ dependencies = [
  "paste",
  "rand",
  "serde_json",
- "sha2 0.10.2",
+ "sha2 0.10.3",
  "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror",
@@ -2801,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2817,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2835,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7658755#76587550b86ddd9b70ea1e6dea952daae2be7b2d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9c4d6cc74#9c4d6cc74fa51ed2d58dfa0b13b73a13ad47c6fe"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2846,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
 name = "arrayref"
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.18"
+version = "3.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15f2ea93df33549dbe2e8eecd1ca55269d63ae0b3ba1f55db030817d1c2867f"
+checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
 dependencies = [
  "atty",
  "bitflags",
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "peeking_take_while"
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "anyhow",
  "clap",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2354,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2417,12 +2417,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "anyhow",
  "colored",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2690,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2698,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2707,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2718,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2728,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=5888d15#5888d1520bb303773b3bf0327ec81cb9f17c507b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2847,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -2956,18 +2956,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "9c4d6cc74"
+rev = "bbc81d0"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "990b467"
+rev = "9c4d6cc74"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "7658755"
+rev = "990b467"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "bbc81d0"
+rev = "5888d15"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "bbc81d0"
+rev = "5888d15"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "990b467"
+rev = "9c4d6cc74"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "7658755"
+rev = "990b467"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "9c4d6cc74"
+rev = "bbc81d0"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -15,11 +15,12 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Ledger;
+use snarkvm::prelude::{AdditionalFee, Deployment, Execution, Field, Network, ProgramID, RecordsFilter, Transaction, ViewKey, U64};
+
 use anyhow::Result;
 use core::marker::PhantomData;
 use indexmap::IndexMap;
 use serde_json::json;
-use snarkvm::prelude::{AdditionalFee, Deployment, Execution, Field, Network, ProgramID, RecordsFilter, Transaction, ViewKey, U64};
 use std::sync::Arc;
 use tokio::{sync::mpsc, task::JoinHandle};
 use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -351,17 +351,14 @@ impl<N: Network> Server<N> {
         }
     }
 
-    /// Broadcasts the transaction to the ledger.
+    /// Send a program deployment transaction to the ledger
     async fn deploy_program(
         deployment: Deployment<N>,
         ledger: Arc<Ledger<N>>,
         ledger_sender: LedgerSender<N>,
     ) -> Result<impl Reply, Rejection> {
         let additional_fee = Self::execute_additional_fee(ledger)?;
-
-        // Create the transaction.
         let transaction = Transaction::from_deployment(deployment.clone(), additional_fee).or_reject()?;
-        // Send the transaction to the ledger.
         match ledger_sender.send(LedgerRequest::TransactionBroadcast(transaction)).await {
             Ok(()) => Ok(reply::with_status(
                 reply::json(&json!({ "deployment": deployment })),

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -195,7 +195,7 @@ impl<N: Network> Server<N> {
             .and(with(ledger_sender.clone()))
             .and_then(Self::transaction_broadcast);
 
-        // GET /testnet3/program/program_id
+        // GET /testnet3/program/{id}
         let get_program = warp::get()
             .and(warp::path!("testnet3" / "program" / u32))
             .and(with(ledger.clone()))

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -382,8 +382,7 @@ impl<N: Network> Server<N> {
         }
     }
 
-    /// Spends the record with the smallest value with at least `1 gate` as the fee
-    /// for the execution of a transaction.
+    /// Spends the record with the smallest value with at least `1 gate` as a transaction fee.
     fn execute_additional_fee(ledger: Arc<Ledger<N>>) -> Result<AdditionalFee<N>, Rejection> {
         let records = ledger.find_unspent_records().or_reject()?;
 

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -198,7 +198,6 @@ impl<N: Network> Server<N> {
         // GET /testnet3/program/program_id
         let get_program = warp::get()
             .and(warp::path!("testnet3" / "program" / u32))
-            .and(warp::body::content_length_limit(128))
             .and(with(ledger.clone()))
             .and_then(Self::get_program);
 

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -197,7 +197,7 @@ impl<N: Network> Server<N> {
 
         // GET /testnet3/program/program_id
         let get_program = warp::get()
-            .and(warp::path!("testnet3" / "program" / String))
+            .and(warp::path!("testnet3" / "program" / u32))
             .and(warp::body::content_length_limit(128))
             .and(with(ledger.clone()))
             .and_then(Self::get_program);
@@ -281,7 +281,7 @@ impl<N: Network> Server<N> {
     }
 
     /// Returns the program with the given id
-    async fn get_program(program_id: String, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
+    async fn get_program(program_id: u32, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(&ledger.ledger.read().get_program(program_id).or_reject()?))
     }
 

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -378,10 +378,7 @@ impl<N: Network> Server<N> {
         ledger_sender: LedgerSender<N>,
     ) -> Result<impl Reply, Rejection> {
         let additional_fee = Self::execute_additional_fee(ledger)?;
-
-        // Create the transaction.
         let transaction = Transaction::from_execution(execution.clone(), Some(additional_fee)).or_reject()?;
-        // Send the transaction to the ledger.
         match ledger_sender.send(LedgerRequest::TransactionBroadcast(transaction)).await {
             Ok(()) => Ok(reply::with_status(
                 reply::json(&json!({ "execution": execution })),

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Ledger;
-use snarkvm::prelude::{Deployment, Field, Network, RecordsFilter, Transaction, ViewKey, U64, AdditionalFee, Execution};
+use snarkvm::prelude::{AdditionalFee, Deployment, Execution, Field, Network, RecordsFilter, Transaction, ViewKey, U64};
 
 use anyhow::Result;
 use core::marker::PhantomData;
@@ -377,10 +377,7 @@ impl<N: Network> Server<N> {
         let additional_fee = Self::execute_additional_fee(ledger)?;
         let transaction = Transaction::from_execution(execution.clone(), Some(additional_fee)).or_reject()?;
         match ledger_sender.send(LedgerRequest::TransactionBroadcast(transaction)).await {
-            Ok(()) => Ok(reply::with_status(
-                reply::json(&json!({ "execution": execution })),
-                StatusCode::OK,
-            )),
+            Ok(()) => Ok(reply::with_status(reply::json(&json!({ "execution": execution })), StatusCode::OK)),
             Err(error) => Err(reject::custom(ServerError::Request(format!("{error}")))),
         }
     }
@@ -410,5 +407,4 @@ impl<N: Network> Server<N> {
             .map(|(_, additional_fee)| additional_fee)
             .or_reject()
     }
-
 }

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -196,18 +196,18 @@ impl<N: Network> Server<N> {
             .and(with(ledger_sender.clone()))
             .and_then(Self::transaction_broadcast);
 
-        // POST /testnet3/deploy
+        // POST /testnet3/program/deploy
         let deploy_program = warp::post()
-            .and(warp::path!("testnet3" / "deploy"))
+            .and(warp::path!("testnet3" / "program" / "deploy"))
             .and(warp::body::content_length_limit(10 * 1024 * 1024))
             .and(warp::body::json())
             .and(with(ledger.clone()))
             .and(with(ledger_sender.clone()))
             .and_then(Self::deploy_program);
 
-        // POST /testnet3/execute
+        // POST /testnet3/program/execute
         let execute_program = warp::post()
-            .and(warp::path!("testnet3" / "execute"))
+            .and(warp::path!("testnet3" / "program" / "execute"))
             .and(warp::body::content_length_limit(10 * 1024 * 1024))
             .and(warp::body::json())
             .and(with(ledger))

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 use core::marker::PhantomData;
 use indexmap::IndexMap;
 use serde_json::json;
-use snarkvm::prelude::{AdditionalFee, Deployment, Execution, Field, Network, RecordsFilter, Transaction, ViewKey, U64};
+use snarkvm::prelude::{AdditionalFee, Deployment, Execution, Field, Network, ProgramID, RecordsFilter, Transaction, ViewKey, U64};
 use std::sync::Arc;
 use tokio::{sync::mpsc, task::JoinHandle};
 use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};
@@ -197,7 +197,9 @@ impl<N: Network> Server<N> {
 
         // GET /testnet3/program/{id}
         let get_program = warp::get()
-            .and(warp::path!("testnet3" / "program" / u32))
+            .and(warp::path!("testnet3" / "program" / ..))
+            .and(warp::path::param::<ProgramID<N>>())
+            .and(warp::path::end())
             .and(with(ledger.clone()))
             .and_then(Self::get_program);
 
@@ -280,7 +282,7 @@ impl<N: Network> Server<N> {
     }
 
     /// Returns the program with the given id
-    async fn get_program(program_id: u32, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
+    async fn get_program(program_id: ProgramID<N>, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         Ok(reply::json(&ledger.ledger.read().get_program(program_id).or_reject()?))
     }
 


### PR DESCRIPTION
This adds a program execution endpoint, similar to the deployment one. The additional fee calculation (assumed to be the same for both) has been extracted to a helper function. This also fixes a couple of stale comments mentioned in another PR.

This is currently pointing to the #1897 branch, I can send it to the testnet3 branch once that's merged if preferred.

This also incorporates the get program endpoint from #1901 