### PR TITLE
Fixes an erroneous message when the validator is ahead

### DIFF
--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -72,9 +72,11 @@ pub async fn sync_ledger_with_cdn<N: Network, C: ConsensusStorage<N>>(
                 return Err((*completed_height, err));
             }
         }
-    }
 
-    result
+        Ok(*completed_height)
+    } else {
+        result
+    }
 }
 
 /// Loads blocks from a CDN and process them with the given function.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR fixes an erroneous `error!` message when the validator boots up and is ahead of the CDN.
```
2022-11-30T23:16:32.771608Z  WARN The given start height (124429) must be less than the CDN height (124400)
2022-11-30T23:16:32.771680Z ERROR Storage corruption detected! Run `snarkos clean` to reset storage
thread 'main' panicked at 'Failed to parse the node: The given start height (124429) must be less than the CDN height (124400)', cli/src/commands/start.rs:103:67
```

The error message triggers when the validator is ahead of the CDN. In this case, there is no corruption to storage, and the error message should not trigger.

