### PR TITLE
Fix inbound and outbound cache for solutions and transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,8 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0119b2b558bba04e3cce3775da77f898b5fcf08cf177e692fa6037fe3a4aeea"
 dependencies = [
  "anyhow",
  "clap",
@@ -2752,8 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44717bf78752fe98f0e4228743d9384cb0abc30bf025b9d844c737b378976a3b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2778,8 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae23f5a63cf5b3bf835e577e3530d0579bf65c38dba587b904593b615a2e23a5"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2792,8 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e94a73d8a411e1cdc3a4f4bc03dc6466fe83aeaadb9266a50cdde6d687f42a4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2803,8 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b97bf7f521574c2f2621ec1e174a89a4d795a7d7857833a7d82e026b28084ab"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2813,8 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3da410fb8e73d73a5e4a8c9c9b1d81c6f7cf6dffc1ee35a9a0d198ed36d712d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2823,8 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a052b464f06508b82118d37047068786fa62c1087b5e87cc9a4c6602a25686"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2841,13 +2848,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017fcdd952676f810a830e8d42a1444b6144f1c9282c3ca8babc26811869bb23"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8993d3074498d46e29f796acd65ce1dea449edb8bbb6fb1d86a3e5fa2328829"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2857,8 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a166f49dc4b27e47cd28d79ce1b91587f07f6b76c14960fd3a4dbf434943866"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2870,8 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169d6e14aaf6618dd62c1346a8dd3f72aee99eb0c61bbb90fba10e98ca0ed6a0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2885,8 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769d137b210ab665a2fe02d71f96deeee9122392fddb611d00a4f679068f7053"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2898,8 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875fbb8814bc05a4b174619f1f9755d41d91d85bee1ba444fb45e7036b139914"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2907,8 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef6adcde1a0e001a3f59804923ca6fbc8d28bf481aa01568f75db7c4bf5cd3d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2917,8 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a83de038afb89793afa62c7e0141c90b595903512b6ce95457128b154214029"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2929,8 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90b73a5f8f38e0c6700122766144f46588d72a4d8cc67af4738e6b672af988f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2940,8 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e24dd3f098b55473336370ac95e812bbaf97eb40d865ced893534d3f2133c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2951,8 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d941aab85e62f58ac0be502ba885c119f325811ab305e628e9574163dca47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2963,8 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f950fcb58d6ff6e965c3d79de272778a25d7dd3fd7fdf25d6e93d2e4faecc67"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2976,8 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8b2acd1bc1e4770b14ac3042cd95c5705f6c2bf9a6bbac9917a265b778209"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2986,8 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd88d7d3528537656ed13440f149103f23395423e8b5b4ce014d6f4d6e503a1"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2998,8 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3f93eb4f4457a92913e19fbdd30659c46614cdcc15d78c1a010cd9b5499f6e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3009,8 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54da72a6ef1cbd290ab5a0a084d90a75582826f58a60bfddf415784ca72afc5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3032,8 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad5d6bcd9f8ef8e40f94d4649600116f4d78342f523326d4b63a511581e0a2a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3049,8 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7064b815282ca08d53b34df2c27d00ad380d716b305823260a7312a71e3ce08a"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3067,8 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0582bdd683f021a755e846da497cc7d9c69b7b59524d1ed96487609b9e2f014"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3082,8 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb0026fbe5e3e2fbbfbbf605eb4efff2cafbec46cd4e8dda927d23485fc586d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3093,16 +3120,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4624d2f6eb15859253859133c65c9db52a8018db3f64b62ea0a8c76ad8e70ef"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31e4ddde61ba9894b0be08cbed6e4111a1cf9099858a8bd848c89bcaacfee0f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3110,8 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043cc4040b14289ff680281f107f9d85db7b266325d2aff1b55773b4a6553784"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3121,8 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71792e017e031c7cacf61b67823fcc19dae92f7a906caaf109d94517e47f974b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3131,8 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e174287012d02d30e90c8ebeec1751a809e70d0f32750e7fe0ea5bd55f0157f8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3141,8 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd1abad7a2f2e718f4c360d1f65e56d48bb647285776d3bdfec7df3f7c6b1df"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3152,8 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4362d677bc2eb36077fb884cb39dfac2a0c03f86cb548b5e0439848bcc0e3d8e"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3165,8 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc2ff7e15862dc0cbf2891616433a0b823d4bbcafae1e0c35d5dd11ee14e8a5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3182,8 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67857e7df8f2a5bdfbed6dde7e58295b01e51fe1258ebb6b6e52642df75e8d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3207,8 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a734842ac8c5e994745034c6f83aaf324c3a091d830669e79bb056514f11aa"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3223,8 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5823efe283822ba821a78975078619149195df0f0cd60546c3c64ecc7ff4972e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3250,8 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10add1d9b3c360603461a9974714f7e0942280cc72df28edfe6f4f0a2b2b82d1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3268,8 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.9.9"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64872cc1fb4e8304881ce6838f2b2115ed82df3983e8b19ea639bbb2183f540e"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,8 +2726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013af4df75ac663ff6fd542b0d46660d4a2dc9a4bf63e774f33ba86d8f5c1edf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2754,8 +2753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6f17a3bfcc5ef54e923cb69b64c1270d6ef2a51293977e98024664e791e0b0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2781,8 +2779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f6003e7e2c04eab4d0ec1f86410a6f0463160bc32fb13b73be33e2fe078c2a"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2796,8 +2793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818690afd662700d128dfcffd404e5a7c002746eccca5e3f04778c1ea2e59e2f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2808,8 +2804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413f0e0f559b4536636219bc4099039206c99cb113b7fe909a65e530297e455"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2819,8 +2814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25034795092f5383ca06adc167108a0eb2844cafb57f4924eafb2c64a706518c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2830,8 +2824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cdccedae232012dc29cf1e961a7ffeebfb790b3a848466b6efbe3673f4bbb5"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2849,14 +2842,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612990cef245d43ab975b75bc7b6cb069b5e985f2b45a4691c65d1b3e4bb9922"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d94033b76989575d404ea11dc6c4aa9e43b0e906b76e7c6e66a7531657189cdc"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2867,8 +2858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5b51c284249deb1d3107f1e9502ee167e2dc5acc74af71e59c4e3b23249ec"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2881,8 +2871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30828919b5046b92f0d4fa96210745c89df3a8697b7a9d51569b2b1fb7843586"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2897,8 +2886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03588ccdb0462a3694674f8ba1a80a7e45560aab1f681a5e8d6aa81dc50559ce"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2911,8 +2899,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97da778a5acb02f55cad0eada09f5bef073d1ad2341c0cfd06fa69c58960cbce"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2921,8 +2908,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e3b537b6597225b152180c067a89756d97564558c4309864511f2cf3bc27d1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2932,8 +2918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f870135215aea56b08a150a6568100e0d60fcc5f652b38f25e0e2b5be00376"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2945,8 +2930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1e895affaa4503a08c88a8382dbc19b1309459ff5baa7a478c7ac1a3fa06c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2957,8 +2941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787f2c535478ad51cc22beda66868ddd7aff24e39d9057d3d60935ad02593b0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2969,8 +2952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc962ffd7673096a73cd4d0ec90325cc32abbeb9322af10ef8c0455d396e1463"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2982,8 +2964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd429b0b19762c1c87097d94495d1cb4d74323ae4710ece62173f9750682e447"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2996,8 +2977,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b577a54fafe65db1f02ac4a3f9b6bd05e2a35accecb9aa9ac37bfcc04a2bb42d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3007,8 +2987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53d801829816af87b537505b85a82d5b6e1e5815a174d55484b46ffc9915721"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3020,8 +2999,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01358566b823aa77fe1d61b825c8e0c812238f091c8311dfa571c6195a6581cf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3032,8 +3010,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45cb7cd4d0c52d73dc891cdf557b9114561ba9949a46099b96401b201fe1fdd0"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3056,8 +3033,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cae3cc04ee4d4b90d754aa38fb792a949178ea74e20f4f586daf4608f16518"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3074,8 +3050,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d0dd970fe030fcfeaa0929fd69682ce25343a7c6570b0c585676599bdd14df"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3093,8 +3068,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306d43ebfae7b537f3e70959f0195f7572722437ba693261a6444ca04e64ea9a"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3109,8 +3083,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4814ea1fc021f09fa360990668986862bfdd3cbec9fea2d5d298959764894e0d"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3121,8 +3094,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38656e2914ac9e457bf2d3dd6997e7118182afe8485929787e847d1071a5e73"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3130,8 +3102,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c81acd1d36d413ee62ecf5ecd22ed27f05bea46aa3bc828b0c3aeb123fc8c84"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3140,8 +3111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a71396560a122db6785bbfcfda75d76692c06acced36bc5c614b5abff5db9"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3152,8 +3122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940be406f3cac8ab3b9b914171c920c5322148fdc02423d11e5856b60df4740"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3163,8 +3132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b71af9c038a84714f19a9e1761736de983900b6837be2ae144f98610529157"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3174,8 +3142,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5463846e8a031eeed2271fe1f4f0d7491c4d31461a9fc9d79f544cdf11d0469"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3186,8 +3153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cd683c142fe10686a0cfedcd22d262ce3f442843e9cf124b4802d394055361"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3200,8 +3166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63451df92ff0a741a22affdea8057d2c15017fc1f987eba141b7e9cd1cbdf28"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3218,8 +3183,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a66dc87a7453b1d1cf6ca4f8aee71b5feb913af592da783b26af696fbde3f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3244,8 +3208,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f6b98f5f09c8bfff3206ba885a5698ebb196bfc8ed7a331094c1dc6823edbe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3261,8 +3224,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143155ee59b25954bb20f47b9dc50b1d4cbc3d8a698e85daf3a9757d3b82b7c9"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3289,8 +3251,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27308001f04a0ceb0a22f68abd4ed1bace6536f2aea5f6a75ffe044884f1093"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3308,8 +3269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85ab3a492f904c732fd1e108742c53c4a8601683f2f505d256887db1079cb9c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d27939f#d27939fb8f4707b0506b71494d3612941bd407a4"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
-#git = "https://github.com/AleoHQ/snarkVM.git"
-#rev = "7ac6eee"
-version = "0.9.9"
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "d27939f"
+#version = "0.9.9"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 # path = "../snarkvm"
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "d27939f"
-#version = "0.9.9"
+#git = "https://github.com/AleoHQ/snarkVM.git"
+#rev = "d27939f"
+version = "0.9.10"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -43,17 +43,17 @@ pub struct Cache<N: Network> {
     /// The map of peer IPs to their recent timestamps.
     seen_inbound_puzzle_requests: Arc<RwLock<IndexMap<SocketAddr, VecDeque<OffsetDateTime>>>>,
     /// The map of solution commitments to their last seen timestamp.
-    seen_inbound_solutions: Arc<RwLock<LinkedHashMap<PuzzleCommitment<N>, OffsetDateTime>>>,
+    seen_inbound_solutions: Arc<RwLock<LinkedHashMap<(SocketAddr, PuzzleCommitment<N>), OffsetDateTime>>>,
     /// The map of transaction IDs to their last seen timestamp.
-    seen_inbound_transactions: Arc<RwLock<LinkedHashMap<N::TransactionID, OffsetDateTime>>>,
+    seen_inbound_transactions: Arc<RwLock<LinkedHashMap<(SocketAddr, N::TransactionID), OffsetDateTime>>>,
     /// The map of peer IPs to their block requests.
     seen_outbound_block_requests: Arc<RwLock<IndexMap<SocketAddr, IndexSet<BlockRequest>>>>,
     /// The map of peer IPs to the number of puzzle requests.
     seen_outbound_puzzle_requests: Arc<RwLock<IndexMap<SocketAddr, Arc<AtomicU16>>>>,
     /// The map of solution commitments to their last seen timestamp.
-    seen_outbound_solutions: Arc<RwLock<LinkedHashMap<PuzzleCommitment<N>, OffsetDateTime>>>,
+    seen_outbound_solutions: Arc<RwLock<LinkedHashMap<(SocketAddr, PuzzleCommitment<N>), OffsetDateTime>>>,
     /// The map of transaction IDs to their last seen timestamp.
-    seen_outbound_transactions: Arc<RwLock<LinkedHashMap<N::TransactionID, OffsetDateTime>>>,
+    seen_outbound_transactions: Arc<RwLock<LinkedHashMap<(SocketAddr, N::TransactionID), OffsetDateTime>>>,
 }
 
 impl<N: Network> Default for Cache<N> {
@@ -97,13 +97,21 @@ impl<N: Network> Cache<N> {
     }
 
     /// Inserts a solution commitment into the cache, returning the previously seen timestamp if it existed.
-    pub fn insert_inbound_solution(&self, solution: PuzzleCommitment<N>) -> Option<OffsetDateTime> {
-        Self::refresh_and_insert(&self.seen_inbound_solutions, solution)
+    pub fn insert_inbound_solution(
+        &self,
+        peer_ip: SocketAddr,
+        solution: PuzzleCommitment<N>,
+    ) -> Option<OffsetDateTime> {
+        Self::refresh_and_insert(&self.seen_inbound_solutions, (peer_ip, solution))
     }
 
     /// Inserts a transaction ID into the cache, returning the previously seen timestamp if it existed.
-    pub fn insert_inbound_transaction(&self, transaction: N::TransactionID) -> Option<OffsetDateTime> {
-        Self::refresh_and_insert(&self.seen_inbound_transactions, transaction)
+    pub fn insert_inbound_transaction(
+        &self,
+        peer_ip: SocketAddr,
+        transaction: N::TransactionID,
+    ) -> Option<OffsetDateTime> {
+        Self::refresh_and_insert(&self.seen_inbound_transactions, (peer_ip, transaction))
     }
 }
 
@@ -145,13 +153,21 @@ impl<N: Network> Cache<N> {
     }
 
     /// Inserts a solution commitment into the cache, returning the previously seen timestamp if it existed.
-    pub fn insert_outbound_solution(&self, solution: PuzzleCommitment<N>) -> Option<OffsetDateTime> {
-        Self::refresh_and_insert(&self.seen_outbound_solutions, solution)
+    pub fn insert_outbound_solution(
+        &self,
+        peer_ip: SocketAddr,
+        solution: PuzzleCommitment<N>,
+    ) -> Option<OffsetDateTime> {
+        Self::refresh_and_insert(&self.seen_outbound_solutions, (peer_ip, solution))
     }
 
     /// Inserts a transaction ID into the cache, returning the previously seen timestamp if it existed.
-    pub fn insert_outbound_transaction(&self, transaction: N::TransactionID) -> Option<OffsetDateTime> {
-        Self::refresh_and_insert(&self.seen_outbound_transactions, transaction)
+    pub fn insert_outbound_transaction(
+        &self,
+        peer_ip: SocketAddr,
+        transaction: N::TransactionID,
+    ) -> Option<OffsetDateTime> {
+        Self::refresh_and_insert(&self.seen_outbound_transactions, (peer_ip, transaction))
     }
 }
 
@@ -213,5 +229,103 @@ impl<N: Network> Cache<N> {
     ) -> Option<OffsetDateTime> {
         Self::refresh(map);
         map.write().insert(key, OffsetDateTime::now_utc())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm::prelude::Testnet3;
+
+    use std::net::Ipv4Addr;
+
+    type CurrentNetwork = Testnet3;
+
+    #[test]
+    fn test_inbound_solution() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let peer_ip = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+        let solution = PuzzleCommitment::<CurrentNetwork>::default();
+
+        // Check that the cache is empty.
+        assert_eq!(cache.seen_inbound_solutions.read().len(), 0);
+
+        // Insert a solution.
+        assert!(cache.insert_inbound_solution(peer_ip, solution).is_none());
+
+        // Check that the cache contains the solution.
+        assert_eq!(cache.seen_inbound_solutions.read().len(), 1);
+
+        // Insert the same solution again.
+        assert!(cache.insert_inbound_solution(peer_ip, solution).is_some());
+
+        // Check that the cache still contains the solution.
+        assert_eq!(cache.seen_inbound_solutions.read().len(), 1);
+    }
+
+    #[test]
+    fn test_inbound_transaction() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let peer_ip = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+        let transaction = Default::default();
+
+        // Check that the cache is empty.
+        assert_eq!(cache.seen_inbound_transactions.read().len(), 0);
+
+        // Insert a transaction.
+        assert!(cache.insert_inbound_transaction(peer_ip, transaction).is_none());
+
+        // Check that the cache contains the transaction.
+        assert_eq!(cache.seen_inbound_transactions.read().len(), 1);
+
+        // Insert the same transaction again.
+        assert!(cache.insert_inbound_transaction(peer_ip, transaction).is_some());
+
+        // Check that the cache still contains the transaction.
+        assert_eq!(cache.seen_inbound_transactions.read().len(), 1);
+    }
+
+    #[test]
+    fn test_outbound_solution() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let peer_ip = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+        let solution = PuzzleCommitment::<CurrentNetwork>::default();
+
+        // Check that the cache is empty.
+        assert_eq!(cache.seen_outbound_solutions.read().len(), 0);
+
+        // Insert a solution.
+        assert!(cache.insert_outbound_solution(peer_ip, solution).is_none());
+
+        // Check that the cache contains the solution.
+        assert_eq!(cache.seen_outbound_solutions.read().len(), 1);
+
+        // Insert the same solution again.
+        assert!(cache.insert_outbound_solution(peer_ip, solution).is_some());
+
+        // Check that the cache still contains the solution.
+        assert_eq!(cache.seen_outbound_solutions.read().len(), 1);
+    }
+
+    #[test]
+    fn test_outbound_transaction() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let peer_ip = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+        let transaction = Default::default();
+
+        // Check that the cache is empty.
+        assert_eq!(cache.seen_outbound_transactions.read().len(), 0);
+
+        // Insert a transaction.
+        assert!(cache.insert_outbound_transaction(peer_ip, transaction).is_none());
+
+        // Check that the cache contains the transaction.
+        assert_eq!(cache.seen_outbound_transactions.read().len(), 1);
+
+        // Insert the same transaction again.
+        assert!(cache.insert_outbound_transaction(peer_ip, transaction).is_some());
+
+        // Check that the cache still contains the transaction.
+        assert_eq!(cache.seen_outbound_transactions.read().len(), 1);
     }
 }

--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -34,6 +34,11 @@ use time::{Duration, OffsetDateTime};
 /// The maximum number of items to store in the cache.
 const MAX_CACHE_SIZE: usize = 4096;
 
+/// A helper containing the peer IP and solution commitment.
+type SolutionKey<N> = (SocketAddr, PuzzleCommitment<N>);
+/// A helper containing the peer IP and transaction ID.
+type TransactionKey<N> = (SocketAddr, <N as Network>::TransactionID);
+
 #[derive(Clone, Debug)]
 pub struct Cache<N: Network> {
     /// The map of peer connections to their recent timestamps.
@@ -43,17 +48,17 @@ pub struct Cache<N: Network> {
     /// The map of peer IPs to their recent timestamps.
     seen_inbound_puzzle_requests: Arc<RwLock<IndexMap<SocketAddr, VecDeque<OffsetDateTime>>>>,
     /// The map of solution commitments to their last seen timestamp.
-    seen_inbound_solutions: Arc<RwLock<LinkedHashMap<(SocketAddr, PuzzleCommitment<N>), OffsetDateTime>>>,
+    seen_inbound_solutions: Arc<RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>>,
     /// The map of transaction IDs to their last seen timestamp.
-    seen_inbound_transactions: Arc<RwLock<LinkedHashMap<(SocketAddr, N::TransactionID), OffsetDateTime>>>,
+    seen_inbound_transactions: Arc<RwLock<LinkedHashMap<TransactionKey<N>, OffsetDateTime>>>,
     /// The map of peer IPs to their block requests.
     seen_outbound_block_requests: Arc<RwLock<IndexMap<SocketAddr, IndexSet<BlockRequest>>>>,
     /// The map of peer IPs to the number of puzzle requests.
     seen_outbound_puzzle_requests: Arc<RwLock<IndexMap<SocketAddr, Arc<AtomicU16>>>>,
     /// The map of solution commitments to their last seen timestamp.
-    seen_outbound_solutions: Arc<RwLock<LinkedHashMap<(SocketAddr, PuzzleCommitment<N>), OffsetDateTime>>>,
+    seen_outbound_solutions: Arc<RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>>,
     /// The map of transaction IDs to their last seen timestamp.
-    seen_outbound_transactions: Arc<RwLock<LinkedHashMap<(SocketAddr, N::TransactionID), OffsetDateTime>>>,
+    seen_outbound_transactions: Arc<RwLock<LinkedHashMap<TransactionKey<N>, OffsetDateTime>>>,
 }
 
 impl<N: Network> Default for Cache<N> {

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -225,7 +225,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 // Clone the serialized message.
                 let serialized = message.clone();
                 // Update the timestamp for the unconfirmed solution.
-                let seen_before = self.router().cache.insert_inbound_solution(message.puzzle_commitment).is_some();
+                let seen_before =
+                    self.router().cache.insert_inbound_solution(peer_ip, message.puzzle_commitment).is_some();
                 // Determine whether to propagate the solution.
                 if seen_before {
                     bail!("Skipping 'UnconfirmedSolution' from '{peer_ip}'")
@@ -249,7 +250,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 // Clone the serialized message.
                 let serialized = message.clone();
                 // Update the timestamp for the unconfirmed transaction.
-                let seen_before = self.router().cache.insert_inbound_transaction(message.transaction_id).is_some();
+                let seen_before =
+                    self.router().cache.insert_inbound_transaction(peer_ip, message.transaction_id).is_some();
                 // Determine whether to propagate the transaction.
                 if seen_before {
                     bail!("Skipping 'UnconfirmedTransaction' from '{peer_ip}'")

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -168,13 +168,15 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
         match message {
             Message::UnconfirmedSolution(message) => {
                 // Update the timestamp for the unconfirmed solution.
-                let seen_before = self.router().cache.insert_outbound_solution(message.puzzle_commitment).is_some();
+                let seen_before =
+                    self.router().cache.insert_outbound_solution(peer_ip, message.puzzle_commitment).is_some();
                 // Determine whether to send the solution.
                 !seen_before
             }
             Message::UnconfirmedTransaction(message) => {
                 // Update the timestamp for the unconfirmed transaction.
-                let seen_before = self.router().cache.insert_outbound_transaction(message.transaction_id).is_some();
+                let seen_before =
+                    self.router().cache.insert_outbound_transaction(peer_ip, message.transaction_id).is_some();
                 // Determine whether to send the transaction.
                 !seen_before
             }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the cache to handle duplicate solutions and transactions on a per IP address basis. The logic prior to this change could inadvertently cause peers to become disconnected due to duplicate transmissions from different peers over the network.

## Tests

This PR adds unit tests to ensure the cache updates the entry for the inbound and outbound solutions and transactions.