### PR TITLE
Cache current_block_locators and update it when add_next_block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,6 +2617,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "snarkos-node-messages",
  "snarkvm",
  "tracing",
 ]

--- a/node/ledger/Cargo.toml
+++ b/node/ledger/Cargo.toml
@@ -50,3 +50,7 @@ workspace = true
 
 [dependencies.tracing]
 version = "0.1"
+
+[dependencies.snarkos-node-messages]
+path = "../messages"
+

--- a/node/src/helpers.rs
+++ b/node/src/helpers.rs
@@ -14,38 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_node_ledger::Ledger;
-use snarkos_node_messages::{BlockLocators, CHECKPOINT_INTERVAL, NUM_RECENTS};
-use snarkvm::prelude::{ConsensusStorage, Network};
-
-use anyhow::Result;
-use indexmap::IndexMap;
-
-/// Returns the block locators for the given ledger.
-pub fn get_block_locators<N: Network, C: ConsensusStorage<N>>(ledger: &Ledger<N, C>) -> Result<BlockLocators<N>> {
-    // Retrieve the latest height.
-    let latest_height = ledger.latest_height();
-
-    // Initialize the recents map.
-    let mut recents = IndexMap::with_capacity(NUM_RECENTS);
-
-    // Retrieve the recent block hashes.
-    for height in latest_height.saturating_sub((NUM_RECENTS - 1) as u32)..=latest_height {
-        recents.insert(height, ledger.get_hash(height)?);
-    }
-
-    // Initialize the checkpoints map.
-    let mut checkpoints = IndexMap::with_capacity((latest_height % CHECKPOINT_INTERVAL).try_into()?);
-
-    // Retrieve the checkpoint block hashes.
-    for height in (0..=latest_height).step_by(CHECKPOINT_INTERVAL as usize) {
-        checkpoints.insert(height, ledger.get_hash(height)?);
-    }
-
-    // Construct the block locators.
-    Ok(BlockLocators::new(recents, checkpoints))
-}
-
 /// A helper to log instructions to recover.
 pub fn log_clean_error(dev: Option<u16>) {
     match dev {

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -162,7 +162,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
     /// Initializes the sync pool.
     fn initialize_sync(&self) -> Result<()> {
         // Retrieve the canon locators.
-        let canon_locators = crate::helpers::get_block_locators(&self.ledger)?;
+        let canon_locators = self.ledger().latest_block_locators();
         // Insert the canon locators into the sync pool.
         self.router.sync().insert_canon_locators(canon_locators).unwrap();
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -53,17 +53,14 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Validator<N, C> {
         let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
 
         // Retrieve the block locators.
-        let block_locators = match crate::helpers::get_block_locators(&self.ledger) {
-            Ok(block_locators) => Some(block_locators),
-            Err(e) => {
-                error!("Failed to get block locators: {e}");
-                return Err(error(format!("Failed to get block locators: {e}")));
-            }
-        };
+        let block_locators = self.ledger().latest_block_locators();
 
         // Send the first `Ping` message to the peer.
-        let message =
-            Message::Ping(Ping::<N> { version: Message::<N>::VERSION, node_type: self.node_type(), block_locators });
+        let message = Message::Ping(Ping::<N> {
+            version: Message::<N>::VERSION,
+            node_type: self.node_type(),
+            block_locators: Some(block_locators),
+        });
         trace!("Sending '{}' to '{peer_ip}'", message.name());
         framed.send(message).await?;
 
@@ -172,11 +169,8 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
             // Sleep for the preset time before sending a `Ping` request.
             tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
             // Retrieve the block locators.
-            match crate::helpers::get_block_locators(&self_clone.ledger) {
-                // Send a `Ping` message to the peer.
-                Ok(block_locators) => self_clone.send_ping(peer_ip, Some(block_locators)),
-                Err(e) => error!("Failed to get block locators: {e}"),
-            }
+            let block_locators = self_clone.ledger().latest_block_locators();
+            self_clone.send_ping(peer_ip, Some(block_locators));
         });
         true
     }


### PR DESCRIPTION
## Motivation
This pr will decrease times of calling block locators when the node is stable。However get_block_locators will be callled when a add_next_block is called，and slow down the sync speed。 Maybe exist a better way to do this。




