### PR TITLE
Use `last_coinbase_target` for `coinbase_target` calculation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
   node-consensus:
     docker:
       - image: cimg/rust:1.64
-    resource_class: xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: node/consensus
@@ -286,110 +286,6 @@ jobs:
       - check_windows:
           workspace_member: << parameters.workspace_member >>
 
-  build-and-publish-docker-arm:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
-    resource_class: arm.2xlarge
-    steps:
-      - checkout
-      - run: mkdir -p my_workspace
-      - run:
-          name: "Build snarkOS Docker image arm-v8"
-          no_output_timeout: 2h
-          command: |
-            VERSION=$(git rev-parse --short HEAD)
-            docker build -f Dockerfile -t $DOCKER_REPO:$CIRCLE_BRANCH-$VERSION-arm64 .
-      - run:
-          name: "Push snarkOS Docker image arm-v8"
-          command: |
-            VERSION=$(git rev-parse --short HEAD)
-            echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin
-            # CREATE THE SHELL FILE WITH IMAGE NAME AND TAG
-            docker push $DOCKER_REPO:$CIRCLE_BRANCH-$VERSION-arm64
-            echo "Pushed $DOCKER_REPO:$CIRCLE_BRANCH-$VERSION-arm64"
-      - run:
-          name: "Save arm-v8 image tag"
-          command: |
-            VERSION=$(git rev-parse --short HEAD)
-            echo "$CIRCLE_BRANCH-$VERSION-arm64" > my_workspace/docker_tag_arm
-      - persist_to_workspace:
-          root: my_workspace
-          paths:
-            - docker_tag_arm
-
-  build-and-publish-docker-amd:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
-    resource_class: 2xlarge
-    steps:
-      - checkout
-      - run: mkdir -p my_workspace
-      - run:
-          name: "Build snarkOS Docker image amd64"
-          no_output_timeout: 2h
-          command: |
-            VERSION=$(git rev-parse --short HEAD)
-            docker build -f Dockerfile -t $DOCKER_REPO:$CIRCLE_BRANCH-$VERSION-amd64 .
-      - run:
-          name: "Push snarkOS Docker image amd64"
-          command: |
-            VERSION=$(git rev-parse --short HEAD)
-            echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin
-            docker push $DOCKER_REPO:$CIRCLE_BRANCH-$VERSION-amd64
-            echo "Pushed $DOCKER_REPO:$CIRCLE_BRANCH-$VERSION-amd64"
-      - run:
-          name: "Save amd64 image tag"
-          command: |
-            VERSION=$(git rev-parse --short HEAD)
-            echo "$CIRCLE_BRANCH-$VERSION-amd64" > my_workspace/docker_tag_amd
-      - persist_to_workspace:
-          root: my_workspace
-          paths:
-            - docker_tag_amd
-
-  publish_snarkos_manifest:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
-    resource_class: arm.2xlarge
-    steps:
-      - checkout
-      - attach_workspace:
-          at: my_workspace
-      - run:
-          name: "Pull ARM Docker image"
-          command: |
-            ARM_TAG=$(cat my_workspace/docker_tag_arm)
-            echo $ARM_TAG
-            echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin
-            docker pull $DOCKER_REPO:$ARM_TAG
-      - run:
-          name: "Pull AMD Docker image"
-          command: |
-            AMD_TAG=$(cat my_workspace/docker_tag_amd)
-            echo $AMD_TAG
-            docker pull $DOCKER_REPO:$AMD_TAG
-      - run:
-          name: "Create and push Docker multi-arch manifests"
-          command: |
-            ARM_TAG=$(cat my_workspace/docker_tag_arm)
-            AMD_TAG=$(cat my_workspace/docker_tag_amd)
-            echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin
-            echo $DOCKER_REPO
-            echo $CIRCLE_BRANCH
-            echo $ARM_TAG
-            echo $AMD_TAG
-            docker manifest create $DOCKER_REPO:${CIRCLE_BRANCH}-latest --amend $DOCKER_REPO:${ARM_TAG} --amend $DOCKER_REPO:${AMD_TAG}
-            docker manifest inspect $DOCKER_REPO:${CIRCLE_BRANCH}-latest
-            docker manifest push $DOCKER_REPO:${CIRCLE_BRANCH}-latest
-            echo "Pushed $DOCKER_REPO:${CIRCLE_BRANCH}-latest"
-            docker manifest create $DOCKER_REPO:latest --amend $DOCKER_REPO:${ARM_TAG} --amend $DOCKER_REPO:${AMD_TAG}
-            docker manifest inspect $DOCKER_REPO:latest
-            docker manifest push $DOCKER_REPO:latest
-            echo "Pushed $DOCKER_REPO:latest"
-
 workflows:
   version: 2
 
@@ -421,15 +317,3 @@ workflows:
 #                display
 #                node
               ]
-
-  build-snarkos-docker-images:
-    when:
-      or:
-        - equal: [ testnet3, << pipeline.git.branch >> ]
-    jobs:
-      - build-and-publish-docker-arm
-      - build-and-publish-docker-amd
-      - publish_snarkos_manifest:
-          requires:
-            - build-and-publish-docker-arm
-            - build-and-publish-docker-amd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "anyhow",
  "clap",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2517,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2548,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2566,12 +2566,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2755,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2772,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,8 +2450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9abdef8347e33770fd61b887bed0fd076ef1ddf8dadc0ef7acf3cc2aa01cb4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "anyhow",
  "clap",
@@ -2478,8 +2477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e03b27711fde89b8aa30f6a48a0e7424e604d6e19c65e42d3bf73ecda9d536"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2505,8 +2503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b470c8961de8e5564cf726132dbbba65386cb284902c7ae9a82f9b989eb2c0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2520,8 +2517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9edf046f16408079b9c1aa31475861158809239ad91e26aedbb99b480cdc08"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2532,8 +2528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e18c58d663be274116884fc0acd448b218cd9a7995830bb90fc7c4a82911ec"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2543,8 +2538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d97fed5ddad9cbbbe2ece79db86568e8c30be2f124fbac4e22389d8b216e18"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2554,8 +2548,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34edb4e98b7ad68f69d339647646fe698c9971b947947554804ded9c859efdd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2573,14 +2566,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597d7b5e9a8b0f81503234b9e417788dd6005a10a23df853cd0e0430c60b8d60"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797c4fa627af9528f2d57bbaf6ce263c94a602d0e822fb6ffc06cf2574bc8b45"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2591,8 +2582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a18dd5e68a90bd6dab011533812c4f59688e4a2bc7406897e6da669e06c495"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2605,8 +2595,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad6fa91f66216f39d9dcb6d621453792f9cfb1e2650c18faffa91adcf0059c6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2621,8 +2610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151289533edfb171fd3847485c969dbc99221aca7159f0d4f6655f44554ba1a"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2635,8 +2623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ea095474ee16f4b17dfbd65fc1dc428b10d8439f59e8b56dea74fce9508d96"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2645,8 +2632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437e6088045a88f7ada6e8a729167489ae3478e4208ba2efc0f22cc3467e6030"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2656,8 +2642,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc6c021f1b13249fa305d1987934526d57147bdbba09961c9986ba05061c126"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2669,8 +2654,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064f3014917e7a917b4f7a6bcf46cae6fa9833d6c76d064482edb600addf415a"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2681,8 +2665,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a388155052f877cbd8dcec2249cba512ff52081c7063144cb59c6ad77483b22b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2693,8 +2676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2afdfd9b9b28d492d4324ec85441bf4c14ca0113b3aa78c0e9f08bda58427dd"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2706,8 +2688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e026ceb04a235849dc57e01492cea4dceb89316c01804437a652b32bfaec8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2720,8 +2701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086d215004b7c879724b37cdf0dc6efd1437025d860f74d19577f0a1577284f1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2731,8 +2711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f3ffd3cf8c6b4a8800ef09a8f8535db6bbf9c7e7052b058f7ee847f5e6f7e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2744,8 +2723,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bac1e860b7242a462571c22612231c31a1bbd08e625d24c9d11866d7ffe6c8b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2756,8 +2734,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd943c1abd36f74802734160599b834d898eb2e911c2efaaf8170c104ae9c54"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2778,8 +2755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7935f071e0af0737c40fd26beef0a670480fd9ca752c1e186b7ca092a57c7bb4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2796,8 +2772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feba5c588f6a4c2dbb0ee3ed9ff48759c2b6126668aa2a467bc5de0fb9c5872c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2815,8 +2790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64767599f3696a41e7c74221014193b3fb254790e2ec55b4f4c69697bd74abf7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2831,8 +2805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627c4355cbcbbc88af372215683880967de42bceab627b0f4ac17e73ffdf43eb"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2843,8 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b171db7e8712a5c06b067275b7bcc760a78e93cf558dad5c02db9f35143cc0dc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2852,8 +2824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7ccc733cf0d66bb37190acb2c3bda4dbd287e1d7a45a99104730a3345a6649"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2862,8 +2833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1d6f260e6c8643a464e264e723dd63f14197f5c9b003dc34a8a77f5871fc5e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2874,8 +2844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87d10fcbae79a00ad3bef324678b49f1198faefb166259696e25788bdd8800"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2885,8 +2854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9c1d575f86366859b56deaba87eedcb68b18c4826887ac29408e14c6a486a6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2896,8 +2864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabaf89173783b6866d4b4a31727ba4c3db3e455ef56811d8cc874dfab009dec"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2908,8 +2875,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2251bd0af011b0bbc6be0ba1ab05adaf58603cae2ddff624caa1c1e4980cfcf3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2922,8 +2888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3c41b58c5d210bcd569d2fe113b04a7992a09a2b4b9cc8cd86f8af18d13860"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2940,8 +2905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fcf327850ab251b5268ea26a457afea27653cdc9950c00b082f81db73e325d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2966,8 +2930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8a5920b059589be88bdf6d3b364a1eee9f0ce61be5b584e3300e2be869bf0e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2983,8 +2946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d4ca9e45c8af50bbca57118800db757de582eb8e0852389412318c54f74376"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3009,8 +2971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfb2bd680efbeb21c6996a276de3be98f3b43417310827f00b198232bab9344"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3028,8 +2989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e84309d230eea4f0eb798cce6044d789cbb37789ca310b4db07bda62319c36f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,8 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde68e89f693978203c833e454cf8fdea521570321b68ae0d49ce55006743baf"
 dependencies = [
  "anyhow",
  "clap",
@@ -2476,8 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c79a3523956696735c51f7e55ab5f4d7592c01c6b3935bfba20266b03b579cc"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2502,8 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65262d3b5c4cec5445432081d3ca2f11dc19dfaa61e231aefb2c42a996dbdf2d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2516,8 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b6508411cce8985ddd2613ef2e1f1418721ce31ebc7b37eca5bb5533e5d534"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2527,8 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69536db9e7286651490730e531c76b0e76ed971d1db4c5a4e47f34c9084e551c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2537,8 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d815def15169991b1a6f5ae667254edaf5888bc44a1acfa24beada1728edef6f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2547,8 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c33378b6478306517704393e8788d69bc059ae95dfab60a1fffbc1acaf39bc"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2565,13 +2572,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78638a4dda036c49611434ec5bf619126c04f80062009cb69f52a589bdd4680b"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bf431c3c11bb8baa3d84a5a18d04700cd031d50dcccab2438dc586106e218f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2581,8 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc90b1a58276e3bd883eb7525bc8948ccc4748212c20ddfb0dcbbf0ca55c15f5"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2594,8 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f532360108d7c9da030d6c9f84a8e6e3d6a9263aa8f337005261ca0722c2676"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2609,8 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2753288260ed21ed139866f01e9c15d594ac68889e5a77bd731e7b37f6cd43f2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2622,8 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f7588a8fb5398eb48158e89c3253193fbf04aa08c5331a5b8db6d75383cd1b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2631,8 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed1a6635b4b53741afae241647e6800df9470156929ffdd1cccc9438934f4b2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2641,8 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c3a336d23322e4b22bd3541e99465a665177199bfb0c90dd8e365baf2be20b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2653,8 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1360b8e844e545857645ae98b4ecb6967d6434f29a1bcdd6dc0b4bc938324685"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2664,8 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719844e5c513d64e71e3b192f9ebbd7d264bc0f3991091e1ba867520e664cf87"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2675,8 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ad2a7fd00a4a87529419a893fffb054cb6a904933046c8180a834be56552cb"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2687,8 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e896067a9a6a34bd7393a7418b65498d3dd4b39a73a9c0997d40689b19ea4"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2700,8 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f33efbb6318a10cfa70867e0a5a34472d6cb4b3274b01ace1e2aa4bffa4b665"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2710,8 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1077f089b7090d70f55e1bfca84f4da6f512e1aec664e3ae2bb3f8c05d44df23"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2722,8 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c7c6cfc6c8c68b633a14ed50ed4e87f83685b862ddbb819c587a301cb025cc"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2733,8 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f806fe6b7554987c42444f9bff00fda03332857742b4aef0553fc86505796f52"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2754,8 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd21d90d52c9cff3b64ef470a5a367342ed09fbb24c8b0318e59898f717124c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2771,8 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d8221c5a245709deec1dc74e7e74e17dfee530037fdbb1ad4cc16b5af035fc"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2789,8 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e413c2abd7c28e164ca616e353d0ca3cb6c1eb9fe379731d90fae6b673f59d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2804,8 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934a1efc633e2588278f47b26b678be3dd2c60b9df57a3ef88d9522320f3bd47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2815,16 +2842,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93238b452825beaca8757a437856e37864680e0086dd46255aaaf80f083bfa05"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33b6753f5b480688eac2620ee4cb9b2d6a9699e8907e5f01d6da3b76d173d5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2832,8 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb70a3268feb390275e7c86015711325d4b4e9c79f871d25ecd117e76db3bdd4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2843,8 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222f05d7b44d32f7a94d2ff67cd9319fba4fb7945e4c3ac2a6270d9575cc4a16"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2853,8 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3a900f68293f205f97d65192215a5f06d44cc4e157faf523ac6b2c45d416a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2863,8 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ea077036487fe3051d6681116ea10d56ae84fdcfa963123cc9b54d4e159d07"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2874,8 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf63de5aea898d48cd5ef793df5debf255fc898cae6f6bdc268367091c2cfcd"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2887,8 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b68aff042187cfdb0c182e601bf886fcd1b55053d64a9481e18b51363e3074e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2904,8 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d685bf2beef7c6f7700727ab9199617b050fe99568deb8494aa8af1aa5751e77"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2929,8 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41886cce299ae7c17a2b72ceb41a995c69b6e997a441d8846c4eddc69fc2212b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2945,8 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91af93b09bc221de2ca73c7a622de757c55fc5b96cf07584aa2599bd4715278e"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2970,8 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d9e31a85d710c4a290e84800dfe08765377ad38129b975d2ed9a032e8a83"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2988,8 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3e7421b#3e7421bcab7752fe9c00d60a135bce9c99cbb867"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70d3403826e58a64be1b56c215457a3317d01f7e2676ef88fb591130c32cde"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2503,7 +2503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2517,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2538,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2548,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2566,12 +2566,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2755,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2772,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2854,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dc0460a#dc0460a13b4aacf5a9f3518a2d25841f416722aa"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=94c03b8#94c03b823cad3f58369976ecde41a8c1eb52bda0"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
-#git = "https://github.com/AleoHQ/snarkVM.git"
-#rev = "3e1f5d7"
-version = "0.9.3"
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "dc0460a"
+#version = "0.9.3"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ path = "snarkos/main.rs"
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "dc0460a"
+rev = "94c03b8"
 #version = "0.9.3"
 features = ["circuit", "console", "parallel"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "3e7421b"
-#version = "0.9.3"
+#git = "https://github.com/AleoHQ/snarkVM.git"
+#rev = "3e7421b"
+version = "0.9.4"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ path = "snarkos/main.rs"
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "94c03b8"
+rev = "3e7421b"
 #version = "0.9.3"
 features = ["circuit", "console", "parallel"]
 

--- a/node/consensus/src/helpers/mod.rs
+++ b/node/consensus/src/helpers/mod.rs
@@ -213,9 +213,9 @@ mod tests {
 
     const ITERATIONS: usize = 1000;
 
-    const EXPECTED_ANCHOR_REWARD: u64 = 8;
-    const EXPECTED_STAKING_REWARD: u64 = 17_440_385;
-    const EXPECTED_COINBASE_REWARD_FOR_BLOCK_1: u64 = 126_143_992;
+    const EXPECTED_ANCHOR_REWARD: u64 = 13;
+    const EXPECTED_STAKING_REWARD: u64 = 21_800_481;
+    const EXPECTED_COINBASE_REWARD_FOR_BLOCK_1: u64 = 163_987_187;
 
     #[test]
     fn test_anchor_reward() {

--- a/node/consensus/src/helpers/mod.rs
+++ b/node/consensus/src/helpers/mod.rs
@@ -107,7 +107,7 @@ pub fn coinbase_target(
 
 /// Calculate the minimum proof target for the given coinbase target.
 pub fn proof_target(coinbase_target: u64) -> u64 {
-    coinbase_target.checked_shr(7).unwrap_or(8)
+    coinbase_target.checked_shr(7).unwrap_or(7).saturating_add(1)
 }
 
 /// Retarget algorithm using fixed point arithmetic from https://www.reference.cash/protocol/forks/2020-11-15-asert.

--- a/node/consensus/src/helpers/mod.rs
+++ b/node/consensus/src/helpers/mod.rs
@@ -107,7 +107,7 @@ pub fn coinbase_target(
 
 /// Calculate the minimum proof target for the given coinbase target.
 pub fn proof_target(coinbase_target: u64) -> u64 {
-    coinbase_target.checked_shr(10).unwrap_or(0)
+    coinbase_target.checked_shr(7).unwrap_or(8)
 }
 
 /// Retarget algorithm using fixed point arithmetic from https://www.reference.cash/protocol/forks/2020-11-15-asert.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -416,7 +416,7 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
         // Ensure the coinbase target is correct.
         let expected_coinbase_target = coinbase_target(
             self.ledger.last_coinbase_target(),
-            self.ledger.latest_coinbase_timestamp(),
+            self.ledger.last_coinbase_timestamp(),
             block.timestamp(),
             N::ANCHOR_TIME,
             N::NUM_BLOCKS_PER_EPOCH,
@@ -535,8 +535,8 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
             if block.header().coinbase_accumulator_point() != Field::<N>::zero() {
                 bail!("Coinbase accumulator point should be zero as there is no coinbase solution in the block.");
             }
-            // Ensure the last coinbase timestamp matches the *latest coinbase timestamp*.
-            if block.height() > 0 && block.last_coinbase_timestamp() != self.ledger.latest_coinbase_timestamp() {
+            // Ensure the last coinbase timestamp is the same as the previous block (i.e. the latest block).
+            if block.height() > 0 && block.last_coinbase_timestamp() != self.ledger.last_coinbase_timestamp() {
                 bail!("The last coinbase timestamp does not match the latest coinbase timestamp.");
             }
         }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -247,7 +247,7 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
 
         // Construct the next coinbase target.
         let next_coinbase_target = coinbase_target(
-            latest_coinbase_target,
+            latest_block.last_coinbase_target(),
             latest_block.last_coinbase_timestamp(),
             next_timestamp,
             N::ANCHOR_TIME,
@@ -257,10 +257,10 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
         // Construct the next proof target.
         let next_proof_target = proof_target(next_coinbase_target);
 
-        // Construct the next coinbase timestamp.
-        let next_coinbase_timestamp = match coinbase {
-            Some(_) => next_timestamp,
-            None => latest_block.last_coinbase_timestamp(),
+        // Construct the next coinbase target and next coinbase timestamp.
+        let (next_coinbase_target, next_coinbase_timestamp) = match coinbase {
+            Some(_) => (next_coinbase_target, next_timestamp),
+            None => (latest_block.last_coinbase_target(), latest_block.last_coinbase_timestamp()),
         };
 
         // Construct the metadata.
@@ -270,6 +270,7 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
             next_height,
             next_coinbase_target,
             next_proof_target,
+            next_coinbase_target,
             next_coinbase_timestamp,
             next_timestamp,
         )?;
@@ -410,6 +411,24 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
         // Ensure the block header is valid.
         if !block.header().is_valid() {
             bail!("Invalid block header: {:?}", block.header());
+        }
+
+        // Ensure the coinbase target is correct.
+        let expected_coinbase_target = coinbase_target(
+            self.ledger.last_coinbase_target(),
+            self.ledger.latest_coinbase_timestamp(),
+            block.timestamp(),
+            N::ANCHOR_TIME,
+            N::NUM_BLOCKS_PER_EPOCH,
+        )?;
+        if block.coinbase_target() != expected_coinbase_target {
+            bail!("Invalid coinbase target: expected {}, got {}", expected_coinbase_target, block.coinbase_target())
+        }
+
+        // Ensure the proof target is correct.
+        let expected_proof_target = proof_target(expected_coinbase_target);
+        if block.proof_target() != expected_proof_target {
+            bail!("Invalid proof target: expected {}, got {}", expected_proof_target, block.proof_target())
         }
 
         /* Block Hash */

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -119,7 +119,7 @@ pub(crate) mod test_helpers {
                     r"
 program testing.aleo;
 
-interface message:
+struct message:
     amount as u128;
 
 record token:

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -193,6 +193,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.current_block.read().last_coinbase_timestamp()
     }
 
+    /// Returns the last coinbase target.
+    pub fn last_coinbase_target(&self) -> u64 {
+        self.current_block.read().last_coinbase_target()
+    }
+
     /// Returns the latest block timestamp.
     pub fn latest_timestamp(&self) -> i64 {
         self.current_block.read().timestamp()

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -188,14 +188,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.current_block.read().proof_target()
     }
 
-    /// Returns the latest coinbase timestamp.
-    pub fn latest_coinbase_timestamp(&self) -> i64 {
-        self.current_block.read().last_coinbase_timestamp()
-    }
-
     /// Returns the last coinbase target.
     pub fn last_coinbase_target(&self) -> u64 {
         self.current_block.read().last_coinbase_target()
+    }
+
+    /// Returns the latest coinbase timestamp.
+    pub fn latest_coinbase_timestamp(&self) -> i64 {
+        self.current_block.read().last_coinbase_timestamp()
     }
 
     /// Returns the latest block timestamp.

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -193,8 +193,8 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         self.current_block.read().last_coinbase_target()
     }
 
-    /// Returns the latest coinbase timestamp.
-    pub fn latest_coinbase_timestamp(&self) -> i64 {
+    /// Returns the last coinbase timestamp.
+    pub fn last_coinbase_timestamp(&self) -> i64 {
         self.current_block.read().last_coinbase_timestamp()
     }
 

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -189,7 +189,7 @@ impl<N: Network> Beacon<N> {
         let beacon = self.clone();
         spawn_task_loop!(Self, {
             // Expected time per block.
-            const ROUND_TIME: u64 = 5; // 5 seconds per block
+            const ROUND_TIME: u64 = 15; // 15 seconds per block
 
             // Produce blocks.
             loop {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the calculation of `coinbase_targets` using the `last_coinbase_target` attribute in the block header `Metadata`. 


Once https://github.com/AleoHQ/snarkVM/pull/1253 has been included in a new release, the snarkVM dependency here should be updated.