### PR TITLE
Guard against "two-way" connections

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -52,12 +52,23 @@ impl<N: Network> Router<N> {
         peer_side: ConnectionSide,
         genesis_header: Header<N>,
     ) -> io::Result<(SocketAddr, Framed<&mut TcpStream, MessageCodec<N>>)> {
-        // Construct the stream.
-        let mut framed = Framed::new(stream, MessageCodec::<N>::default());
-
         if peer_side == ConnectionSide::Initiator {
             debug!("Received a connection request from '{peer_addr}'");
         }
+
+        self.handshake_inner(peer_addr, stream, peer_side, genesis_header).await
+    }
+
+    /// A helper that facilitates some extra error handling in `Router::handshake`.
+    async fn handshake_inner<'a>(
+        &'a self,
+        peer_addr: SocketAddr,
+        stream: &'a mut TcpStream,
+        peer_side: ConnectionSide,
+        genesis_header: Header<N>,
+    ) -> io::Result<(SocketAddr, Framed<&mut TcpStream, MessageCodec<N>>)> {
+        // Construct the stream.
+        let mut framed = Framed::new(stream, MessageCodec::<N>::default());
 
         /* Step 1: Send the challenge request. */
 

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -53,13 +53,10 @@ impl<N: Network> Router<N> {
         genesis_header: Header<N>,
     ) -> io::Result<(SocketAddr, Framed<&mut TcpStream, MessageCodec<N>>)> {
         // If this is an inbound connection, we log it, but don't know the listening address yet.
-        // Otherwise, we can immediately register the listening address and check for its uniqueness.
+        // Otherwise, we can immediately register the listening address.
         let mut peer_ip = if peer_side == ConnectionSide::Initiator {
             debug!("Received a connection request from '{peer_addr}'");
             None
-        } else if !self.connecting_peers.lock().insert(peer_addr) {
-            warn!("Already accepting a connection from '{peer_addr}', rejecting the duplicate handshake attempt");
-            return Err(io::ErrorKind::ConnectionRefused.into());
         } else {
             Some(peer_addr)
         };
@@ -197,10 +194,6 @@ impl<N: Network> Router<N> {
         // Ensure the peer IP is not this node.
         if self.is_local_ip(&peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (attempted to self-connect)")
-        }
-        // Ensure the node does not surpass the maximum number of peer connections.
-        if self.number_of_connected_peers() >= self.max_connected_peers() {
-            bail!("Dropping connection request from '{peer_ip}' (maximum peers reached)")
         }
         // Ensure the node is not already connecting to this peer.
         if !self.connecting_peers.lock().insert(peer_ip) {

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -55,10 +55,6 @@ impl<N: Network> Router<N> {
         // Construct the stream.
         let mut framed = Framed::new(stream, MessageCodec::<N>::default());
 
-        // Ensure the peer is allowed to connect.
-        if let Err(forbidden_message) = self.ensure_peer_is_allowed(peer_addr) {
-            return Err(error(format!("{forbidden_message}")));
-        }
         if peer_side == ConnectionSide::Initiator {
             debug!("Received a connection request from '{peer_addr}'");
         }
@@ -93,6 +89,21 @@ impl<N: Network> Router<N> {
             _ => return Err(error(format!("'{peer_addr}' did not send a challenge request"))),
         };
         trace!("Received '{}-B' from '{peer_addr}'", request_b.name());
+
+        // Obtain the peer's listening address if it's an inbound connection.
+        let peer_ip = match peer_side {
+            // The peer initiated the connection.
+            ConnectionSide::Initiator => SocketAddr::new(peer_addr.ip(), request_b.listener_port),
+            // This node initiated the connection.
+            ConnectionSide::Responder => peer_addr,
+        };
+
+        // Knowing the peer's listening address, ensure it is allowed to connect.
+        if peer_side == ConnectionSide::Initiator {
+            if let Err(forbidden_message) = self.ensure_peer_is_allowed(peer_ip) {
+                return Err(error(format!("{forbidden_message}")));
+            }
+        }
 
         // Verify the challenge request. If a disconnect reason was returned, send the disconnect message and abort.
         if let Some(reason) = self.verify_challenge_request(peer_addr, &request_b) {
@@ -140,12 +151,6 @@ impl<N: Network> Router<N> {
         /* Step 5: Add the peer to the router. */
 
         // Prepare the peer.
-        let peer_ip = match peer_side {
-            // The peer initiated the connection.
-            ConnectionSide::Initiator => SocketAddr::new(peer_addr.ip(), request_b.listener_port),
-            // This node initiated the connection.
-            ConnectionSide::Responder => peer_addr,
-        };
         let peer_address = request_b.address;
         let peer_type = request_b.node_type;
         let peer_version = request_b.version;

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -48,7 +48,7 @@ use anyhow::{bail, Result};
 use core::str::FromStr;
 use indexmap::{IndexMap, IndexSet};
 use parking_lot::{Mutex, RwLock};
-use std::{collections::HashSet, future::Future, net::SocketAddr, sync::Arc, time::Instant};
+use std::{collections::HashSet, future::Future, net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
 use tokio::task::JoinHandle;
 
 #[derive(Clone)]
@@ -83,7 +83,7 @@ pub struct InnerRouter<N: Network> {
     /// and prevents duplicate outbound connection attempts to the same IP address, it is unable to
     /// prevent simultaneous "two-way" connections between two peers (i.e. both nodes simultaneously
     /// attempt to connect to each other). This set is used to prevent this from happening.
-    connecting_peers: Arc<Mutex<HashSet<SocketAddr>>>,
+    connecting_peers: Mutex<HashSet<SocketAddr>>,
     /// The set of candidate peer IPs.
     candidate_peers: RwLock<IndexSet<SocketAddr>>,
     /// The set of restricted peer IPs.
@@ -124,7 +124,6 @@ impl<N: Network> Router<N> {
             cache: Default::default(),
             resolver: Default::default(),
             sync: Default::default(),
-            connecting_peers: Default::default(),
             trusted_peers: trusted_peers.iter().copied().collect(),
             connected_peers: Default::default(),
             connecting_peers: Default::default(),

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -75,17 +75,15 @@ pub struct InnerRouter<N: Network> {
     resolver: Resolver,
     /// The sync pool.
     sync: Sync<N>,
-    /// The set of peers that the node is currently performing a handshake with. While
-    /// Tcp already recognizes the notion of connecting addresses and will deny duplicate
-    /// attempts to connect to outbound ones, that collection has no way of knowing the listening
-    /// addresses of peers connecting to us, which is only known during the handshake. The only
-    /// purpose of this collection is to avoid undesirable, simultaneous "two-way" connections
-    /// with a single peer.
-    connecting_peers: Arc<Mutex<HashSet<SocketAddr>>>,
     /// The set of trusted peers.
     trusted_peers: IndexSet<SocketAddr>,
     /// The map of connected peer IPs to their peer handlers.
     connected_peers: RwLock<IndexMap<SocketAddr, Peer<N>>>,
+    /// The set of handshaking peers. While `Tcp` already recognizes the connecting IP addresses
+    /// and prevents duplicate outbound connection attempts to the same IP address, it is unable to
+    /// prevent simultaneous "two-way" connections between two peers (i.e. both nodes simultaneously
+    /// attempt to connect to each other). This set is used to prevent this from happening.
+    connecting_peers: Arc<Mutex<HashSet<SocketAddr>>>,
     /// The set of candidate peer IPs.
     candidate_peers: RwLock<IndexSet<SocketAddr>>,
     /// The set of restricted peer IPs.
@@ -129,6 +127,7 @@ impl<N: Network> Router<N> {
             connecting_peers: Default::default(),
             trusted_peers: trusted_peers.iter().copied().collect(),
             connected_peers: Default::default(),
+            connecting_peers: Default::default(),
             candidate_peers: Default::default(),
             restricted_peers: Default::default(),
             handles: Default::default(),
@@ -214,11 +213,6 @@ impl<N: Network> Router<N> {
         self.resolver.get_ambiguous(peer_ip)
     }
 
-    /// Returns `true` if the node is currently connecting to the given peer IP.
-    pub fn is_connecting(&self, ip: &SocketAddr) -> bool {
-        self.connecting_peers.lock().contains(ip)
-    }
-
     /// Returns `true` if the node is connected to the given peer IP.
     pub fn is_connected(&self, ip: &SocketAddr) -> bool {
         self.connected_peers.read().contains_key(ip)
@@ -242,6 +236,11 @@ impl<N: Network> Router<N> {
     /// Returns `true` if the given peer IP is a connected client.
     pub fn is_connected_client(&self, peer_ip: &SocketAddr) -> bool {
         self.connected_peers.read().get(peer_ip).map_or(false, |peer| peer.is_client())
+    }
+
+    /// Returns `true` if the node is currently connecting to the given peer IP.
+    pub fn is_connecting(&self, ip: &SocketAddr) -> bool {
+        self.connecting_peers.lock().contains(ip)
     }
 
     /// Returns `true` if the given IP is restricted.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -47,8 +47,8 @@ use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 use anyhow::{bail, Result};
 use core::str::FromStr;
 use indexmap::{IndexMap, IndexSet};
-use parking_lot::RwLock;
-use std::{future::Future, net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
+use parking_lot::{Mutex, RwLock};
+use std::{collections::HashSet, future::Future, net::SocketAddr, sync::Arc, time::Instant};
 use tokio::task::JoinHandle;
 
 #[derive(Clone)]
@@ -75,6 +75,13 @@ pub struct InnerRouter<N: Network> {
     resolver: Resolver,
     /// The sync pool.
     sync: Sync<N>,
+    /// The set of peers that the node is currently performing a handshake with. While
+    /// Tcp already recognizes the notion of connecting addresses and will deny duplicate
+    /// attempts to connect to outbound ones, that collection has no way of knowing the listening
+    /// addresses of peers connecting to us, which is only known during the handshake. The only
+    /// purpose of this collection is to avoid undesirable, simultaneous "two-way" connections
+    /// with a single peer.
+    connecting_peers: Arc<Mutex<HashSet<SocketAddr>>>,
     /// The set of trusted peers.
     trusted_peers: IndexSet<SocketAddr>,
     /// The map of connected peer IPs to their peer handlers.
@@ -119,6 +126,7 @@ impl<N: Network> Router<N> {
             cache: Default::default(),
             resolver: Default::default(),
             sync: Default::default(),
+            connecting_peers: Default::default(),
             trusted_peers: trusted_peers.iter().copied().collect(),
             connected_peers: Default::default(),
             candidate_peers: Default::default(),
@@ -204,6 +212,11 @@ impl<N: Network> Router<N> {
     /// Returns the (ambiguous) peer address from the listener IP address.
     pub fn resolve_to_ambiguous(&self, peer_ip: &SocketAddr) -> Option<SocketAddr> {
         self.resolver.get_ambiguous(peer_ip)
+    }
+
+    /// Returns `true` if the node is currently connecting to the given peer IP.
+    pub fn is_connecting(&self, ip: &SocketAddr) -> bool {
+        self.connecting_peers.lock().contains(ip)
     }
 
     /// Returns `true` if the node is connected to the given peer IP.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -136,6 +136,12 @@ impl<N: Network> Router<N> {
 
     /// Attempts to connect to the given peer IP.
     pub fn connect(&self, peer_ip: SocketAddr) {
+        // Return early if the attempt is against the protocol rules.
+        if let Err(forbidden_message) = self.check_connection_attempt(peer_ip) {
+            warn!("{forbidden_message}");
+            return;
+        }
+
         let router = self.clone();
         self.spawn(async move {
             // Attempt to connect to the candidate peer.
@@ -147,6 +153,31 @@ impl<N: Network> Router<N> {
                 Err(error) => warn!("Unable to connect to '{peer_ip}' - {error}"),
             }
         });
+    }
+
+    /// Ensure we are allowed to connect to the given peer.
+    fn check_connection_attempt(&self, peer_ip: SocketAddr) -> Result<()> {
+        // Ensure the peer IP is not this node.
+        if self.is_local_ip(&peer_ip) {
+            bail!("Dropping connection attempt to '{peer_ip}' (attempted to self-connect)")
+        }
+        // Ensure the node does not surpass the maximum number of peer connections.
+        if self.number_of_connected_peers() >= self.max_connected_peers() {
+            bail!("Dropping connection attempt to '{peer_ip}' (maximum peers reached)")
+        }
+        // Ensure the node is not already connecting to this peer.
+        if !self.connecting_peers.lock().insert(peer_ip) {
+            bail!("Dropping connection attempt to '{peer_ip}' (already shaking hands as the initiator)")
+        }
+        // Ensure the node is not already connected to this peer.
+        if self.is_connected(&peer_ip) {
+            bail!("Dropping connection attempt to '{peer_ip}' (already connected)")
+        }
+        // Ensure the peer is not restricted.
+        if self.is_restricted(&peer_ip) {
+            bail!("Dropping connection attempt to '{peer_ip}' (restricted)")
+        }
+        Ok(())
     }
 
     /// Disconnects from the given peer IP, if the peer is connected.


### PR DESCRIPTION
In some rare cases, two nodes can attempt to connect to one another at almost the exact same time, which can result in an undesirable "two-way" connection. This PR introduces additional safeguards to avoid this.