### PR TITLE
Change HTTP GET Requests with body to HTTP POST Requests

### DIFF
--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -152,7 +152,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             .and_then(Self::find_transition_id);
 
         // GET /testnet3/records/all
-        let records_all = warp::get()
+        let records_all = warp::post()
             .and(warp::path!("testnet3" / "records" / "all"))
             .and(with_auth())
             .untuple_one()
@@ -162,7 +162,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             .and_then(Self::records_all);
 
         // GET /testnet3/records/spent
-        let records_spent = warp::get()
+        let records_spent = warp::post()
             .and(warp::path!("testnet3" / "records" / "spent"))
             .and(with_auth())
             .untuple_one()
@@ -172,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             .and_then(Self::records_spent);
 
         // GET /testnet3/records/unspent
-        let records_unspent = warp::get()
+        let records_unspent = warp::post()
             .and(warp::path!("testnet3" / "records" / "unspent"))
             .and(with_auth())
             .untuple_one()


### PR DESCRIPTION
## Motivation

We're unable to fetch records from any JS client because HTTP GET Requests should not have a body. Any request that requires a body should be a HTTP POST.

This fixes one of the issues in: https://github.com/AleoHQ/snarkOS/issues/2010

Specifically, this fixes the REST server for JS-based clients: https://xhr.spec.whatwg.org/#the-send()-method
