### PR TITLE
Skip computing block locators if peer is disconnected

### DIFF
--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -187,11 +187,14 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Beacon<N, C> {
         tokio::spawn(async move {
             // Sleep for the preset time before sending a `Ping` request.
             tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
-            // Retrieve the block locators.
-            match crate::helpers::get_block_locators(&self_clone.ledger) {
-                // Send a `Ping` message to the peer.
-                Ok(block_locators) => self_clone.send_ping(peer_ip, Some(block_locators)),
-                Err(e) => error!("Failed to get block locators: {e}"),
+            // Check that the peer is still connected.
+            if self_clone.router().is_connected(&peer_ip) {
+                // Retrieve the block locators.
+                match crate::helpers::get_block_locators(&self_clone.ledger) {
+                    // Send a `Ping` message to the peer.
+                    Ok(block_locators) => self_clone.send_ping(peer_ip, Some(block_locators)),
+                    Err(e) => error!("Failed to get block locators: {e}"),
+                }
             }
         });
         true

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -132,8 +132,11 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         tokio::spawn(async move {
             // Sleep for the preset time before sending a `Ping` request.
             tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
-            // Send a `Ping` message to the peer.
-            self_clone.send_ping(peer_ip, None);
+            // Check that the peer is still connected.
+            if self_clone.router().is_connected(&peer_ip) {
+                // Send a `Ping` message to the peer.
+                self_clone.send_ping(peer_ip, None);
+            }
         });
         true
     }

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -139,8 +139,11 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
         tokio::spawn(async move {
             // Sleep for the preset time before sending a `Ping` request.
             tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
-            // Send a `Ping` message to the peer.
-            self_clone.send_ping(peer_ip, None);
+            // Check that the peer is still connected.
+            if self_clone.router().is_connected(&peer_ip) {
+                // Send a `Ping` message to the peer.
+                self_clone.send_ping(peer_ip, None);
+            }
         });
         true
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -171,11 +171,14 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         tokio::spawn(async move {
             // Sleep for the preset time before sending a `Ping` request.
             tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
-            // Retrieve the block locators.
-            match crate::helpers::get_block_locators(&self_clone.ledger) {
-                // Send a `Ping` message to the peer.
-                Ok(block_locators) => self_clone.send_ping(peer_ip, Some(block_locators)),
-                Err(e) => error!("Failed to get block locators: {e}"),
+            // Check that the peer is still connected.
+            if self_clone.router().is_connected(&peer_ip) {
+                // Retrieve the block locators.
+                match crate::helpers::get_block_locators(&self_clone.ledger) {
+                    // Send a `Ping` message to the peer.
+                    Ok(block_locators) => self_clone.send_ping(peer_ip, Some(block_locators)),
+                    Err(e) => error!("Failed to get block locators: {e}"),
+                }
             }
         });
         true


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR improves the efficiency of validators and beacons by checking that the peer is still connected prior to preparing a `Ping` message.

While the call to `send_ping` will already check that the peer is still connected (via logic in `can_send`), it was observed that validators and beacons (due to the number of connections they maintain) frequently prepare block locators that are not used as the peer has already disconnected.

This PR thus significantly reduces the number of calls to `Ledger` for validators and beacons, thereby improving the efficiency in usage of RocksDB for other operations such as syncing blocks.
