### PR TITLE
TCP review - adds comments, tests, and reorganizes some methods

### DIFF
--- a/node/tcp/Cargo.toml
+++ b/node/tcp/Cargo.toml
@@ -25,3 +25,6 @@ parking_lot = "0.12"
 tokio = { version = "1.22", features = ["io-util", "net", "parking_lot", "rt", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = { version = "0.1", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1.22", features = ["macros"] }

--- a/node/tcp/src/helpers/mod.rs
+++ b/node/tcp/src/helpers/mod.rs
@@ -25,3 +25,27 @@ pub use known_peers::KnownPeers;
 
 mod stats;
 pub use stats::Stats;
+
+use tracing::{debug_span, error_span, info_span, trace_span, warn_span, Span};
+
+// FIXME: this can probably be done more elegantly
+/// Creates the Tcp's tracing span based on its name.
+pub fn create_span(tcp_name: &str) -> Span {
+    let mut span = trace_span!("tcp", name = tcp_name);
+    if !span.is_disabled() {
+        return span;
+    } else {
+        span = debug_span!("tcp", name = tcp_name);
+    }
+    if !span.is_disabled() {
+        return span;
+    } else {
+        span = info_span!("tcp", name = tcp_name);
+    }
+    if !span.is_disabled() {
+        return span;
+    } else {
+        span = warn_span!("tcp", name = tcp_name);
+    }
+    if !span.is_disabled() { span } else { error_span!("tcp", name = tcp_name) }
+}

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -255,7 +255,7 @@ impl Tcp {
 
         if !self.can_add_connection() {
             error!(parent: self.span(), "too many connections; refusing to connect to {}", addr);
-            return Err(io::ErrorKind::PermissionDenied.into());
+            return Err(io::ErrorKind::ConnectionRefused.into());
         }
 
         if self.is_connected(addr) {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds and updates comments and traces in the `Tcp` stack, and reorganizes methods for easier readability.

The following are the **only** logic changes to the `Tcp` stack.
- Abstracts the listening task logic into 2 new methods: `enable_listener` and `handle_connection`
- Adds `Tcp::connecting_addrs` to retrieve the pending IP addresses
- (https://github.com/AleoHQ/snarkOS/pull/2143/commits/316c75654a2753857aeb747bb065ad150c497d46) Switches `!can_add_connection` error from `PermissionDenied` to `ConnectionRefused`

## Test Plan

This PR adds tests on the following `Tcp` methods:
- `new`
- `connect`
- `disconnect`
- `can_add_connection`
- `handle_connection`
- `adapt_stream`

## Related PRs

None