### PR TITLE
Consistent genesis block in storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
  "snarkos-account",
  "snarkos-display",
  "snarkos-node",
+ "snarkos-node-store",
  "snarkvm",
  "thiserror",
  "tokio",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,6 +65,9 @@ path = "../display"
 [dependencies.snarkos-node]
 path = "../node"
 
+[dependencies.snarkos-node-store]
+path = "../node/store"
+
 [dependencies.snarkvm]
 workspace = true
 

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -37,7 +37,7 @@ impl Clean {
     }
 
     /// Removes the specified ledger from storage.
-    fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
+    pub(super) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
         let path = aleo_std::aleo_ledger_dir(network, dev);
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -14,10 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::commands::Clean;
+
 use snarkos_account::Account;
 use snarkos_display::Display;
 use snarkos_node::Node;
-use snarkvm::prelude::{Block, ConsensusMemory, ConsensusStore, Network, PrivateKey, Testnet3, VM};
+use snarkos_node_store::ConsensusDB;
+use snarkvm::prelude::{Block, ConsensusMemory, ConsensusStore, FromBytes, Network, PrivateKey, Testnet3, VM};
 
 use anyhow::{bail, Result};
 use clap::Parser;
@@ -197,6 +200,24 @@ impl Start {
             true => None,
             false => Some(self.rest),
         };
+
+        // If development mode is not set, check that the existing genesis block is correct.
+        {
+            if self.dev.is_none() && genesis.is_none() {
+                let consensus = ConsensusStore::<N, ConsensusDB<N>>::open(None)?;
+                // Check if a genesis block exists.
+                if let Ok(Some(genesis_block_hash)) = consensus.block_store().get_block_hash(0) {
+                    // Check if the genesis block is correct.
+                    let expected_genesis_block_hash = Block::<N>::from_bytes_le(N::genesis_bytes())?.hash();
+                    // If the existing genesis block hash does not match the expected genesis block hash, then clear the ledger.
+                    if genesis_block_hash != expected_genesis_block_hash {
+                        drop(consensus);
+                        let remove_ledger = Clean::remove_ledger(N::ID, None)?;
+                        println!("{}", remove_ledger);
+                    }
+                }
+            }
+        }
 
         // Ensures only one of the four flags is set. If no flags are set, defaults to a client node.
         match (&self.beacon, &self.validator, &self.prover, &self.client) {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds a check (for each non-development node) that the genesis block in storage matches the one defined in the `Network`. In the case that the genesis block is mismatched, the ledger will be cleared. 
