### PR TITLE
Update build_ubuntu.sh

### DIFF
--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -21,7 +21,8 @@ apt-get install -y \
     make \
     pkg-config \
     tmux \
-    xz-utils
+    xz-utils \
+    ufw
 
 # Install Rust
 


### PR DESCRIPTION
adding ufw for installation. it doesn't come preinstalled with some cloud providers.

Signed-off-by: Tim - o2Stake <77958700+timsmith1337@users.noreply.github.com>

<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

UFW doesn't come preinstalled with some cloud providers.

## Test Plan

(If you changed any code, please provide clear instructions on how you verified your changes work.)

## Related PRs

(Link any related PRs here)
