### PR TITLE
Resolve the addresses for the purposes of handle_disconnect

### DIFF
--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -74,7 +74,9 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Beacon<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Beacon<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
-        self.router.remove_connected_peer(peer_addr);
+        if let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) {
+            self.router.remove_connected_peer(peer_ip);
+        }
     }
 }
 

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -59,7 +59,9 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Client<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Client<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
-        self.router.remove_connected_peer(peer_addr);
+        if let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) {
+            self.router.remove_connected_peer(peer_ip);
+        }
     }
 }
 

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -66,7 +66,9 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Prover<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Prover<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
-        self.router.remove_connected_peer(peer_addr);
+        if let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) {
+            self.router.remove_connected_peer(peer_ip);
+        }
     }
 }
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -75,7 +75,9 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Validator<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Validator<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
-        self.router.remove_connected_peer(peer_addr);
+        if let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) {
+            self.router.remove_connected_peer(peer_ip);
+        }
     }
 }
 


### PR DESCRIPTION
This is a simple bugfix: the address provided in `Disconnect::handle_disconnect` is always the _true_ connected address, so it potentially (i.e. in case of inbound connections) needs to be resolved to the listener address which is used for all the higher-level peer-related accounting.