### PR TITLE
Updates router connect and restricted peer logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,6 +2671,7 @@ dependencies = [
  "bytes",
  "colored",
  "futures",
+ "futures-util",
  "indexmap",
  "itertools",
  "linked-hash-map",
@@ -2688,6 +2689,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -97,6 +97,14 @@ version = "=0.1"
 [dependencies.tracing]
 version = "0.1"
 
+[dev-dependencies.futures-util]
+version = "0.3"
+features = ["sink"]
+
 [dev-dependencies.snarkos-node-messages]
 path = "../messages"
 features = [ "test" ]
+
+[dev-dependencies.tracing-subscriber]
+version = "0.3"
+features = [ "env-filter", "fmt" ]

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -29,6 +29,19 @@ use snarkos_node_messages::NodeType;
 use snarkos_node_router::Router;
 use snarkvm::prelude::{Block, FromBytes, Network, Testnet3 as CurrentNetwork};
 
+/// A helper macro to print the TCP listening address, along with the connected and connecting peers.
+#[macro_export]
+macro_rules! print_tcp {
+    ($node:expr) => {
+        println!(
+            "{}: Active - {:?}, Pending - {:?}",
+            $node.local_ip(),
+            $node.tcp().connected_addrs(),
+            $node.tcp().connecting_addrs()
+        );
+    };
+}
+
 /// Returns a fixed account.
 pub fn sample_account() -> Account<CurrentNetwork> {
     Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap()

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -1,0 +1,123 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+#[allow(dead_code)]
+pub mod router;
+pub use router::*;
+
+use std::{
+    env,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
+
+use snarkos_account::Account;
+use snarkos_node_messages::NodeType;
+use snarkos_node_router::Router;
+use snarkvm::prelude::{Block, FromBytes, Network, Testnet3 as CurrentNetwork};
+
+/// Returns a fixed account.
+pub fn sample_account() -> Account<CurrentNetwork> {
+    Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap()
+}
+
+/// Loads the current network's genesis block.
+pub fn sample_genesis_block<N: Network>() -> Block<N> {
+    Block::<N>::from_bytes_le(N::genesis_bytes()).unwrap()
+}
+
+/// Enables logging in tests.
+#[allow(dead_code)]
+pub fn initialize_logger(level: u8) {
+    match level {
+        0 => env::set_var("RUST_LOG", "info"),
+        1 => env::set_var("RUST_LOG", "debug"),
+        2 | 3 => env::set_var("RUST_LOG", "trace"),
+        _ => env::set_var("RUST_LOG", "info"),
+    };
+
+    // Filter out undesirable logs.
+    let filter = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive("tokio_util=off".parse().unwrap())
+        .add_directive("mio=off".parse().unwrap());
+
+    // Initialize tracing.
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).with_target(level == 3).try_init();
+}
+
+/// Initializes a beacon router. Setting the `listening_port = 0` will result in a random port being assigned.
+#[allow(dead_code)]
+pub async fn beacon(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
+    Router::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
+        NodeType::Beacon,
+        sample_account(),
+        &[],
+        max_peers,
+        true,
+    )
+    .await
+    .expect("couldn't create beacon router")
+    .into()
+}
+
+/// Initializes a client router. Setting the `listening_port = 0` will result in a random port being assigned.
+#[allow(dead_code)]
+pub async fn client(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
+    Router::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
+        NodeType::Client,
+        sample_account(),
+        &[],
+        max_peers,
+        true,
+    )
+    .await
+    .expect("couldn't create client router")
+    .into()
+}
+
+/// Initializes a prover router. Setting the `listening_port = 0` will result in a random port being assigned.
+#[allow(dead_code)]
+pub async fn prover(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
+    Router::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
+        NodeType::Prover,
+        sample_account(),
+        &[],
+        max_peers,
+        true,
+    )
+    .await
+    .expect("couldn't create prover router")
+    .into()
+}
+
+/// Initializes a validator router. Setting the `listening_port = 0` will result in a random port being assigned.
+#[allow(dead_code)]
+pub async fn validator(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
+    Router::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
+        NodeType::Validator,
+        sample_account(),
+        &[],
+        max_peers,
+        true,
+    )
+    .await
+    .expect("couldn't create validator router")
+    .into()
+}

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -1,0 +1,194 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::common::sample_genesis_block;
+use snarkos_node_messages::{
+    BlockRequest,
+    DisconnectReason,
+    Message,
+    MessageCodec,
+    Ping,
+    Pong,
+    PuzzleResponse,
+    UnconfirmedSolution,
+    UnconfirmedTransaction,
+};
+use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
+use snarkos_node_tcp::{
+    protocols::{Disconnect, Handshake, Reading, Writing},
+    Connection,
+    ConnectionSide,
+    Tcp,
+    P2P,
+};
+use snarkvm::prelude::{Block, Header, Network, ProverSolution, Transaction};
+
+use async_trait::async_trait;
+use futures_util::sink::SinkExt;
+use std::{io, net::SocketAddr};
+use tracing::*;
+
+#[derive(Clone)]
+pub struct TestRouter<N: Network>(Router<N>);
+
+impl<N: Network> From<Router<N>> for TestRouter<N> {
+    fn from(router: Router<N>) -> Self {
+        Self(router)
+    }
+}
+
+impl<N: Network> core::ops::Deref for TestRouter<N> {
+    type Target = Router<N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<N: Network> P2P for TestRouter<N> {
+    /// Returns a reference to the TCP instance.
+    fn tcp(&self) -> &Tcp {
+        self.router().tcp()
+    }
+}
+
+#[async_trait]
+impl<N: Network> Handshake for TestRouter<N> {
+    /// Performs the handshake protocol.
+    async fn perform_handshake(&self, mut connection: Connection) -> io::Result<Connection> {
+        // Perform the handshake.
+        let peer_addr = connection.addr();
+        let conn_side = connection.side();
+        let stream = self.borrow_stream(&mut connection);
+        let genesis_header = *sample_genesis_block().header();
+        let (peer_ip, mut framed) = self.router().handshake(peer_addr, stream, conn_side, genesis_header).await?;
+
+        // Send the first `Ping` message to the peer.
+        let message = Message::Ping(Ping::<N> {
+            version: Message::<N>::VERSION,
+            node_type: self.node_type(),
+            block_locators: None,
+        });
+        trace!("Sending '{}' to '{peer_ip}'", message.name());
+        framed.send(message).await?;
+
+        Ok(connection)
+    }
+}
+
+#[async_trait]
+impl<N: Network> Disconnect for TestRouter<N> {
+    /// Any extra operations to be performed during a disconnect.
+    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+        self.router().remove_connected_peer(peer_addr);
+    }
+}
+
+#[async_trait]
+impl<N: Network> Writing for TestRouter<N> {
+    type Codec = MessageCodec<N>;
+    type Message = Message<N>;
+
+    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
+    /// The `side` parameter indicates the connection side **from the node's perspective**.
+    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+        Default::default()
+    }
+}
+
+#[async_trait]
+impl<N: Network> Reading for TestRouter<N> {
+    type Codec = MessageCodec<N>;
+    type Message = Message<N>;
+
+    /// Creates a [`Decoder`] used to interpret messages from the network.
+    /// The `side` param indicates the connection side **from the node's perspective**.
+    fn codec(&self, _peer_addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+        Default::default()
+    }
+
+    /// Processes a message received from the network.
+    async fn process_message(&self, peer_ip: SocketAddr, message: Self::Message) -> io::Result<()> {
+        // Process the message. Disconnect if the peer violated the protocol.
+        if let Err(error) = self.inbound(peer_ip, message).await {
+            warn!("Disconnecting from '{peer_ip}' - {error}");
+            self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+            // Disconnect from this peer.
+            self.router().disconnect(peer_ip);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<N: Network> Routing<N> for TestRouter<N> {}
+
+impl<N: Network> Heartbeat<N> for TestRouter<N> {}
+
+impl<N: Network> Outbound<N> for TestRouter<N> {
+    /// Returns a reference to the router.
+    fn router(&self) -> &Router<N> {
+        &self.0
+    }
+}
+
+#[async_trait]
+impl<N: Network> Inbound<N> for TestRouter<N> {
+    /// Handles a `BlockRequest` message.
+    fn block_request(&self, _peer_ip: SocketAddr, _message: BlockRequest) -> bool {
+        true
+    }
+
+    /// Handles a `BlockResponse` message.
+    fn block_response(&self, _peer_ip: SocketAddr, _blocks: Vec<Block<N>>) -> bool {
+        true
+    }
+
+    /// Handles an `Pong` message.
+    fn pong(&self, _peer_ip: SocketAddr, _message: Pong) -> bool {
+        true
+    }
+
+    /// Handles an `PuzzleRequest` message.
+    fn puzzle_request(&self, _peer_ip: SocketAddr) -> bool {
+        true
+    }
+
+    /// Handles an `PuzzleResponse` message.
+    fn puzzle_response(&self, _peer_ip: SocketAddr, _serialized: PuzzleResponse<N>, _header: Header<N>) -> bool {
+        true
+    }
+
+    /// Handles an `UnconfirmedSolution` message.
+    async fn unconfirmed_solution(
+        &self,
+        _peer_ip: SocketAddr,
+        _serialized: UnconfirmedSolution<N>,
+        _solution: ProverSolution<N>,
+    ) -> bool {
+        true
+    }
+
+    /// Handles an `UnconfirmedTransaction` message.
+    fn unconfirmed_transaction(
+        &self,
+        _peer_ip: SocketAddr,
+        _serialized: UnconfirmedTransaction<N>,
+        _transaction: Transaction<N>,
+    ) -> bool {
+        true
+    }
+}

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -1,0 +1,198 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+mod common;
+use common::*;
+
+use snarkos_node_tcp::{protocols::Handshake, P2P};
+
+use core::time::Duration;
+
+macro_rules! print_tcp {
+    ($node:expr) => {
+        println!(
+            "{}: Active - {:?}, Pending - {:?}",
+            $node.local_ip(),
+            $node.tcp().connected_addrs(),
+            $node.tcp().connecting_addrs()
+        );
+    };
+}
+
+#[tokio::test]
+async fn test_connect_without_handshake() {
+    initialize_logger(3);
+
+    // Create 2 routers.
+    let node0 = validator(0, 2).await;
+    let node1 = client(0, 2).await;
+    assert_eq!(node0.number_of_connected_peers(), 0);
+    assert_eq!(node1.number_of_connected_peers(), 0);
+
+    {
+        // Connect node0 to node1.
+        node0.connect(node1.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        assert_eq!(node0.tcp().num_connected(), 1);
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 1);
+        assert_eq!(node1.tcp().num_connecting(), 0);
+    }
+    {
+        // Connect node0 from node1 again.
+        node0.connect(node1.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        assert_eq!(node0.tcp().num_connected(), 1);
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 1);
+        assert_eq!(node1.tcp().num_connecting(), 0);
+    }
+    {
+        // Connect node1 from node0.
+        node1.connect(node0.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        assert_eq!(node0.tcp().num_connected(), 2); // node0 has no way of deduping the connection.
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 2); // node1 has no way of deduping the connection.
+        assert_eq!(node1.tcp().num_connecting(), 0);
+    }
+}
+
+#[tokio::test]
+async fn test_connect_with_handshake() {
+    initialize_logger(3);
+
+    // Create 2 routers.
+    let node0 = validator(0, 2).await;
+    let node1 = client(0, 2).await;
+    assert_eq!(node0.number_of_connected_peers(), 0);
+    assert_eq!(node1.number_of_connected_peers(), 0);
+
+    // Enable handshake protocol.
+    node0.enable_handshake().await;
+    node1.enable_handshake().await;
+
+    {
+        // Connect node0 to node1.
+        node0.connect(node1.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        // Check the TCP level.
+        assert_eq!(node0.tcp().num_connected(), 1);
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 1);
+        assert_eq!(node1.tcp().num_connecting(), 0);
+
+        // Check the router level.
+        assert_eq!(node0.number_of_connected_peers(), 1);
+        assert_eq!(node1.number_of_connected_peers(), 1);
+    }
+    {
+        // Connect node0 to node1 again.
+        node0.connect(node1.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        // Check the TCP level.
+        assert_eq!(node0.tcp().num_connected(), 1);
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 1);
+        assert_eq!(node1.tcp().num_connecting(), 0);
+
+        // Check the router level.
+        assert_eq!(node0.number_of_connected_peers(), 1);
+        assert_eq!(node1.number_of_connected_peers(), 1);
+    }
+    {
+        // Connect node1 to node0.
+        node1.connect(node0.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        // Check the TCP level.
+        assert_eq!(node0.tcp().num_connected(), 1);
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 1);
+        assert_eq!(node1.tcp().num_connecting(), 0);
+
+        // Check the router level.
+        assert_eq!(node0.number_of_connected_peers(), 1);
+        assert_eq!(node1.number_of_connected_peers(), 1);
+    }
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_connect_simultaneously_with_handshake() {
+    initialize_logger(3);
+
+    // Create 2 routers.
+    let node0 = validator(0, 2).await;
+    let node1 = client(0, 2).await;
+    assert_eq!(node0.number_of_connected_peers(), 0);
+    assert_eq!(node1.number_of_connected_peers(), 0);
+
+    // Enable handshake protocol.
+    node0.enable_handshake().await;
+    node1.enable_handshake().await;
+
+    {
+        // Connect node0 to node1.
+        node0.connect(node1.local_ip());
+        // Connect node1 to node0.
+        node1.connect(node0.local_ip());
+        // Sleep briefly.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        print_tcp!(node0);
+        print_tcp!(node1);
+
+        // Check the TCP level.
+        assert_eq!(node0.tcp().num_connected(), 1);
+        assert_eq!(node0.tcp().num_connecting(), 0);
+        assert_eq!(node1.tcp().num_connected(), 1);
+        assert_eq!(node1.tcp().num_connecting(), 0);
+
+        // Check the router level.
+        assert_eq!(node0.number_of_connected_peers(), 1);
+        assert_eq!(node1.number_of_connected_peers(), 1);
+    }
+}

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -21,17 +21,6 @@ use snarkos_node_tcp::{protocols::Handshake, P2P};
 
 use core::time::Duration;
 
-macro_rules! print_tcp {
-    ($node:expr) => {
-        println!(
-            "{}: Active - {:?}, Pending - {:?}",
-            $node.local_ip(),
-            $node.tcp().connected_addrs(),
-            $node.tcp().connecting_addrs()
-        );
-    };
-}
-
 #[tokio::test]
 async fn test_connect_without_handshake() {
     initialize_logger(3);

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -21,17 +21,6 @@ use snarkos_node_tcp::{protocols::Handshake, P2P};
 
 use core::time::Duration;
 
-macro_rules! print_tcp {
-    ($node:expr) => {
-        println!(
-            "{}: Active - {:?}, Pending - {:?}",
-            $node.local_ip(),
-            $node.tcp().connected_addrs(),
-            $node.tcp().connecting_addrs()
-        );
-    };
-}
-
 #[tokio::test]
 async fn test_disconnect_without_handshake() {
     initialize_logger(3);

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -1,0 +1,116 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+mod common;
+use common::*;
+
+use snarkos_node_tcp::{protocols::Handshake, P2P};
+
+use core::time::Duration;
+
+macro_rules! print_tcp {
+    ($node:expr) => {
+        println!(
+            "{}: Active - {:?}, Pending - {:?}",
+            $node.local_ip(),
+            $node.tcp().connected_addrs(),
+            $node.tcp().connecting_addrs()
+        );
+    };
+}
+
+#[tokio::test]
+async fn test_disconnect_without_handshake() {
+    initialize_logger(3);
+
+    // Create 2 routers.
+    let node0 = validator(0, 1).await;
+    let node1 = client(0, 1).await;
+    assert_eq!(node0.number_of_connected_peers(), 0);
+    assert_eq!(node1.number_of_connected_peers(), 0);
+
+    // Connect node0 to node1.
+    node0.connect(node1.local_ip());
+    // Sleep briefly.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    print_tcp!(node0);
+    print_tcp!(node1);
+
+    assert_eq!(node0.tcp().num_connected(), 1);
+    assert_eq!(node0.tcp().num_connecting(), 0);
+    assert_eq!(node1.tcp().num_connected(), 1);
+    assert_eq!(node1.tcp().num_connecting(), 0);
+
+    // Disconnect node0 from node1.
+    node0.disconnect(node1.local_ip());
+    // Sleep briefly.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    print_tcp!(node0);
+    print_tcp!(node1);
+
+    assert_eq!(node0.tcp().num_connected(), 0);
+    assert_eq!(node0.tcp().num_connecting(), 0);
+    assert_eq!(node1.tcp().num_connected(), 1); // Router 1 has no way of knowing that Router 0 disconnected.
+    assert_eq!(node1.tcp().num_connecting(), 0);
+}
+
+#[tokio::test]
+async fn test_disconnect_with_handshake() {
+    initialize_logger(3);
+
+    // Create 2 routers.
+    let node0 = validator(0, 1).await;
+    let node1 = client(0, 1).await;
+    assert_eq!(node0.number_of_connected_peers(), 0);
+    assert_eq!(node1.number_of_connected_peers(), 0);
+
+    // Enable handshake protocol.
+    node0.enable_handshake().await;
+    node1.enable_handshake().await;
+
+    // Connect node0 to node1.
+    node0.connect(node1.local_ip());
+    // Sleep briefly.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    print_tcp!(node0);
+    print_tcp!(node1);
+
+    // Check the TCP level.
+    assert_eq!(node0.tcp().num_connected(), 1);
+    assert_eq!(node0.tcp().num_connecting(), 0);
+    assert_eq!(node1.tcp().num_connected(), 1);
+    assert_eq!(node1.tcp().num_connecting(), 0);
+
+    // Check the router level.
+    assert_eq!(node0.number_of_connected_peers(), 1);
+    assert_eq!(node1.number_of_connected_peers(), 1);
+
+    // Disconnect node0 from node1.
+    node0.disconnect(node1.local_ip());
+    // Sleep briefly.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    print_tcp!(node0);
+    print_tcp!(node1);
+
+    assert_eq!(node0.tcp().num_connected(), 0);
+    assert_eq!(node0.tcp().num_connecting(), 0);
+    assert_eq!(node1.tcp().num_connected(), 1); // Router 1 has no way of knowing that Router 0 disconnected.
+    assert_eq!(node1.tcp().num_connecting(), 0);
+}


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `Router` `connect` and `insert_restricted_peer` logic.

## Tests

This PR introduces a test framework for `Router` by implementing a `TestRouter`. Currently, only the `Handshake` and `Disconnect` capabilities are needed in testing, however the `Reading` and `Writing` traits are implemented with `Inbound`, `Outbound`, and `Heartbeat` traits as stubs to support extensibility in the future.
