### PR TITLE
Fix/2102

### DIFF
--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -148,10 +148,6 @@ impl<N: Network> Router<N> {
             // Disconnect from this peer.
             let _disconnected = router.tcp.disconnect(peer_ip).await;
             debug_assert!(_disconnected);
-            // TODO (howardwu): Revisit this. It appears `handle_disconnect` does not necessarily trigger.
-            //  See https://github.com/AleoHQ/snarkOS/issues/2102.
-            // Remove the peer from the connected peers.
-            router.remove_connected_peer(peer_ip);
         });
     }
 

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -287,11 +287,9 @@ impl Tcp {
     /// Disconnects from the provided `SocketAddr`.
     pub async fn disconnect(&self, addr: SocketAddr) -> bool {
         if let Some(handler) = self.protocols.disconnect.get() {
-            if self.is_connected(addr) {
-                let (sender, receiver) = oneshot::channel();
-                handler.trigger((addr, sender));
-                let _ = receiver.await; // can't really fail
-            }
+            let (sender, receiver) = oneshot::channel();
+            handler.trigger((addr, sender));
+            let _ = receiver.await; // can't really fail
         }
 
         let conn = self.connections.remove(addr);


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Fixes #2102

With this change, in the case that the disconnecting peer truly is not connected, the trigger for `handle_disconnect` will still trigger, giving the `Router` an opportunity to perform a clean up of the connection as well.

Based on the `Tcp` protocols, I think the originally intention of this `is_connected` conditional check was to prevent the trigger from being called multiple times. In case this occurs, I can confirm that multiple calls to `handle_disconnect` in the `Router` for a given peer IP is safe.

