### PR TITLE
Add `is_dev` flag to `Consensus`

### DIFF
--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -107,7 +107,7 @@ pub(crate) mod test_helpers {
         assert_eq!(genesis.round(), ledger.latest_round());
         assert_eq!(genesis, ledger.get_block(0).unwrap());
 
-        CurrentConsensus::new(ledger).unwrap()
+        CurrentConsensus::new(ledger, true).unwrap()
     }
 
     pub(crate) fn sample_program() -> Program<CurrentNetwork> {

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -115,7 +115,7 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
         }
 
         // Initialize the consensus.
-        let consensus = Consensus::new(ledger.clone())?;
+        let consensus = Consensus::new(ledger.clone(), dev.is_some())?;
         lap!(timer, "Initialize consensus");
 
         // Initialize the node router.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -94,7 +94,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             }
         }
         // Initialize the consensus.
-        let consensus = Consensus::new(ledger.clone())?;
+        let consensus = Consensus::new(ledger.clone(), dev.is_some())?;
 
         // Initialize the node router.
         let router = Router::new(


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR introduces the `is_dev` flag to `Consensus` so development nodes use the new retargeting algorithm instead of waiting until the `V4_START_HEIGHT`.
