### PR TITLE
Initial GPU prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "6118baab6285accf088b31d5ea5029c37bbf9d98e62b4d8720a0a5a66bc2e427"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -194,7 +194,7 @@ checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -320,6 +320,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "which",
+ "zeroize",
 ]
 
 [[package]]
@@ -499,7 +512,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -740,7 +753,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "scratch",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -757,7 +770,7 @@ checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -781,7 +794,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -974,7 +987,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1608,7 +1621,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1684,7 +1697,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1801,7 +1814,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1866,7 +1879,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
  "version_check",
 ]
 
@@ -2287,7 +2300,7 @@ checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2336,7 +2349,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2715,8 +2728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013af4df75ac663ff6fd542b0d46660d4a2dc9a4bf63e774f33ba86d8f5c1edf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "anyhow",
  "clap",
@@ -2743,8 +2755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6f17a3bfcc5ef54e923cb69b64c1270d6ef2a51293977e98024664e791e0b0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2759,6 +2770,7 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
+ "snarkvm-cuda",
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-parameters",
@@ -2770,8 +2782,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f6003e7e2c04eab4d0ec1f86410a6f0463160bc32fb13b73be33e2fe078c2a"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2785,8 +2796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818690afd662700d128dfcffd404e5a7c002746eccca5e3f04778c1ea2e59e2f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2797,8 +2807,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413f0e0f559b4536636219bc4099039206c99cb113b7fe909a65e530297e455"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2808,8 +2817,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25034795092f5383ca06adc167108a0eb2844cafb57f4924eafb2c64a706518c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2819,8 +2827,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cdccedae232012dc29cf1e961a7ffeebfb790b3a848466b6efbe3673f4bbb5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2838,14 +2845,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612990cef245d43ab975b75bc7b6cb069b5e985f2b45a4691c65d1b3e4bb9922"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94033b76989575d404ea11dc6c4aa9e43b0e906b76e7c6e66a7531657189cdc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2856,8 +2861,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5b51c284249deb1d3107f1e9502ee167e2dc5acc74af71e59c4e3b23249ec"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2870,8 +2874,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30828919b5046b92f0d4fa96210745c89df3a8697b7a9d51569b2b1fb7843586"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2886,8 +2889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03588ccdb0462a3694674f8ba1a80a7e45560aab1f681a5e8d6aa81dc50559ce"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2900,8 +2902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97da778a5acb02f55cad0eada09f5bef073d1ad2341c0cfd06fa69c58960cbce"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2910,8 +2911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e3b537b6597225b152180c067a89756d97564558c4309864511f2cf3bc27d1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2921,8 +2921,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f870135215aea56b08a150a6568100e0d60fcc5f652b38f25e0e2b5be00376"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2934,8 +2933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1e895affaa4503a08c88a8382dbc19b1309459ff5baa7a478c7ac1a3fa06c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2946,8 +2944,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787f2c535478ad51cc22beda66868ddd7aff24e39d9057d3d60935ad02593b0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2958,8 +2955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc962ffd7673096a73cd4d0ec90325cc32abbeb9322af10ef8c0455d396e1463"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2971,8 +2967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd429b0b19762c1c87097d94495d1cb4d74323ae4710ece62173f9750682e447"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2985,8 +2980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b577a54fafe65db1f02ac4a3f9b6bd05e2a35accecb9aa9ac37bfcc04a2bb42d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2996,8 +2990,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53d801829816af87b537505b85a82d5b6e1e5815a174d55484b46ffc9915721"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3009,8 +3002,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01358566b823aa77fe1d61b825c8e0c812238f091c8311dfa571c6195a6581cf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3021,8 +3013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45cb7cd4d0c52d73dc891cdf557b9114561ba9949a46099b96401b201fe1fdd0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3045,8 +3036,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cae3cc04ee4d4b90d754aa38fb792a949178ea74e20f4f586daf4608f16518"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3063,8 +3053,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d0dd970fe030fcfeaa0929fd69682ce25343a7c6570b0c585676599bdd14df"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3082,8 +3071,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306d43ebfae7b537f3e70959f0195f7572722437ba693261a6444ca04e64ea9a"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3098,8 +3086,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4814ea1fc021f09fa360990668986862bfdd3cbec9fea2d5d298959764894e0d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3110,8 +3097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38656e2914ac9e457bf2d3dd6997e7118182afe8485929787e847d1071a5e73"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3119,8 +3105,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c81acd1d36d413ee62ecf5ecd22ed27f05bea46aa3bc828b0c3aeb123fc8c84"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3129,8 +3114,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a71396560a122db6785bbfcfda75d76692c06acced36bc5c614b5abff5db9"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3141,8 +3125,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940be406f3cac8ab3b9b914171c920c5322148fdc02423d11e5856b60df4740"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3152,8 +3135,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b71af9c038a84714f19a9e1761736de983900b6837be2ae144f98610529157"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3163,8 +3145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5463846e8a031eeed2271fe1f4f0d7491c4d31461a9fc9d79f544cdf11d0469"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3173,10 +3154,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkvm-cuda"
+version = "0.9.8"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
+dependencies = [
+ "blst",
+ "cc",
+ "sppark",
+ "which",
+]
+
+[[package]]
 name = "snarkvm-curves"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cd683c142fe10686a0cfedcd22d262ce3f442843e9cf124b4802d394055361"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3189,8 +3180,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63451df92ff0a741a22affdea8057d2c15017fc1f987eba141b7e9cd1cbdf28"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3207,8 +3197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a66dc87a7453b1d1cf6ca4f8aee71b5feb913af592da783b26af696fbde3f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3233,8 +3222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f6b98f5f09c8bfff3206ba885a5698ebb196bfc8ed7a331094c1dc6823edbe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3250,8 +3238,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143155ee59b25954bb20f47b9dc50b1d4cbc3d8a698e85daf3a9757d3b82b7c9"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3278,8 +3265,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27308001f04a0ceb0a22f68abd4ed1bace6536f2aea5f6a75ffe044884f1093"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3297,12 +3283,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85ab3a492f904c732fd1e108742c53c4a8601683f2f505d256887db1079cb9c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=dafd8cc#dafd8cc08196043c7eca11525786b978ce3f8606"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3336,6 +3321,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "sppark"
+version = "0.1.2"
+source = "git+https://github.com/supranational/sppark?rev=48f6ac6#48f6ac606be53a3186dea98a407b067ec758614a"
+dependencies = [
+ "cc",
+ "which",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3379,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -3395,6 +3389,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
  "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -3453,7 +3459,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3463,6 +3469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -3529,13 +3544,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3634,7 +3649,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3740,7 +3755,7 @@ checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
 dependencies = [
  "lazy_static",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3751,7 +3766,7 @@ checksum = "744324b12d69a9fc1edea4b38b7b1311295b662d161ad5deac17bb1358224a08"
 dependencies = [
  "lazy_static",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3860,6 +3875,12 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -4016,7 +4037,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -4050,7 +4071,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4088,6 +4109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -4235,3 +4267,18 @@ name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+ "synstructure",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,27 @@ members = [
 name = "snarkos"
 path = "snarkos/main.rs"
 
+[features]
+cuda = [
+    "snarkos-account/cuda",
+    "snarkos-cli/cuda",
+    "snarkos-display/cuda",
+    "snarkos-node/cuda",
+    "snarkos-node-cdn/cuda",
+    "snarkos-node-consensus/cuda",
+    "snarkos-node-ledger/cuda",
+    "snarkos-node-messages/cuda",
+    "snarkos-node-rest/cuda",
+    "snarkos-node-router/cuda",
+    "snarkos-node-store/cuda",
+]
+
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 #git = "https://github.com/AleoHQ/snarkVM.git"
 #rev = "67f8829"
 version = "0.9.13"
-features = ["circuit", "console", "cuda", "parallel"]
+features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]
 version = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
-#git = "https://github.com/AleoHQ/snarkVM.git"
-#rev = "7ac6eee"
-version = "0.9.9"
-features = ["circuit", "console", "parallel"]
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "dafd8cc"
+#version = "0.9.9"
+features = ["circuit", "console", "cuda", "parallel"]
 
 [dependencies.anyhow]
 version = "1"

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+cuda = ["snarkvm/cuda"]
+
 [dependencies.anyhow]
 version = "1"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+cuda = ["snarkvm/cuda"]
+
 [dependencies.aleo-std]
 version = "0.1.15"
 default-features = false

--- a/display/Cargo.toml
+++ b/display/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+cuda = ["snarkvm/cuda"]
+
 [dependencies.anyhow]
 version = "1"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ ]
 timer = [ "aleo-std/timer", "snarkos-node-ledger/timer" ]
+cuda = ["snarkvm/cuda"]
 
 [dependencies.aleo-std]
 version = "0.1.15"

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "snarkvm/parallel", "snarkos-node-ledger/parallel" ]
+cuda = ["snarkvm/cuda"]
 
 [dependencies.anyhow]
 version = "1"

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "rayon" ]
+cuda = ["snarkvm/cuda"]
 
 [dependencies.anyhow]
 version = "1"

--- a/node/ledger/Cargo.toml
+++ b/node/ledger/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2021"
 default = [ "parallel" ]
 parallel = [ "rayon" ]
 timer = [ "aleo-std/timer" ]
+cuda = ["snarkvm/cuda"]
 
 [dependencies.aleo-std]
 version = "0.1.15"

--- a/node/messages/Cargo.toml
+++ b/node/messages/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = []
 test = []
+cuda = ["snarkvm/cuda"]
 
 [dependencies.anyhow]
 version = "1"

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+cuda = ["snarkvm/cuda"]
+
 [dependencies.anyhow]
 version = "1"
 

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2021"
 
 [features]
 test = []
+cuda = ["snarkvm/cuda"]
 
 [dependencies.anyhow]
 version = "1"

--- a/node/store/Cargo.toml
+++ b/node/store/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+cuda = ["snarkvm/cuda"]
+
 [dependencies.aleo-std]
 version = "0.1.15"
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR enables basic GPU support for underlying snarkVM operations (MSMs and NTTs). This is still **UNDER ACTIVE DEVELOPMENT** as there are many additional optimizations to be made (and audits to be conducted). 

At this time, the optimizations are only available for Nvidia GPUs with support for Cuda 9 or later.

### Requirements:
Cuda sm_70 or later
[Cuda Toolkit (nvcc)](https://docs.nvidia.com/cuda/index.html#installation-guides)

### Notes: 
- This PR relies on rev [dafd8cc](https://github.com/AleoHQ/snarkVM/pull/1288/commits/dafd8cc08196043c7eca11525786b978ce3f8606) from https://github.com/AleoHQ/snarkVM/pull/1288. Once this is added to a new snarkVM release, we can update this dependency.
- The resource pool in snarkOS should also be updated to ensure more optimal use of the GPU resources.