### PR TITLE
Independent prover tasks

### DIFF
--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -88,7 +88,7 @@ impl<N: Network> Beacon<N> {
         // Initialize the block production.
         node.initialize_block_production().await;
         // Initialize the signal handler.
-        node.handle_signals();
+        node.handle_signals(None);
         // Return the node.
         Ok(node)
     }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -60,7 +60,7 @@ impl<N: Network> Client<N> {
         // Initialize the heartbeat.
         node.initialize_heartbeat().await;
         // Initialize the signal handler.
-        node.handle_signals();
+        node.handle_signals(None);
         // Return the node.
         Ok(node)
     }

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -67,11 +67,9 @@ impl<N: Network> Prover<N> {
         // Initialize the prover tasks.
         let mut prover_tasks = Vec::new();
         // Initialize the heartbeat.
-        let heartbeat = node.initialize_heartbeat().await;
-        prover_tasks.push(heartbeat);
+        prover_tasks.push(node.initialize_heartbeat().await);
         // Initialize the coinbase puzzle.
-        let coinbase_puzzle = node.initialize_coinbase_puzzle().await;
-        prover_tasks.push(coinbase_puzzle);
+        prover_tasks.push(node.initialize_coinbase_puzzle().await);
         // Initialize the signal handler.
         node.handle_signals(Some(prover_tasks));
         // Return the node.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -67,7 +67,7 @@ impl<N: Network> Validator<N> {
         // Initialize the router handler.
         router.initialize_handler(node.clone(), router_receiver).await;
         // Initialize the signal handler.
-        node.handle_signals();
+        node.handle_signals(None);
         // Return the node.
         Ok(node)
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR decouples the prover tasks from the `E::Resource` tracking. Instead we manually hold the `JoinHandle`s and drop them when a shutdown is detected.
