### PR TITLE
Allow the node to start listening at any given time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,15 @@ jobs:
           workspace_member: node/store
           cache_key: snarkos-node-store-cache
 
+  node-tcp:
+    docker:
+      - image: cimg/rust:1.65
+    resource_class: xlarge
+    steps:
+      - run_serial:
+          workspace_member: node/tcp
+          cache_key: snarkos-node-tcp-cache
+
   check-fmt:
     docker:
       - image: cimg/rust:1.65
@@ -315,6 +324,7 @@ workflows:
       - node-rest
       - node-router
       - node-store
+      - node-tcp
       - check-fmt
       - check-clippy
 

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -73,7 +73,7 @@ impl<N: Network> Router<N> {
         // Send a challenge request to the peer.
         let message_a = Message::<N>::ChallengeRequest(ChallengeRequest {
             version: Message::<N>::VERSION,
-            listener_port: self.local_ip.port(),
+            listener_port: self.local_ip().port(),
             node_type: self.node_type,
             address: self.address(),
             nonce: nonce_a,

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -55,8 +55,6 @@ use tokio::task::JoinHandle;
 pub struct Router<N: Network> {
     /// The TCP stack.
     tcp: Tcp,
-    /// The local IP address of the node.
-    local_ip: SocketAddr,
     /// The node type.
     node_type: NodeType,
     /// The account of the node.
@@ -102,18 +100,15 @@ impl<N: Network> Router<N> {
         is_dev: bool,
     ) -> Result<Self> {
         // Initialize the TCP stack.
-        let tcp = Tcp::new(Config::new(node_ip, max_peers)).await?;
-        // Fetch the listening IP address.
-        let local_ip = tcp.listening_addr().expect("The listening address for this node must be present");
+        let tcp = Tcp::new(Config::new(node_ip, max_peers));
         // Initialize the router.
         Ok(Self {
-            tcp,
-            local_ip,
+            tcp: tcp.clone(),
             node_type,
             account,
             cache: Default::default(),
             resolver: Default::default(),
-            sync: Sync::new(local_ip),
+            sync: Sync::new(tcp),
             trusted_peers: Arc::new(trusted_peers.iter().copied().collect()),
             connected_peers: Default::default(),
             candidate_peers: Default::default(),
@@ -153,8 +148,8 @@ impl<N: Network> Router<N> {
     }
 
     /// Returns the IP address of this node.
-    pub const fn local_ip(&self) -> SocketAddr {
-        self.local_ip
+    pub fn local_ip(&self) -> SocketAddr {
+        self.tcp.listening_addr().unwrap()
     }
 
     /// Returns `true` if the given IP is this node.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -149,7 +149,7 @@ impl<N: Network> Router<N> {
 
     /// Returns the IP address of this node.
     pub fn local_ip(&self) -> SocketAddr {
-        self.tcp.listening_addr().unwrap()
+        self.tcp.listening_addr().expect("The TCP listener is not enabled")
     }
 
     /// Returns `true` if the given IP is this node.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -103,12 +103,12 @@ impl<N: Network> Router<N> {
         let tcp = Tcp::new(Config::new(node_ip, max_peers));
         // Initialize the router.
         Ok(Self {
-            tcp: tcp.clone(),
+            tcp,
             node_type,
             account,
             cache: Default::default(),
             resolver: Default::default(),
-            sync: Sync::new(tcp),
+            sync: Default::default(),
             trusted_peers: Arc::new(trusted_peers.iter().copied().collect()),
             connected_peers: Default::default(),
             candidate_peers: Default::default(),

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -34,11 +34,17 @@ pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbo
         self.enable_writing().await;
         self.enable_disconnect().await;
         // Enable the TCP listener. Note: This must be called after the above protocols.
-        self.tcp().enable_listener().await.expect("Failed to enable the TCP listener");
+        self.enable_listener().await;
         // Initialize the heartbeat.
         self.initialize_heartbeat();
         // Initialize the report.
         self.initialize_report();
+    }
+
+    // Start listening for inbound connections.
+    async fn enable_listener(&self) {
+        let listening_addr = self.tcp().enable_listener().await.expect("Failed to enable the TCP listener");
+        self.router().sync.set_local_ip(listening_addr);
     }
 
     /// Initialize a new instance of the heartbeat.

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -33,8 +33,8 @@ pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbo
         self.enable_reading().await;
         self.enable_writing().await;
         self.enable_disconnect().await;
-        // Start the listener.
-        self.tcp().enable_listener().await.unwrap();
+        // Enable the TCP listener. Note: This must be called after the above protocols.
+        self.tcp().enable_listener().await.expect("Failed to enable the TCP listener");
         // Initialize the heartbeat.
         self.initialize_heartbeat();
         // Initialize the report.

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -33,6 +33,8 @@ pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbo
         self.enable_reading().await;
         self.enable_writing().await;
         self.enable_disconnect().await;
+        // Start the listener.
+        self.tcp().enable_listener().await.unwrap();
         // Initialize the heartbeat.
         self.initialize_heartbeat();
         // Initialize the report.

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -31,6 +31,10 @@ async fn test_connect_without_handshake() {
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 
+    // Start listening.
+    node0.tcp().enable_listener().await.unwrap();
+    node1.tcp().enable_listener().await.unwrap();
+
     {
         // Connect node0 to node1.
         node0.connect(node1.local_ip());
@@ -88,6 +92,10 @@ async fn test_connect_with_handshake() {
     // Enable handshake protocol.
     node0.enable_handshake().await;
     node1.enable_handshake().await;
+
+    // Start listening.
+    node0.tcp().enable_listener().await.unwrap();
+    node1.tcp().enable_listener().await.unwrap();
 
     {
         // Connect node0 to node1.

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -31,6 +31,10 @@ async fn test_disconnect_without_handshake() {
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 
+    // Start listening.
+    node0.tcp().enable_listener().await.unwrap();
+    node1.tcp().enable_listener().await.unwrap();
+
     // Connect node0 to node1.
     node0.connect(node1.local_ip());
     // Sleep briefly.
@@ -71,6 +75,10 @@ async fn test_disconnect_with_handshake() {
     // Enable handshake protocol.
     node0.enable_handshake().await;
     node1.enable_handshake().await;
+
+    // Start listening.
+    node0.tcp().enable_listener().await.unwrap();
+    node1.tcp().enable_listener().await.unwrap();
 
     // Connect node0 to node1.
     node0.connect(node1.local_ip());

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -278,6 +278,45 @@ impl Tcp {
 }
 
 impl Tcp {
+    /// Spawns a task that listens for incoming connections.
+    pub async fn enable_listener(&self) -> io::Result<SocketAddr> {
+        // Retrieve the listening IP address, which must be set.
+        let listener_ip =
+            self.config().listener_ip.expect("Tcp::enable_listener was called, but Config::listener_ip is not set");
+
+        // Initialize the TCP listener.
+        let listener = self.create_listener(listener_ip).await?;
+
+        // Discover the port, if it was unspecified.
+        let port = listener.local_addr()?.port();
+
+        // Set the listening IP address.
+        let listening_addr = (listener_ip, port).into();
+        self.listening_addr.set(listening_addr).expect("The node's listener was started more than once");
+
+        // Use a channel to know when the listening task is ready.
+        let (tx, rx) = oneshot::channel();
+
+        let tcp = self.clone();
+        let listening_task = tokio::spawn(async move {
+            trace!(parent: tcp.span(), "Spawned the listening task");
+            tx.send(()).unwrap(); // safe; the channel was just opened
+
+            loop {
+                // Await for a new connection.
+                match listener.accept().await {
+                    Ok((stream, addr)) => tcp.handle_connection(stream, addr),
+                    Err(e) => error!(parent: tcp.span(), "Failed to accept a connection: {e}"),
+                }
+            }
+        });
+        self.tasks.lock().push(listening_task);
+        let _ = rx.await;
+        debug!(parent: self.span(), "Listening on {}", listening_addr);
+
+        Ok(listening_addr)
+    }
+
     /// Creates an instance of `TcpListener` based on the node's configuration.
     async fn create_listener(&self, listener_ip: IpAddr) -> io::Result<TcpListener> {
         let listener = if let Some(port) = self.config().desired_listening_port {
@@ -308,40 +347,6 @@ impl Tcp {
         };
 
         Ok(listener)
-    }
-
-    /// Spawns a task that listens for incoming connections.
-    pub async fn enable_listener(&self) -> io::Result<SocketAddr> {
-        let listener_ip =
-            self.config().listener_ip.expect("Tcp::enable_listener was called, but Config::listener_ip is not set");
-        let listener = self.create_listener(listener_ip).await?;
-        // Discover the port if it was unspecified.
-        let port = listener.local_addr()?.port();
-        let listening_addr = (listener_ip, port).into();
-
-        self.listening_addr.set(listening_addr).expect("The node's listener was started more than once");
-
-        // Use a channel to know when the listening task is ready.
-        let (tx, rx) = oneshot::channel();
-
-        let tcp = self.clone();
-        let listening_task = tokio::spawn(async move {
-            trace!(parent: tcp.span(), "Spawned the listening task");
-            tx.send(()).unwrap(); // safe; the channel was just opened
-
-            loop {
-                // Await for a new connection.
-                match listener.accept().await {
-                    Ok((stream, addr)) => tcp.handle_connection(stream, addr),
-                    Err(e) => error!(parent: tcp.span(), "Failed to accept a connection: {e}"),
-                }
-            }
-        });
-        self.tasks.lock().push(listening_task);
-        let _ = rx.await;
-        debug!(parent: self.span(), "Listening on {}", listening_addr);
-
-        Ok(listening_addr)
     }
 
     /// Handles a new inbound connection.

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -16,8 +16,9 @@
 
 use std::{
     collections::HashSet,
+    fmt,
     io,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     ops::Deref,
     sync::{
         atomic::{AtomicUsize, Ordering::*},
@@ -25,6 +26,7 @@ use std::{
     },
 };
 
+use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tokio::{
     io::split,
@@ -64,7 +66,7 @@ pub struct InnerTcp {
     /// The node's configuration.
     config: Config,
     /// The node's listening address.
-    listening_addr: Option<SocketAddr>,
+    listening_addr: OnceCell<SocketAddr>,
     /// Contains objects used by the protocols implemented by the node.
     pub(crate) protocols: Protocols,
     /// A list of connections that have not been finalized yet.
@@ -81,7 +83,7 @@ pub struct InnerTcp {
 
 impl Tcp {
     /// Creates a new [`Tcp`] using the given [`Config`].
-    pub async fn new(mut config: Config) -> io::Result<Self> {
+    pub fn new(mut config: Config) -> Self {
         // If there is no pre-configured name, assign a sequential numeric identifier.
         if config.name.is_none() {
             config.name = Some(SEQUENTIAL_NODE_ID.fetch_add(1, SeqCst).to_string());
@@ -90,51 +92,11 @@ impl Tcp {
         // Create a tracing span containing the node's name.
         let span = crate::helpers::create_span(config.name.as_deref().unwrap());
 
-        // Procure a listening IP address, if the configuration is set.
-        let listener = if let Some(listener_ip) = config.listener_ip {
-            let listener = if let Some(port) = config.desired_listening_port {
-                // Construct the desired listening IP address.
-                let desired_listening_addr = SocketAddr::new(listener_ip, port);
-                // If a desired listening port is set, try to bind to it.
-                match TcpListener::bind(desired_listening_addr).await {
-                    Ok(listener) => listener,
-                    Err(e) => {
-                        if config.allow_random_port {
-                            warn!(parent: &span, "Trying any listening port, as the desired port is unavailable: {e}");
-                            let random_available_addr = SocketAddr::new(listener_ip, 0);
-                            TcpListener::bind(random_available_addr).await?
-                        } else {
-                            error!(parent: &span, "The desired listening port is unavailable: {e}");
-                            return Err(e);
-                        }
-                    }
-                }
-            } else if config.allow_random_port {
-                let random_available_addr = SocketAddr::new(listener_ip, 0);
-                TcpListener::bind(random_available_addr).await?
-            } else {
-                panic!("As 'listener_ip' is set, either 'desired_listening_port' or 'allow_random_port' must be set")
-            };
-
-            Some(listener)
-        } else {
-            None
-        };
-
-        // If a listener is set, get the listening IP address.
-        let listening_addr = if let Some(ref listener) = listener {
-            let ip = config.listener_ip.unwrap(); // safe; listener.is_some() => config.listener_ip.is_some()
-            let port = listener.local_addr()?.port(); // discover the port if it was unspecified
-            Some((ip, port).into())
-        } else {
-            None
-        };
-
         // Initialize the Tcp stack.
         let tcp = Tcp(Arc::new(InnerTcp {
             span,
             config,
-            listening_addr,
+            listening_addr: Default::default(),
             protocols: Default::default(),
             connecting: Default::default(),
             connections: Default::default(),
@@ -143,15 +105,9 @@ impl Tcp {
             tasks: Default::default(),
         }));
 
-        // If a listener is set, start listening for incoming connections.
-        if let Some(listener) = listener {
-            // Spawn a task that listens for incoming connections.
-            tcp.enable_listener(listener).await;
-        }
-
         debug!(parent: tcp.span(), "The node is ready");
 
-        Ok(tcp)
+        tcp
     }
 
     /// Returns the name assigned.
@@ -170,7 +126,7 @@ impl Tcp {
     /// Returns the listening address; returns an error if Tcp was not configured
     /// to listen for inbound connections.
     pub fn listening_addr(&self) -> io::Result<SocketAddr> {
-        self.listening_addr.ok_or_else(|| io::ErrorKind::AddrNotAvailable.into())
+        self.listening_addr.get().copied().ok_or_else(|| io::ErrorKind::AddrNotAvailable.into())
     }
 
     /// Checks whether the provided address is connected.
@@ -322,8 +278,49 @@ impl Tcp {
 }
 
 impl Tcp {
+    /// Creates an instance of `TcpListener` based on the node's configuration.
+    async fn create_listener(&self, listener_ip: IpAddr) -> io::Result<TcpListener> {
+        let listener = if let Some(port) = self.config().desired_listening_port {
+            // Construct the desired listening IP address.
+            let desired_listening_addr = SocketAddr::new(listener_ip, port);
+            // If a desired listening port is set, try to bind to it.
+            match TcpListener::bind(desired_listening_addr).await {
+                Ok(listener) => listener,
+                Err(e) => {
+                    if self.config().allow_random_port {
+                        warn!(
+                            parent: self.span(),
+                            "Trying any listening port, as the desired port is unavailable: {e}"
+                        );
+                        let random_available_addr = SocketAddr::new(listener_ip, 0);
+                        TcpListener::bind(random_available_addr).await?
+                    } else {
+                        error!(parent: self.span(), "The desired listening port is unavailable: {e}");
+                        return Err(e);
+                    }
+                }
+            }
+        } else if self.config().allow_random_port {
+            let random_available_addr = SocketAddr::new(listener_ip, 0);
+            TcpListener::bind(random_available_addr).await?
+        } else {
+            panic!("As 'listener_ip' is set, either 'desired_listening_port' or 'allow_random_port' must be set");
+        };
+
+        Ok(listener)
+    }
+
     /// Spawns a task that listens for incoming connections.
-    async fn enable_listener(&self, listener: TcpListener) {
+    pub async fn enable_listener(&self) -> io::Result<SocketAddr> {
+        let listener_ip =
+            self.config().listener_ip.expect("Tcp::enable_listener was called, but Config::listener_ip is not set");
+        let listener = self.create_listener(listener_ip).await?;
+        // Discover the port if it was unspecified.
+        let port = listener.local_addr()?.port();
+        let listening_addr = (listener_ip, port).into();
+
+        self.listening_addr.set(listening_addr).expect("The node's listener was started more than once");
+
         // Use a channel to know when the listening task is ready.
         let (tx, rx) = oneshot::channel();
 
@@ -342,7 +339,9 @@ impl Tcp {
         });
         self.tasks.lock().push(listening_task);
         let _ = rx.await;
-        debug!(parent: self.span(), "Listening on {}", self.listening_addr.unwrap());
+        debug!(parent: self.span(), "Listening on {}", listening_addr);
+
+        Ok(listening_addr)
     }
 
     /// Handles a new inbound connection.
@@ -470,6 +469,12 @@ impl Tcp {
     }
 }
 
+impl fmt::Debug for Tcp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "The TCP stack")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -482,13 +487,11 @@ mod tests {
             listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             max_connections: 200,
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        });
 
         assert_eq!(tcp.config.max_connections, 200);
         assert_eq!(tcp.config.listener_ip, Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));
-        assert_eq!(tcp.listening_addr().unwrap().ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(tcp.enable_listener().await.unwrap().ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
 
         assert_eq!(tcp.num_connected(), 0);
         assert_eq!(tcp.num_connecting(), 0);
@@ -496,8 +499,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect() {
-        let tcp = Tcp::new(Config::default()).await.unwrap();
-        let node_ip = tcp.listening_addr().unwrap();
+        let tcp = Tcp::new(Config::default());
+        let node_ip = tcp.enable_listener().await.unwrap();
 
         // Ensure self-connecting is not possible.
         tcp.connect(node_ip).await.unwrap_err();
@@ -512,10 +515,8 @@ mod tests {
             desired_listening_port: Some(0),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
-        let peer_ip = peer.listening_addr().unwrap();
+        });
+        let peer_ip = peer.enable_listener().await.unwrap();
 
         // Connect to the peer.
         tcp.connect(peer_ip).await.unwrap();
@@ -527,8 +528,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_disconnect() {
-        let tcp = Tcp::new(Config::default()).await.unwrap();
-        let _node_ip = tcp.listening_addr().unwrap();
+        let tcp = Tcp::new(Config::default());
+        let _node_ip = tcp.enable_listener().await.unwrap();
 
         // Initialize the peer.
         let peer = Tcp::new(Config {
@@ -536,10 +537,8 @@ mod tests {
             desired_listening_port: Some(0),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
-        let peer_ip = peer.listening_addr().unwrap();
+        });
+        let peer_ip = peer.enable_listener().await.unwrap();
 
         // Connect to the peer.
         tcp.connect(peer_ip).await.unwrap();
@@ -565,7 +564,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_can_add_connection() {
-        let tcp = Tcp::new(Config { max_connections: 1, ..Default::default() }).await.unwrap();
+        let tcp = Tcp::new(Config { max_connections: 1, ..Default::default() });
 
         // Initialize the peer.
         let peer = Tcp::new(Config {
@@ -573,10 +572,8 @@ mod tests {
             desired_listening_port: Some(0),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
-        let peer_ip = peer.listening_addr().unwrap();
+        });
+        let peer_ip = peer.enable_listener().await.unwrap();
 
         assert!(tcp.can_add_connection());
 
@@ -615,9 +612,7 @@ mod tests {
             listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
+        });
 
         // Initialize peer 1.
         let peer1 = Tcp::new(Config {
@@ -625,10 +620,8 @@ mod tests {
             desired_listening_port: Some(0),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
-        let peer1_ip = peer1.listening_addr().unwrap();
+        });
+        let peer1_ip = peer1.enable_listener().await.unwrap();
 
         // Simulate an active connection.
         let stream = TcpStream::connect(peer1_ip).await.unwrap();
@@ -645,10 +638,8 @@ mod tests {
             desired_listening_port: Some(0),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
-        let peer2_ip = peer2.listening_addr().unwrap();
+        });
+        let peer2_ip = peer2.enable_listener().await.unwrap();
 
         // Handle the connection.
         let stream = TcpStream::connect(peer2_ip).await.unwrap();
@@ -664,7 +655,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_adapt_stream() {
-        let tcp = Tcp::new(Config { max_connections: 1, ..Default::default() }).await.unwrap();
+        let tcp = Tcp::new(Config { max_connections: 1, ..Default::default() });
 
         // Initialize the peer.
         let peer = Tcp::new(Config {
@@ -672,10 +663,8 @@ mod tests {
             desired_listening_port: Some(0),
             max_connections: 1,
             ..Default::default()
-        })
-        .await
-        .unwrap();
-        let peer_ip = peer.listening_addr().unwrap();
+        });
+        let peer_ip = peer.enable_listener().await.unwrap();
 
         // Simulate a pending connection.
         tcp.connecting.lock().insert(peer_ip);

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -312,7 +312,7 @@ impl Tcp {
         });
         self.tasks.lock().push(listening_task);
         let _ = rx.await;
-        debug!(parent: self.span(), "Listening on {}", listening_addr);
+        debug!(parent: self.span(), "Listening on {listening_addr}");
 
         Ok(listening_addr)
     }


### PR DESCRIPTION
This PR allows the node to begin listening for connection requests at a specified point in time (rather than at the point of creation of `Tcp`), allowing it to have greater control over its startup. This also allows `Tcp::new` to no longer be `async` or fallible.

`Router::initialize_routing` was chosen as the point where the node starts listening; more specifically, this now happens right after all the TCP protocols are enabled.

In order to reflect the fact that listening can start at any point in time, some objects that used to be able to rely on a predefined listening address now need to instead rely on `Tcp` (which can be cloned around freely).