### PR TITLE
Get deploy transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "2.0.2"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "5888d15"
+rev = "9bd18a0"
 features = ["circuit", "console", "parallel", "utilities"]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -36,7 +36,7 @@ version = "1"
 
 [dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "5888d15"
+rev = "9bd18a0"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/ledger/server.rs
+++ b/snarkos/ledger/server.rs
@@ -373,9 +373,10 @@ impl<N: Network> Server<N> {
     ) -> Result<impl Reply, Rejection> {
         let additional_fee = Self::execute_additional_fee(ledger)?;
         let transaction = Transaction::from_deployment(deployment.clone(), additional_fee).or_reject()?;
+        let transaction_id = transaction.id().to_string();
         match ledger_sender.send(LedgerRequest::TransactionBroadcast(transaction)).await {
             Ok(()) => Ok(reply::with_status(
-                reply::json(&json!({ "deployment": deployment })),
+                reply::json(&json!({ "deployment": deployment , "transaction_id": transaction_id})),
                 StatusCode::OK,
             )),
             Err(error) => Err(reject::custom(ServerError::Request(format!("{error}")))),


### PR DESCRIPTION
## Motivation

The user of the Aleo CLI tool needs to know the transaction ID associated with the deployment of their programs. This PR includes the transaction_id field on the deployment response to send it to the Aleo CLI tool and show it to the user.
