### PR TITLE
deps: use kadmium 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,8 @@ dependencies = [
 [[package]]
 name = "kadmium"
 version = "0.6.0"
-source = "git+https://github.com/niklaslong/kadmium#fbeca669083d9042a589ff8930313b9c29d662e1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b367a58a53900cadde9087e3290dbf00dc5e85f94904bd017c43d6c7bb5782"
 dependencies = [
  "async-trait",
  "bincode 2.0.0-rc.2",

--- a/node/messages/Cargo.toml
+++ b/node/messages/Cargo.toml
@@ -26,7 +26,7 @@ version = "1.0"
 version = "1.0.0"
 
 [dependencies.kadmium]
-git = "https://github.com/niklaslong/kadmium"
+version = "0.6.0"
 features = ["codec", "sync"]
 
 [dependencies.rayon]


### PR DESCRIPTION
The `NoiseCodec` doesn't depend on the new changes on the main branch making this version non-breaking for the purposes of what's currently implemented in snarkOS. 
