### PR TITLE
Introduce a consolidated SnarkOS, Noise and Kadmium codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +208,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +313,9 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -302,6 +359,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
 dependencies = [
  "envmnt",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -510,6 +601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +637,19 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.0.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dc3116fe595d7847c701796ac1b189bd86b81f4f593c6f775f9d80fb2e29f4"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -826,6 +939,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1178,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kadmium"
+version = "0.6.0"
+source = "git+https://github.com/niklaslong/kadmium#fbeca669083d9042a589ff8930313b9c29d662e1"
+dependencies = [
+ "async-trait",
+ "bincode 2.0.0-rc.2",
+ "bytes",
+ "parking_lot",
+ "rand",
+ "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1332,6 +1470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1610,29 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "poly1305"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2176,11 +2343,14 @@ name = "snarkos-node-messages"
 version = "2.0.2"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "bytes",
+ "kadmium",
+ "rayon",
  "serde",
  "snarkos-node-executor",
  "snarkvm",
+ "snow",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2209,7 +2379,7 @@ version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
+ "bincode 1.3.3",
  "bytes",
  "futures",
  "indexmap",
@@ -2231,7 +2401,7 @@ version = "2.0.2"
 dependencies = [
  "aleo-std",
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "indexmap",
  "once_cell",
  "parking_lot",
@@ -2703,7 +2873,7 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=147c567#147c56720e9c42a4
 dependencies = [
  "aleo-std",
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "cfg-if",
  "curl",
  "hex",
@@ -2767,7 +2937,7 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=147c567#147c56720e9c42a4
 dependencies = [
  "aleo-std",
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "num-bigint",
  "num_cpus",
  "rand",
@@ -2786,6 +2956,22 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
+]
+
+[[package]]
+name = "snow"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core",
+ "rustc_version",
+ "sha2",
+ "subtle",
 ]
 
 [[package]]
@@ -2963,6 +3149,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3237,6 +3424,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,6 +3492,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
 
 [[package]]
 name = "walkdir"
@@ -3588,3 +3791,9 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/cli/src/commands/update.rs
+++ b/cli/src/commands/update.rs
@@ -39,7 +39,7 @@ impl Update {
         match self.list {
             true => match Updater::show_available_releases() {
                 Ok(output) => Ok(output),
-                Err(error) => Ok(format!("Failed to list the available versions of snarkOS\n{}\n", error)),
+                Err(error) => Ok(format!("Failed to list the available versions of snarkOS\n{error}\n")),
             },
             false => {
                 let result = Updater::update_to_release(!self.quiet, self.version);
@@ -54,7 +54,7 @@ impl Update {
                                 Ok(String::new())
                             }
                         }
-                        Err(e) => Ok(format!("\nFailed to update snarkOS to the latest version\n{}\n", e)),
+                        Err(e) => Ok(format!("\nFailed to update snarkOS to the latest version\n{e}\n")),
                     }
                 } else {
                     Ok(String::new())

--- a/cli/src/helpers/updater.rs
+++ b/cli/src/helpers/updater.rs
@@ -85,7 +85,7 @@ impl Updater {
         if let Ok(latest_version) = Self::update_available() {
             let mut output = "🟢 A new version is available! Run".bold().green().to_string();
             output += &" `aleo update` ".bold().white();
-            output += &format!("to update to v{}.", latest_version).bold().green();
+            output += &format!("to update to v{latest_version}.").bold().green();
             output
         } else {
             String::new()

--- a/display/src/lib.rs
+++ b/display/src/lib.rs
@@ -104,7 +104,7 @@ impl<N: Network> Display<N> {
 
             // Exit.
             if let Err(err) = res {
-                println!("{:?}", err)
+                println!("{err:?}")
             }
         }
 

--- a/node/executor/src/node_type.rs
+++ b/node/executor/src/node_type.rs
@@ -63,6 +63,6 @@ impl NodeType {
 
 impl core::fmt::Display for NodeType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }

--- a/node/executor/src/status.rs
+++ b/node/executor/src/status.rs
@@ -40,7 +40,7 @@ pub enum Status {
 
 impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/node/ledger/src/consensus/mod.rs
+++ b/node/ledger/src/consensus/mod.rs
@@ -486,7 +486,7 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
         let signer = block.signature().to_address();
         if !self.beacons.contains_key(&signer) {
             let beacon = self.beacons.iter().next().unwrap().0;
-            eprintln!("{} {} {} {}", *beacon, signer, *beacon == signer, self.beacons.contains_key(&signer));
+            eprintln!("{} {signer} {} {}", *beacon, *beacon == signer, self.beacons.contains_key(&signer));
             bail!("Block {} ({}) is signed by an unauthorized beacon ({})", block.height(), block.hash(), signer);
         }
 

--- a/node/messages/Cargo.toml
+++ b/node/messages/Cargo.toml
@@ -25,6 +25,13 @@ version = "1.0"
 [dependencies.bytes]
 version = "1.0.0"
 
+[dependencies.kadmium]
+git = "https://github.com/niklaslong/kadmium"
+features = ["codec", "sync"]
+
+[dependencies.rayon]
+version = "1"
+
 [dependencies.serde]
 version = "1"
 
@@ -33,6 +40,9 @@ path = "../executor"
 
 [dependencies.snarkvm]
 workspace = true
+
+[dependencies.snow]
+version = "0.9.0"
 
 [dependencies.tokio]
 version = "1.21"

--- a/node/messages/src/block_request.rs
+++ b/node/messages/src/block_request.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockRequest {
     pub start_block_height: u32,
     pub end_block_height: u32,

--- a/node/messages/src/block_response.rs
+++ b/node/messages/src/block_response.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockResponse<N: Network> {
     pub block: Data<Block<N>>,
 }

--- a/node/messages/src/challenge_request.rs
+++ b/node/messages/src/challenge_request.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChallengeRequest {
     pub version: u32,
     pub fork_depth: u32,

--- a/node/messages/src/challenge_response.rs
+++ b/node/messages/src/challenge_response.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChallengeResponse<N: Network> {
     pub header: Data<Header<N>>,
 }

--- a/node/messages/src/disconnect.rs
+++ b/node/messages/src/disconnect.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Disconnect {
     pub reason: DisconnectReason,
 }

--- a/node/messages/src/helpers/data.rs
+++ b/node/messages/src/helpers/data.rs
@@ -23,7 +23,7 @@ use tokio::task;
 
 /// This object enables deferred deserialization / ahead-of-time serialization for objects that
 /// take a while to deserialize / serialize, in order to allow these operations to be non-blocking.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Data<T: FromBytes + ToBytes + Send + 'static> {
     Object(T),
     Buffer(Bytes),

--- a/node/messages/src/helpers/mod.rs
+++ b/node/messages/src/helpers/mod.rs
@@ -17,6 +17,8 @@
 mod codec;
 pub use codec::MessageCodec;
 
+mod noise_codec;
+
 mod data;
 pub use data::Data;
 

--- a/node/messages/src/helpers/noise_codec.rs
+++ b/node/messages/src/helpers/noise_codec.rs
@@ -46,7 +46,7 @@ impl TryFrom<u8> for MessageType {
             0 => Ok(MessageType::Bytes),
             1 => Ok(MessageType::SnarkOS),
             2 => Ok(MessageType::Kadmium),
-            _ => Err(format!("u8 value: {} doesn't correspond to a message variant", value)),
+            _ => Err(format!("u8 value: {value} doesn't correspond to a message variant")),
         }
     }
 }

--- a/node/messages/src/helpers/noise_codec.rs
+++ b/node/messages/src/helpers/noise_codec.rs
@@ -1,0 +1,272 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{io, sync::Arc};
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use kadmium::{codec::MessageCodec, message::Message as KadmiumMessage};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use snarkvm::prelude::Testnet3;
+use snow::{HandshakeState, StatelessTransportState};
+use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
+
+use crate::{Message as SnarkOSMessage, MessageCodec as SnarkOSCodec};
+
+type CurrentNetwork = Testnet3;
+
+// The maximum message size for noise messages. If the data to be encrypted exceedes it, it is
+// chunked.
+const MAX_MESSAGE_LEN: usize = 65535;
+
+#[repr(u8)]
+pub enum MessageType {
+    Bytes = 0,
+    SnarkOS,
+    Kadmium,
+}
+
+impl TryFrom<u8> for MessageType {
+    type Error = String;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(MessageType::Bytes),
+            1 => Ok(MessageType::SnarkOS),
+            2 => Ok(MessageType::Kadmium),
+            _ => Err(format!("u8 value: {} doesn't correspond to a message variant", value)),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum MessageOrBytes {
+    Bytes(Bytes),
+    SnarkOSMessage(SnarkOSMessage<CurrentNetwork>),
+    KadmiumMessage(KadmiumMessage),
+}
+
+impl MessageOrBytes {
+    fn message_type(&self) -> MessageType {
+        match self {
+            MessageOrBytes::Bytes(_) => MessageType::Bytes,
+            MessageOrBytes::SnarkOSMessage(_) => MessageType::SnarkOS,
+            MessageOrBytes::KadmiumMessage(_) => MessageType::Kadmium,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PostHandshakeState {
+    state: Arc<StatelessTransportState>,
+    tx_nonce: u64,
+    rx_nonce: u64,
+}
+
+pub enum NoiseState {
+    Handshake(Box<HandshakeState>),
+    PostHandshake(PostHandshakeState),
+}
+
+impl Clone for NoiseState {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Handshake(..) => unimplemented!(),
+            Self::PostHandshake(ph_state) => Self::PostHandshake(ph_state.clone()),
+        }
+    }
+}
+
+impl NoiseState {
+    pub fn into_post_handshake_state(self) -> Self {
+        if let Self::Handshake(noise_state) = self {
+            let noise_state = noise_state.into_stateless_transport_mode().unwrap();
+            Self::PostHandshake(PostHandshakeState { state: Arc::new(noise_state), tx_nonce: 0, rx_nonce: 0 })
+        } else {
+            panic!()
+        }
+    }
+}
+
+pub struct NoiseCodec {
+    codec: LengthDelimitedCodec,
+    kadmium_codec: MessageCodec,
+    snarkos_codec: SnarkOSCodec<CurrentNetwork>,
+    pub noise_state: NoiseState,
+}
+
+impl NoiseCodec {
+    pub fn new(noise_state: NoiseState) -> Self {
+        Self {
+            codec: LengthDelimitedCodec::new(),
+            kadmium_codec: MessageCodec::new(),
+            snarkos_codec: SnarkOSCodec::default(),
+            noise_state,
+        }
+    }
+}
+
+impl Encoder<MessageOrBytes> for NoiseCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, message_or_bytes: MessageOrBytes, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let message_type = message_or_bytes.message_type();
+
+        let ciphertext = match self.noise_state {
+            NoiseState::Handshake(ref mut noise) => {
+                match message_or_bytes {
+                    // Don't allow message sending before the noise handshake has completed.
+                    MessageOrBytes::SnarkOSMessage(_) | MessageOrBytes::KadmiumMessage(_) => unimplemented!(),
+                    MessageOrBytes::Bytes(bytes) => {
+                        let mut buffer = [0u8; MAX_MESSAGE_LEN + 1];
+                        let len = noise.write_message(&bytes, &mut buffer[1..]).unwrap();
+
+                        // Set the message type flag.
+                        buffer[0] = message_type as u8;
+
+                        buffer[..len + 1].into()
+                    }
+                }
+            }
+
+            NoiseState::PostHandshake(ref mut noise) => {
+                // Encode the message using the appropriate codec.
+                let mut bytes = BytesMut::new();
+                match message_or_bytes {
+                    // Don't allow sending raw bytes after the noise handshake has completed.
+                    MessageOrBytes::Bytes(_) => unimplemented!(),
+                    MessageOrBytes::SnarkOSMessage(message) => self.snarkos_codec.encode(message, &mut bytes).unwrap(),
+                    MessageOrBytes::KadmiumMessage(message) => self.kadmium_codec.encode(message, &mut bytes).unwrap(),
+                }
+
+                // Chunk the payload if necessary.
+                let chunked_plaintext_msg: Vec<_> = bytes.chunks(MAX_MESSAGE_LEN - 16).collect();
+                let num_chunks = chunked_plaintext_msg.len() as u64;
+
+                // Encrypt the resulting bytes with Noise.
+                let encrypted_chunks: Vec<Vec<u8>> = chunked_plaintext_msg
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(nonce_offset, plaintext_chunk)| {
+                        let mut buffer = vec![0u8; MAX_MESSAGE_LEN];
+
+                        let len = noise
+                            .state
+                            .write_message(noise.tx_nonce + nonce_offset as u64, plaintext_chunk, &mut buffer)
+                            .unwrap();
+
+                        buffer.truncate(len);
+                        buffer
+                    })
+                    .collect();
+
+                let mut buffer = BytesMut::new();
+                // Set the message type flag.
+                buffer.put_u8(message_type as u8);
+
+                for chunk in encrypted_chunks {
+                    buffer.extend_from_slice(&chunk)
+                }
+
+                noise.tx_nonce += num_chunks;
+
+                buffer
+            }
+        };
+
+        // Encode the resulting ciphertext using the length-delimited codec.
+        self.codec.encode(ciphertext.freeze(), dst)
+    }
+}
+
+impl Decoder for NoiseCodec {
+    type Error = io::Error;
+    type Item = MessageOrBytes;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        // Decode the ciphertext with the length-delimited codec.
+        let (flag, bytes) = if let Some(mut bytes) = self.codec.decode(src)? {
+            let flag =
+                MessageType::try_from(bytes.get_u8()).map_err(|e| Self::Error::new(io::ErrorKind::InvalidData, e))?;
+            (flag, bytes)
+        } else {
+            return Ok(None);
+        };
+
+        let msg = match self.noise_state {
+            NoiseState::Handshake(ref mut noise) => {
+                if let MessageType::SnarkOS | MessageType::Kadmium = flag {
+                    // Ignore any messages before the noise handshake has completed.
+                    return Ok(None);
+                }
+
+                // Decrypt the ciphertext in handshake mode.
+                let mut buffer = [0u8; MAX_MESSAGE_LEN];
+                let len = noise.read_message(&bytes, &mut buffer).map_err(|_| io::ErrorKind::InvalidData)?;
+
+                Some(MessageOrBytes::Bytes(Bytes::copy_from_slice(&buffer[..len])))
+            }
+
+            NoiseState::PostHandshake(ref mut noise) => {
+                // Ignore raw bytes after the noise handshake has completed.
+                if let MessageType::Bytes = flag {
+                    return Ok(None);
+                }
+
+                // Noise decryption.
+                let chunked_encrypted_msg: Vec<_> = bytes.chunks(MAX_MESSAGE_LEN).collect();
+                let num_chunks = chunked_encrypted_msg.len() as u64;
+
+                let decrypted_chunks: Vec<io::Result<Vec<u8>>> = chunked_encrypted_msg
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(nonce_offset, encrypted_chunk)| {
+                        let mut buffer = vec![0u8; MAX_MESSAGE_LEN];
+
+                        // Decrypt the ciphertext in post-handshake mode.
+                        let len = noise
+                            .state
+                            .read_message(noise.rx_nonce + nonce_offset as u64, encrypted_chunk, &mut buffer)
+                            .map_err(|_| io::ErrorKind::InvalidData)?;
+
+                        buffer.truncate(len);
+                        Ok(buffer)
+                    })
+                    .collect();
+
+                noise.rx_nonce += num_chunks;
+
+                // Collect chunks into plaintext to be passed to the message codecs.
+                let mut plaintext = BytesMut::new();
+                for chunk in decrypted_chunks {
+                    plaintext.extend_from_slice(&chunk?);
+                }
+
+                // Decode with message codecs.
+                match flag {
+                    MessageType::SnarkOS => {
+                        self.snarkos_codec.decode(&mut plaintext)?.map(MessageOrBytes::SnarkOSMessage)
+                    }
+                    MessageType::Kadmium => {
+                        self.kadmium_codec.decode(&mut plaintext)?.map(MessageOrBytes::KadmiumMessage)
+                    }
+                    _ => unreachable!("bytes variant was handled as an early return"),
+                }
+            }
+        };
+
+        Ok(msg)
+    }
+}

--- a/node/messages/src/helpers/noise_codec.rs
+++ b/node/messages/src/helpers/noise_codec.rs
@@ -270,3 +270,67 @@ impl Decoder for NoiseCodec {
         Ok(msg)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Pong;
+    use snow::{params::NoiseParams, Builder};
+
+    fn handshake_xx() -> (NoiseCodec, NoiseCodec) {
+        let params: NoiseParams = "Noise_XX_25519_ChaChaPoly_BLAKE2s".parse().unwrap();
+
+        let initiator_builder = Builder::new(params.clone());
+        let initiator_kp = initiator_builder.generate_keypair().unwrap();
+        let initiator = initiator_builder.local_private_key(&initiator_kp.private).build_initiator().unwrap();
+
+        let responder_builder = Builder::new(params);
+        let responder_kp = responder_builder.generate_keypair().unwrap();
+        let responder = responder_builder.local_private_key(&responder_kp.private).build_responder().unwrap();
+
+        let mut initiator_codec = NoiseCodec::new(NoiseState::Handshake(Box::new(initiator)));
+        let mut responder_codec = NoiseCodec::new(NoiseState::Handshake(Box::new(responder)));
+
+        let mut ciphertext = BytesMut::new();
+
+        // -> e
+        assert!(initiator_codec.encode(MessageOrBytes::Bytes(Bytes::new()), &mut ciphertext).is_ok());
+        assert!(
+            matches!(responder_codec.decode(&mut ciphertext).unwrap().unwrap(), MessageOrBytes::Bytes(bytes) if bytes.is_empty())
+        );
+
+        // <- e, ee, s, es
+        assert!(responder_codec.encode(MessageOrBytes::Bytes(Bytes::new()), &mut ciphertext).is_ok());
+        assert!(
+            matches!(initiator_codec.decode(&mut ciphertext).unwrap().unwrap(), MessageOrBytes::Bytes(bytes) if bytes.is_empty())
+        );
+
+        // -> s, se
+        assert!(initiator_codec.encode(MessageOrBytes::Bytes(Bytes::new()), &mut ciphertext).is_ok());
+        assert!(
+            matches!(responder_codec.decode(&mut ciphertext).unwrap().unwrap(), MessageOrBytes::Bytes(bytes) if bytes.is_empty())
+        );
+
+        initiator_codec.noise_state = initiator_codec.noise_state.into_post_handshake_state();
+        responder_codec.noise_state = responder_codec.noise_state.into_post_handshake_state();
+
+        (initiator_codec, responder_codec)
+    }
+
+    #[test]
+    fn pong_roundtrip() {
+        let (mut initiator_codec, mut responder_codec) = handshake_xx();
+        let mut ciphertext = BytesMut::new();
+
+        let expected_pong = Pong { is_fork: Some(true) };
+
+        assert!(
+            initiator_codec
+                .encode(MessageOrBytes::SnarkOSMessage(SnarkOSMessage::Pong(expected_pong.clone())), &mut ciphertext)
+                .is_ok()
+        );
+        assert!(matches!(responder_codec.decode(&mut ciphertext).unwrap().unwrap(),
+            MessageOrBytes::SnarkOSMessage(SnarkOSMessage::Pong(pong)) if pong == expected_pong));
+    }
+}

--- a/node/messages/src/helpers/noise_codec.rs
+++ b/node/messages/src/helpers/noise_codec.rs
@@ -51,7 +51,7 @@ impl TryFrom<u8> for MessageType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MessageOrBytes {
     Bytes(Bytes),
     Message(Message<CurrentNetwork>),

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -82,7 +82,7 @@ pub trait MessageTrait {
         Self: Sized;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Message<N: Network> {
     BlockRequest(BlockRequest),
     BlockResponse(BlockResponse<N>),

--- a/node/messages/src/peer_request.rs
+++ b/node/messages/src/peer_request.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerRequest;
 
 impl MessageTrait for PeerRequest {

--- a/node/messages/src/peer_response.rs
+++ b/node/messages/src/peer_response.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerResponse {
     pub peers: Vec<SocketAddr>,
 }

--- a/node/messages/src/ping.rs
+++ b/node/messages/src/ping.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Ping {
     pub version: u32,
     pub fork_depth: u32,

--- a/node/messages/src/pong.rs
+++ b/node/messages/src/pong.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Pong {
     pub is_fork: Option<bool>,
 }

--- a/node/messages/src/puzzle_request.rs
+++ b/node/messages/src/puzzle_request.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PuzzleRequest;
 
 impl MessageTrait for PuzzleRequest {

--- a/node/messages/src/puzzle_response.rs
+++ b/node/messages/src/puzzle_response.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PuzzleResponse<N: Network> {
     pub epoch_challenge: EpochChallenge<N>,
     pub block: Data<Block<N>>,

--- a/node/messages/src/unconfirmed_block.rs
+++ b/node/messages/src/unconfirmed_block.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnconfirmedBlock<N: Network> {
     pub block_height: u32,
     pub block_hash: N::BlockHash,

--- a/node/messages/src/unconfirmed_solution.rs
+++ b/node/messages/src/unconfirmed_solution.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnconfirmedSolution<N: Network> {
     pub solution: Data<ProverSolution<N>>,
 }

--- a/node/messages/src/unconfirmed_transaction.rs
+++ b/node/messages/src/unconfirmed_transaction.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnconfirmedTransaction<N: Network> {
     pub transaction: Data<Transaction<N>>,
 }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -15,7 +15,6 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use anyhow::bail;
 
 /// The `get_blocks` query object.
 #[derive(Deserialize, Serialize)]

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -144,7 +144,7 @@ impl<N: Network> Router<N> {
         // Initialize a new TCP listener at the given IP.
         let (local_ip, listener) = match TcpListener::bind(node_ip).await {
             Ok(listener) => (listener.local_addr().expect("Failed to fetch the local IP"), listener),
-            Err(error) => panic!("Failed to bind listener: {:?}. Check if another Aleo node is running", error),
+            Err(error) => panic!("Failed to bind listener: {error:?}. Check if another Aleo node is running"),
         };
 
         // Initialize an MPSC channel for sending requests to the `Router` struct.

--- a/node/store/src/rocksdb/mod.rs
+++ b/node/store/src/rocksdb/mod.rs
@@ -99,7 +99,7 @@ impl Database for RocksDB {
                 let rocksdb = {
                     options.increase_parallelism(2);
                     options.create_if_missing(true);
-                    Arc::new(rocksdb::DB::open(&options, &primary)?)
+                    Arc::new(rocksdb::DB::open(&options, primary)?)
                 };
 
                 Ok::<_, anyhow::Error>(RocksDB {


### PR DESCRIPTION
This PR introduces a consolidated SnarkOS, Noise and Kadmium codec with some sanity check tests for snarkOS using the `Noise_XX_25519_ChaChaPoly_BLAKE2s` handshake. If messages exceed the max length allowed by noise, they are broken into chunks encoded and decoded in parallel. 

~~@howardwu it would be most helpful to make all message types `PartialEq` and `Eq`. This would make testing much easier. I've already started this process with messages that don't depend on SnarkVM types but this unfortunately a soft blocker for further testing in that it will limit our coverage. We'll also be able to condense the existing tests once this is in.~~ Fixed in this PR. 
