### PR TITLE
Add fee checks and fee records to `create_transfer`

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -529,7 +529,7 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
 
         // Ensure transactions with a positive balance must pay for its storage in bytes.
         let fee = transaction.fee()?;
-        if fee >= 0 && transaction.to_bytes_le()?.len() < usize::try_from(fee)? {
+        if fee >= 0 && usize::try_from(fee)? < transaction.to_bytes_le()?.len() {
             bail!("Transaction '{transaction_id}' has insufficient fee to cover its storage in bytes")
         }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Added a minor fix to the fee requirement, and introduced fee records to `Ledger::create_transfer`.