### PR TITLE
No need to `Arc` `SocketAddr`, it's `Copy`

### DIFF
--- a/node/messages/src/helpers/mod.rs
+++ b/node/messages/src/helpers/mod.rs
@@ -17,6 +17,7 @@
 mod codec;
 pub use codec::MessageCodec;
 
+#[allow(unused)]
 mod noise_codec;
 
 mod data;

--- a/node/router/src/peer/mod.rs
+++ b/node/router/src/peer/mod.rs
@@ -41,7 +41,7 @@ pub(crate) type PeerHandler<N> = mpsc::Receiver<Message<N>>;
 #[derive(Clone, Debug)]
 pub struct Peer<N: Network> {
     /// The IP address of the peer, with the port set to the listener port.
-    ip: Arc<SocketAddr>,
+    ip: SocketAddr,
     /// The message version of the peer.
     pub version: Arc<RwLock<u32>>,
     /// The node type of the peer.
@@ -72,7 +72,7 @@ impl<N: Network> Peer<N> {
 
         // Construct the peer.
         let peer = Peer {
-            ip: Arc::new(ip),
+            ip,
             version: Arc::new(RwLock::new(0)),
             node_type: Arc::new(RwLock::new(node_type)),
             status: Arc::new(RwLock::new(status)),

--- a/node/store/src/rocksdb/mod.rs
+++ b/node/store/src/rocksdb/mod.rs
@@ -163,7 +163,7 @@ impl RocksDB {
                 let rocksdb = {
                     options.increase_parallelism(2);
                     options.create_if_missing(true);
-                    Arc::new(rocksdb::DB::open(&options, &primary)?)
+                    Arc::new(rocksdb::DB::open(&options, primary)?)
                 };
 
                 Ok::<_, anyhow::Error>(RocksDB {


### PR DESCRIPTION
Quick fix for something I found whilst perusing the current network stack. 
