### PR TITLE
Reduce Arcing

### DIFF
--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -24,10 +24,7 @@ use parking_lot::RwLock;
 use std::{
     collections::VecDeque,
     net::{IpAddr, SocketAddr},
-    sync::{
-        atomic::{AtomicU16, Ordering::SeqCst},
-        Arc,
-    },
+    sync::atomic::{AtomicU16, Ordering::SeqCst},
 };
 use time::{Duration, OffsetDateTime};
 
@@ -39,26 +36,26 @@ type SolutionKey<N> = (SocketAddr, PuzzleCommitment<N>);
 /// A helper containing the peer IP and transaction ID.
 type TransactionKey<N> = (SocketAddr, <N as Network>::TransactionID);
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Cache<N: Network> {
     /// The map of peer connections to their recent timestamps.
-    seen_inbound_connections: Arc<RwLock<IndexMap<IpAddr, VecDeque<OffsetDateTime>>>>,
+    seen_inbound_connections: RwLock<IndexMap<IpAddr, VecDeque<OffsetDateTime>>>,
     /// The map of peer IPs to their recent timestamps.
-    seen_inbound_messages: Arc<RwLock<IndexMap<SocketAddr, VecDeque<OffsetDateTime>>>>,
+    seen_inbound_messages: RwLock<IndexMap<SocketAddr, VecDeque<OffsetDateTime>>>,
     /// The map of peer IPs to their recent timestamps.
-    seen_inbound_puzzle_requests: Arc<RwLock<IndexMap<SocketAddr, VecDeque<OffsetDateTime>>>>,
+    seen_inbound_puzzle_requests: RwLock<IndexMap<SocketAddr, VecDeque<OffsetDateTime>>>,
     /// The map of solution commitments to their last seen timestamp.
-    seen_inbound_solutions: Arc<RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>>,
+    seen_inbound_solutions: RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>,
     /// The map of transaction IDs to their last seen timestamp.
-    seen_inbound_transactions: Arc<RwLock<LinkedHashMap<TransactionKey<N>, OffsetDateTime>>>,
+    seen_inbound_transactions: RwLock<LinkedHashMap<TransactionKey<N>, OffsetDateTime>>,
     /// The map of peer IPs to their block requests.
-    seen_outbound_block_requests: Arc<RwLock<IndexMap<SocketAddr, IndexSet<BlockRequest>>>>,
+    seen_outbound_block_requests: RwLock<IndexMap<SocketAddr, IndexSet<BlockRequest>>>,
     /// The map of peer IPs to the number of puzzle requests.
-    seen_outbound_puzzle_requests: Arc<RwLock<IndexMap<SocketAddr, Arc<AtomicU16>>>>,
+    seen_outbound_puzzle_requests: RwLock<IndexMap<SocketAddr, AtomicU16>>,
     /// The map of solution commitments to their last seen timestamp.
-    seen_outbound_solutions: Arc<RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>>,
+    seen_outbound_solutions: RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>,
     /// The map of transaction IDs to their last seen timestamp.
-    seen_outbound_transactions: Arc<RwLock<LinkedHashMap<TransactionKey<N>, OffsetDateTime>>>,
+    seen_outbound_transactions: RwLock<LinkedHashMap<TransactionKey<N>, OffsetDateTime>>,
 }
 
 impl<N: Network> Default for Cache<N> {
@@ -75,12 +72,12 @@ impl<N: Network> Cache<N> {
             seen_inbound_connections: Default::default(),
             seen_inbound_messages: Default::default(),
             seen_inbound_puzzle_requests: Default::default(),
-            seen_inbound_solutions: Arc::new(RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE))),
-            seen_inbound_transactions: Arc::new(RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE))),
+            seen_inbound_solutions: RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE)),
+            seen_inbound_transactions: RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE)),
             seen_outbound_block_requests: Default::default(),
             seen_outbound_puzzle_requests: Default::default(),
-            seen_outbound_solutions: Arc::new(RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE))),
-            seen_outbound_transactions: Arc::new(RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE))),
+            seen_outbound_solutions: RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE)),
+            seen_outbound_transactions: RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE)),
         }
     }
 }
@@ -179,7 +176,7 @@ impl<N: Network> Cache<N> {
 impl<N: Network> Cache<N> {
     /// Insert a new timestamp for the given key, returning the number of recent entries.
     fn retain_and_insert<K: Eq + Hash + Clone>(
-        map: &Arc<RwLock<IndexMap<K, VecDeque<OffsetDateTime>>>>,
+        map: &RwLock<IndexMap<K, VecDeque<OffsetDateTime>>>,
         key: K,
         interval_in_secs: i64,
     ) -> usize {
@@ -199,7 +196,7 @@ impl<N: Network> Cache<N> {
     }
 
     /// Increments the key's counter in the map, returning the updated counter.
-    fn increment_counter<K: Hash + Eq>(map: &Arc<RwLock<IndexMap<K, Arc<AtomicU16>>>>, key: K) -> u16 {
+    fn increment_counter<K: Hash + Eq>(map: &RwLock<IndexMap<K, AtomicU16>>, key: K) -> u16 {
         // Load the entry for the key, and increment the counter.
         let previous_entry = map.write().entry(key).or_default().fetch_add(1, SeqCst);
         // Return the updated counter.
@@ -207,7 +204,7 @@ impl<N: Network> Cache<N> {
     }
 
     /// Decrements the key's counter in the map, returning the updated counter.
-    fn decrement_counter<K: Hash + Eq>(map: &Arc<RwLock<IndexMap<K, Arc<AtomicU16>>>>, key: K) -> u16 {
+    fn decrement_counter<K: Hash + Eq>(map: &RwLock<IndexMap<K, AtomicU16>>, key: K) -> u16 {
         let mut map_write = map.write();
         // Load the entry for the key.
         let entry = map_write.entry(key).or_default();

--- a/node/router/src/helpers/resolver.rs
+++ b/node/router/src/helpers/resolver.rs
@@ -16,14 +16,14 @@
 
 use indexmap::IndexMap;
 use parking_lot::RwLock;
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct Resolver {
     /// The map of the listener address to (ambiguous) peer address.
-    from_listener: Arc<RwLock<IndexMap<SocketAddr, SocketAddr>>>,
+    from_listener: RwLock<IndexMap<SocketAddr, SocketAddr>>,
     /// The map of the (ambiguous) peer address to listener address.
-    to_listener: Arc<RwLock<IndexMap<SocketAddr, SocketAddr>>>,
+    to_listener: RwLock<IndexMap<SocketAddr, SocketAddr>>,
 }
 
 impl Default for Resolver {

--- a/node/router/src/helpers/sync.rs
+++ b/node/router/src/helpers/sync.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
 use rand::{prelude::IteratorRandom, CryptoRng, Rng};
-use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, net::SocketAddr, time::Instant};
 
 pub const REDUNDANCY_FACTOR: usize = 3;
 pub const EXTRA_REDUNDANCY_FACTOR: usize = REDUNDANCY_FACTOR * 2;
@@ -66,31 +66,31 @@ impl Hash for PeerPair {
 /// - the `request_timestamps` map remains unchanged.
 /// - When a response is removed/completed, the `requests` map and `request_timestamps` map also remove the entry for the request height.
 /// - When a request is timed out, the `requests`, `request_timestamps`, and `responses` map remove the entry for the request height;
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Sync<N: Network> {
     local_ip: OnceCell<SocketAddr>,
     /// The canonical map of block height to block hash.
     /// This map is a linearly-increasing map of block heights to block hashes,
     /// updated solely from the ledger and candidate blocks (not from peers' block locators, to ensure there are no forks).
-    canon: Arc<RwLock<BTreeMap<u32, N::BlockHash>>>,
+    canon: RwLock<BTreeMap<u32, N::BlockHash>>,
     /// The map of peer IP to their block locators.
     /// The block locators are consistent with the canonical map and every other peer's block locators.
-    locators: Arc<RwLock<IndexMap<SocketAddr, BlockLocators<N>>>>,
+    locators: RwLock<IndexMap<SocketAddr, BlockLocators<N>>>,
     /// The map of peer-to-peer to their common ancestor.
     /// This map is used to determine which peers to request blocks from.
-    common_ancestors: Arc<RwLock<IndexMap<PeerPair, u32>>>,
+    common_ancestors: RwLock<IndexMap<PeerPair, u32>>,
     /// The map of block height to the expected block hash and peer IPs.
     /// Each entry is removed when its corresponding entry in the responses map is removed.
-    requests: Arc<RwLock<BTreeMap<u32, SyncRequest<N>>>>,
+    requests: RwLock<BTreeMap<u32, SyncRequest<N>>>,
     /// The map of block height to the received blocks.
     /// Removing an entry from this map must remove the corresponding entry from the requests map.
-    responses: Arc<RwLock<BTreeMap<u32, Block<N>>>>,
+    responses: RwLock<BTreeMap<u32, Block<N>>>,
     /// The map of block height to the timestamp of the last time the block was requested.
     /// This map is used to determine which requests to remove if they have been pending for too long.
-    request_timestamps: Arc<RwLock<BTreeMap<u32, Instant>>>,
+    request_timestamps: RwLock<BTreeMap<u32, Instant>>,
     /// The map of (timed out) peer IPs to their request timestamps.
     /// This map is used to determine which peers to remove if they have timed out too many times.
-    request_timeouts: Arc<RwLock<IndexMap<SocketAddr, Vec<Instant>>>>,
+    request_timeouts: RwLock<IndexMap<SocketAddr, Vec<Instant>>>,
 }
 
 impl<N: Network> Default for Sync<N> {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -48,11 +48,21 @@ use anyhow::{bail, Result};
 use core::str::FromStr;
 use indexmap::{IndexMap, IndexSet};
 use parking_lot::RwLock;
-use std::{future::Future, net::SocketAddr, sync::Arc, time::Instant};
+use std::{future::Future, net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
 use tokio::task::JoinHandle;
 
 #[derive(Clone)]
-pub struct Router<N: Network> {
+pub struct Router<N: Network>(Arc<InnerRouter<N>>);
+
+impl<N: Network> Deref for Router<N> {
+    type Target = Arc<InnerRouter<N>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct InnerRouter<N: Network> {
     /// The TCP stack.
     tcp: Tcp,
     /// The node type.
@@ -60,21 +70,21 @@ pub struct Router<N: Network> {
     /// The account of the node.
     account: Account<N>,
     /// The cache.
-    cache: Arc<Cache<N>>,
+    cache: Cache<N>,
     /// The resolver.
-    resolver: Arc<Resolver>,
+    resolver: Resolver,
     /// The sync pool.
-    sync: Arc<Sync<N>>,
+    sync: Sync<N>,
     /// The set of trusted peers.
-    trusted_peers: Arc<IndexSet<SocketAddr>>,
+    trusted_peers: IndexSet<SocketAddr>,
     /// The map of connected peer IPs to their peer handlers.
-    connected_peers: Arc<RwLock<IndexMap<SocketAddr, Peer<N>>>>,
+    connected_peers: RwLock<IndexMap<SocketAddr, Peer<N>>>,
     /// The set of candidate peer IPs.
-    candidate_peers: Arc<RwLock<IndexSet<SocketAddr>>>,
+    candidate_peers: RwLock<IndexSet<SocketAddr>>,
     /// The set of restricted peer IPs.
-    restricted_peers: Arc<RwLock<IndexMap<SocketAddr, Instant>>>,
+    restricted_peers: RwLock<IndexMap<SocketAddr, Instant>>,
     /// The spawned handles.
-    handles: Arc<RwLock<Vec<JoinHandle<()>>>>,
+    handles: RwLock<Vec<JoinHandle<()>>>,
     /// The boolean flag for the development mode.
     is_dev: bool,
 }
@@ -102,20 +112,20 @@ impl<N: Network> Router<N> {
         // Initialize the TCP stack.
         let tcp = Tcp::new(Config::new(node_ip, max_peers));
         // Initialize the router.
-        Ok(Self {
+        Ok(Self(Arc::new(InnerRouter {
             tcp,
             node_type,
             account,
             cache: Default::default(),
             resolver: Default::default(),
             sync: Default::default(),
-            trusted_peers: Arc::new(trusted_peers.iter().copied().collect()),
+            trusted_peers: trusted_peers.iter().copied().collect(),
             connected_peers: Default::default(),
             candidate_peers: Default::default(),
             restricted_peers: Default::default(),
             handles: Default::default(),
             is_dev,
-        })
+        })))
     }
 
     /// Attempts to connect to the given peer IP.
@@ -157,22 +167,22 @@ impl<N: Network> Router<N> {
     }
 
     /// Returns the node type.
-    pub const fn node_type(&self) -> NodeType {
+    pub fn node_type(&self) -> NodeType {
         self.node_type
     }
 
     /// Returns the account private key of the node.
-    pub const fn private_key(&self) -> &PrivateKey<N> {
+    pub fn private_key(&self) -> &PrivateKey<N> {
         self.account.private_key()
     }
 
     /// Returns the account view key of the node.
-    pub const fn view_key(&self) -> &ViewKey<N> {
+    pub fn view_key(&self) -> &ViewKey<N> {
         self.account.view_key()
     }
 
     /// Returns the account address of the node.
-    pub const fn address(&self) -> Address<N> {
+    pub fn address(&self) -> Address<N> {
         self.account.address()
     }
 
@@ -182,7 +192,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Returns `true` if the node is in development mode.
-    pub const fn is_dev(&self) -> bool {
+    pub fn is_dev(&self) -> bool {
         self.is_dev
     }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -60,7 +60,7 @@ pub struct Router<N: Network> {
     /// The account of the node.
     account: Account<N>,
     /// The cache.
-    cache: Cache<N>,
+    cache: Arc<Cache<N>>,
     /// The resolver.
     resolver: Resolver,
     /// The sync pool.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -64,7 +64,7 @@ pub struct Router<N: Network> {
     /// The resolver.
     resolver: Arc<Resolver>,
     /// The sync pool.
-    sync: Sync<N>,
+    sync: Arc<Sync<N>>,
     /// The set of trusted peers.
     trusted_peers: Arc<IndexSet<SocketAddr>>,
     /// The map of connected peer IPs to their peer handlers.
@@ -177,7 +177,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Returns the sync pool.
-    pub const fn sync(&self) -> &Sync<N> {
+    pub fn sync(&self) -> &Sync<N> {
         &self.sync
     }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Router<N: Network> {
     /// The cache.
     cache: Arc<Cache<N>>,
     /// The resolver.
-    resolver: Resolver,
+    resolver: Arc<Resolver>,
     /// The sync pool.
     sync: Sync<N>,
     /// The set of trusted peers.


### PR DESCRIPTION
Many objects in the `Router` contain numerous `Arc`s to allow cloning; however, those objects are never cloned individually (only as part of the entire `Router`), so there is no need for those `Arc`s to be so fine-grained.

This PR removes all the internal `Arc`s under `Router`, and wraps the `Router` itself in an `Arc`; this will greatly reduce the number of atomic operations done during each call to `Router::{connect, disconnect}` and any other future operation that requires the `Router` to be cloned.