### PR TITLE
Remove records endpoints to prevent view key leakage

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -26,15 +26,11 @@ mod routes;
 pub use routes::*;
 
 use snarkos_node_consensus::Consensus;
-use snarkos_node_ledger::{Ledger, RecordsFilter};
+use snarkos_node_ledger::Ledger;
 use snarkos_node_messages::{Data, Message, UnconfirmedTransaction};
 use snarkos_node_router::{Router, RouterRequest};
 use snarkvm::{
-    console::{
-        account::{Address, ViewKey},
-        program::ProgramID,
-        types::Field,
-    },
+    console::{account::Address, program::ProgramID, types::Field},
     prelude::{cfg_into_iter, Network},
     synthesizer::{ConsensusStorage, Program, Transaction},
 };
@@ -42,11 +38,10 @@ use snarkvm::{
 use anyhow::Result;
 use colored::*;
 use http::header::HeaderName;
-use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, str::FromStr, sync::Arc};
 use tokio::task::JoinHandle;
-use warp::{http::StatusCode, reject, reply, Filter, Rejection, Reply};
+use warp::{reject, reply, Filter, Rejection, Reply};
 
 /// A REST API server for the ledger.
 #[derive(Clone)]


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR removes the `/testnet3/records/*` endpoints, to **prevent account view key leakage**.

## Problems

In most cases, **client-side** software should be trial decrypting records by tracking the last block height that the software checked for, and merely scan the delta since the last block height for new records. The current REST endpoints do not protect this user-journey as the endpoints can easily be made accessible by third-parties.

For some software, an initial one-time sync (from genesis to tip) may be desirable to ensure the history of the account has been retrieved. In these instances, users should either 1) trial decrypt client-side, or 2) delegate the request to a third-party in a secure enclave if performance is required. The current REST endpoints are unable to enforce either of these design goals transparently for the user.

Lastly, for some software, they require merely a subset of records that belong to the account. For example, a program may only care about records produced and consumed by the program itself, or a program may only desire records pertaining to a subset of known programs that are already encoded in the program. Again, in this instance, the current REST endpoints are unable to offer filtering with these requirements.

## Solutions

The recommended approach to detecting records is from **client-side** software to fetch blocks and perform trial decryption **client-side**. This can be done by using the `GET blocks` endpoint to fetch blocks, and subsequently check `block.records().filter(|record| record.is_owner(view_key))` on the **client-side** in order to prevent node operators and third-parties from learning user account data.

In order to support the other capabilities that are described as missing in the problems section, Aleo is exploring the development of a secure enclave service to offer users the ability to perform performant scanning. In addition, future work to enable better filtering capabilities will be contemplated as part of the design of state in snarkVM.

