### PR TITLE
Add parallelism to ledger and introduce `timer` for  Ledger and Beacon initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "rayon",
  "snarkos-node-store",
  "snarkvm",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,9 @@ name = "aleo-std-timer"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
+dependencies = [
+ "colored",
+]
 
 [[package]]
 name = "anyhow"
@@ -143,6 +146,27 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
 
 [[package]]
 name = "async-trait"
@@ -2310,10 +2334,12 @@ dependencies = [
 name = "snarkos-node"
 version = "2.0.2"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "async-trait",
  "parking_lot",
  "rand",
+ "rand_chacha",
  "serde_json",
  "snarkos-account",
  "snarkos-node-consensus",
@@ -2326,6 +2352,7 @@ dependencies = [
  "snarkvm",
  "time",
  "tokio",
+ "tokio-test",
  "tracing",
 ]
 
@@ -2367,6 +2394,7 @@ dependencies = [
 name = "snarkos-node-ledger"
 version = "2.0.2"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "indexmap",
  "once_cell",
@@ -3297,6 +3325,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,7 +17,8 @@ license = "GPL-3.0"
 edition = "2021"
 
 [features]
-timer = [ "aleo-std/timer" ]
+default = [ ]
+timer = [ "aleo-std/timer", "snarkos-node-ledger/timer" ]
 
 [dependencies.aleo-std]
 version = "0.1.15"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,6 +16,13 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+timer = [ "aleo-std/timer" ]
+
+[dependencies.aleo-std]
+version = "0.1.15"
+default-features = false
+
 [dependencies.anyhow]
 version = "1"
 
@@ -68,3 +75,9 @@ features = ["rt", "signal"]
 
 [dependencies.tracing]
 version = "0.1"
+
+[dev-dependencies.tokio-test]
+version = "0.4"
+
+[dev-dependencies.rand_chacha]
+version = "0.3.0"

--- a/node/ledger/Cargo.toml
+++ b/node/ledger/Cargo.toml
@@ -20,6 +20,10 @@ edition = "2021"
 default = [ "parallel" ]
 parallel = [ "rayon" ]
 
+[dependencies.aleo-std]
+version = "0.1.15"
+default-features = false
+
 [dependencies.anyhow]
 version = "1"
 

--- a/node/ledger/Cargo.toml
+++ b/node/ledger/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "rayon" ]
+timer = [ "aleo-std/timer" ]
 
 [dependencies.aleo-std]
 version = "0.1.15"

--- a/node/ledger/Cargo.toml
+++ b/node/ledger/Cargo.toml
@@ -16,6 +16,10 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+default = [ "parallel" ]
+parallel = [ "rayon" ]
+
 [dependencies.anyhow]
 version = "1"
 
@@ -31,6 +35,10 @@ version = "0.12"
 
 [dependencies.rand]
 version = "0.8"
+
+[dependencies.rayon]
+version = "1"
+optional = true
 
 [dependencies.snarkos-node-store]
 path = "../store"

--- a/node/ledger/src/get.rs
+++ b/node/ledger/src/get.rs
@@ -54,7 +54,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns the blocks in the given block range.
-    pub fn get_blocks(&self, heights: std::ops::Range<u32>) -> Result<Vec<Block<N>>> {
+    pub fn get_blocks(&self, heights: Range<u32>) -> Result<Vec<Block<N>>> {
         cfg_into_iter!(heights).map(|height| self.get_block(height)).collect()
     }
 

--- a/node/ledger/src/get.rs
+++ b/node/ledger/src/get.rs
@@ -53,6 +53,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         }
     }
 
+    /// Returns the blocks in the given block range.
+    pub fn get_blocks(&self, heights: std::ops::Range<u32>) -> Result<Vec<Block<N>>> {
+        cfg_into_iter!(heights).map(|height| self.get_block(height)).collect()
+    }
+
     /// Returns the block for the given block hash.
     pub fn get_block_by_hash(&self, block_hash: &N::BlockHash) -> Result<Block<N>> {
         // Retrieve the block.

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -43,6 +43,7 @@ use snarkvm::{
     },
 };
 
+use aleo_std::prelude::{finish, lap, timer};
 use anyhow::Result;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
@@ -80,21 +81,31 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Loads the ledger from storage.
     pub fn load(genesis: Option<Block<N>>, dev: Option<u16>) -> Result<Self> {
+        let timer = timer!("Ledger::load");
+
         // Retrieve the genesis hash.
         let genesis_hash = match genesis {
             Some(ref genesis) => genesis.hash(),
             None => Block::<N>::from_bytes_le(N::genesis_bytes())?.hash(),
         };
+        lap!(timer, "Load genesis hash");
 
         // Initialize the consensus store.
         let store = match ConsensusStore::<N, C>::open(dev) {
             Ok(store) => store,
             _ => bail!("Failed to load ledger (run 'snarkos clean' and try again)"),
         };
+        lap!(timer, "Load consensus store");
+
         // Initialize a new VM.
         let vm = VM::from(store)?;
+        lap!(timer, "Initialize a new VM");
+
         // Initialize the ledger.
         let ledger = Self::from(vm, genesis)?;
+        lap!(timer, "Initialize ledger");
+
+        finish!(timer);
 
         // Ensure the ledger contains the correct genesis block.
         match ledger.contains_block_hash(&genesis_hash)? {
@@ -105,11 +116,14 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Initializes the ledger from storage, with an optional genesis block.
     pub fn from(vm: VM<N, C>, genesis: Option<Block<N>>) -> Result<Self> {
+        let timer = timer!("Ledger::from");
+
         // Load the genesis block.
         let genesis = match genesis {
             Some(genesis) => genesis,
             None => Block::<N>::from_bytes_le(N::genesis_bytes())?,
         };
+        lap!(timer, "Load genesis block");
 
         // Initialize the ledger.
         let mut ledger = Self {
@@ -136,12 +150,16 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         ledger.current_block = Arc::new(RwLock::new(block));
         // Set the current epoch challenge.
         ledger.current_epoch_challenge = Arc::new(RwLock::new(Some(ledger.get_epoch_challenge(latest_height)?)));
+        lap!(timer, "Initialize ledger state");
 
         // Safety check the existence of every block.
         cfg_into_iter!((0..=latest_height)).try_for_each(|height| {
             ledger.get_block(height)?;
             Ok::<_, Error>(())
         })?;
+        lap!(timer, "Check existence of {latest_height} blocks");
+
+        finish!(timer);
 
         Ok(ledger)
     }

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -137,11 +137,11 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Set the current epoch challenge.
         ledger.current_epoch_challenge = Arc::new(RwLock::new(Some(ledger.get_epoch_challenge(latest_height)?)));
 
-        // // Safety check the existence of every block.
-        // cfg_into_iter!((0..=latest_height)).try_for_each(|height| {
-        //     ledger.get_block(height)?;
-        //     Ok::<_, Error>(())
-        // })?;
+        // Safety check the existence of every block.
+        cfg_into_iter!((0..=latest_height)).try_for_each(|height| {
+            ledger.get_block(height)?;
+            Ok::<_, Error>(())
+        })?;
 
         Ok(ledger)
     }

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -45,6 +45,7 @@ use snarkvm::{
 
 use aleo_std::prelude::{finish, lap, timer};
 use anyhow::Result;
+use core::ops::Range;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use std::{borrow::Cow, sync::Arc};

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -95,14 +95,20 @@ impl<N: Network> Beacon<N> {
 
         // Initialize the node account.
         let account = Account::from(private_key)?;
+        lap!(timer, "Initialize the account");
+
         // Initialize the ledger.
         let ledger = Ledger::load(genesis, dev)?;
         lap!(timer, "Initialize the ledger");
+
         // Initialize the consensus.
         let consensus = Consensus::new(ledger.clone())?;
         lap!(timer, "Initialize consensus");
+
         // Initialize the node router.
         let (router, router_receiver) = Router::new::<Self>(node_ip, account.address(), trusted_peers).await?;
+        lap!(timer, "Initialize the router");
+
         // Initialize the REST server.
         let rest = match rest_ip {
             Some(rest_ip) => {
@@ -118,11 +124,13 @@ impl<N: Network> Beacon<N> {
             }
             None => None,
         };
+
         // Initialize the block generation time.
         let block_generation_time = Arc::new(AtomicU64::new(2));
         // Retrieve the unspent records.
         let unspent_records = ledger.find_unspent_records(account.view_key())?;
-        lap!(timer, "Retrieve unspent records");
+        lap!(timer, "Retrieve the unspent records");
+
         // Initialize the node.
         let node = Self {
             account,
@@ -140,7 +148,7 @@ impl<N: Network> Beacon<N> {
         node.initialize_block_production().await;
         // Initialize the signal handler.
         node.handle_signals();
-        lap!(timer, "Initialize handlers");
+        lap!(timer, "Initialize the handlers");
 
         finish!(timer);
         // Return the node.

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -46,6 +46,7 @@ use snarkvm::prelude::{
     Zero,
 };
 
+use aleo_std::prelude::{finish, lap, timer};
 use anyhow::{bail, Result};
 use core::{str::FromStr, time::Duration};
 use parking_lot::RwLock;
@@ -90,29 +91,38 @@ impl<N: Network> Beacon<N> {
         genesis: Option<Block<N>>,
         dev: Option<u16>,
     ) -> Result<Self> {
+        let timer = timer!("Beacon::new");
+
         // Initialize the node account.
         let account = Account::from(private_key)?;
         // Initialize the ledger.
         let ledger = Ledger::load(genesis, dev)?;
+        lap!(timer, "Initialize the ledger");
         // Initialize the consensus.
         let consensus = Consensus::new(ledger.clone())?;
+        lap!(timer, "Initialize consensus");
         // Initialize the node router.
         let (router, router_receiver) = Router::new::<Self>(node_ip, account.address(), trusted_peers).await?;
         // Initialize the REST server.
         let rest = match rest_ip {
-            Some(rest_ip) => Some(Arc::new(Rest::start(
-                rest_ip,
-                account.address(),
-                Some(consensus.clone()),
-                ledger.clone(),
-                router.clone(),
-            )?)),
+            Some(rest_ip) => {
+                let server = Arc::new(Rest::start(
+                    rest_ip,
+                    account.address(),
+                    Some(consensus.clone()),
+                    ledger.clone(),
+                    router.clone(),
+                )?);
+                lap!(timer, "Initialize REST server");
+                Some(server)
+            }
             None => None,
         };
         // Initialize the block generation time.
         let block_generation_time = Arc::new(AtomicU64::new(2));
         // Retrieve the unspent records.
         let unspent_records = ledger.find_unspent_records(account.view_key())?;
+        lap!(timer, "Retrieve unspent records");
         // Initialize the node.
         let node = Self {
             account,
@@ -126,11 +136,13 @@ impl<N: Network> Beacon<N> {
         };
         // Initialize the router handler.
         router.initialize_handler(node.clone(), router_receiver).await;
-
         // Initialize the block production.
         node.initialize_block_production().await;
         // Initialize the signal handler.
         node.handle_signals();
+        lap!(timer, "Initialize handlers");
+
+        finish!(timer);
         // Return the node.
         Ok(node)
     }
@@ -438,5 +450,49 @@ impl<N: Network> Beacon<N> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm::prelude::{ConsensusMemory, ConsensusStore, Testnet3, VM};
+
+    use rand::SeedableRng;
+    use rand_chacha::ChaChaRng;
+
+    type CurrentNetwork = Testnet3;
+
+    /// Use `RUST_MIN_STACK=67108864 cargo test --release profiler --features timer` to run this test.
+    #[ignore]
+    #[tokio::test]
+    async fn test_profiler() -> Result<()> {
+        // Specify the node attributes.
+        let node = SocketAddr::from_str("0.0.0.0:4133").unwrap();
+        let rest = SocketAddr::from_str("0.0.0.0:3033").unwrap();
+
+        let dev = Some(0);
+
+        // Initialize an (insecure) fixed RNG.
+        let mut rng = ChaChaRng::seed_from_u64(1234567890u64);
+        // Initialize the beacon private key.
+        let beacon_private_key = PrivateKey::<CurrentNetwork>::new(&mut rng)?;
+        // Initialize a new VM.
+        let vm = VM::from(ConsensusStore::<CurrentNetwork, ConsensusMemory<CurrentNetwork>>::open(None)?)?;
+        // Initialize the genesis block.
+        let genesis = Block::genesis(&vm, &beacon_private_key, &mut rng)?;
+
+        println!("Initializing beacon node...");
+
+        let beacon =
+            Beacon::<CurrentNetwork>::new(node, Some(rest), beacon_private_key, &[], Some(genesis), dev).await.unwrap();
+
+        println!(
+            "Loaded beacon node with {} blocks and {} records",
+            beacon.ledger.latest_height(),
+            beacon.unspent_records.read().len()
+        );
+
+        bail!("\n\nRemember to #[ignore] this test!\n\n")
     }
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 #![forbid(unsafe_code)]
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate async_trait;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds the `parallel` feature to `snarkos-node-ledger` to enable parallelized block checks. Previously the block checks weren't properly being parallelized, leading to slow bootup times. Additionally, `timer`s have been added to `Ledger::load`, `Ledger::from`, and `Beacon::new` to help trace operation times.

Here is a quick benchmark for loading blocks from the database:

| **Num Blocks** | **Serial** | **Time Per Block (Serial)** | **Parallel** | **Time Per Block (Parallel)** |
|----------------|------------|-----------------------------|--------------|-------------------------------|
| 1              | 7.12ms     | 7.12ms                      | -            | -                             |
| 500            | 3.722s     | 7.445ms                     | 142.423ms    | 284.846μs                     |
| 1000           | 7.482s     | 7.482ms                     | 265.575ms    | 265.575μs                     |
| 10000          | 73.327s    | 7.332ms                     | 2.522s       | 252.222μs                     |
| 20000          | 148.191s   | 7.409ms                     | 5.040s       | 252.033μs                     |
| 100000         | -          | -                           | 25.322s      | 253.229μs                     |