### PR TITLE
Proactively disconnect, remove redundant request

### DIFF
--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -65,7 +65,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
                 info!("Disconnecting from '{oldest}' (periodic refresh of peers)");
                 self.send(oldest, Message::Disconnect(DisconnectReason::PeerRefresh.into()));
                 // Disconnect from this peer.
-                self.router().disconnect(oldest).await;
+                self.router().disconnect(oldest);
             }
         }
     }
@@ -79,7 +79,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
             if elapsed > Router::<N>::RADIO_SILENCE_IN_SECS {
                 warn!("Peer {} has not communicated in {elapsed} seconds", peer.ip());
                 // Disconnect from this peer.
-                self.router().disconnect(peer.ip()).await;
+                self.router().disconnect(peer.ip());
             }
         }
     }
@@ -97,7 +97,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
                 info!("Disconnecting from 'beacon' {peer_ip} (exceeded maximum beacons)");
                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers.into()));
                 // Disconnect from this peer.
-                self.router().disconnect(peer_ip).await;
+                self.router().disconnect(peer_ip);
             }
         }
     }
@@ -130,7 +130,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
                 info!("Disconnecting from '{peer_ip}' (exceeded maximum connections)");
                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers.into()));
                 // Disconnect from this peer.
-                self.router().disconnect(peer_ip).await;
+                self.router().disconnect(peer_ip);
             }
         }
 
@@ -140,7 +140,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
 
             // Attempt to connect to more peers.
             for peer_ip in self.router().candidate_peers().into_iter().choose_multiple(rng, num_deficient) {
-                self.router().connect(peer_ip).await;
+                self.router().connect(peer_ip);
             }
             // Request more peers from the connected peers.
             for peer_ip in self.router().connected_peers().into_iter().choose_multiple(rng, 3) {
@@ -163,7 +163,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
             let rng = &mut OsRng::default();
             // Attempt to connect to a bootstrap peer.
             if let Some(peer_ip) = self.router().bootstrap_peers().into_iter().choose(rng) {
-                self.router().connect(peer_ip).await;
+                self.router().connect(peer_ip);
             }
         }
 
@@ -177,7 +177,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
                 info!("Disconnecting from '{peer_ip}' (exceeded maximum bootstrap)");
                 self.send(peer_ip, Message::Disconnect(DisconnectReason::TooManyPeers.into()));
                 // Disconnect from this peer.
-                self.router().disconnect(peer_ip).await;
+                self.router().disconnect(peer_ip);
             }
         }
     }
@@ -189,7 +189,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
             // If the peer is not connected, attempt to connect to it.
             if !self.router().is_connected(peer_ip) {
                 // Attempt to connect to the trusted peer.
-                self.router().connect(*peer_ip).await;
+                self.router().connect(*peer_ip);
             }
         }
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -126,7 +126,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Attempts to connect to the given peer IP.
-    pub async fn connect(&self, peer_ip: SocketAddr) {
+    pub fn connect(&self, peer_ip: SocketAddr) {
         let router = self.clone();
         tokio::spawn(async move {
             // Attempt to connect to the candidate peer.
@@ -144,7 +144,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Disconnects from the given peer IP, if the peer is connected.
-    pub async fn disconnect(&self, peer_ip: SocketAddr) {
+    pub fn disconnect(&self, peer_ip: SocketAddr) {
         let router = self.clone();
         tokio::spawn(async move {
             // Disconnect from this peer.

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -59,17 +59,6 @@ pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbo
     /// TODO (howardwu): Change this for Phase 3.
     /// Initialize a new instance of the puzzle request.
     fn initialize_puzzle_request(&self) {
-        if self.router().node_type().is_prover() && Self::PUZZLE_REQUEST_IN_SECS > 0 {
-            let self_clone = self.clone();
-            self.router().spawn(async move {
-                loop {
-                    // Handle the bootstrap peers.
-                    self_clone.handle_bootstrap_peers().await;
-                    // Sleep for brief period.
-                    tokio::time::sleep(Duration::from_millis(2500)).await;
-                }
-            });
-        }
         if !self.router().node_type().is_beacon() && Self::PUZZLE_REQUEST_IN_SECS > 0 {
             let self_clone = self.clone();
             self.router().spawn(async move {

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -80,7 +80,7 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Beacon<N, C> {
             warn!("Disconnecting from '{peer_ip}' - {error}");
             self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
             // Disconnect from this peer.
-            self.router().disconnect(peer_ip).await;
+            self.router().disconnect(peer_ip);
         }
         Ok(())
     }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -81,7 +81,7 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Client<N, C> {
             warn!("Disconnecting from '{peer_ip}' - {error}");
             self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
             // Disconnect from this peer.
-            self.router().disconnect(peer_ip).await;
+            self.router().disconnect(peer_ip);
         }
         Ok(())
     }

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -184,7 +184,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
         loop {
             // If the node is not connected to any peers, then skip this iteration.
             if self.router.number_of_connected_peers() == 0 {
-                warn!("Skipping an iteration of the coinbase puzzle (no connected peers)");
+                trace!("Skipping an iteration of the coinbase puzzle (no connected peers)");
                 tokio::time::sleep(Duration::from_secs(N::ANCHOR_TIME as u64)).await;
                 continue;
             }

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -80,7 +80,7 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Prover<N, C> {
             warn!("Disconnecting from '{peer_ip}' - {error}");
             self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
             // Disconnect from this peer.
-            self.router().disconnect(peer_ip).await;
+            self.router().disconnect(peer_ip);
         }
         Ok(())
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -80,7 +80,7 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
             warn!("Disconnecting from '{peer_ip}' - {error}");
             self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
             // Disconnect from this peer.
-            self.router().disconnect(peer_ip).await;
+            self.router().disconnect(peer_ip);
         }
         Ok(())
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR proactively disconnects any peers (on `send`) that are no longer active.

This should help to reduce the number of erroneous sends.

# Related PRs

This logic was pulled out of PR #2089 to get it out sooner.
