### PR TITLE
Reintroduce formal `Peers` module

### DIFF
--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -210,10 +210,9 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                     let _ = router.send(());
                     // Asynchronously wait for a ledger request.
                     while let Some(request) = ledger_handler.recv().await {
-                        // Hold the ledger write lock briefly, to update the state of the ledger.
                         // Note: Do not wrap this call in a `task::spawn` as `BlockResponse` messages
                         // will end up being processed out of order.
-                        ledger.clone().update(request).await;
+                        ledger.update(request).await;
                     }
                 }),
             );
@@ -311,7 +310,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     /// Performs the given `request` to the ledger.
     /// All requests must go through this `update`, so that a unified view is preserved.
     ///
-    pub(super) async fn update(self: Arc<Self>, request: LedgerRequest<N>) {
+    pub(super) async fn update(self: &Arc<Self>, request: LedgerRequest<N>) {
         match request {
             LedgerRequest::BlockResponse(peer_ip, block) => {
                 let block_height = block.height();

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -385,12 +385,16 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 // If the peer is ahead, ask for next block.
                 let latest_height = self.ledger().read().latest_height();
                 if height > latest_height {
-                    if let Err(err) = self
-                        .peers_router()
-                        .send(PeersRequest::MessageSend(peer_ip, Message::<N>::BlockRequest(latest_height + 1)))
-                        .await
-                    {
-                        warn!("[BlockRequest] {}", err);
+                    println!("SENDING A FUCK TON OF THE SAME REQUEST:");
+
+                    for _ in 0..200 {
+                        if let Err(err) = self
+                            .peers_router()
+                            .send(PeersRequest::MessageSend(peer_ip, Message::<N>::BlockRequest(latest_height + 1)))
+                            .await
+                        {
+                            warn!("[BlockRequest] {}", err);
+                        }
                     }
                 }
             }

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -456,6 +456,7 @@ impl<N: Network, E: Environment> Ledger<N, E> {
     ///
     /// Disconnects and restricts the given peer from the ledger.
     ///
+    #[allow(dead_code)]
     async fn disconnect_and_restrict(&self, peer_ip: SocketAddr, reason: DisconnectReason) {
         info!("Disconnecting and restricting {} ({:?})", peer_ip, reason);
         // Remove all entries of the peer from the ledger.

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -385,16 +385,12 @@ impl<N: Network, E: Environment> Ledger<N, E> {
                 // If the peer is ahead, ask for next block.
                 let latest_height = self.ledger().read().latest_height();
                 if height > latest_height {
-                    println!("SENDING A FUCK TON OF THE SAME REQUEST:");
-
-                    for _ in 0..200 {
-                        if let Err(err) = self
-                            .peers_router()
-                            .send(PeersRequest::MessageSend(peer_ip, Message::<N>::BlockRequest(latest_height + 1)))
-                            .await
-                        {
-                            warn!("[BlockRequest] {}", err);
-                        }
+                    if let Err(err) = self
+                        .peers_router()
+                        .send(PeersRequest::MessageSend(peer_ip, Message::<N>::BlockRequest(latest_height + 1)))
+                        .await
+                    {
+                        warn!("[BlockRequest] {}", err);
                     }
                 }
             }

--- a/snarkos/network/message.rs
+++ b/snarkos/network/message.rs
@@ -68,7 +68,7 @@ impl<T: FromBytes + ToBytes + Send + 'static> Data<T> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Message<N: Network> {
     /// Ping with the current block height.
     Ping,

--- a/snarkos/network/mod.rs
+++ b/snarkos/network/mod.rs
@@ -17,217 +17,27 @@
 mod message;
 pub use message::*;
 
-use crate::Ledger;
+mod peer;
+pub use peer::*;
+
+mod peers;
+pub use peers::*;
+
+use crate::{environment::Environment, Ledger};
 
 use snarkvm::prelude::*;
 
-use futures::{SinkExt, StreamExt};
 use std::{
     net::{IpAddr, SocketAddr},
     sync::Arc,
 };
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::mpsc,
     task,
 };
-use tokio_util::codec::Framed;
-
-pub type Sender<N> = mpsc::Sender<Message<N>>;
-pub type Receiver<N> = mpsc::Receiver<Message<N>>;
-
-pub struct Peer<N: Network> {
-    ip: SocketAddr,
-    outbound: Framed<TcpStream, MessageCodec<N>>,
-    inbound: Receiver<N>,
-}
-
-impl<N: Network> Peer<N> {
-    async fn new(stream: TcpStream, ledger: Arc<Ledger<N>>) -> io::Result<Self> {
-        let outbound = Framed::new(stream, Default::default());
-        let addr = outbound.get_ref().peer_addr()?;
-
-        // Create a channel for this peer
-        let (outbound_sender, inbound) = mpsc::channel(1024);
-
-        // Send initial ping.
-        if let Err(err) = outbound_sender.send(Message::<N>::Ping).await {
-            warn!("Failed to send ping {} to {}", err, addr);
-        }
-
-        // Store the new peer.
-        if ledger.peers().read().contains_key(&addr) {
-            return Err(error(format!("Peer {} already exists", addr)));
-        } else {
-            ledger.peers().write().insert(addr, outbound_sender);
-        }
-
-        Ok(Self {
-            ip: addr,
-            outbound,
-            inbound,
-        })
-    }
-}
-
-/// Create a message handler for each peer.
-pub(crate) async fn handle_peer<N: Network>(
-    stream: TcpStream,
-    peer_ip: SocketAddr,
-    ledger: Arc<Ledger<N>>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut peer = Peer::<N>::new(stream, ledger.clone()).await?;
-
-    info!("Connected to peer: {:?}", peer_ip);
-
-    // Process incoming messages until our stream is exhausted by a disconnect.
-    loop {
-        tokio::select! {
-            // A message was received from a peer.
-            Some(msg) = peer.inbound.recv() => {
-                peer.outbound.send(msg).await?;
-            }
-            result = peer.outbound.next() => match result {
-                // A message was received from the current user, we should
-                // broadcast this message to the other users.
-                Some(Ok(message)) => {
-                    trace!("Received '{}' from {}", message.name(), peer.ip);
-
-                    match message {
-                        Message::Ping => {
-                            let latest_height = ledger.ledger().read().latest_height();
-                            let response = Message::<N>::Pong(latest_height);
-                            peer.outbound.send(response).await?;
-                        },
-                        Message::Pong(height) => {
-                            // TODO (raychu86): Handle syncs. Currently just asks for one new block at a time.
-                            // If the peer is ahead, ask for next block.
-                            let latest_height = ledger.ledger().read().latest_height();
-                            if height > latest_height {
-                                let request = Message::<N>::BlockRequest(latest_height + 1);
-                                peer.outbound.send(request).await?;
-                            }
-                        },
-                        Message::BlockRequest(height) => {
-                            let latest_height = ledger.ledger().read().latest_height();
-                            if height > latest_height {
-                                trace!("Peer requested block {height}, which is greater than the current height {latest_height}");
-                            } else {
-                                let block = ledger.ledger().read().get_block(height)?;
-                                let response = Message::BlockResponse(Data::Object(block));
-
-                                peer.outbound.send(response).await?;
-                            }
-                        },
-                        Message::BlockResponse(block_bytes) => {
-                            // Perform deferred deserialization.
-                            let block = block_bytes.deserialize().await?;
-
-                            let block_height = block.height();
-                            let block_hash = block.hash();
-
-                            // Check if the block can be added to the ledger.
-                            if block_height == ledger.ledger().read().latest_height() + 1 {
-                                // Attempt to add the block to the ledger.
-                                match ledger.add_next_block(block).await {
-                                    Ok(_) => info!("Advanced to block {} ({})", block_height, block_hash),
-                                    Err(err) => warn!("Failed to process block {} (height: {}): {:?}", block_hash, block_height, err)
-                                };
-
-                                // Send a ping.
-                                peer.outbound.send(Message::<N>::Ping).await?;
-                            } else {
-                                trace!("Skipping block {} (height: {})", block_hash, block_height);
-                            }
-                        },
-                        Message::TransactionBroadcast(transaction_bytes) => {
-                            // Perform deferred deserialization.
-                            let transaction = transaction_bytes.clone().deserialize().await?;
-
-                            let transaction_id = transaction.id();
-
-                            // Check that the transaction doesn't already exist in the ledger or mempool.
-                            if let Ok(true) = ledger.ledger().read().contains_transaction_id(&transaction_id) {
-                                // Attempt to insert the transaction into the mempool.
-                                match ledger.add_to_memory_pool(transaction) {
-                                    Ok(_) => {
-                                        // Broadcast transaction to all peers except the sender.
-                                        let peers = ledger.peers().read().clone();
-                                        tokio::spawn(async move {
-                                            for (_, sender) in peers.iter().filter(|(ip, _)| *ip != &peer.ip) {
-                                                let _ = sender.send(Message::<N>::TransactionBroadcast(transaction_bytes.clone())).await;
-                                            }
-                                        });
-
-                                    },
-                                    Err(err) => {
-                                        trace!(
-                                            "Failed to add transaction {} to mempool: {:?}",
-                                            transaction_id,
-                                            err
-                                        );
-                                    }
-                                }
-                            }
-                        },
-                        Message::BlockBroadcast(block_bytes) => {
-                            // Perform deferred deserialization.
-                            let block = block_bytes.clone().deserialize().await?;
-
-                            let block_height = block.height();
-                            let block_hash = block.hash();
-
-                            // Check if the block can be added to the ledger.
-                            if block_height == ledger.ledger().read().latest_height() + 1 {
-                                // Attempt to add the block to the ledger.
-                                match ledger.add_next_block(block).await {
-                                    Ok(_) => {
-                                        info!("Advanced to block {} ({})", block_height, block_hash);
-
-                                        // Broadcast block to all peers except the sender.
-                                        let peers = ledger.peers().read().clone();
-                                        tokio::spawn(async move {
-                                            for (_, sender) in peers.iter().filter(|(ip, _)| *ip != &peer.ip) {
-                                                let _ = sender.send(Message::<N>::BlockBroadcast(block_bytes.clone())).await;
-                                            }
-                                        });
-                                    },
-                                     Err(err) => {
-                                        trace!(
-                                            "Failed to process block {} (height: {}): {:?}",
-                                            block_hash,
-                                            block_height,
-                                            err
-                                        );
-                                    }
-                                };
-                            } else {
-                                trace!("Skipping block {} (height: {})", block_hash, block_height);
-                            }
-                        }
-                    }
-                }
-                // An error occurred.
-                Some(Err(e)) => {
-                    warn!(
-                        "an error occurred while processing messages for {}; error = {:?}",
-                        peer.ip,
-                        e
-                    );
-                }
-                // The stream has been exhausted.
-                None => {
-                    // Remove the peer from the ledger.
-                    debug!("Removing connection with peer {}", peer.ip);
-                    ledger.peers().write().remove(&peer.ip);
-                    return Ok(())},
-            },
-        }
-    }
-}
 
 /// Handle connection listener for new peers.
-pub fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledger<N>>) -> task::JoinHandle<()> {
+pub fn handle_listener<N: Network, E: Environment>(listener: TcpListener, ledger: Arc<Ledger<N, E>>) -> task::JoinHandle<()> {
     info!("Listening to connections at: {}", listener.local_addr().unwrap());
 
     tokio::spawn(async move {
@@ -237,11 +47,12 @@ pub fn handle_listener<N: Network>(listener: TcpListener, ledger: Arc<Ledger<N>>
             match listener.accept().await {
                 // Process the inbound connection request.
                 Ok((stream, peer_ip)) => {
-                    tokio::spawn(async move {
-                        if let Err(err) = handle_peer::<N>(stream, peer_ip, ledger_clone.clone()).await {
-                            warn!("Error handling peer {}: {:?}", peer_ip, err);
-                        }
-                    });
+                    E::resources().register_task(
+                        None,
+                        tokio::spawn(
+                            async move { Peer::handler(stream, peer_ip, ledger_clone.clone(), &ledger_clone.peers().router()).await },
+                        ),
+                    );
                 }
                 Err(error) => warn!("Failed to accept a connection: {}", error),
             }
@@ -260,38 +71,40 @@ pub(super) async fn request_genesis_block<N: Network>(leader_ip: IpAddr) -> Resu
 }
 
 /// Send a ping to all peers every 10 seconds.
-pub fn send_pings<N: Network>(ledger: Arc<Ledger<N>>) -> task::JoinHandle<()> {
+pub fn send_pings<N: Network, E: Environment>(ledger: Arc<Ledger<N, E>>) -> task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(time::Duration::from_secs(10));
         loop {
             interval.tick().await;
 
-            let peers = ledger.peers().read().clone();
-
-            for (addr, outbound) in peers.iter() {
-                if let Err(err) = outbound.try_send(Message::<N>::Ping) {
-                    warn!("Error sending ping {} to {}", err, addr);
-                }
+            if let Err(err) = ledger
+                .peers()
+                .router()
+                .send(PeersRequest::MessagePropagate(*ledger.peers().local_ip(), Message::<N>::Ping))
+                .await
+            {
+                warn!("Error broadcasting Ping to peers: {}", err);
             }
         }
     })
 }
 
 /// Handle connection with the leader.
-pub fn connect_to_leader<N: Network>(initial_peer: SocketAddr, ledger: Arc<Ledger<N>>) -> task::JoinHandle<()> {
+pub fn connect_to_leader<N: Network, E: Environment>(initial_peer: SocketAddr, ledger: Arc<Ledger<N, E>>) -> task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(time::Duration::from_secs(10));
         loop {
-            if !ledger.peers().read().contains_key(&initial_peer) {
+            if !ledger.peers().is_connected_to(&initial_peer).await {
                 trace!("Attempting to connect to peer {}", initial_peer);
                 match TcpStream::connect(initial_peer).await {
                     Ok(stream) => {
                         let ledger_clone = ledger.clone();
-                        tokio::spawn(async move {
-                            if let Err(err) = handle_peer::<N>(stream, initial_peer, ledger_clone).await {
-                                warn!("Error handling peer {}: {:?}", initial_peer, err);
-                            }
-                        });
+                        E::resources().register_task(
+                            None,
+                            tokio::spawn(async move {
+                                Peer::handler(stream, initial_peer, ledger_clone.clone(), &ledger_clone.peers().router()).await;
+                            }),
+                        );
                     }
                     Err(error) => warn!("Failed to connect to peer {}: {}", initial_peer, error),
                 }

--- a/snarkos/network/peer.rs
+++ b/snarkos/network/peer.rs
@@ -1,0 +1,370 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+use crate::{
+    environment::{helpers::NodeType, Environment},
+    Data,
+    Ledger,
+    Message,
+    MessageCodec,
+    OldPeer,
+    PeersRequest,
+    PeersRouter,
+};
+
+use snarkvm::prelude::*;
+
+use anyhow::Result;
+use futures::{SinkExt, StreamExt};
+use std::{
+    collections::HashMap,
+    marker::PhantomData,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime},
+};
+use tokio::{net::TcpStream, sync::mpsc};
+use tokio_util::codec::Framed;
+
+/// Shorthand for the parent half of the `Peer` outbound message channel.
+pub(crate) type OutboundRouter<N> = mpsc::Sender<Message<N>>;
+/// Shorthand for the child half of the `Peer` outbound message channel.
+type OutboundHandler<N> = mpsc::Receiver<Message<N>>;
+
+///
+/// The state for each connected client.
+///
+pub(crate) struct Peer<N: Network, E: Environment> {
+    /// The IP address of the peer, with the port set to the listener port.
+    listener_ip: SocketAddr,
+    /// The message version of the peer.
+    version: u32,
+    /// The timestamp of the last message received from this peer.
+    last_seen: Instant,
+    /// The TCP socket that handles sending and receiving data with this peer.
+    outbound_socket: Framed<TcpStream, MessageCodec<N>>,
+    /// The `outbound_handler` half of the MPSC message channel, used to receive messages from peers.
+    /// When a message is received on this `OutboundHandler`, it will be written to the socket.
+    outbound_handler: OutboundHandler<N>,
+    /// The map of transaction IDs to their last seen timestamp.
+    seen_inbound_transactions: HashMap<N::TransactionID, SystemTime>,
+    /// The map of peers to a map of transaction IDs to their last seen timestamp.
+    seen_outbound_transactions: HashMap<N::TransactionID, SystemTime>,
+    _phantom: PhantomData<E>,
+}
+
+impl<N: Network, E: Environment> Peer<N, E> {
+    /// Create a new instance of `Peer`.
+    async fn new(stream: TcpStream, peers_router: &PeersRouter<N>) -> Result<Self> {
+        // Construct the socket.
+        let outbound_socket = Framed::new(stream, Default::default());
+        let peer_ip = outbound_socket.get_ref().peer_addr()?;
+
+        // Create a channel for this peer.
+        let (outbound_router, outbound_handler) = mpsc::channel(1024);
+
+        // Send the first `Ping` message to the peer.
+        if let Err(err) = outbound_router.send(Message::<N>::Ping).await {
+            warn!("Failed to send ping {} to {}", err, peer_ip);
+        }
+
+        // Add an entry for this `Peer` in the connected peers.
+        peers_router.send(PeersRequest::PeerConnected(peer_ip, outbound_router)).await?;
+
+        Ok(Self {
+            listener_ip: peer_ip,
+            version: 0,
+            last_seen: Instant::now(),
+            outbound_socket,
+            outbound_handler,
+            seen_inbound_transactions: Default::default(),
+            seen_outbound_transactions: Default::default(),
+            _phantom: PhantomData,
+        })
+    }
+
+    /// Returns the IP address of the peer, with the port set to the listener port.
+    fn peer_ip(&self) -> SocketAddr {
+        self.listener_ip
+    }
+
+    /// Sends the given message to this peer.
+    async fn send(&mut self, message: Message<N>) -> Result<()> {
+        trace!("Sending '{}' to {}", message.name(), self.peer_ip());
+        self.outbound_socket.send(message).await?;
+        Ok(())
+    }
+
+    /// A handler to process an individual peer.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn handler(stream: TcpStream, peer_ip: SocketAddr, ledger: Arc<Ledger<N>>, peers_router: &PeersRouter<N>) {
+        let peers_router = peers_router.clone();
+
+        // TODO (raychu86): Use a ledger router for ledger operations.
+
+        // Register our peer with state which internally sets up some channels.
+        let mut peer = match Peer::<N, E>::new(stream, &peers_router).await {
+            Ok(peer) => peer,
+            Err(err) => {
+                warn!("Failed to register peer {}: {}", peer_ip, err);
+                return;
+            }
+        };
+
+        // Retrieve the peer IP.
+        info!("Connected to {}", peer_ip);
+
+        // Process incoming messages until this stream is disconnected.
+        loop {
+            tokio::select! {
+                // Message channel is routing a message outbound to the peer.
+                Some(mut message) = peer.outbound_handler.recv() => {
+                    // Disconnect if the peer has not communicated back within the predefined time.
+                    if peer.last_seen.elapsed() > Duration::from_secs(E::RADIO_SILENCE_IN_SECS) {
+                        warn!("Peer {} has not communicated in {} seconds", peer_ip, peer.last_seen.elapsed().as_secs());
+                        break;
+                    } else {
+                        // Ensure sufficient time has passed before needing to send the message.
+                        let is_ready_to_send = match message {
+                            Message::Ping => {
+                                true
+                            }
+                            Message::TransactionBroadcast(ref mut data) => {
+                                let transaction = if let Data::Object(transaction) = data {
+                                    transaction
+                                } else {
+                                    panic!("Logic error: the transaction shouldn't have been serialized yet.");
+                                };
+
+                                // Retrieve the last seen timestamp of this transaction for this peer.
+                                let last_seen = peer
+                                    .seen_outbound_transactions
+                                    .entry(transaction.id())
+                                    .or_insert(SystemTime::UNIX_EPOCH);
+                                let is_ready_to_send = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
+
+                                // Update the timestamp for the peer and sent transaction.
+                                peer.seen_outbound_transactions.insert(transaction.id(), SystemTime::now());
+                                // Report the unconfirmed block height.
+                                if is_ready_to_send {
+                                    trace!(
+                                        "Preparing to send 'TransactionBroadcast {}' to {}",
+                                        transaction.id(),
+                                        peer_ip
+                                    );
+                                }
+
+                                // Perform non-blocking serialization of the transaction.
+                                let serialized_transaction = Data::serialize(data.clone()).await.expect("Transaction serialization is bugged");
+                                let _ = std::mem::replace(data, Data::Buffer(serialized_transaction));
+
+                                is_ready_to_send
+                            }
+                            _ => true,
+                        };
+                        // Send the message if it is ready.
+                        if is_ready_to_send {
+                            // Route a message to the peer.
+                            if let Err(error) = peer.send(message).await {
+                                warn!("[OutboundRouter] {}", error);
+                            }
+                        }
+                    }
+                }
+                result = peer.outbound_socket.next() => match result {
+                    // Received a message from the peer.
+                    Some(Ok(message)) => {
+                        // Disconnect if the peer has not communicated back within the predefined time.
+                        match peer.last_seen.elapsed() > Duration::from_secs(E::RADIO_SILENCE_IN_SECS) {
+                            true => {
+                                let last_seen = peer.last_seen.elapsed().as_secs();
+                                warn!("Failed to receive a message from {} in {} seconds", peer_ip, last_seen);
+                                break;
+                            },
+                            false => {
+                                // Update the last seen timestamp.
+                                peer.last_seen = Instant::now();
+                            }
+                        }
+                        // Process the message.
+                        trace!("Received '{}' from {}", message.name(), peer_ip);
+                        match message {
+                            Message::Ping => {
+                                // Send a `Pong` message to the peer.
+                                let latest_height = ledger.ledger().read().latest_height();
+                                if let Err(error) = peer.send(Message::<N>::Pong(latest_height)).await {
+                                    warn!("[Pong] {}", error);
+                                }
+                            }
+                            Message::Pong(height) => {
+                                // TODO (raychu86): Handle syncs. Currently just asks for one new block at a time.
+                                // If the peer is ahead, ask for next block.
+                                let latest_height = ledger.ledger().read().latest_height();
+                                if height > latest_height {
+                                    if let Err(err) = peer.send(Message::<N>::BlockRequest(latest_height + 1)).await {
+                                        warn!("[BlockRequest] {}", err);
+                                    }
+                                }
+                            },
+                            Message::BlockRequest(height) => {
+                                let latest_height = ledger.ledger().read().latest_height();
+                                if height > latest_height {
+                                    trace!("Peer requested block {height}, which is greater than the current height {latest_height}");
+                                } else {
+
+                                    let block = match ledger.ledger().read().get_block(height) {
+                                        Ok(block) => block,
+                                        Err(err) => {
+                                            warn!("Failed to retrieve block {height} from the ledger: {err}");
+                                            break;
+                                        }
+                                    };
+
+                                    if let Err(error) = peer.send(Message::BlockResponse(Data::Object(block))).await {
+                                        warn!("[BlockResponse] {}", error);
+                                    }
+                                }
+                            },
+                            Message::BlockResponse(block_bytes) => {
+                                // Perform the deferred non-blocking deserialization of the block.
+                                match block_bytes.deserialize().await {
+                                    Ok(block) => {
+                                        let block_height = block.height();
+                                        let block_hash = block.hash();
+
+                                        // Check if the block can be added to the ledger.
+                                        if block_height == ledger.ledger().read().latest_height() + 1 {
+                                            // Attempt to add the block to the ledger.
+                                            match ledger.add_next_block(block).await {
+                                                Ok(_) => info!("Advanced to block {} ({})", block_height, block_hash),
+                                                Err(err) => warn!("Failed to process block {} (height: {}): {:?}", block_hash, block_height, err)
+                                            };
+
+                                            // TODO (raychu86): Remove this. Currently used for naive sync.
+                                            // Send a ping.
+                                             if let Err(err) = peer.send(Message::<N>::Ping).await {
+                                                warn!("[Ping] {}", err);
+                                            }
+                                        }  else {
+                                            trace!("Skipping block {} (height: {})", block_hash, block_height);
+                                        }
+                                    },
+                                    // Log the block deserialization error.
+                                    Err(error) => warn!("[Failure] {}", error),
+                                }
+                            }
+
+                            Message::TransactionBroadcast(transaction_bytes) => {
+                                // Drop the peer, if they have sent more than 500 unconfirmed transactions in the last 5 seconds.
+                                let frequency = peer.seen_inbound_transactions.values().filter(|t| t.elapsed().unwrap().as_secs() <= 5).count();
+                                if frequency >= 500 {
+                                    warn!("Dropping {} for spamming unconfirmed transactions (frequency = {})", peer_ip, frequency);
+                                    // Send a `PeerRestricted` message.
+                                    if let Err(error) = peers_router.send(PeersRequest::PeerRestricted(peer_ip)).await {
+                                        warn!("[PeerRestricted] {}", error);
+                                    }
+                                    break;
+                                }
+
+                                // Perform the deferred non-blocking deserialization of the
+                                // transaction.
+                                match transaction_bytes.clone().deserialize().await {
+                                    Ok(transaction) => {
+                                        // Retrieve the last seen timestamp of the received transaction.
+                                        let last_seen = peer.seen_inbound_transactions.entry(transaction.id()).or_insert(SystemTime::UNIX_EPOCH);
+                                        let is_router_ready = last_seen.elapsed().unwrap().as_secs() > E::RADIO_SILENCE_IN_SECS;
+
+                                        // Update the timestamp for the received transaction.
+                                        peer.seen_inbound_transactions.insert(transaction.id(), SystemTime::now());
+
+                                        let transaction_id = transaction.id();
+                                        if E::NODE_TYPE == NodeType::Beacon || !is_router_ready {
+                                            trace!("Skipping 'TransactionBroadcast {}' from {}", transaction_id, peer_ip);
+                                        } else {
+                                            // Attempt to insert the transaction into the mempool.
+                                            match ledger.add_to_memory_pool(transaction.clone()) {
+                                                Ok(_) => {
+                                                // Broadcast transaction to all peers except the sender.
+                                                if let Err(error) = peers_router.send(PeersRequest::MessagePropagate(peer.peer_ip(),  Message::TransactionBroadcast(transaction_bytes))).await {
+                                                    warn!("[TransactionBroadcast] {}", error);
+                                                }
+
+                                                },
+                                                Err(err) => {
+                                                    trace!(
+                                                        "Failed to add transaction {} to mempool: {:?}",
+                                                        transaction_id,
+                                                        err
+                                                    );
+                                                }
+                                            }
+                                        }
+
+                                    }
+                                    Err(error) => warn!("[TransactionBroadcast] {}", error)
+                                }
+                            }
+                            Message::BlockBroadcast(block_bytes) => {
+                                // Perform the deferred non-blocking deserialization of the block.
+                                match block_bytes.clone().deserialize().await {
+                                    Ok(block) => {
+                                        let block_height = block.height();
+                                        let block_hash = block.hash();
+
+                                        // Check if the block can be added to the ledger.
+                                        if block_height == ledger.ledger().read().latest_height() + 1 {
+                                            // Attempt to add the block to the ledger.
+                                            match ledger.add_next_block(block).await {
+                                                Ok(_) => {
+                                                    info!("Advanced to block {} ({})", block_height, block_hash);
+
+                                                    // Broadcast block to all peers except the sender.
+                                                    if let Err(error) = peers_router.send(PeersRequest::MessagePropagate(peer.peer_ip(), Message::<N>::BlockBroadcast(block_bytes))).await {
+                                                        warn!("[BlockBroadcast] {}", error);
+                                                    }
+                                                },
+                                                 Err(err) => {
+                                                    trace!(
+                                                        "Failed to process block {} (height: {}): {:?}",
+                                                        block_hash,
+                                                        block_height,
+                                                        err
+                                                    );
+                                                }
+                                            };
+                                        } else {
+                                            trace!("Skipping block {} (height: {})", block_hash, block_height);
+                                        }
+                                    },
+                                    Err(error) => warn!("[BlockBroadcast] {}", error)
+                                }
+                            }
+                        }
+                    }
+                    // An error occurred.
+                    Some(Err(error)) => error!("Failed to read message from {}: {}", peer_ip, error),
+                    // The stream has been disconnected.
+                    None => break,
+                },
+            }
+        }
+
+        // When this is reached, it means the peer has disconnected.
+        // Route a `Disconnect` to the peers handler.
+        if let Err(error) = peers_router.send(PeersRequest::PeerDisconnected(peer_ip)).await {
+            warn!("[[Peer::Disconnect] {}", error);
+        }
+    }
+}

--- a/snarkos/network/peers.rs
+++ b/snarkos/network/peers.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{environment::Environment, Data, Message, OldPeer, OutboundRouter};
+use crate::{environment::Environment, Data, Message, OutboundRouter};
 
 use snarkvm::prelude::*;
 
@@ -78,7 +78,7 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Initializes a new instance of `Peers`.
     ///
-    pub(crate) async fn new(local_ip: SocketAddr) -> Arc<Self> {
+    pub async fn new(local_ip: SocketAddr) -> Arc<Self> {
         // Initialize an mpsc channel for sending requests to the `Peers` struct.
         let (peers_router, mut peers_handler) = mpsc::channel(1024);
 
@@ -128,11 +128,16 @@ impl<N: Network, E: Environment> Peers<N, E> {
         self.peers_router.clone()
     }
 
+    /// Returns the IP address of this node.
+    pub const fn local_ip(&self) -> &SocketAddr {
+        &self.local_ip
+    }
+
     ///
     /// Returns `true` if the node is connected to the given IP.
     ///
-    pub async fn is_connected_to(&self, ip: SocketAddr) -> bool {
-        self.connected_peers.read().await.contains_key(&ip)
+    pub async fn is_connected_to(&self, ip: &SocketAddr) -> bool {
+        self.connected_peers.read().await.contains_key(ip)
     }
 
     ///

--- a/snarkos/network/peers.rs
+++ b/snarkos/network/peers.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{environment::Environment, Data, Message, OutboundRouter};
+use crate::{environment::Environment, Data, LedgerRouter, Message, OutboundRouter, Peer};
 
-use snarkvm::prelude::*;
+use snarkvm::prelude::Network;
 
 use indexmap::IndexMap;
 use std::{
@@ -26,6 +26,7 @@ use std::{
     time::{Instant, SystemTime},
 };
 use tokio::{
+    net::TcpStream,
     sync::{mpsc, oneshot, RwLock},
     task,
 };
@@ -47,6 +48,8 @@ pub enum PeersRequest<N: Network> {
     MessagePropagate(SocketAddr, Message<N>),
     /// MessageSend := (peer_ip, message)
     MessageSend(SocketAddr, Message<N>),
+    /// PeerConnecting := (stream, peer_ip, ledger_router)
+    PeerConnecting(TcpStream, SocketAddr, LedgerRouter<N>),
     /// PeerConnected := (peer_ip, outbound_router)
     PeerConnected(SocketAddr, OutboundRouter<N>),
     /// PeerDisconnected := (peer_ip)
@@ -143,8 +146,8 @@ impl<N: Network, E: Environment> Peers<N, E> {
     ///
     /// Returns `true` if the given IP is restricted.
     ///
-    pub async fn is_restricted(&self, ip: SocketAddr) -> bool {
-        match self.restricted_peers.read().await.get(&ip) {
+    pub async fn is_restricted(&self, ip: &SocketAddr) -> bool {
+        match self.restricted_peers.read().await.get(ip) {
             Some(timestamp) => timestamp.elapsed().as_secs() < E::RADIO_SILENCE_IN_SECS,
             None => false,
         }
@@ -182,6 +185,71 @@ impl<N: Network, E: Environment> Peers<N, E> {
             PeersRequest::PeerConnected(peer_ip, outbound) => {
                 // Add an entry for this `Peer` in the connected peers.
                 self.connected_peers.write().await.insert(peer_ip, outbound);
+            }
+            PeersRequest::PeerConnecting(stream, peer_ip, ledger_router) => {
+                // Ensure the peer IP is not this node.
+                if peer_ip == self.local_ip
+                    || (peer_ip.ip().is_unspecified() || peer_ip.ip().is_loopback()) && peer_ip.port() == self.local_ip.port()
+                {
+                    debug!("Skipping connection request to {} (attempted to self-connect)", peer_ip);
+                }
+                // Ensure the node does not surpass the maximum number of peer connections.
+                else if self.number_of_connected_peers().await >= E::MAXIMUM_NUMBER_OF_PEERS {
+                    debug!("Dropping connection request from {} (maximum peers reached)", peer_ip);
+                }
+                // Ensure the node is not already connected to this peer.
+                else if self.is_connected_to(&peer_ip).await {
+                    debug!("Dropping connection request from {} (already connected)", peer_ip);
+                }
+                // Ensure the peer is not restricted.
+                else if self.is_restricted(&peer_ip).await {
+                    debug!("Dropping connection request from {} (restricted)", peer_ip);
+                } else {
+                    // TODO (raychu86): Implement this.
+
+                    // Sanitize the port from the peer, if it is a remote IP address.
+                    let (peer_lookup, peer_port) = match peer_ip.ip().is_loopback() {
+                        // Loopback case - Do not sanitize, merely pass through.
+                        true => (peer_ip, peer_ip.port()),
+                        // Remote case - Sanitize, storing u16::MAX for the peer IP address to dedup the peer next time.
+                        false => (SocketAddr::new(peer_ip.ip(), u16::MAX), peer_ip.port()),
+                    };
+
+                    // Lock seen_inbound_connections for further processing.
+                    let mut seen_inbound_connections = self.seen_inbound_connections.write().await;
+
+                    // Fetch the inbound tracker entry for this peer.
+                    let ((initial_port, num_attempts), last_seen) = seen_inbound_connections
+                        .entry(peer_lookup)
+                        .or_insert(((peer_port, 0), SystemTime::UNIX_EPOCH));
+                    let elapsed = last_seen.elapsed().unwrap_or(std::time::Duration::MAX).as_secs();
+
+                    // Reset the inbound tracker entry for this peer, if the predefined elapsed time has passed.
+                    if elapsed > E::RADIO_SILENCE_IN_SECS {
+                        // Reset the initial port for this peer.
+                        *initial_port = peer_port;
+                        // Reset the number of attempts for this peer.
+                        *num_attempts = 0;
+                        // Reset the last seen timestamp for this peer.
+                        *last_seen = SystemTime::now();
+                    }
+
+                    // Ensure the connecting peer has not surpassed the connection attempt limit.
+                    if *initial_port < peer_port && *num_attempts > E::MAXIMUM_CONNECTION_FAILURES {
+                        trace!("Dropping connection request from {} (tried {} secs ago)", peer_ip, elapsed);
+                        // Add an entry for this `Peer` in the restricted peers.
+                        self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+                    } else {
+                        debug!("Received a connection request from {}", peer_ip);
+                        // Update the number of attempts for this peer.
+                        *num_attempts += 1;
+
+                        // Release the lock over seen_inbound_connections.
+                        drop(seen_inbound_connections);
+
+                        Peer::<N, E>::handler(stream, peer_ip, self.peers_router.clone(), ledger_router).await;
+                    }
+                }
             }
             PeersRequest::PeerDisconnected(peer_ip) => {
                 // Remove an entry for this `Peer` in the connected peers, if it exists.

--- a/snarkos/network/peers.rs
+++ b/snarkos/network/peers.rs
@@ -1,0 +1,242 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{environment::Environment, Data, Message, OldPeer, OutboundRouter};
+
+use snarkvm::prelude::*;
+
+use indexmap::IndexMap;
+use std::{
+    marker::PhantomData,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Instant, SystemTime},
+};
+use tokio::{
+    sync::{mpsc, oneshot, RwLock},
+    task,
+};
+
+/// Shorthand for the parent half of the `Peers` message channel.
+pub(crate) type PeersRouter<N> = mpsc::Sender<PeersRequest<N>>;
+#[allow(unused)]
+/// Shorthand for the child half of the `Peers` message channel.
+type PeersHandler<N> = mpsc::Receiver<PeersRequest<N>>;
+
+///
+/// An enum of requests that the `Peers` struct processes.
+///
+#[derive(Debug)]
+pub enum PeersRequest<N: Network> {
+    /// Heartbeat
+    Heartbeat,
+    /// MessagePropagate := (peer_ip, message)
+    MessagePropagate(SocketAddr, Message<N>),
+    /// MessageSend := (peer_ip, message)
+    MessageSend(SocketAddr, Message<N>),
+    /// PeerConnected := (peer_ip, outbound_router)
+    PeerConnected(SocketAddr, OutboundRouter<N>),
+    /// PeerDisconnected := (peer_ip)
+    PeerDisconnected(SocketAddr),
+    /// PeerRestricted := (peer_ip)
+    PeerRestricted(SocketAddr),
+}
+
+///
+/// A list of peers connected to the node server.
+///
+pub struct Peers<N: Network, E: Environment> {
+    /// The peers router of the node.
+    peers_router: PeersRouter<N>,
+    /// The local address of this node.
+    local_ip: SocketAddr,
+    /// The map connected peer IPs to their nonce and outbound message router.
+    connected_peers: RwLock<IndexMap<SocketAddr, OutboundRouter<N>>>,
+    /// The set of restricted peer IPs.
+    restricted_peers: RwLock<IndexMap<SocketAddr, Instant>>,
+    /// The map of peers to their first-seen port number, number of attempts, and timestamp of the last inbound connection request.
+    seen_inbound_connections: RwLock<IndexMap<SocketAddr, ((u16, u32), SystemTime)>>,
+    /// The map of peers to the timestamp of their last outbound connection request.
+    seen_outbound_connections: RwLock<IndexMap<SocketAddr, SystemTime>>,
+    _phantom: PhantomData<E>,
+}
+
+impl<N: Network, E: Environment> Peers<N, E> {
+    ///
+    /// Initializes a new instance of `Peers`.
+    ///
+    pub(crate) async fn new(local_ip: SocketAddr) -> Arc<Self> {
+        // Initialize an mpsc channel for sending requests to the `Peers` struct.
+        let (peers_router, mut peers_handler) = mpsc::channel(1024);
+
+        // Initialize the peers.
+        let peers = Arc::new(Self {
+            peers_router,
+            local_ip,
+            connected_peers: Default::default(),
+            restricted_peers: Default::default(),
+            seen_inbound_connections: Default::default(),
+            seen_outbound_connections: Default::default(),
+            _phantom: PhantomData,
+        });
+
+        // Initialize the peers router process.
+        {
+            let peers = peers.clone();
+            let (router, handler) = oneshot::channel();
+            E::resources().register_task(
+                None,
+                task::spawn(async move {
+                    // Notify the outer function that the task is ready.
+                    let _ = router.send(());
+                    // Asynchronously wait for a peers request.
+                    while let Some(request) = peers_handler.recv().await {
+                        let peers = peers.clone();
+                        // Asynchronously process a peers request.
+                        E::resources().register_task(
+                            None,
+                            task::spawn(async move {
+                                // Hold the peers write lock briefly, to update the state of the peers.
+                                peers.update(request).await;
+                            }),
+                        );
+                    }
+                }),
+            );
+            // Wait until the peers router task is ready.
+            let _ = handler.await;
+        }
+
+        peers
+    }
+
+    /// Returns an instance of the peers router.
+    pub fn router(&self) -> PeersRouter<N> {
+        self.peers_router.clone()
+    }
+
+    ///
+    /// Returns `true` if the node is connected to the given IP.
+    ///
+    pub async fn is_connected_to(&self, ip: SocketAddr) -> bool {
+        self.connected_peers.read().await.contains_key(&ip)
+    }
+
+    ///
+    /// Returns `true` if the given IP is restricted.
+    ///
+    pub async fn is_restricted(&self, ip: SocketAddr) -> bool {
+        match self.restricted_peers.read().await.get(&ip) {
+            Some(timestamp) => timestamp.elapsed().as_secs() < E::RADIO_SILENCE_IN_SECS,
+            None => false,
+        }
+    }
+
+    ///
+    /// Returns the list of connected peers.
+    ///
+    pub async fn connected_peers(&self) -> Vec<SocketAddr> {
+        self.connected_peers.read().await.keys().copied().collect()
+    }
+
+    ///
+    /// Returns the number of connected peers.
+    ///
+    pub async fn number_of_connected_peers(&self) -> usize {
+        self.connected_peers.read().await.len()
+    }
+
+    ///
+    /// Performs the given `request` to the peers.
+    /// All requests must go through this `update`, so that a unified view is preserved.
+    ///
+    pub(super) async fn update(&self, request: PeersRequest<N>) {
+        match request {
+            PeersRequest::Heartbeat => {
+                // TODO (raychu86): Implement this.
+            }
+            PeersRequest::MessagePropagate(sender, message) => {
+                self.propagate(sender, message).await;
+            }
+            PeersRequest::MessageSend(sender, message) => {
+                self.send(sender, message).await;
+            }
+            PeersRequest::PeerConnected(peer_ip, outbound) => {
+                // Add an entry for this `Peer` in the connected peers.
+                self.connected_peers.write().await.insert(peer_ip, outbound);
+            }
+            PeersRequest::PeerDisconnected(peer_ip) => {
+                // Remove an entry for this `Peer` in the connected peers, if it exists.
+                self.connected_peers.write().await.remove(&peer_ip);
+            }
+            PeersRequest::PeerRestricted(peer_ip) => {
+                // Remove an entry for this `Peer` in the connected peers, if it exists.
+                self.connected_peers.write().await.remove(&peer_ip);
+                // Add an entry for this `Peer` in the restricted peers.
+                self.restricted_peers.write().await.insert(peer_ip, Instant::now());
+            }
+        }
+    }
+
+    ///
+    /// Sends the given message to specified peer.
+    ///
+    async fn send(&self, peer: SocketAddr, message: Message<N>) {
+        let target_peer = self.connected_peers.read().await.get(&peer).cloned();
+        match target_peer {
+            Some(outbound) => {
+                if let Err(error) = outbound.send(message).await {
+                    trace!("Outbound channel failed: {}", error);
+                    self.connected_peers.write().await.remove(&peer);
+                }
+            }
+            None => warn!("Attempted to send to a non-connected peer {}", peer),
+        }
+    }
+
+    ///
+    /// Sends the given message to every connected peer, excluding the sender.
+    ///
+    async fn propagate(&self, sender: SocketAddr, mut message: Message<N>) {
+        // Perform ahead-of-time, non-blocking serialization just once for applicable objects.
+        if let Message::BlockBroadcast(ref mut data) = message {
+            let serialized_block = Data::serialize(data.clone()).await.expect("Block serialization is bugged");
+            let _ = std::mem::replace(data, Data::Buffer(serialized_block));
+        }
+
+        // Iterate through all peers that are not the sender, sync node, or beacon node.
+        for peer in self
+            .connected_peers()
+            .await
+            .iter()
+            .filter(|peer_ip| *peer_ip != &sender && !E::beacon_nodes().contains(peer_ip))
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.send(peer, message.clone()).await;
+        }
+    }
+
+    ///
+    /// Removes the addresses of all known peers.
+    ///
+    #[cfg(feature = "test")]
+    pub async fn reset_known_peers(&self) {
+        self.restricted_peers.write().await.clear();
+        self.seen_inbound_connections.write().await.clear();
+        self.seen_outbound_connections.write().await.clear();
+    }
+}

--- a/snarkos/node.rs
+++ b/snarkos/node.rs
@@ -29,6 +29,8 @@ use tokio::sync::oneshot;
 pub struct Node<N: Network, E: Environment> {
     /// The ledger.
     ledger: Arc<Ledger<N, E>>,
+    /// The list of peers for the node.
+    peers: Arc<Peers<N, E>>,
     /// PhantomData.
     _phantom: PhantomData<(N, E)>,
 }
@@ -76,6 +78,7 @@ impl<N: Network, E: Environment> Node<N, E> {
 
         Ok(Self {
             ledger,
+            peers,
             _phantom: PhantomData,
         })
     }
@@ -88,8 +91,8 @@ impl<N: Network, E: Environment> Node<N, E> {
         let (router, handler) = oneshot::channel();
 
         // Route a `Connect` request to the peer manager.
-        self.ledger
-            .peers_router()
+        self.peers
+            .router()
             .send(PeersRequest::Connect(peer_ip, self.ledger.router(), router))
             .await?;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR re-introduces the formal `Peer` and `Peers` modules from `testnet2`. This enables additional support for organizing and handling peers by separating the peer logic from the ledger.

