### PR TITLE
Fix map tests

### DIFF
--- a/node/store/src/rocksdb/map.rs
+++ b/node/store/src/rocksdb/map.rs
@@ -208,7 +208,7 @@ impl<
             };
 
             // Retrieve the atomic batch.
-            let batch = core::mem::take(&mut *self.database.atomic_batch.lock());
+            let batch = self.database.atomic_batch.lock();
 
             // Initialize the operation finder.
             let mut finder = OperationFinder { key: raw_key, value: None };


### PR DESCRIPTION
As discussed @howardwu, this PR fixes the map tests by making sure a new db is instantiated for each test (removal of the `static OnceCell`). It also ensures `get_batched` doesn't mutate the searched batch. 