### PR TITLE
Remove a redundant call to Router::remove_connected_peer

### DIFF
--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -145,10 +145,6 @@ impl<N: Network> Router<N> {
             // Disconnect from this peer.
             let _disconnected = router.tcp.disconnect(peer_ip).await;
             debug_assert!(_disconnected);
-            // TODO (howardwu): Revisit this. It appears `handle_disconnect` does not necessarily trigger.
-            //  See https://github.com/AleoHQ/snarkOS/issues/2102.
-            // Remove the peer from the connected peers.
-            router.remove_connected_peer(peer_ip);
         });
     }
 


### PR DESCRIPTION
If we're confident that https://github.com/AleoHQ/snarkOS/pull/2168 solved the issue of missing calls to `Disconnect::handle_disconnect`, we can now remove this duplicate cleanup call.

Closes #2102.