### PR TITLE
Fix(cli): increase compilation recursion limit to `256` 

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 #![forbid(unsafe_code)]
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate thiserror;


### PR DESCRIPTION
This fixes the compilation issue with the cli crate. I understand this crate may be rearchitected; we should consider lowering this limit, if possible, in future. 
