### PR TITLE
Implement fast-sync and syncing for Validator nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,9 +2299,12 @@ version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode 1.3.3",
  "parking_lot",
  "rand",
+ "reqwest",
  "serde_json",
+ "sha2",
  "snarkos-account",
  "snarkos-node-consensus",
  "snarkos-node-executor",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,6 +19,9 @@ edition = "2021"
 [dependencies.anyhow]
 version = "1"
 
+[dependencies.bincode]
+version = "1.0"
+
 [dependencies.async-trait]
 version = "0.1"
 
@@ -29,8 +32,15 @@ version = "0.12"
 version = "0.8"
 default-features = false
 
+[dependencies.reqwest]
+version = "0.11"
+
 [dependencies.serde_json]
 version = "1"
+
+[dependencies.sha2]
+version = "0.10"
+default-features = false
 
 [dependencies.snarkos-account]
 path = "../account"

--- a/node/ledger/src/get.rs
+++ b/node/ledger/src/get.rs
@@ -53,6 +53,17 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
     }
 
+    /// Returns the blocks for the given start block height and end block height.
+    pub fn get_blocks(&self, start_height: u32, end_height: u32) -> Result<Vec<Block<N>>> {
+        // Ensure that the start block height is less than or equal to the end block height.
+        if start_height > end_height {
+            bail!("Start block height ({start_height}) is greater than end block height ({end_height})")
+        }
+
+        // Retrieve the blocks.
+        (start_height..=end_height).map(|height| self.get_block(height)).collect()
+    }
+
     /// Returns the block hash for the given block height.
     pub fn get_hash(&self, height: u32) -> Result<N::BlockHash> {
         match self.vm.block_store().get_block_hash(height)? {

--- a/node/messages/src/block_request.rs
+++ b/node/messages/src/block_request.rs
@@ -18,7 +18,9 @@ use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockRequest {
+    /// The starting block height (inclusive).
     pub start_block_height: u32,
+    /// The ending block height (inclusive).
     pub end_block_height: u32,
 }
 

--- a/node/messages/src/block_response.rs
+++ b/node/messages/src/block_response.rs
@@ -18,12 +18,12 @@ use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockResponse<N: Network> {
-    pub blocks: Data<Blocks<N>>,
+    pub blocks: Data<RequestedBlocks<N>>,
 }
 
 impl<N: Network> BlockResponse<N> {
     pub fn new(blocks: Vec<Block<N>>) -> Self {
-        Self { blocks: Data::Object(Blocks(blocks)) }
+        Self { blocks: Data::Object(RequestedBlocks(blocks)) }
     }
 }
 
@@ -47,11 +47,13 @@ impl<N: Network> MessageTrait for BlockResponse<N> {
     }
 }
 
+// TODO (raychu86): Add enforcement for maximum number of blocks.
+
 /// Wrapper struct around a vector of blocks.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Blocks<N: Network>(pub Vec<Block<N>>);
+pub struct RequestedBlocks<N: Network>(pub Vec<Block<N>>);
 
-impl<N: Network> ToBytes for Blocks<N> {
+impl<N: Network> ToBytes for RequestedBlocks<N> {
     #[inline]
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         (self.0.len() as u32).write_le(&mut writer)?;
@@ -63,7 +65,7 @@ impl<N: Network> ToBytes for Blocks<N> {
     }
 }
 
-impl<N: Network> FromBytes for Blocks<N> {
+impl<N: Network> FromBytes for RequestedBlocks<N> {
     #[inline]
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         let num_blocks = u32::read_le(&mut reader)? as usize;

--- a/node/messages/src/helpers/noise_codec.rs
+++ b/node/messages/src/helpers/noise_codec.rs
@@ -391,6 +391,7 @@ mod tests {
             version: 0,
             fork_depth: 0,
             node_type: NodeType::Client,
+            block_height: Some(0),
             status: Status::Ready,
         })));
 

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -79,7 +79,10 @@ use snarkvm::prelude::{
 
 use ::bytes::{Buf, BytesMut};
 use anyhow::{bail, Result};
-use std::{io::Write, net::SocketAddr};
+use std::{
+    io::{Read, Result as IoResult, Write},
+    net::SocketAddr,
+};
 
 pub trait MessageTrait {
     /// Returns the message name.

--- a/node/messages/src/ping.rs
+++ b/node/messages/src/ping.rs
@@ -21,6 +21,7 @@ pub struct Ping {
     pub version: u32,
     pub fork_depth: u32,
     pub node_type: NodeType,
+    pub block_height: Option<u32>,
     pub status: Status,
 }
 
@@ -34,14 +35,17 @@ impl MessageTrait for Ping {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        Ok(bincode::serialize_into(&mut *writer, &(self.version, self.fork_depth, self.node_type, self.status))?)
+        Ok(bincode::serialize_into(
+            &mut *writer,
+            &(self.version, self.fork_depth, self.node_type, self.block_height, self.status),
+        )?)
     }
 
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
         let mut reader = bytes.reader();
-        let (version, fork_depth, node_type, status) = bincode::deserialize_from(&mut reader)?;
-        Ok(Self { version, fork_depth, node_type, status })
+        let (version, fork_depth, node_type, block_height, status) = bincode::deserialize_from(&mut reader)?;
+        Ok(Self { version, fork_depth, node_type, block_height, status })
     }
 }

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -174,6 +174,7 @@ pub trait Handshake: Executor {
                                     version: Message::<N>::VERSION,
                                     fork_depth: ALEO_MAXIMUM_FORK_DEPTH,
                                     node_type: Self::NODE_TYPE,
+                                    block_height: None,
                                     status: Self::status().get(),
                                 });
                                 trace!("Sending '{}' to '{peer_ip}'", message.name());

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -52,7 +52,7 @@ pub trait Inbound<N: Network>: Executor {
             Message::Ping(message) => Self::ping(message, peer_ip, peer).await,
             Message::Pong(message) => self.pong(message, peer_ip, router).await,
             Message::PuzzleRequest(..) => self.puzzle_request(peer_ip, router).await,
-            Message::PuzzleResponse(message) => self.puzzle_response(message, peer_ip).await,
+            Message::PuzzleResponse(message) => self.puzzle_response(message, peer_ip, peer).await,
             Message::UnconfirmedBlock(message) => {
                 // Clone the message.
                 let message_clone = message.clone();
@@ -333,7 +333,7 @@ pub trait Inbound<N: Network>: Executor {
         false
     }
 
-    async fn puzzle_response(&self, _message: PuzzleResponse<N>, peer_ip: SocketAddr) -> bool {
+    async fn puzzle_response(&self, _message: PuzzleResponse<N>, peer_ip: SocketAddr, _peer: &Peer<N>) -> bool {
         debug!("Disconnecting '{peer_ip}' for the following reason - {:?}", DisconnectReason::ProtocolViolation);
         false
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -55,7 +55,7 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
 // TODO (raychu86): Move this declaration.
-const ALEO_MAXIMUM_FORK_DEPTH: u32 = 4096;
+pub const ALEO_MAXIMUM_FORK_DEPTH: u32 = 4096;
 
 /// Shorthand for the parent half of the `Router` channel.
 pub type RouterSender<N> = mpsc::Sender<RouterRequest<N>>;
@@ -138,7 +138,7 @@ impl<N: Network> Router<N> {
     /// The maximum number of connection failures permitted by an inbound connecting peer.
     const MAXIMUM_CONNECTION_FAILURES: u32 = 3;
     /// The duration in seconds to sleep in between ping requests with a connected peer.
-    const PING_SLEEP_IN_SECS: u64 = 60; // 1 minute
+    pub const PING_SLEEP_IN_SECS: u64 = 60; // 1 minute
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
     const RADIO_SILENCE_IN_SECS: u64 = 180; // 3 minutes

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -269,6 +269,16 @@ impl<N: Network> Router<N> {
         self.restricted_peers.read().await.len()
     }
 
+    /// Returns the list of connected peers and their block heights.
+    pub async fn connected_peer_block_heights(&self) -> IndexMap<SocketAddr, u32> {
+        let mut peer_block_heights = IndexMap::new();
+        for (ip, peer) in self.connected_peers.read().await.iter() {
+            peer_block_heights.insert(*ip, *peer.block_height.read().await);
+        }
+
+        peer_block_heights
+    }
+
     /// Sends a "PuzzleRequest" to a reliable peer.
     pub async fn send_puzzle_request(&self, node_type: NodeType) {
         // Retrieve a reliable peer.

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -22,6 +22,8 @@ use snarkos_node_consensus::Consensus;
 use snarkos_node_executor::{spawn_task_loop, Executor, NodeType, Status};
 use snarkos_node_ledger::{Ledger, RecordMap};
 use snarkos_node_messages::{
+    BlockRequest,
+    BlockResponse,
     Data,
     Message,
     PuzzleResponse,

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -19,20 +19,22 @@ mod router;
 use crate::traits::NodeInterface;
 use snarkos_account::Account;
 use snarkos_node_consensus::Consensus;
-use snarkos_node_executor::{spawn_task_loop, Executor, NodeType, Status};
+use snarkos_node_executor::{spawn_task, spawn_task_loop, Executor, NodeType, Status};
 use snarkos_node_ledger::{Ledger, RecordMap};
 use snarkos_node_messages::{
     BlockRequest,
     BlockResponse,
     Data,
     Message,
+    Ping,
+    Pong,
     PuzzleResponse,
     UnconfirmedBlock,
     UnconfirmedSolution,
     UnconfirmedTransaction,
 };
 use snarkos_node_rest::Rest;
-use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest};
+use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest, ALEO_MAXIMUM_FORK_DEPTH};
 use snarkos_node_store::ConsensusDB;
 use snarkvm::prelude::{
     Address,

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -63,7 +63,7 @@ impl<N: Network> Inbound<N> for Beacon<N> {
     async fn pong(&self, _message: Pong, peer_ip: SocketAddr, router: &Router<N>) -> bool {
         // Spawn an asynchronous task for the `Ping` request.
         let router = router.clone();
-        let latest_height = self.ledger.latest_height();
+        let ledger = self.ledger.clone();
         spawn_task!(Self, {
             // Sleep for the preset time before sending a `Ping` request.
             tokio::time::sleep(Duration::from_secs(Router::<N>::PING_SLEEP_IN_SECS)).await;
@@ -73,7 +73,7 @@ impl<N: Network> Inbound<N> for Beacon<N> {
                 version: Message::<N>::VERSION,
                 fork_depth: ALEO_MAXIMUM_FORK_DEPTH,
                 node_type: Self::NODE_TYPE,
-                block_height: Some(latest_height),
+                block_height: Some(ledger.latest_height()),
                 status: Self::status().get(),
             });
             if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -49,14 +49,40 @@ impl<N: Network> Inbound<N> for Beacon<N> {
                 return false;
             }
         };
-        let blocks = blocks.into_iter().map(Data::Object).collect();
 
-        // Send the `PuzzleResponse` message to the peer.
-        let message = Message::BlockResponse(BlockResponse { blocks });
-        if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {
-            warn!("[BlockResponse] {}", error);
+        // Send the blocks to the peer.
+        for block in blocks {
+            // Send the `PuzzleResponse` message to the peer.
+            let message = Message::BlockResponse(BlockResponse { block: Data::Object(block) });
+            if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {
+                warn!("[BlockResponse] {}", error);
+            }
         }
 
+        true
+    }
+
+    /// Send a ping message to the peer after `PING_SLEEP_IN_SECS` seconds.
+    async fn pong(&self, _message: Pong, peer_ip: SocketAddr, router: &Router<N>) -> bool {
+        // Spawn an asynchronous task for the `Ping` request.
+        let router = router.clone();
+        let latest_height = self.ledger.latest_height();
+        spawn_task!(Self, {
+            // Sleep for the preset time before sending a `Ping` request.
+            tokio::time::sleep(Duration::from_secs(Router::<N>::PING_SLEEP_IN_SECS)).await;
+
+            // Send a `Ping` request to the peer.
+            let message = Message::Ping(Ping {
+                version: Message::<N>::VERSION,
+                fork_depth: ALEO_MAXIMUM_FORK_DEPTH,
+                node_type: Self::NODE_TYPE,
+                block_height: Some(latest_height),
+                status: Self::status().get(),
+            });
+            if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {
+                warn!("[Ping] {error}");
+            }
+        });
         true
     }
 

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -50,13 +50,10 @@ impl<N: Network> Inbound<N> for Beacon<N> {
             }
         };
 
-        // Send the blocks to the peer.
-        for block in blocks {
-            // Send the `PuzzleResponse` message to the peer.
-            let message = Message::BlockResponse(BlockResponse { block: Data::Object(block) });
-            if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {
-                warn!("[BlockResponse] {}", error);
-            }
+        // Send the `BlockResponse` message to the peer.
+        let message = Message::BlockResponse(BlockResponse::new(blocks));
+        if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {
+            warn!("[BlockResponse] {}", error);
         }
 
         true

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -20,7 +20,7 @@ use crate::traits::NodeInterface;
 use snarkos_account::Account;
 use snarkos_node_executor::{Executor, NodeType};
 use snarkos_node_messages::{Message, PuzzleResponse, UnconfirmedSolution};
-use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest};
+use snarkos_node_router::{Handshake, Inbound, Outbound, Peer, Router, RouterRequest};
 use snarkvm::prelude::{Address, Block, CoinbasePuzzle, EpochChallenge, Network, PrivateKey, ProverSolution, ViewKey};
 
 use anyhow::Result;

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -22,7 +22,7 @@ impl<N: Network> Handshake for Client<N> {}
 #[async_trait]
 impl<N: Network> Inbound<N> for Client<N> {
     /// Saves the latest epoch challenge and latest block in the node.
-    async fn puzzle_response(&self, message: PuzzleResponse<N>, peer_ip: SocketAddr) -> bool {
+    async fn puzzle_response(&self, message: PuzzleResponse<N>, peer_ip: SocketAddr, peer: &Peer<N>) -> bool {
         let epoch_challenge = message.epoch_challenge;
         match message.block.deserialize().await {
             Ok(block) => {
@@ -41,6 +41,8 @@ impl<N: Network> Inbound<N> for Client<N> {
                 self.latest_epoch_challenge.write().await.replace(epoch_challenge);
                 // Save the latest block in the node.
                 self.latest_block.write().await.replace(block);
+                // Update the block height of the peer.
+                *peer.block_height.write().await = block_height;
 
                 trace!("Received 'PuzzleResponse' from '{peer_ip}' (Epoch {epoch_number}, Block {block_height})");
                 true

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -20,7 +20,7 @@ use crate::traits::NodeInterface;
 use snarkos_account::Account;
 use snarkos_node_executor::{spawn_task, spawn_task_loop, Executor, NodeType, Status};
 use snarkos_node_messages::{Data, Message, PuzzleResponse, UnconfirmedSolution};
-use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest};
+use snarkos_node_router::{Handshake, Inbound, Outbound, Peer, Router, RouterRequest};
 use snarkvm::prelude::{Address, Block, CoinbasePuzzle, EpochChallenge, Network, PrivateKey, ProverSolution, ViewKey};
 
 use anyhow::Result;

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -22,7 +22,7 @@ impl<N: Network> Handshake for Prover<N> {}
 #[async_trait]
 impl<N: Network> Inbound<N> for Prover<N> {
     /// Saves the latest epoch challenge and latest block in the prover.
-    async fn puzzle_response(&self, message: PuzzleResponse<N>, peer_ip: SocketAddr) -> bool {
+    async fn puzzle_response(&self, message: PuzzleResponse<N>, peer_ip: SocketAddr, peer: &Peer<N>) -> bool {
         let epoch_challenge = message.epoch_challenge;
         match message.block.deserialize().await {
             Ok(block) => {
@@ -35,6 +35,8 @@ impl<N: Network> Inbound<N> for Prover<N> {
                 self.latest_epoch_challenge.write().await.replace(epoch_challenge);
                 // Save the latest block in the prover.
                 self.latest_block.write().await.replace(block);
+                // Update the block height of the peer.
+                *peer.block_height.write().await = block_height;
 
                 trace!("Received 'PuzzleResponse' from '{peer_ip}' (Epoch {epoch_number}, Block {block_height})");
                 true

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -18,7 +18,8 @@ mod router;
 
 use crate::traits::NodeInterface;
 use snarkos_account::Account;
-use snarkos_node_executor::{Executor, NodeType, Status};
+use snarkos_node_consensus::Consensus;
+use snarkos_node_executor::{spawn_task_loop, Executor, NodeType, Status};
 use snarkos_node_ledger::Ledger;
 use snarkos_node_messages::{Data, Message, PuzzleResponse};
 use snarkos_node_rest::Rest;
@@ -26,15 +27,27 @@ use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest};
 use snarkos_node_store::ConsensusDB;
 use snarkvm::prelude::{Address, Block, Network, PrivateKey, ViewKey};
 
-use anyhow::Result;
-use std::{net::SocketAddr, sync::Arc};
+use anyhow::{bail, ensure, Result};
+use sha2::{Digest, Sha256};
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 use tokio::sync::RwLock;
+
+/// The number of blocks in each fast-sync chunk.
+const NUM_BLOCKS_PER_CHUNK: u32 = 50;
 
 /// A validator is a full node, capable of validating blocks.
 #[derive(Clone)]
 pub struct Validator<N: Network> {
     /// The account of the node.
     account: Account<N>,
+    /// The consensus module of the node.
+    consensus: Consensus<N, ConsensusDB<N>>,
     /// The ledger of the node.
     ledger: Ledger<N, ConsensusDB<N>>,
     /// The router of the node.
@@ -43,6 +56,8 @@ pub struct Validator<N: Network> {
     rest: Option<Arc<Rest<N, ConsensusDB<N>>>>,
     /// The latest puzzle response.
     latest_puzzle_response: Arc<RwLock<Option<PuzzleResponse<N>>>>,
+    /// The shutdown signal.
+    shutdown: Arc<AtomicBool>,
 }
 
 impl<N: Network> Validator<N> {
@@ -59,6 +74,8 @@ impl<N: Network> Validator<N> {
         let account = Account::from(private_key)?;
         // Initialize the ledger.
         let ledger = Ledger::load(genesis, dev)?;
+        // Initialize the consensus.
+        let consensus = Consensus::new(ledger.clone())?;
         // Initialize the node router.
         let (router, router_receiver) = Router::new::<Self>(node_ip, account.address(), trusted_peers).await?;
         // Initialize the REST server.
@@ -69,11 +86,22 @@ impl<N: Network> Validator<N> {
             None => None,
         };
         // Initialize the node.
-        let node = Self { account, ledger, router: router.clone(), rest, latest_puzzle_response: Default::default() };
+        let node = Self {
+            account,
+            consensus,
+            ledger,
+            router: router.clone(),
+            rest,
+            latest_puzzle_response: Default::default(),
+            shutdown: Default::default(),
+        };
+
         // Initialize the router handler.
         router.initialize_handler(node.clone(), router_receiver).await;
         // Initialize the signal handler.
         node.handle_signals();
+        // Initialize the standard block sync.
+        node.initialize_block_sync().await;
         // Return the node.
         Ok(node)
     }
@@ -102,7 +130,7 @@ impl<N: Network> Executor for Validator<N> {
 
         // Shut down the ledger.
         trace!("Proceeding to shut down the ledger...");
-        // self.state.ledger().shut_down().await;
+        self.shutdown.store(true, Ordering::SeqCst);
 
         // Flush the tasks.
         Self::resources().shut_down();
@@ -134,5 +162,145 @@ impl<N: Network> NodeInterface<N> for Validator<N> {
     /// Returns the account address of the node.
     fn address(&self) -> Address<N> {
         self.account.address()
+    }
+}
+
+impl<N: Network> Validator<N> {
+    /// Fetches the block chunk with the given starting block height from the fast sync server.
+    async fn request_fast_sync_blocks(start_height: u32) -> Result<Vec<Block<N>>> {
+        // Sha256 hasher.
+        pub fn sha256(data: &[u8]) -> [u8; 32] {
+            let digest = Sha256::digest(data);
+            let mut ret = [0u8; 32];
+            ret.copy_from_slice(&digest);
+            ret
+        }
+
+        // TODO (raychu86): Use a proxy fast-sync server.
+        const FAST_SYNC_SERVER: &str = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase2/";
+
+        ensure!(start_height % NUM_BLOCKS_PER_CHUNK == 0, "Invalid starting height for fast-sync. ({start_height})");
+
+        // Fetch the end height for the chunk.
+        let end_height = start_height + NUM_BLOCKS_PER_CHUNK;
+
+        trace!("Requesting fast-sync blocks from {start_height} to {end_height}...");
+
+        // Specify the URLs for fetching blocks.
+        let blocks_url = format!("{FAST_SYNC_SERVER}{start_height}.{end_height}.blocks");
+        let blocks_checksum_url = format!("{blocks_url}.sum");
+
+        // Request the blocks from the fast-sync server.
+        let blocks_bytes = match reqwest::Client::new().get(&blocks_url).send().await?.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                bail!("Failed to fetch blocks from {blocks_url}: {error}");
+            }
+        };
+        let blocks_checksum = reqwest::Client::new().get(&blocks_checksum_url).send().await?.bytes().await?;
+        ensure!(
+            sha256(&blocks_bytes) == blocks_checksum.as_ref(),
+            "Invalid checksum for fast-sync blocks. ({blocks_url})"
+        );
+
+        // Deserialize the blocks.
+        let blocks: Vec<Block<N>> = bincode::deserialize(&blocks_bytes)?;
+
+        trace!("Received fast-sync blocks from {start_height} to {end_height}...");
+
+        Ok(blocks)
+    }
+
+    /// Attempts to sync the node with the fast sync server. This will return an error if the
+    /// node failed to sync or has finished syncing.
+    async fn initialize_block_fast_sync(&self) -> Result<()> {
+        // Set the sync status to `Syncing`.
+        Self::status().update(Status::Syncing);
+
+        info!("Performing fast sync...");
+
+        loop {
+            // Fetch the latest block height.
+            let latest_height = self.ledger().latest_height();
+
+            // Fetch the number of blocks that you already have in a chunk.
+            let num_overlapping_blocks = latest_height.saturating_add(1) % NUM_BLOCKS_PER_CHUNK;
+
+            // Fetch the starting height of the requested chunk of blocks.
+            let start_height = latest_height.saturating_add(1).saturating_sub(num_overlapping_blocks);
+
+            // Fetch the blocks from the fast-sync server.
+            let new_blocks = Self::request_fast_sync_blocks(start_height).await?;
+
+            // Insert the blocks into the ledger. Skip the blocks that we already own.
+            for block in new_blocks.iter() {
+                // Skip the block if it already exists in the ledger.
+                if self.ledger.contains_block_hash(&block.hash())? {
+                    continue;
+                }
+
+                // Check that the next block is valid.
+                self.consensus.check_next_block(block)?;
+
+                // Attempt to add the block to the ledger.
+                self.consensus.advance_to_next_block(block)?;
+
+                trace!("Ledger advanced to block {} (block hash: {})", block.height(), block.hash());
+            }
+
+            // If the Ctrl-C handler registered the signal, stop the node once the current block is complete.
+            if self.shutdown.load(Ordering::Relaxed) {
+                info!("Shutting down block fast sync");
+                return Ok(());
+            }
+        }
+    }
+
+    /// Perform a fast sync by downloading blocks.
+    async fn initialize_block_sync(&self) {
+        // Initialize the syncing protocol.
+        let validator = self.clone();
+        spawn_task_loop!(Self, {
+            // Perform the fast sync.
+            let _ = validator.initialize_block_fast_sync().await;
+            info!("Fast sync completed, switching to standard sync protocol.");
+
+            // Set the sync status to `Ready`.
+            Self::status().update(Status::Ready);
+
+            // Perform the standard block sync protocol.
+            loop {
+                // If the Ctrl-C handler registered the signal, stop the node once the current block is complete.
+                if validator.shutdown.load(Ordering::Relaxed) {
+                    info!("Shutting down block sync");
+                    break;
+                }
+
+                // TODO (raychu86): Implement the standard block sync protocol.
+
+                // // Fetch the current height.
+                // let current_height = validator.ledger().latest_height();
+                //
+                // // Fetch the latest block height of the connected peers.
+                //
+                // // If the node is caught up, then continue.
+                //
+                // // Sync the node with the peers.
+                // Self::status().update(Status::Syncing);
+                // // TODO (raychu86): Sync the node with the peer.
+                //
+                // // Set the sync status to `Ready`.
+                // Self::status().update(Status::Ready);
+                //
+                // // If the Ctrl-C handler registered the signal, stop the node once the current block is complete.
+                // if validator.shutdown.load(Ordering::Relaxed) {
+                //     info!("Shutting down block sync");
+                //     break;
+                // }
+
+                // Sleep for 10 seconds.
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            }
+        });
     }
 }

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -21,7 +21,7 @@ use snarkos_account::Account;
 use snarkos_node_consensus::Consensus;
 use snarkos_node_executor::{spawn_task_loop, Executor, NodeType, Status};
 use snarkos_node_ledger::Ledger;
-use snarkos_node_messages::{Data, Message, PuzzleResponse, UnconfirmedSolution};
+use snarkos_node_messages::{BlockRequest, BlockResponse, Data, Message, PuzzleResponse, UnconfirmedSolution};
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest};
 use snarkos_node_store::ConsensusDB;

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -265,7 +265,7 @@ impl<N: Network> Validator<N> {
                 // Attempt to add the block to the ledger.
                 self.consensus.advance_to_next_block(block)?;
 
-                trace!("Ledger advanced to block {} ({})", block.height(), block.hash());
+                info!("Ledger advanced to block {} ({})", block.height(), block.hash());
             }
 
             // If the Ctrl-C handler registered the signal, stop the node once the current block is complete.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -29,6 +29,7 @@ use snarkos_node_messages::{
     Ping,
     Pong,
     PuzzleResponse,
+    UnconfirmedBlock,
     UnconfirmedSolution,
 };
 use snarkos_node_rest::Rest;

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -32,7 +32,7 @@ use snarkos_node_messages::{
     UnconfirmedSolution,
 };
 use snarkos_node_rest::Rest;
-use snarkos_node_router::{Handshake, Inbound, Outbound, Router, RouterRequest, ALEO_MAXIMUM_FORK_DEPTH};
+use snarkos_node_router::{Handshake, Inbound, Outbound, Peer, Router, RouterRequest, ALEO_MAXIMUM_FORK_DEPTH};
 use snarkos_node_store::ConsensusDB;
 use snarkvm::prelude::{Address, Block, CoinbasePuzzle, EpochChallenge, Network, PrivateKey, ProverSolution, ViewKey};
 
@@ -352,7 +352,8 @@ impl<N: Network> Validator<N> {
                     // Sleep for 1 second.
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 } else {
-                    // Sleep for 10 seconds.
+                    // Sleep for
+                    // 10 seconds.
                     tokio::time::sleep(Duration::from_secs(10)).await;
                 }
             }

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -266,7 +266,7 @@ impl<N: Network> Validator<N> {
                 // Attempt to add the block to the ledger.
                 self.consensus.advance_to_next_block(block)?;
 
-                info!("Ledger advanced to block {} ({})", block.height(), block.hash());
+                info!("Ledger successfully advanced to block {} ({})", block.height(), block.hash());
             }
 
             // If the Ctrl-C handler registered the signal, stop the node once the current block is complete.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -59,6 +59,7 @@ impl<N: Network> Inbound<N> for Validator<N> {
         true
     }
 
+    /// Attempts to update the ledger with the received blocks.
     async fn block_response(&self, message: BlockResponse<N>, peer_ip: SocketAddr, _router: &Router<N>) -> bool {
         // Deserialize the block response.
         let blocks = match message.blocks.deserialize().await {

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -24,6 +24,69 @@ impl<N: Network> Handshake for Validator<N> {
 
 #[async_trait]
 impl<N: Network> Inbound<N> for Validator<N> {
+    /// Retrieves the blocks within the block request range, and returns the block response to the peer.
+    async fn block_request(&self, message: BlockRequest, peer_ip: SocketAddr, router: &Router<N>) -> bool {
+        // Ensure the block request is well formed.
+        if message.start_block_height > message.end_block_height {
+            debug!("Invalid BlockRequest received from '{peer_ip}' - start height is greater than end height");
+            return false;
+        }
+
+        // Ensure that the block request is within the proper bounds.
+        if message.end_block_height - message.start_block_height > Self::MAXIMUM_BLOCK_REQUEST {
+            debug!("Invalid BlockRequest received from '{peer_ip}' - exceeds maximum block request");
+            return false;
+        }
+
+        // Retrieve the requested blocks.
+        let blocks = match self.ledger.get_blocks(message.start_block_height, message.end_block_height) {
+            Ok(blocks) => blocks,
+            Err(error) => {
+                error!(
+                    "Failed to retrieve blocks {} to {} from the ledger: {error}",
+                    message.start_block_height, message.end_block_height
+                );
+                return false;
+            }
+        };
+        let blocks = blocks.into_iter().map(Data::Object).collect();
+
+        // Send the `PuzzleResponse` message to the peer.
+        let message = Message::BlockResponse(BlockResponse { blocks });
+        if let Err(error) = router.process(RouterRequest::MessageSend(peer_ip, message)).await {
+            warn!("[BlockResponse] {}", error);
+        }
+
+        true
+    }
+
+    async fn block_response(&self, message: BlockResponse<N>, peer_ip: SocketAddr, _router: &Router<N>) -> bool {
+        // Add the blocks from the block response to the ledger.
+        for block in message.blocks {
+            let block = match block.deserialize().await {
+                Ok(block) => block,
+                Err(error) => {
+                    error!("Failed to deserialize block from '{peer_ip}': {error}");
+                    return false;
+                }
+            };
+
+            // Check that the next block is valid.
+            if let Err(error) = self.consensus.check_next_block(&block) {
+                trace!("[BlockResponse] {error}");
+                return true;
+            }
+
+            // Attempt to add the block to the ledger.
+            if let Err(error) = self.consensus.advance_to_next_block(&block) {
+                trace!("[BlockResponse] {error}");
+                return true;
+            }
+        }
+
+        true
+    }
+
     /// Retrieves the latest epoch challenge and latest block, and returns the puzzle response to the peer.
     async fn puzzle_request(&self, peer_ip: SocketAddr, router: &Router<N>) -> bool {
         // Send the latest puzzle response, if it exists.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -83,7 +83,7 @@ impl<N: Network> Inbound<N> for Validator<N> {
                 return true;
             }
 
-            info!("Ledger advanced to block {} ({})", block.height(), block.hash());
+            info!("Ledger successfully advanced to block {} ({})", block.height(), block.hash());
         }
 
         true
@@ -199,7 +199,7 @@ impl<N: Network> Inbound<N> for Validator<N> {
                 return true;
             }
 
-            info!("Ledger advanced to block {} ({})", block.height(), block.hash());
+            info!("Ledger successfully advanced to block {} ({})", block.height(), block.hash());
         }
 
         // Propagate the `UnconfirmedBlock`.

--- a/run-validator.sh
+++ b/run-validator.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# USAGE examples: 
+  # CLI with env vars: VALIDATOR_PRIVATE_KEY=APrivateKey1...  ./run-prover.sh
+  # CLI with prompts for vars:  ./run-prover.sh
+
+# If the env var VALIDATOR_PRIVATE_KEY is not set, prompt for it
+if [ -z "${VALIDATOR_PRIVATE_KEY}" ]
+then
+  read -r -p "Enter the Aleo Validator account private key: "
+  VALIDATOR_PRIVATE_KEY=$REPLY
+fi
+
+if [ "${VALIDATOR_PRIVATE_KEY}" == "" ]
+then
+  VALIDATOR_PRIVATE_KEY="APrivateKey1zkp8cC4jgHEBnbtu3xxs1Ndja2EMizcvTRDq5Nikdkukg1p"
+fi
+
+COMMAND="cargo run --release -- start --nodisplay --validator ${VALIDATOR_PRIVATE_KEY}"
+
+for word in $*;
+do
+  COMMAND="${COMMAND} ${word}"
+done
+
+function exit_node()
+{
+    echo "Exiting..."
+    kill $!
+    exit
+}
+
+trap exit_node SIGINT
+
+echo "Running an Aleo Validator node..."
+$COMMAND &
+
+while :
+do
+  echo "Checking for updates..."
+  git stash
+  rm Cargo.lock
+  STATUS=$(git pull)
+
+  if [ "$STATUS" != "Already up to date." ]; then
+    echo "Updated code found, rebuilding and relaunching prover"
+    cargo clean
+    kill -INT $!; sleep 2; $COMMAND &
+  fi
+
+  sleep 1800;
+done


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR implements fast sync and standard (naive) syncs. 

A validator node will first attempt to fast-sync the node (for non-development nodes only). Once the fast sync is completed, the node will attempt to sync to any node that has a larger block height. 

Currently each peer's block height is found from `Ping` and `CoinbasePuzzle` messages. Additionally, `UnconfirmedBlock` messages are now processed by the validator before attempting to broadcast.


Notable changes: 
 - `BlockRequest` and `BlockResponse` support multiple blocks (currently limited to 10).
 - `Ping` messages now have an optional `block_height` variable.
    - Beacon and Validator nodes now have a custom handler to send their block heights.
 
