### PR TITLE
Add support for REST authorization checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -2469,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2558,12 +2558,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2574,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2667,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "anyhow",
  "colored",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2750,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2839,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2859,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2869,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2879,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2943,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2959,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-rest"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "anyhow",
  "http",
@@ -2976,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=577b8f5#577b8f5ca7bd3093dda92f54c1e15d8ad87222a2"
 dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "backoff",
+ "base64",
  "bincode",
  "bytes",
  "clap 4.0.14",
@@ -2440,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -2468,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2494,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2508,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2519,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2529,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2539,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2557,12 +2558,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2573,7 +2574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-network",
@@ -2585,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2600,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2613,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2622,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2632,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2644,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2655,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2666,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2678,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-compiler"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "anyhow",
  "colored",
@@ -2703,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2716,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2726,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2738,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2749,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2770,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2787,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2804,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2819,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2830,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2838,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2847,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2858,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2868,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2878,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2889,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2902,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2919,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2942,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2958,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-rest"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "anyhow",
  "http",
@@ -2975,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2993,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.0"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=1f0f2c9#1f0f2c98e7a04fc9e6a5ee61b6936257a599addc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e971bc4#e971bc4bed033c46b002c4b30ae454d43afc3e31"
 dependencies = [
  "proc-macro2 1.0.46",
  "quote 1.0.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ version = "2.0.2"
 [dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "e971bc4"
+rev = "577b8f5"
 features = ["circuit", "console", "parallel", "rest", "utilities"]
 
 [dependencies.aleo-std]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ path = "snarkos/main.rs"
 
 [dependencies]
 backoff = { version = "0.4", features = ["tokio"] }
+base64 = { version = "0.13" }
 bytes = { version = "1" }
 dotenv = { version = "0.15" }
 futures = { version = "0.3" }
@@ -51,7 +52,7 @@ version = "2.0.2"
 [dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "1f0f2c9"
+rev = "e971bc4"
 features = ["circuit", "console", "parallel", "rest", "utilities"]
 
 [dependencies.aleo-std]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -37,7 +37,7 @@ version = "1"
 [dependencies.snarkvm]
 #path = "../../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "1f0f2c9"
+rev = "e971bc4"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -37,7 +37,7 @@ version = "1"
 [dependencies.snarkvm]
 #path = "../../snarkVM"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "e971bc4"
+rev = "577b8f5"
 features = ["console", "utilities"]
 
 [dependencies.tokio]

--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -51,18 +51,18 @@ pub struct CLI {
     #[clap(long = "connect")]
     pub connect: Option<String>,
 
-    /// Specify the IP address and port for the RPC server.
-    #[clap(default_value = "0.0.0.0:3033", long = "rpc")]
-    pub rpc: SocketAddr,
-    /// Specify the username for the RPC server.
+    /// Specify the IP address and port for the REST server.
+    #[clap(hide = true, long = "rest_port")]
+    pub rest_port: Option<u16>,
+    /// Specify the username for the REST server.
     #[clap(default_value = "root", long = "username")]
-    pub rpc_username: String,
-    /// Specify the password for the RPC server.
+    pub rest_username: String,
+    /// Specify the password for the REST server.
     #[clap(default_value = "pass", long = "password")]
-    pub rpc_password: String,
-    /// If the flag is set, the node will not initialize the RPC server.
-    #[clap(long)]
-    pub norpc: bool,
+    pub rest_password: String,
+    /// If the flag is set, the node will not initialize the REST server.
+    #[clap(hide = true, long)]
+    pub norest: bool,
 
     /// Specify the verbosity of the node [options: 0, 1, 2, 3]
     #[clap(default_value = "2", long = "verbosity")]

--- a/snarkos/cli.rs
+++ b/snarkos/cli.rs
@@ -55,10 +55,10 @@ pub struct CLI {
     #[clap(hide = true, long = "rest_port")]
     pub rest_port: Option<u16>,
     /// Specify the username for the REST server.
-    #[clap(default_value = "root", long = "username")]
+    #[clap(hide = true, default_value = "root", long = "username")]
     pub rest_username: String,
     /// Specify the password for the REST server.
-    #[clap(default_value = "pass", long = "password")]
+    #[clap(hide = true, default_value = "pass", long = "password")]
     pub rest_password: String,
     /// If the flag is set, the node will not initialize the REST server.
     #[clap(hide = true, long)]

--- a/snarkos/ledger/mod.rs
+++ b/snarkos/ledger/mod.rs
@@ -54,7 +54,13 @@ pub struct Ledger<N: Network> {
 
 impl<N: Network> Ledger<N> {
     /// Initializes a new instance of the ledger.
-    pub(super) fn new_with_genesis(private_key: PrivateKey<N>, genesis_block: Block<N>, dev: Option<u16>) -> Result<Arc<Self>> {
+    pub(super) fn new_with_genesis(
+        private_key: PrivateKey<N>,
+        genesis_block: Block<N>,
+        dev: Option<u16>,
+        custom_port: Option<u16>,
+        auth_token: String,
+    ) -> Result<Arc<Self>> {
         // Initialize the ledger.
         let ledger = match InternalLedger::new_with_genesis(&genesis_block, genesis_block.signature().to_address(), dev) {
             Ok(ledger) => Arc::new(RwLock::new(ledger)),
@@ -70,19 +76,24 @@ impl<N: Network> Ledger<N> {
         };
 
         // Return the ledger.
-        Self::from(ledger, private_key)
+        Self::from(ledger, private_key, custom_port, auth_token)
     }
 
     /// Opens an instance of the ledger.
-    pub fn load(private_key: PrivateKey<N>, dev: Option<u16>) -> Result<Arc<Self>> {
+    pub fn load(private_key: PrivateKey<N>, dev: Option<u16>, custom_port: Option<u16>, auth_token: String) -> Result<Arc<Self>> {
         // Initialize the ledger.
         let ledger = Arc::new(RwLock::new(InternalLedger::open(dev)?));
         // Return the ledger.
-        Self::from(ledger, private_key)
+        Self::from(ledger, private_key, custom_port, auth_token)
     }
 
     /// Initializes a new instance of the ledger.
-    pub fn from(ledger: Arc<RwLock<InternalLedger<N>>>, private_key: PrivateKey<N>) -> Result<Arc<Self>> {
+    pub fn from(
+        ledger: Arc<RwLock<InternalLedger<N>>>,
+        private_key: PrivateKey<N>,
+        custom_port: Option<u16>,
+        auth_token: String,
+    ) -> Result<Arc<Self>> {
         // Derive the view key and address.
         let view_key = ViewKey::try_from(private_key)?;
         let address = Address::try_from(&view_key)?;
@@ -125,7 +136,7 @@ impl<N: Network> Ledger<N> {
         };
 
         // Initialize the server.
-        let server = InternalServer::<N>::start(ledger.clone(), Some(additional_routes), None)?;
+        let server = InternalServer::<N>::start(ledger.clone(), Some(additional_routes), custom_port, auth_token)?;
 
         // Return the ledger.
         Ok(Arc::new(Self {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds support for header authorization checks for record related REST API endpoints. 

The username and password for "Basic Authorization" headers can be specified using the `--username` and `--password` cli flags. Additionally, a custom port can be selected for the REST server using `--rest_port`.


This uses the latest rev from snarkVM PR: https://github.com/AleoHQ/snarkVM/pull/1191
