### PR TITLE
Reorders router initialization to after computing unspent records

### DIFF
--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -118,6 +118,12 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
         let consensus = Consensus::new(ledger.clone(), dev.is_some())?;
         lap!(timer, "Initialize consensus");
 
+        // Initialize the block generation time.
+        let block_generation_time = Arc::new(AtomicU64::new(2));
+        // Retrieve the unspent records.
+        let unspent_records = ledger.find_unspent_records(account.view_key())?;
+        lap!(timer, "Retrieve the unspent records");
+
         // Initialize the node router.
         let router = Router::new(
             node_ip,
@@ -129,12 +135,6 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
         )
         .await?;
         lap!(timer, "Initialize the router");
-
-        // Initialize the block generation time.
-        let block_generation_time = Arc::new(AtomicU64::new(2));
-        // Retrieve the unspent records.
-        let unspent_records = ledger.find_unspent_records(account.view_key())?;
-        lap!(timer, "Retrieve the unspent records");
 
         // Initialize the node.
         let mut node = Self {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR reorders router initialization to take place after computing the unspent records.

It was observed that the TCP stack accepts inbound connects despite **not** calling `enable_handshake`. By moving the router to bind right before `enable_handshake` is called at runtime, this mitigates some of the `permission denied` bug that some had previously ran into.
