### PR TITLE
Enforce user provides account private key to startup scripts

### DIFF
--- a/run-prover.sh
+++ b/run-prover.sh
@@ -12,7 +12,8 @@ fi
 
 if [ "${PROVER_PRIVATE_KEY}" == "" ]
 then
-  PROVER_PRIVATE_KEY="APrivateKey1zkp8cC4jgHEBnbtu3xxs1Ndja2EMizcvTRDq5Nikdkukg1p"
+  echo "Missing account private key. (run 'snarkos account new' and try again)"
+  exit
 fi
 
 COMMAND="cargo run --release -- start --nodisplay --prover ${PROVER_PRIVATE_KEY}"

--- a/run-validator.sh
+++ b/run-validator.sh
@@ -12,7 +12,8 @@ fi
 
 if [ "${VALIDATOR_PRIVATE_KEY}" == "" ]
 then
-  VALIDATOR_PRIVATE_KEY="APrivateKey1zkp8cC4jgHEBnbtu3xxs1Ndja2EMizcvTRDq5Nikdkukg1p"
+  echo "Missing account private key. (run 'snarkos account new' and try again)"
+  exit
 fi
 
 COMMAND="cargo run --release -- start --nodisplay --validator ${VALIDATOR_PRIVATE_KEY}"


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR removes the default private key from `run-prover.sh` and `run-validator.sh` and enforces that the user manually provides a private key.
