### PR TITLE
Only show received connection log as the responder

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -61,7 +61,9 @@ impl<N: Network> Router<N> {
         if let Err(forbidden_message) = self.ensure_peer_is_allowed(peer_addr) {
             return Err(error(format!("{forbidden_message}")));
         }
-        debug!("Received a connection request from '{peer_addr}'");
+        if peer_side == ConnectionSide::Initiator {
+            debug!("Received a connection request from '{peer_addr}'");
+        }
 
         /* Step 1: Send the challenge request. */
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

The log was showing `Received a connection request from '...'` even if the connection is initiated by the local node. While the actual initiator could be inferred from the surrounding logs, this line itself is misleading.
