### PR TITLE
Updates the handshake to use the genesis header

### DIFF
--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
         // Initialize the genesis block.
         let genesis = Block::<CurrentNetwork>::read_le(CurrentNetwork::genesis_bytes()).unwrap();
         // Initialize the ledger.
-        let ledger = Ledger::<_, ConsensusMemory<_>>::load(Some(genesis), None).unwrap();
+        let ledger = Ledger::<_, ConsensusMemory<_>>::load(genesis, None).unwrap();
         // Perform the sync.
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -17,7 +17,7 @@
 use snarkos_account::Account;
 use snarkos_display::Display;
 use snarkos_node::{Node, NodeType};
-use snarkvm::prelude::{Block, ConsensusMemory, ConsensusStore, Network, PrivateKey, Testnet3, VM};
+use snarkvm::prelude::{Block, ConsensusMemory, ConsensusStore, FromBytes, Network, PrivateKey, Testnet3, VM};
 
 use anyhow::{bail, Result};
 use clap::Parser;
@@ -158,8 +158,8 @@ impl Start {
     }
 
     /// Updates the configurations if the node is in development mode, and returns the
-    /// alternative genesis block if the node is in development mode.
-    fn parse_development<N: Network>(&mut self, trusted_peers: &mut Vec<SocketAddr>) -> Result<Option<Block<N>>> {
+    /// alternative genesis block if the node is in development mode. Otherwise, returns the actual genesis block.
+    fn parse_development<N: Network>(&mut self, trusted_peers: &mut Vec<SocketAddr>) -> Result<Block<N>> {
         // If `--dev` is set, assume the dev nodes are initialized from 0 to `dev`,
         // and add each of them to the trusted peers. In addition, set the node IP to `4130 + dev`,
         // and the REST IP to `3030 + dev`.
@@ -216,9 +216,9 @@ impl Start {
                 sample_account(&mut self.client, false)?;
             }
 
-            Ok(Some(genesis))
+            Ok(genesis)
         } else {
-            Ok(None)
+            Block::from_bytes_le(N::genesis_bytes())
         }
     }
 
@@ -294,8 +294,8 @@ impl Start {
         match node_type {
             NodeType::Beacon => Node::new_beacon(self.node, rest_ip, account, &trusted_peers, genesis, cdn, self.dev).await,
             NodeType::Validator => Node::new_validator(self.node, rest_ip, account, &trusted_peers, genesis, cdn, self.dev).await,
-            NodeType::Prover => Node::new_prover(self.node, account, &trusted_peers, self.dev).await,
-            NodeType::Client => Node::new_client(self.node, account, &trusted_peers, self.dev).await,
+            NodeType::Prover => Node::new_prover(self.node, account, &trusted_peers, genesis, self.dev).await,
+            NodeType::Client => Node::new_client(self.node, account, &trusted_peers, genesis, self.dev).await,
         }
     }
 
@@ -447,6 +447,8 @@ mod tests {
 
     #[test]
     fn test_parse_development() {
+        let prod_genesis = Block::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
+
         let _config = Start::try_parse_from(["snarkos", "--dev", ""].iter()).unwrap_err();
 
         // Remove this for Phase 3.
@@ -463,7 +465,7 @@ mod tests {
         assert!(config.validator.is_none());
         assert!(config.prover.is_none());
         assert!(config.client.is_none());
-        assert!(expected_genesis.is_some());
+        assert_ne!(expected_genesis, prod_genesis);
 
         let mut trusted_peers = vec![];
         let mut config = Start::try_parse_from(["snarkos", "--dev", "0", "--beacon", ""].iter()).unwrap();

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -101,7 +101,7 @@ pub(crate) mod test_helpers {
         let genesis = sample_genesis_block_with_private_key(rng, private_key);
 
         // Initialize the ledger with the genesis block and the associated private key.
-        let ledger = CurrentLedger::load(Some(genesis.clone()), None).unwrap();
+        let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
         assert_eq!(0, ledger.latest_height());
         assert_eq!(genesis.hash(), ledger.latest_hash());
         assert_eq!(genesis.round(), ledger.latest_round());

--- a/node/ledger/src/get.rs
+++ b/node/ledger/src/get.rs
@@ -177,7 +177,7 @@ mod tests {
         let genesis = Block::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
 
         // Initialize a new ledger.
-        let ledger = CurrentLedger::load(None, None).unwrap();
+        let ledger = CurrentLedger::load(genesis.clone(), None).unwrap();
         // Retrieve the genesis block.
         let candidate = ledger.get_block(0).unwrap();
         // Ensure the genesis block matches.

--- a/node/ledger/src/get.rs
+++ b/node/ledger/src/get.rs
@@ -82,6 +82,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the block hash for the given block height.
     pub fn get_hash(&self, height: u32) -> Result<N::BlockHash> {
+        // If the height is 0, return the genesis block hash.
+        if height == 0 {
+            return Ok(self.genesis.hash());
+        }
         match self.vm.block_store().get_block_hash(height)? {
             Some(block_hash) => Ok(block_hash),
             None => bail!("Missing block hash for block {height}"),
@@ -90,6 +94,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the previous block hash for the given block height.
     pub fn get_previous_hash(&self, height: u32) -> Result<N::BlockHash> {
+        // If the height is 0, return the default block hash.
+        if height == 0 {
+            return Ok(N::BlockHash::default());
+        }
         match self.vm.block_store().get_previous_block_hash(height)? {
             Some(previous_hash) => Ok(previous_hash),
             None => bail!("Missing previous block hash for block {height}"),
@@ -151,6 +159,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the block coinbase solution for the given block height.
     pub fn get_coinbase(&self, height: u32) -> Result<Option<CoinbaseSolution<N>>> {
+        // If the height is 0, return the genesis block coinbase.
+        if height == 0 {
+            return Ok(self.genesis.coinbase().cloned());
+        }
         // Retrieve the block hash.
         let block_hash = match self.vm.block_store().get_block_hash(height)? {
             Some(block_hash) => block_hash,
@@ -162,6 +174,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the block signature for the given block height.
     pub fn get_signature(&self, height: u32) -> Result<Signature<N>> {
+        // If the height is 0, return the genesis block signature.
+        if height == 0 {
+            return Ok(*self.genesis.signature());
+        }
         // Retrieve the block hash.
         let block_hash = match self.vm.block_store().get_block_hash(height)? {
             Some(block_hash) => block_hash,

--- a/node/ledger/src/get.rs
+++ b/node/ledger/src/get.rs
@@ -41,6 +41,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the block for the given block height.
     pub fn get_block(&self, height: u32) -> Result<Block<N>> {
+        // If the height is 0, return the genesis block.
+        if height == 0 {
+            return Ok(self.genesis.clone());
+        }
         // Retrieve the block hash.
         let block_hash = match self.vm.block_store().get_block_hash(height)? {
             Some(block_hash) => block_hash,
@@ -94,6 +98,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the block header for the given block height.
     pub fn get_header(&self, height: u32) -> Result<Header<N>> {
+        // If the height is 0, return the genesis block header.
+        if height == 0 {
+            return Ok(*self.genesis.header());
+        }
         // Retrieve the block hash.
         let block_hash = match self.vm.block_store().get_block_hash(height)? {
             Some(block_hash) => block_hash,
@@ -108,6 +116,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
     /// Returns the block transactions for the given block height.
     pub fn get_transactions(&self, height: u32) -> Result<Transactions<N>> {
+        // If the height is 0, return the genesis block transactions.
+        if height == 0 {
+            return Ok(self.genesis.transactions().clone());
+        }
         // Retrieve the block hash.
         let block_hash = match self.vm.block_store().get_block_hash(height)? {
             Some(block_hash) => block_hash,

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -82,15 +82,40 @@ pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
 
 impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     /// Loads the ledger from storage.
-    pub fn load(genesis: Option<Block<N>>, dev: Option<u16>) -> Result<Self> {
+    pub fn load(genesis: Block<N>, dev: Option<u16>) -> Result<Self> {
         let timer = timer!("Ledger::load");
 
         // Retrieve the genesis hash.
-        let genesis_hash = match genesis {
-            Some(ref genesis) => genesis.hash(),
-            None => Block::<N>::from_bytes_le(N::genesis_bytes())?.hash(),
-        };
-        lap!(timer, "Load genesis hash");
+        let genesis_hash = genesis.hash();
+        // Initialize the ledger.
+        let ledger = Self::load_unchecked(genesis, dev)?;
+
+        // Ensure the ledger contains the correct genesis block.
+        if !ledger.contains_block_hash(&genesis_hash)? {
+            bail!("Incorrect genesis block (run 'snarkos clean' and try again)")
+        }
+
+        // Retrieve the latest height.
+        let latest_height =
+            *ledger.vm.block_store().heights().max().ok_or_else(|| anyhow!("Failed to load blocks from the ledger"))?;
+
+        // Safety check the existence of `NUM_BLOCKS` random blocks.
+        const NUM_BLOCKS: usize = 1000;
+        let block_heights: Vec<u32> = (0..=latest_height)
+            .choose_multiple(&mut OsRng::default(), core::cmp::min(NUM_BLOCKS, latest_height as usize));
+        cfg_into_iter!(block_heights).try_for_each(|height| {
+            ledger.get_block(height)?;
+            Ok::<_, Error>(())
+        })?;
+        lap!(timer, "Check existence of {NUM_BLOCKS} random blocks");
+
+        finish!(timer);
+        Ok(ledger)
+    }
+
+    /// Loads the ledger from storage, without performing integrity checks.
+    pub fn load_unchecked(genesis: Block<N>, dev: Option<u16>) -> Result<Self> {
+        let timer = timer!("Ledger::load_unchecked");
 
         // Initialize the consensus store.
         let store = match ConsensusStore::<N, C>::open(dev) {
@@ -104,30 +129,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         lap!(timer, "Initialize a new VM");
 
         // Initialize the ledger.
-        let ledger = Self::from(vm, genesis)?;
-        lap!(timer, "Initialize ledger");
-
-        finish!(timer);
-
-        // Ensure the ledger contains the correct genesis block.
-        match ledger.contains_block_hash(&genesis_hash)? {
-            true => Ok(ledger),
-            false => bail!("Incorrect genesis block (run 'snarkos clean' and try again)"),
-        }
-    }
-
-    /// Initializes the ledger from storage, with an optional genesis block.
-    pub fn from(vm: VM<N, C>, genesis: Option<Block<N>>) -> Result<Self> {
-        let timer = timer!("Ledger::from");
-
-        // Load the genesis block.
-        let genesis = match genesis {
-            Some(genesis) => genesis,
-            None => Block::<N>::from_bytes_le(N::genesis_bytes())?,
-        };
-        lap!(timer, "Load genesis block");
-
-        // Initialize the ledger.
         let mut ledger = Self {
             vm,
             current_block: Arc::new(RwLock::new(genesis.clone())),
@@ -139,6 +140,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             // Add the genesis block.
             ledger.add_next_block(&genesis)?;
         }
+        lap!(timer, "Initialize genesis");
 
         // Retrieve the latest height.
         let latest_height =
@@ -152,20 +154,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         ledger.current_block = Arc::new(RwLock::new(block));
         // Set the current epoch challenge.
         ledger.current_epoch_challenge = Arc::new(RwLock::new(Some(ledger.get_epoch_challenge(latest_height)?)));
-        lap!(timer, "Initialize ledger state");
-
-        // Safety check the existence of `NUM_BLOCKS` random blocks.
-        const NUM_BLOCKS: usize = 1000;
-        let block_heights: Vec<u32> = (0..=latest_height)
-            .choose_multiple(&mut OsRng::default(), core::cmp::min(NUM_BLOCKS, latest_height as usize));
-        cfg_into_iter!(block_heights).try_for_each(|height| {
-            ledger.get_block(height)?;
-            Ok::<_, Error>(())
-        })?;
-        lap!(timer, "Check existence of {NUM_BLOCKS} random blocks");
+        lap!(timer, "Initialize ledger");
 
         finish!(timer);
-
         Ok(ledger)
     }
 

--- a/node/ledger/src/lib.rs
+++ b/node/ledger/src/lib.rs
@@ -74,6 +74,8 @@ pub enum RecordsFilter<N: Network> {
 pub struct Ledger<N: Network, C: ConsensusStorage<N>> {
     /// The VM state.
     vm: VM<N, C>,
+    /// The genesis block.
+    genesis: Block<N>,
     /// The current block.
     current_block: Arc<RwLock<Block<N>>>,
     /// The current epoch challenge.
@@ -131,6 +133,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Initialize the ledger.
         let mut ledger = Self {
             vm,
+            genesis: genesis.clone(),
             current_block: Arc::new(RwLock::new(genesis.clone())),
             current_epoch_challenge: Default::default(),
         };

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -95,7 +95,7 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
         rest_ip: Option<SocketAddr>,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
-        genesis: Option<Block<N>>,
+        genesis: Block<N>,
         cdn: Option<String>,
         dev: Option<u16>,
     ) -> Result<Self> {
@@ -514,7 +514,7 @@ mod tests {
             Some(rest),
             beacon_account,
             &[],
-            Some(genesis),
+            genesis,
             None,
             dev,
         )

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -39,7 +39,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Beacon<N, C> {
         let peer_addr = connection.addr();
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
-        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side).await?;
+        let genesis_header = self.ledger.get_header(0).map_err(|e| error(format!("{e}")))?;
+        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
 
         // Retrieve the block locators.
         let block_locators = match crate::helpers::get_block_locators(&self.ledger) {

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -48,6 +48,8 @@ pub struct Client<N: Network, C: ConsensusStorage<N>> {
     account: Account<N>,
     /// The router of the node.
     router: Router<N>,
+    /// The genesis block.
+    genesis: Block<N>,
     /// The coinbase puzzle.
     coinbase_puzzle: CoinbasePuzzle<N>,
     /// The latest epoch challenge.
@@ -64,6 +66,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         node_ip: SocketAddr,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
+        genesis: Block<N>,
         dev: Option<u16>,
     ) -> Result<Self> {
         // Initialize the node router.
@@ -82,6 +85,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         let node = Self {
             account,
             router,
+            genesis,
             coinbase_puzzle,
             latest_epoch_challenge: Default::default(),
             latest_block: Default::default(),

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -39,7 +39,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Client<N, C> {
         let peer_addr = connection.addr();
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
-        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side).await?;
+        let genesis_header = *self.genesis.header();
+        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
 
         // Send the first `Ping` message to the peer.
         let message = Message::Ping(Ping::<N> {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -66,7 +66,7 @@ impl<N: Network> Node<N> {
         rest_ip: Option<SocketAddr>,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
-        genesis: Option<Block<N>>,
+        genesis: Block<N>,
         cdn: Option<String>,
         dev: Option<u16>,
     ) -> Result<Self> {
@@ -79,7 +79,7 @@ impl<N: Network> Node<N> {
         rest_ip: Option<SocketAddr>,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
-        genesis: Option<Block<N>>,
+        genesis: Block<N>,
         cdn: Option<String>,
         dev: Option<u16>,
     ) -> Result<Self> {
@@ -93,9 +93,10 @@ impl<N: Network> Node<N> {
         node_ip: SocketAddr,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
+        genesis: Block<N>,
         dev: Option<u16>,
     ) -> Result<Self> {
-        Ok(Self::Prover(Arc::new(Prover::new(node_ip, account, trusted_peers, dev).await?)))
+        Ok(Self::Prover(Arc::new(Prover::new(node_ip, account, trusted_peers, genesis, dev).await?)))
     }
 
     /// Initializes a new client node.
@@ -103,9 +104,10 @@ impl<N: Network> Node<N> {
         node_ip: SocketAddr,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
+        genesis: Block<N>,
         dev: Option<u16>,
     ) -> Result<Self> {
-        Ok(Self::Client(Arc::new(Client::new(node_ip, account, trusted_peers, dev).await?)))
+        Ok(Self::Client(Arc::new(Client::new(node_ip, account, trusted_peers, genesis, dev).await?)))
     }
 
     /// Returns the node type.

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -58,6 +58,8 @@ pub struct Prover<N: Network, C: ConsensusStorage<N>> {
     account: Account<N>,
     /// The router of the node.
     router: Router<N>,
+    /// The genesis block.
+    genesis: Block<N>,
     /// The coinbase puzzle.
     coinbase_puzzle: CoinbasePuzzle<N>,
     /// The latest epoch challenge.
@@ -82,6 +84,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
         node_ip: SocketAddr,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
+        genesis: Block<N>,
         dev: Option<u16>,
     ) -> Result<Self> {
         // Initialize the node router.
@@ -102,6 +105,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
         let node = Self {
             account,
             router,
+            genesis,
             coinbase_puzzle,
             latest_epoch_challenge: Default::default(),
             latest_block: Default::default(),

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -39,7 +39,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Prover<N, C> {
         let peer_addr = connection.addr();
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
-        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side).await?;
+        let genesis_header = *self.genesis.header();
+        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
 
         // Send the first `Ping` message to the peer.
         let message = Message::Ping(Ping::<N> {

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -70,7 +70,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         rest_ip: Option<SocketAddr>,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
-        genesis: Option<Block<N>>,
+        genesis: Block<N>,
         cdn: Option<String>,
         dev: Option<u16>,
     ) -> Result<Self> {

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -39,7 +39,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Validator<N, C> {
         let peer_addr = connection.addr();
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
-        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side).await?;
+        let genesis_header = self.ledger.get_header(0).map_err(|e| error(format!("{e}")))?;
+        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
 
         // Retrieve the block locators.
         let block_locators = match crate::helpers::get_block_locators(&self.ledger) {

--- a/node/tests/new_beacon.rs
+++ b/node/tests/new_beacon.rs
@@ -22,9 +22,16 @@ use snarkos_node::{Beacon, NodeInterface};
 use snarkos_node_messages::NodeType;
 use snarkos_node_router::Outbound;
 use snarkos_node_tcp::P2P;
-use snarkvm::prelude::{ConsensusMemory, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{Block, ConsensusMemory, FromBytes, Network, Testnet3};
 
 use std::str::FromStr;
+
+type CurrentNetwork = Testnet3;
+
+/// Loads the current network's genesis block.
+fn sample_genesis_block() -> Block<CurrentNetwork> {
+    Block::<CurrentNetwork>::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap()
+}
 
 #[tokio::test]
 async fn handshake_responder_side() {
@@ -34,7 +41,7 @@ async fn handshake_responder_side() {
         None,
         Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
         &[],
-        None, // Should load the current network's genesis block.
+        sample_genesis_block(),
         None, // No CDN.
         None,
     )
@@ -58,7 +65,7 @@ async fn handshake_initiator_side() {
         None,
         Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
         &[],
-        None, // Should load the current network's genesis block.
+        sample_genesis_block(),
         None, // No CDN.
         None,
     )


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR makes the handshake more efficient by removing the need to deserialize the entire genesis block each time a handshake is made. This PR also fixes a bug whereby the handshake was using the wrong genesis block in `--dev` mode.

## Related PRs

This PR merges into #2089.