### PR TITLE
Bump snarkVM rev - 1aa7af9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "libc",
  "once_cell",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
 
@@ -1139,6 +1140,17 @@ dependencies = [
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
+dependencies = [
+ "console",
+ "number_prefix",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2066,7 +2078,7 @@ dependencies = [
  "either",
  "flate2",
  "hyper",
- "indicatif",
+ "indicatif 0.16.2",
  "log",
  "quick-xml",
  "regex",
@@ -2075,6 +2087,23 @@ dependencies = [
  "serde_json",
  "tempfile",
  "zip",
+]
+
+[[package]]
+name = "self_update"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05ab948d728a6439b9da58a94c9df77d421a8bf558145681f908e170232f120"
+dependencies = [
+ "hyper",
+ "indicatif 0.17.1",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -2286,7 +2315,7 @@ dependencies = [
  "rocksdb",
  "rusoto_core",
  "rusty-hook",
- "self_update",
+ "self_update 0.30.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -2323,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2333,7 +2362,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "self_update",
+ "self_update 0.31.0",
  "serde_json",
  "snarkvm-circuit",
  "snarkvm-compiler",
@@ -2350,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2376,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2390,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2401,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2411,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2421,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2439,12 +2468,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2455,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2467,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2482,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2495,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2504,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2514,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2526,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2537,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2548,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2560,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "anyhow",
  "colored",
@@ -2586,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2599,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2609,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2621,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2632,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2651,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2668,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2685,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2700,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2711,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2719,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2728,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2739,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2749,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2759,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2770,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2783,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2800,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2823,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2839,11 +2868,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-rest"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "anyhow",
  "indexmap",
  "parking_lot",
+ "serde",
  "snarkvm-compiler",
  "snarkvm-console",
  "tokio",
@@ -2854,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2872,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b2cee23#b2cee23ef419a62ae0180f3ac256af48d2a57ca7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,18 +2114,18 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -2352,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "anyhow",
  "clap",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2440,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2468,12 +2468,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2511,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2566,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "anyhow",
  "colored",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "base58",
  "snarkvm-console-network",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2661,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2740,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2829,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2868,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-rest"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2884,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2902,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=44b1802#44b1802589b3cdcd84acc0752210b212f203dfc3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1aa7af9#1aa7af977a90a85fea6e76b9b4bf06aefef30fba"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ version = "2.0.2"
 [dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "b2cee23"
+rev = "44b1802"
 features = ["circuit", "console", "parallel", "rest", "utilities"]
 
 [dependencies.aleo-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ version = "2.0.2"
 [dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "44b1802"
+rev = "1aa7af9"
 features = ["circuit", "console", "parallel", "rest", "utilities"]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -37,7 +37,7 @@ version = "1"
 [dependencies.snarkvm]
 #path = "../../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "44b1802"
+rev = "1aa7af9"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -37,7 +37,7 @@ version = "1"
 [dependencies.snarkvm]
 #path = "../../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "b2cee23"
+rev = "44b1802"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -138,14 +138,20 @@ impl<N: Network> Ledger<N> {
         }))
     }
 
+    // TODO (raychu86): Restrict visibility.
     /// Returns the ledger.
-    pub(super) const fn ledger(&self) -> &Arc<RwLock<InternalLedger<N>>> {
+    pub const fn ledger(&self) -> &Arc<RwLock<InternalLedger<N>>> {
         &self.ledger
     }
 
     /// Returns the connected peers.
     pub(super) const fn peers(&self) -> &Peers<N> {
         &self.peers
+    }
+
+    /// Returns the ledger address.
+    pub const fn address(&self) -> &Address<N> {
+        &self.address
     }
 }
 

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -144,14 +144,14 @@ impl<N: Network> Ledger<N> {
         &self.ledger
     }
 
-    /// Returns the connected peers.
-    pub(super) const fn peers(&self) -> &Peers<N> {
-        &self.peers
-    }
-
     /// Returns the ledger address.
     pub const fn address(&self) -> &Address<N> {
         &self.address
+    }
+
+    /// Returns the connected peers.
+    pub(super) const fn peers(&self) -> &Peers<N> {
+        &self.peers
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the snarkVM rev to https://github.com/AleoHQ/snarkVM/commit/1aa7af977a90a85fea6e76b9b4bf06aefef30fba

Also adds a minor (temporary) visibility change for `Ledger::ledger`. Once the beacon has been unified into snarkOS, the visibility of `address` and `ledger` should be reverted to `pub(super)`