### PR TITLE
Fix start message to only show REST when beacon or validator

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -271,11 +271,14 @@ impl Start {
                 self.node.to_string().bold()
             );
 
-            if let Some(rest_ip) = rest_ip {
-                println!("🌐 Starting the REST server at {}.\n", rest_ip.to_string().bold());
+            // If the node is running a REST server, print the REST IP and JWT.
+            if node_type.is_beacon() || node_type.is_validator() {
+                if let Some(rest_ip) = rest_ip {
+                    println!("🌐 Starting the REST server at {}.\n", rest_ip.to_string().bold());
 
-                if let Ok(jwt_token) = snarkos_node_rest::Claims::new(account.address()).to_jwt_string() {
-                    println!("🔑 Your one-time JWT token is {}\n", jwt_token.dimmed());
+                    if let Ok(jwt_token) = snarkos_node_rest::Claims::new(account.address()).to_jwt_string() {
+                        println!("🔑 Your one-time JWT token is {}\n", jwt_token.dimmed());
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Fixes #2120 

This PR updates the start message to only show REST when beacon or validator.
