### PR TITLE
Add JWT authorization to record endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa4b4af834c6cfd35d8763d359661b90f2e45d8f750a0849156c7f4671af09c"
+dependencies = [
+ "base64",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kadmium"
 version = "0.6.0"
 source = "git+https://github.com/niklaslong/kadmium#fbeca669083d9042a589ff8930313b9c29d662e1"
@@ -1566,6 +1580,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2196,6 +2219,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,12 +2419,16 @@ dependencies = [
  "colored",
  "http",
  "indexmap",
+ "jsonwebtoken",
+ "once_cell",
+ "rand",
  "serde",
  "snarkos-node-consensus",
  "snarkos-node-ledger",
  "snarkos-node-messages",
  "snarkos-node-router",
  "snarkvm",
+ "time",
  "tokio",
  "tracing",
  "warp",
@@ -3144,9 +3183,17 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
+ "itoa",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -28,6 +28,12 @@ version = "0.2"
 [dependencies.indexmap]
 version = "1.8"
 
+[dependencies.jsonwebtoken]
+version = "8.1.1"
+
+[dependencies.once_cell]
+version = "1.13"
+
 [dependencies.serde]
 version = "1"
 default-features = false
@@ -45,8 +51,14 @@ path = "../messages"
 [dependencies.snarkos-node-router]
 path = "../router"
 
+[dependencies.rand]
+version = "0.8"
+
 [dependencies.snarkvm]
 workspace = true
+
+[dependencies.time]
+version = "0.3"
 
 [dependencies.tokio]
 version = "1"

--- a/node/rest/src/helpers/auth.rs
+++ b/node/rest/src/helpers/auth.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::RestError;
+
+use snarkvm::prelude::*;
+
+use anyhow::{anyhow, Result};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use warp::{reject, Filter, Rejection};
+
+/// The time a jwt token is valid for.
+pub const EXPIRATION: i64 = 10 * 365 * 24 * 60 * 60; // 10 years.
+
+/// Returns the JWT secret for the node instance.
+fn jwt_secret() -> &'static Vec<u8> {
+    static SECRET: OnceCell<Vec<u8>> = OnceCell::new();
+    SECRET.get_or_init(|| {
+        let seed: [u8; 16] = rand::thread_rng().gen();
+        seed.to_vec()
+    })
+}
+
+/// The Json web token claims.
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Claims {
+    /// The subject (user).
+    sub: String,
+    /// The UTC timestamp the token was issued at.
+    iat: i64,
+    /// Expiration time (as UTC timestamp).
+    exp: i64,
+}
+
+impl Claims {
+    pub fn new<N: Network>(address: Address<N>) -> Self {
+        let issued_at = OffsetDateTime::now_utc().unix_timestamp();
+        let expiration = issued_at.saturating_add(EXPIRATION);
+
+        Self { sub: address.to_string(), iat: issued_at, exp: expiration }
+    }
+
+    /// Returns true if the token is expired.
+    pub fn is_expired(&self) -> bool {
+        OffsetDateTime::now_utc().unix_timestamp() >= self.exp
+    }
+
+    /// Returns the json web token string.
+    pub fn to_jwt_string(&self) -> Result<String> {
+        encode(&Header::default(), &self, &EncodingKey::from_secret(jwt_secret())).map_err(|e| anyhow!(e))
+    }
+}
+
+/// Checks the authorization header for a valid token.
+pub fn with_auth() -> impl Filter<Extract = ((),), Error = Rejection> + Clone {
+    warp::header::<String>("authorization").and_then(|token: String| async move {
+        if !token.starts_with("Bearer ") {
+            return Err(reject::custom(RestError::Request("Invalid authorization header.".to_string())));
+        }
+
+        // Decode the claims from the token.
+        match decode::<Claims>(
+            token.trim_start_matches("Bearer "),
+            &DecodingKey::from_secret(jwt_secret()),
+            &Validation::new(Algorithm::HS256),
+        ) {
+            Ok(decoded) => {
+                let claims = decoded.claims;
+                if claims.is_expired() {
+                    return Err(reject::custom(RestError::Request("Expired JSON Web Token.".to_string())));
+                }
+
+                Ok(())
+            }
+            Err(_) => Err(reject::custom(RestError::Request("Unauthorized caller.".to_string()))),
+        }
+    })
+}

--- a/node/rest/src/helpers/mod.rs
+++ b/node/rest/src/helpers/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+mod auth;
+pub use auth::*;
+
 mod error;
 pub use error::*;
 

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -104,8 +104,14 @@ impl<N: Network, C: 'static + ConsensusStorage<N>> Rest<N, C> {
         // Initialize the routes.
         let routes = self.routes();
         // Spawn the server.
+        let address = self.address;
         self.handles.push(Arc::new(tokio::spawn(async move {
             println!("🌐 Starting the REST server at {}.\n", rest_ip.to_string().bold());
+
+            if let Ok(jwt_token) = helpers::Claims::new(address).to_jwt_string() {
+                println!("JSON Web Token: {}\n", jwt_token);
+            }
+
             // Start the server.
             warp::serve(routes.with(cors)).run(rest_ip).await
         })))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -154,6 +154,8 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         // GET /testnet3/records/all
         let records_all = warp::get()
             .and(warp::path!("testnet3" / "records" / "all"))
+            .and(with_auth())
+            .untuple_one()
             .and(warp::body::content_length_limit(128))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))
@@ -162,6 +164,8 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         // GET /testnet3/records/spent
         let records_spent = warp::get()
             .and(warp::path!("testnet3" / "records" / "spent"))
+            .and(with_auth())
+            .untuple_one()
             .and(warp::body::content_length_limit(128))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))
@@ -170,6 +174,8 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         // GET /testnet3/records/unspent
         let records_unspent = warp::get()
             .and(warp::path!("testnet3" / "records" / "unspent"))
+            .and(with_auth())
+            .untuple_one()
             .and(warp::body::content_length_limit(128))
             .and(warp::body::json())
             .and(with(self.ledger.clone()))


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR implements JWT authorization for the REST api endpoints related to records. 

On node startup, a JWT secret key is sampled and a new JWT token used to authenticated requests is displayed.