### PR TITLE
Test: handshake with all node combinations (in non-dev mode)

### DIFF
--- a/node/tests/common/mod.rs
+++ b/node/tests/common/mod.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
+use pea2pea::{protocols::Handshake, Config, Connection, Node, Pea2Pea};
 use snarkos_node_messages::{ChallengeRequest, ChallengeResponse, Data, Message, MessageCodec, NodeType, Status};
-use snarkos_node_tcp::{protocols::Handshake, Config, Connection, Tcp, P2P};
 use snarkvm::prelude::{Block, FromBytes, Network, Testnet3 as CurrentNetwork};
 
 use futures_util::{sink::SinkExt, TryStreamExt};
@@ -29,14 +29,13 @@ const ALEO_MAXIMUM_FORK_DEPTH: u32 = 4096;
 
 #[derive(Clone)]
 pub struct TestPeer {
-    // TODO: should be using pea2pea directly (to keep impls separate)
-    tcp: Tcp,
+    node: Node,
     node_type: NodeType,
 }
 
-impl P2P for TestPeer {
-    fn tcp(&self) -> &Tcp {
-        &self.tcp
+impl Pea2Pea for TestPeer {
+    fn node(&self) -> &Node {
+        &self.node
     }
 }
 
@@ -59,7 +58,7 @@ impl TestPeer {
 
     pub async fn new(node_type: NodeType) -> Self {
         let peer = Self {
-            tcp: Tcp::new(Config {
+            node: Node::new(Config {
                 listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 max_connections: 200,
                 ..Default::default()
@@ -85,7 +84,7 @@ impl TestPeer {
 #[async_trait::async_trait]
 impl Handshake for TestPeer {
     async fn perform_handshake(&self, mut conn: Connection) -> io::Result<Connection> {
-        let local_ip = self.tcp().listening_addr().expect("listening address should be present");
+        let local_ip = self.node().listening_addr().expect("listening address should be present");
 
         let stream = self.borrow_stream(&mut conn);
         let mut framed = Framed::new(stream, MessageCodec::<CurrentNetwork>::default());

--- a/node/tests/common/mod.rs
+++ b/node/tests/common/mod.rs
@@ -29,6 +29,7 @@ const ALEO_MAXIMUM_FORK_DEPTH: u32 = 4096;
 
 #[derive(Clone)]
 pub struct TestPeer {
+    // TODO: should be using pea2pea directly (to keep impls separate)
     tcp: Tcp,
     node_type: NodeType,
 }
@@ -40,6 +41,22 @@ impl P2P for TestPeer {
 }
 
 impl TestPeer {
+    pub async fn beacon() -> Self {
+        Self::new(NodeType::Beacon).await
+    }
+
+    pub async fn client() -> Self {
+        Self::new(NodeType::Client).await
+    }
+
+    pub async fn prover() -> Self {
+        Self::new(NodeType::Prover).await
+    }
+
+    pub async fn validator() -> Self {
+        Self::new(NodeType::Validator).await
+    }
+
     pub async fn new(node_type: NodeType) -> Self {
         let peer = Self {
             tcp: Tcp::new(Config {

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -155,6 +155,7 @@ macro_rules! test_handshake {
             // Spin up a test peer (synthetic node).
             let peer = $crate::common::TestPeer::$peer_type().await;
 
+            // Sets up the connection direction as described above.
             if $is_initiator {
                 $crate::assert_connect(node, peer).await;
             } else {
@@ -163,6 +164,7 @@ macro_rules! test_handshake {
         }
     };
 
+    // Initiator side.
     ($($node_type:ident -> $peer_type:ident $(= $attr:meta)?),*) => {
         mod handshake_initiator_side {
             $(
@@ -172,6 +174,7 @@ macro_rules! test_handshake {
 
     };
 
+    // Responder side.
     ($($node_type:ident <- $peer_type:ident $(= $attr:meta)?),*) => {
         mod handshake_responder_side {
             $(

--- a/node/tests/new_beacon.rs
+++ b/node/tests/new_beacon.rs
@@ -44,6 +44,28 @@ async fn beacon() -> Beacon<CurrentNetwork, ConsensusMemory<CurrentNetwork>> {
     .expect("couldn't create beacon instance")
 }
 
+async fn client() -> Client<CurrentNetwork, ConsensusMemory<CurrentNetwork>> {
+    Client::new(
+        "127.0.0.1:0".parse().unwrap(),
+        Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
+        &[],
+        None,
+    )
+    .await
+    .expect("couldn't create client instance")
+}
+
+async fn prover() -> Prover<CurrentNetwork, ConsensusMemory<CurrentNetwork>> {
+    Prover::new(
+        "127.0.0.1:0".parse().unwrap(),
+        Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
+        &[],
+        None,
+    )
+    .await
+    .expect("couldn't create prover instance")
+}
+
 async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNetwork>> {
     Validator::new(
         "127.0.0.1:0".parse().unwrap(),
@@ -55,7 +77,7 @@ async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNetwork
         None,
     )
     .await
-    .expect("couldn't create beacon instance")
+    .expect("couldn't create validator instance")
 }
 
 // Trait to unify Pea2Pea and P2P traits.
@@ -174,6 +196,42 @@ mod beacon {
         beacon <- client,
         beacon <- validator,
         beacon <- prover
+    }
+}
+
+mod client {
+    // Initiator side (full node connects to full node).
+    test_handshake! {
+        client -> beacon,
+        client -> client,
+        client -> validator,
+        client -> prover
+    }
+
+    // Responder side (synthetic peer connects to full node).
+    test_handshake! {
+        client <- beacon,
+        client <- client,
+        client <- validator,
+        client <- prover
+    }
+}
+
+mod prover {
+    // Initiator side (full node connects to full node).
+    test_handshake! {
+        prover -> beacon,
+        prover -> client,
+        prover -> validator,
+        prover -> prover
+    }
+
+    // Responder side (synthetic peer connects to full node).
+    test_handshake! {
+        prover <- beacon,
+        prover <- client,
+        prover <- validator,
+        prover <- prover
     }
 }
 

--- a/node/tests/new_beacon.rs
+++ b/node/tests/new_beacon.rs
@@ -144,8 +144,9 @@ where
 //
 // Test naming: full_node::handshake_<initiator or responder>_side::test_peer.
 macro_rules! test_handshake {
-    ($node_type:ident, $peer_type:ident, $is_initiator:expr) => {
+    ($node_type:ident, $peer_type:ident, $is_initiator:expr, $($attr:meta)?) => {
         #[tokio::test]
+        $(#[$attr])?
         async fn $peer_type () {
 
             // Spin up a full node.
@@ -162,19 +163,19 @@ macro_rules! test_handshake {
         }
     };
 
-    ($($node_type:ident -> $peer_type:ident),*) => {
+    ($($node_type:ident -> $peer_type:ident $(= $attr:meta)?),*) => {
         mod handshake_initiator_side {
             $(
-                test_handshake!($node_type, $peer_type, true);
+                test_handshake!($node_type, $peer_type, true, $($attr)?);
             )*
         }
 
     };
 
-    ($($node_type:ident <- $peer_type:ident),*) => {
+    ($($node_type:ident <- $peer_type:ident $(= $attr:meta)?),*) => {
         mod handshake_responder_side {
             $(
-                test_handshake!($node_type, $peer_type, false);
+                test_handshake!($node_type, $peer_type, false, $($attr)?);
             )*
         }
 
@@ -238,7 +239,7 @@ mod prover {
 mod validator {
     // Initiator side (full node connects to synthetic peer).
     test_handshake! {
-        validator -> beacon,
+        validator -> beacon = should_panic,
         validator -> client,
         validator -> validator,
         validator -> prover
@@ -246,7 +247,7 @@ mod validator {
 
     // Responder side (synthetic peer connects to full node).
     test_handshake! {
-        validator <- beacon,
+        validator <- beacon = should_panic,
         validator <- client,
         validator <- validator,
         validator <- prover

--- a/node/tests/new_beacon.rs
+++ b/node/tests/new_beacon.rs
@@ -182,7 +182,7 @@ macro_rules! test_handshake {
 }
 
 mod beacon {
-    // Initiator side (full node connects to full node).
+    // Initiator side (full node connects to synthetic peer).
     test_handshake! {
         beacon -> beacon,
         beacon -> client,
@@ -200,7 +200,7 @@ mod beacon {
 }
 
 mod client {
-    // Initiator side (full node connects to full node).
+    // Initiator side (full node connects to synthetic peer).
     test_handshake! {
         client -> beacon,
         client -> client,
@@ -218,7 +218,7 @@ mod client {
 }
 
 mod prover {
-    // Initiator side (full node connects to full node).
+    // Initiator side (full node connects to synthetic peer).
     test_handshake! {
         prover -> beacon,
         prover -> client,
@@ -236,7 +236,7 @@ mod prover {
 }
 
 mod validator {
-    // Initiator side (full node connects to full node).
+    // Initiator side (full node connects to synthetic peer).
     test_handshake! {
         validator -> beacon,
         validator -> client,


### PR DESCRIPTION
This PR introduces full coverage for handshake tests. ~~Drafted for now as the validator/beacon pair currently fails, to be investigated.~~ Cases fail because of the phase 2 beacon-related handshake logic. Cases pass if run in dev mode, as expected. 

Test output can be viewed [here](https://app.circleci.com/pipelines/github/AleoHQ/snarkOS/7180/workflows/0eacf84c-809c-4c5b-9d95-08b7a397ca0c/jobs/41042/parallel-runs/0/steps/0-106).