### PR TITLE
Fix the CI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           cache_key: snarkos-stable-cache
       - run_parallel:
           workspace_member: .
-          features: test
+          features: ""
       - clear_environment:
           cache_key: snarkos-stable-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           cache_key: snarkos-environment-cache
       - run_parallel:
           workspace_member: environment
-          features: network
+          features: ""
       - clear_environment:
           cache_key: snarkos-environment-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
 
   environment:
     docker:
-      - image: cimg/rust:1.60
+      - image: cimg/rust:1.62
     resource_class: xlarge
     parallelism: 1
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   snarkos:
     docker:
-      - image: cimg/rust:1.60
+      - image: cimg/rust:1.62
     resource_class: xlarge
     parallelism: 20
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   fmt:
     docker:
-      - image: cimg/rust:1.60
+      - image: cimg/rust:1.62
     resource_class: xlarge
     steps:
       - checkout
@@ -132,7 +132,7 @@ jobs:
 
   clippy:
     docker:
-      - image: cimg/rust:1.60
+      - image: cimg/rust:1.62
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
 
   environment:
     docker:
-      - image: cimg/rust:1.59
+      - image: cimg/rust:1.60
     resource_class: xlarge
     parallelism: 1
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   snarkos:
     docker:
-      - image: cimg/rust:1.59
+      - image: cimg/rust:1.60
     resource_class: xlarge
     parallelism: 20
     steps:
@@ -116,7 +116,7 @@ jobs:
 
   fmt:
     docker:
-      - image: cimg/rust:1.59
+      - image: cimg/rust:1.60
     resource_class: xlarge
     steps:
       - checkout
@@ -132,7 +132,7 @@ jobs:
 
   clippy:
     docker:
-      - image: cimg/rust:1.59
+      - image: cimg/rust:1.60
     resource_class: xlarge
     steps:
       - checkout

--- a/environment/src/helpers/block_locators.rs
+++ b/environment/src/helpers/block_locators.rs
@@ -248,7 +248,6 @@ mod tests {
         // assert_eq!(expected_block_locators, serde_json::from_str(&candidate_string).unwrap());
     }
 
-    #[cfg(feature = "network")]
     #[test]
     fn test_block_locators_bincode() {
         // let expected_block_height = CurrentNetwork::genesis_block().height();


### PR DESCRIPTION
There were 2 issues:
- the CI config referenced currently non-existent features
- the compiler version used in the CI was too low; `rocksdb`'s MSRV is `1.60`, and `snarkVM` requires `1.62`; I was conservative here and chose the lowest working version