### PR TITLE
Add a get ciphertext endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkos-environment",
- "snarkvm 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm",
  "tempfile",
  "thiserror",
  "time",
@@ -2285,7 +2285,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2294,32 +2294,6 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "anyhow",
- "clap",
- "colored",
- "indexmap",
- "once_cell",
- "parking_lot",
- "rand",
- "rayon",
- "self_update",
- "serde_json",
- "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-compiler 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "thiserror",
- "ureq",
- "walkdir",
-]
-
-[[package]]
-name = "snarkvm"
-version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
  "anyhow",
@@ -2332,49 +2306,15 @@ dependencies = [
  "rayon",
  "self_update",
  "serde_json",
- "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-compiler 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit",
+ "snarkvm-compiler",
+ "snarkvm-console",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
  "thiserror",
  "ureq",
  "walkdir",
-]
-
-[[package]]
-name = "snarkvm-algorithms"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "crossbeam-channel",
- "curl",
- "derivative",
- "digest 0.10.3",
- "hashbrown",
- "hex",
- "itertools",
- "lazy_static",
- "num_cpus",
- "once_cell",
- "parking_lot",
- "rand",
- "rand_chacha",
- "rand_core",
- "rayon",
- "serde",
- "sha2 0.10.3",
- "smallvec",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "thiserror",
 ]
 
 [[package]]
@@ -2403,51 +2343,26 @@ dependencies = [
  "serde",
  "sha2 0.10.3",
  "smallvec",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-r1cs",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
-]
-
-[[package]]
-name = "snarkvm-circuit"
-version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-account"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-program",
+ "snarkvm-circuit-types",
 ]
 
 [[package]]
@@ -2455,20 +2370,10 @@ name = "snarkvm-circuit-account"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-algorithms"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-account",
 ]
 
 [[package]]
@@ -2476,19 +2381,9 @@ name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-collections"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types",
+ "snarkvm-console-algorithms",
+ "snarkvm-fields",
 ]
 
 [[package]]
@@ -2496,27 +2391,9 @@ name = "snarkvm-circuit-collections"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-environment"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "indexmap",
- "itertools",
- "nom",
- "num-traits",
- "once_cell",
- "snarkvm-circuit-environment-witness 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-types",
+ "snarkvm-console-collections",
 ]
 
 [[package]]
@@ -2529,18 +2406,13 @@ dependencies = [
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-circuit-environment-witness 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-environment-witness",
+ "snarkvm-console-network",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-r1cs",
+ "snarkvm-utilities",
 ]
-
-[[package]]
-name = "snarkvm-circuit-environment-witness"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
@@ -2550,35 +2422,12 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
-]
-
-[[package]]
-name = "snarkvm-circuit-network"
-version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-program"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-types",
+ "snarkvm-console-network",
 ]
 
 [[package]]
@@ -2586,26 +2435,11 @@ name = "snarkvm-circuit-program"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-program",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2613,27 +2447,14 @@ name = "snarkvm-circuit-types"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-address"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-address",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-circuit-types-string",
 ]
 
 [[package]]
@@ -2641,21 +2462,12 @@ name = "snarkvm-circuit-types-address"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-boolean"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-address",
 ]
 
 [[package]]
@@ -2663,18 +2475,8 @@ name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-field"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-console-types-boolean",
 ]
 
 [[package]]
@@ -2682,21 +2484,9 @@ name = "snarkvm-circuit-types-field"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-group"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-console-types-field",
 ]
 
 [[package]]
@@ -2704,22 +2494,11 @@ name = "snarkvm-circuit-types-group"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-integers"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-group",
 ]
 
 [[package]]
@@ -2727,21 +2506,10 @@ name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-scalar"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-console-types-integers",
 ]
 
 [[package]]
@@ -2749,22 +2517,10 @@ name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-string"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
@@ -2772,37 +2528,11 @@ name = "snarkvm-circuit-types-string"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-compiler"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "anyhow",
- "colored",
- "indexmap",
- "once_cell",
- "parking_lot",
- "paste",
- "rand",
- "rayon",
- "serde",
- "serde_json",
- "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "time",
- "tracing",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-console-types-string",
 ]
 
 [[package]]
@@ -2820,13 +2550,13 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
  "time",
  "tracing",
 ]
@@ -2834,37 +2564,14 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
-]
-
-[[package]]
-name = "snarkvm-console"
-version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-account"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "base58",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-program",
+ "snarkvm-console-types",
 ]
 
 [[package]]
@@ -2873,20 +2580,8 @@ version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
  "base58",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-algorithms"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "blake2s_simd",
- "smallvec",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
 ]
 
 [[package]]
@@ -2896,20 +2591,9 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-collections"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "aleo-std",
- "rayon",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types",
+ "snarkvm-fields",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2919,27 +2603,8 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-network"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "anyhow",
- "itertools",
- "lazy_static",
- "serde",
- "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-types",
 ]
 
 [[package]]
@@ -2951,32 +2616,14 @@ dependencies = [
  "itertools",
  "lazy_static",
  "serde",
- "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-network-environment"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "anyhow",
- "bech32",
- "itertools",
- "nom",
- "num-traits",
- "rand",
- "rand_xorshift",
- "serde",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-algorithms",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -2992,26 +2639,9 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-program"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "enum_index",
- "enum_index_derive",
- "indexmap",
- "num-derive",
- "num-traits",
- "once_cell",
- "serde_json",
- "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3026,24 +2656,9 @@ dependencies = [
  "num-traits",
  "once_cell",
  "serde_json",
- "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-account",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
 ]
 
 [[package]]
@@ -3051,25 +2666,14 @@ name = "snarkvm-console-types"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-address"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-address",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
+ "snarkvm-console-types-integers",
+ "snarkvm-console-types-scalar",
+ "snarkvm-console-types-string",
 ]
 
 [[package]]
@@ -3077,18 +2681,10 @@ name = "snarkvm-console-types-address"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-boolean"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
 ]
 
 [[package]]
@@ -3096,16 +2692,7 @@ name = "snarkvm-console-types-boolean"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-field"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
 ]
 
 [[package]]
@@ -3113,19 +2700,8 @@ name = "snarkvm-console-types-field"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-group"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
 ]
 
 [[package]]
@@ -3133,20 +2709,10 @@ name = "snarkvm-console-types-group"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-integers"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
@@ -3154,19 +2720,9 @@ name = "snarkvm-console-types-integers"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-scalar"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
 ]
 
 [[package]]
@@ -3174,20 +2730,9 @@ name = "snarkvm-console-types-scalar"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-console-types-string"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
 ]
 
 [[package]]
@@ -3195,23 +2740,10 @@ name = "snarkvm-console-types-string"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
- "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
-]
-
-[[package]]
-name = "snarkvm-curves"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "rand",
- "rustc_version",
- "serde",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "thiserror",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-integers",
 ]
 
 [[package]]
@@ -3222,25 +2754,8 @@ dependencies = [
  "rand",
  "rustc_version",
  "serde",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-fields"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "aleo-std",
- "anyhow",
- "derivative",
- "itertools",
- "num-traits",
- "rand",
- "rayon",
- "serde",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3257,30 +2772,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-parameters"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "cfg-if",
- "curl",
- "hex",
- "indexmap",
- "itertools",
- "lazy_static",
- "paste",
- "rand",
- "serde_json",
- "sha2 0.10.3",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3302,24 +2794,8 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2 0.10.3",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-r1cs"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "anyhow",
- "cfg-if",
- "fxhash",
- "indexmap",
- "itertools",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-curves",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3333,27 +2809,9 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools",
- "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-utilities"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "num-bigint",
- "num_cpus",
- "rand",
- "rand_xorshift",
- "rayon",
- "serde",
- "snarkvm-utilities-derives 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3371,20 +2829,8 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "serde",
- "snarkvm-utilities-derives 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities-derives",
  "thiserror",
-]
-
-[[package]]
-name = "snarkvm-utilities-derives"
-version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
-dependencies = [
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkos-environment",
- "snarkvm",
+ "snarkvm 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "tempfile",
  "thiserror",
  "time",
@@ -2285,7 +2285,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm",
+ "snarkvm 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2306,12 +2306,38 @@ dependencies = [
  "rayon",
  "self_update",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-compiler",
- "snarkvm-console",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-compiler 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+ "ureq",
+ "walkdir",
+]
+
+[[package]]
+name = "snarkvm"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "indexmap",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "self_update",
+ "serde_json",
+ "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-compiler 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
  "ureq",
  "walkdir",
@@ -2343,11 +2369,45 @@ dependencies = [
  "serde",
  "sha2 0.10.3",
  "smallvec",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "crossbeam-channel",
+ "curl",
+ "derivative",
+ "digest 0.10.3",
+ "hashbrown",
+ "hex",
+ "itertools",
+ "lazy_static",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rayon",
+ "serde",
+ "sha2 0.10.3",
+ "smallvec",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
 ]
 
@@ -2356,13 +2416,27 @@ name = "snarkvm-circuit"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-account",
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-environment",
- "snarkvm-circuit-network",
- "snarkvm-circuit-program",
- "snarkvm-circuit-types",
+ "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2370,10 +2444,21 @@ name = "snarkvm-circuit-account"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-network",
- "snarkvm-circuit-types",
- "snarkvm-console-account",
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-account"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2381,9 +2466,19 @@ name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-types",
- "snarkvm-console-algorithms",
- "snarkvm-fields",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-algorithms"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2391,9 +2486,19 @@ name = "snarkvm-circuit-collections"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-types",
- "snarkvm-console-collections",
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-collections"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2406,12 +2511,30 @@ dependencies = [
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-circuit-environment-witness",
- "snarkvm-console-network",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-r1cs",
- "snarkvm-utilities",
+ "snarkvm-circuit-environment-witness 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-environment"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "indexmap",
+ "itertools",
+ "nom",
+ "num-traits",
+ "once_cell",
+ "snarkvm-circuit-environment-witness 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-r1cs 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2420,14 +2543,30 @@ version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 
 [[package]]
+name = "snarkvm-circuit-environment-witness"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+
+[[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-types",
- "snarkvm-console-network",
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-network"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2435,11 +2574,23 @@ name = "snarkvm-circuit-program"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-account",
- "snarkvm-circuit-network",
- "snarkvm-circuit-types",
- "snarkvm-console-program",
- "snarkvm-utilities",
+ "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-program"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2447,14 +2598,29 @@ name = "snarkvm-circuit-types"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-address",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-group",
- "snarkvm-circuit-types-integers",
- "snarkvm-circuit-types-scalar",
- "snarkvm-circuit-types-string",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2462,12 +2628,25 @@ name = "snarkvm-circuit-types-address"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-group",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-address",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-address"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2475,8 +2654,17 @@ name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-boolean"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2484,9 +2672,19 @@ name = "snarkvm-circuit-types-field"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-field"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2494,11 +2692,23 @@ name = "snarkvm-circuit-types-group"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-group",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-group"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2506,10 +2716,21 @@ name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-console-types-integers",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-integers"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2517,10 +2738,21 @@ name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-scalar"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2528,11 +2760,23 @@ name = "snarkvm-circuit-types-string"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-integers",
- "snarkvm-console-types-string",
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-string"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-circuit-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2550,13 +2794,39 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-algorithms",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-compiler"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "anyhow",
+ "colored",
+ "indexmap",
+ "once_cell",
+ "parking_lot",
+ "paste",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+ "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-circuit 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-parameters 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "time",
  "tracing",
 ]
@@ -2566,12 +2836,25 @@ name = "snarkvm-console"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-account",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network",
- "snarkvm-console-program",
- "snarkvm-console-types",
+ "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-program 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2580,8 +2863,18 @@ version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
  "base58",
- "snarkvm-console-network",
- "snarkvm-console-types",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "base58",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2591,9 +2884,21 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2603,8 +2908,19 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms",
- "snarkvm-console-types",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2616,14 +2932,33 @@ dependencies = [
  "itertools",
  "lazy_static",
  "serde",
- "snarkvm-algorithms",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network-environment",
- "snarkvm-console-types",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "lazy_static",
+ "serde",
+ "snarkvm-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-algorithms 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-collections 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2639,9 +2974,27 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "itertools",
+ "nom",
+ "num-traits",
+ "rand",
+ "rand_xorshift",
+ "serde",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2656,9 +3009,26 @@ dependencies = [
  "num-traits",
  "once_cell",
  "serde_json",
- "snarkvm-console-account",
- "snarkvm-console-network",
- "snarkvm-console-types",
+ "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "enum_index",
+ "enum_index_derive",
+ "indexmap",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "serde_json",
+ "snarkvm-console-account 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-network 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2666,14 +3036,29 @@ name = "snarkvm-console-types"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-address",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
- "snarkvm-console-types-integers",
- "snarkvm-console-types-scalar",
- "snarkvm-console-types-string",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-address 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-string 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2681,10 +3066,21 @@ name = "snarkvm-console-types-address"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-group 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2692,7 +3088,15 @@ name = "snarkvm-console-types-boolean"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2700,8 +3104,17 @@ name = "snarkvm-console-types-field"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2709,10 +3122,21 @@ name = "snarkvm-console-types-group"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-scalar 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2720,9 +3144,19 @@ name = "snarkvm-console-types-integers"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2730,9 +3164,19 @@ name = "snarkvm-console-types-scalar"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2740,10 +3184,21 @@ name = "snarkvm-console-types-string"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-integers",
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "snarkvm-console-network-environment 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-boolean 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-field 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-console-types-integers 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
 ]
 
 [[package]]
@@ -2754,8 +3209,21 @@ dependencies = [
  "rand",
  "rustc_version",
  "serde",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "rand",
+ "rustc_version",
+ "serde",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
 ]
 
@@ -2772,7 +3240,24 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "derivative",
+ "itertools",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
 ]
 
@@ -2794,8 +3279,31 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2 0.10.3",
- "snarkvm-curves",
- "snarkvm-utilities",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "curl",
+ "hex",
+ "indexmap",
+ "itertools",
+ "lazy_static",
+ "paste",
+ "rand",
+ "serde_json",
+ "sha2 0.10.3",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
 ]
 
@@ -2809,9 +3317,25 @@ dependencies = [
  "fxhash",
  "indexmap",
  "itertools",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-r1cs"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "fxhash",
+ "indexmap",
+ "itertools",
+ "snarkvm-curves 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-fields 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
+ "snarkvm-utilities 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
 ]
 
@@ -2829,7 +3353,25 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "serde",
- "snarkvm-utilities-derives",
+ "snarkvm-utilities-derives 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "num-bigint",
+ "num_cpus",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "snarkvm-utilities-derives 0.9.0 (git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80)",
  "thiserror",
 ]
 
@@ -2837,6 +3379,18 @@ dependencies = [
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
 source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bbc81d0#bbc81d0069a15200b8c4ec7eb681f6a5575c86b3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "0.9.0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d6d2f80#d6d2f80596690538abc917d5385c7b4088134031"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "bbc81d0"
+rev = "d6d2f80"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "bbc81d0"
+rev = "d6d2f80"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -174,13 +174,13 @@ impl<N: Network> Server<N> {
             .and(with(ledger.clone()))
             .and_then(Self::records_unspent);
 
-        // GET /testnet3/ciphertext/unspent/{commitment}
-        let get_unspent_ciphertext = warp::get()
+        // GET /testnet3/ciphertext/{commitment}
+        let get_ciphertext = warp::get()
             .and(warp::path!("testnet3" / "ciphertext" / ..))
             .and(warp::path::param::<Field<N>>())
             .and(warp::path::end())
             .and(with(ledger.clone()))
-            .and_then(Self::get_unspent_ciphertext);
+            .and_then(Self::get_ciphertext);
 
         // GET /testnet3/peers/count
         let peers_count = warp::get()
@@ -259,7 +259,7 @@ impl<N: Network> Server<N> {
             .or(deploy_program)
             .or(execute_program)
             .or(get_program)
-            .or(get_unspent_ciphertext)
+            .or(get_ciphertext)
     }
 
     /// Initializes a ledger handler.
@@ -356,7 +356,7 @@ impl<N: Network> Server<N> {
     }
 
     /// Returns the record ciphertext for the given view key.
-    async fn get_unspent_ciphertext(commitment: Field<N>, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
+    async fn get_ciphertext(commitment: Field<N>, ledger: Arc<Ledger<N>>) -> Result<impl Reply, Rejection> {
         if let Some(record_ciphertext) = ledger.ledger.read().get_record(commitment).or_reject()? {
             Ok(reply::with_status(reply::json(&record_ciphertext), StatusCode::OK))
         } else {

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -15,7 +15,19 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Ledger;
-use snarkvm::prelude::{AdditionalFee, Deployment, Execution, Field, Network, ProgramID, RecordsFilter, Transaction, ViewKey, U64};
+use snarkvm::prelude::{
+    AdditionalFee,
+    Address,
+    Deployment,
+    Execution,
+    Field,
+    Network,
+    ProgramID,
+    RecordsFilter,
+    Transaction,
+    ViewKey,
+    U64,
+};
 
 use anyhow::Result;
 use core::marker::PhantomData;

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -162,6 +162,15 @@ impl<N: Network> Server<N> {
             .and(with(ledger.clone()))
             .and_then(Self::records_unspent);
 
+        let ciphertext_unspent = warp::get()
+            .and(warp::path!("testnet3" / "ciphertext" / ..))
+            .and(warp::path::param::<Field<N>>())
+            .and(warp::path::end())
+            .and(warp::body::content_length_limit(128))
+            .and(warp::body::json())
+            .and(with(ledger.clone()))
+            .and_then(Self::get_unspent_ciphertext);
+
         // GET /testnet3/peers/count
         let peers_count = warp::get()
             .and(warp::path!("testnet3" / "peers" / "count"))

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -164,7 +164,7 @@ impl<N: Network> Server<N> {
 
         // GET /testnet3/ciphertext/unspent/{commitment}
         let get_unspent_ciphertext = warp::get()
-            .and(warp::path!("testnet3" / "ciphertext" / ..))
+            .and(warp::path!("testnet3" / "ciphertext" / "unspent" / ..))
             .and(warp::path::param::<Field<N>>())
             .and(warp::path::end())
             .and(warp::body::content_length_limit(128))

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -353,7 +353,8 @@ impl<N: Network> Server<N> {
             .read()
             .find_record_ciphertexts(&view_key, RecordsFilter::Unspent)
             .or_reject()?
-            .find(|(record_commitment, _)| *record_commitment == commitment) {
+            .find(|(record_commitment, _)| *record_commitment == commitment)
+        {
             Ok(reply::with_status(reply::json(&*record_ciphertext), StatusCode::OK))
         } else {
             Err(warp::reject::not_found())


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This endpoint will be consumed in the `aleo execute` command workflow (https://github.com/AleoHQ/aleo/pull/332). The idea is for this command to be able to get the record to consume in a program execution out of the Record Commitment with the help of the user's View Key.

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/snarkOS,
    and link to your PR here.
-->

This PR branched from #1900 and contains functionality that will be used in https://github.com/AleoHQ/aleo/pull/332.
