### PR TITLE
Correctly resolve addresses when calling Router::disconnect directly

### DIFF
--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -137,13 +137,11 @@ impl<N: Network> Router<N> {
     pub fn disconnect(&self, peer_ip: SocketAddr) {
         let router = self.clone();
         tokio::spawn(async move {
-            // Disconnect from this peer.
-            let _disconnected = router.tcp.disconnect(peer_ip).await;
-            debug_assert!(_disconnected);
-            // TODO (howardwu): Revisit this. It appears `handle_disconnect` does not necessarily trigger.
-            //  See https://github.com/AleoHQ/snarkOS/issues/2102.
-            // Remove the peer from the connected peers.
-            router.remove_connected_peer(peer_ip);
+            if let Some(peer_addr) = router.resolve_to_ambiguous(&peer_ip) {
+                // Disconnect from this peer.
+                let _disconnected = router.tcp.disconnect(peer_addr).await;
+                debug_assert!(_disconnected);
+            }
         });
     }
 

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -93,7 +93,9 @@ impl<N: Network> Handshake for TestRouter<N> {
 impl<N: Network> Disconnect for TestRouter<N> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
-        self.router().remove_connected_peer(peer_addr);
+        if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
+            self.router().remove_connected_peer(peer_ip);
+        }
     }
 }
 

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -49,7 +49,10 @@ async fn test_disconnect_without_handshake() {
     assert_eq!(node1.tcp().num_connecting(), 0);
 
     // Disconnect node0 from node1.
-    node0.disconnect(node1.local_ip());
+    // note: the lower-level disconnect call is used, as the higher-level
+    // collection of connected peers is only altered during the handshake,
+    // as well as the address resolver needed for the higher-level calls
+    node0.tcp().disconnect(node1.local_ip()).await;
     // Sleep briefly.
     tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -104,13 +104,15 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Beacon<N, C> {
     }
 
     /// Processes a message received from the network.
-    async fn process_message(&self, peer_ip: SocketAddr, message: Self::Message) -> io::Result<()> {
+    async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
         // Process the message. Disconnect if the peer violated the protocol.
-        if let Err(error) = self.inbound(peer_ip, message).await {
-            warn!("Disconnecting from '{peer_ip}' - {error}");
-            self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
-            // Disconnect from this peer.
-            self.router().disconnect(peer_ip);
+        if let Err(error) = self.inbound(peer_addr, message).await {
+            if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
+                warn!("Disconnecting from '{peer_ip}' - {error}");
+                self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+                // Disconnect from this peer.
+                self.router().disconnect(peer_ip);
+            }
         }
         Ok(())
     }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -89,13 +89,15 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Client<N, C> {
     }
 
     /// Processes a message received from the network.
-    async fn process_message(&self, peer_ip: SocketAddr, message: Self::Message) -> io::Result<()> {
+    async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
         // Process the message. Disconnect if the peer violated the protocol.
-        if let Err(error) = self.inbound(peer_ip, message).await {
-            warn!("Disconnecting from '{peer_ip}' - {error}");
-            self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
-            // Disconnect from this peer.
-            self.router().disconnect(peer_ip);
+        if let Err(error) = self.inbound(peer_addr, message).await {
+            if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
+                warn!("Disconnecting from '{peer_ip}' - {error}");
+                self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+                // Disconnect from this peer.
+                self.router().disconnect(peer_ip);
+            }
         }
         Ok(())
     }

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -96,13 +96,15 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Prover<N, C> {
     }
 
     /// Processes a message received from the network.
-    async fn process_message(&self, peer_ip: SocketAddr, message: Self::Message) -> io::Result<()> {
+    async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
         // Process the message. Disconnect if the peer violated the protocol.
-        if let Err(error) = self.inbound(peer_ip, message).await {
-            warn!("Disconnecting from '{peer_ip}' - {error}");
-            self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
-            // Disconnect from this peer.
-            self.router().disconnect(peer_ip);
+        if let Err(error) = self.inbound(peer_addr, message).await {
+            if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
+                warn!("Disconnecting from '{peer_addr}' - {error}");
+                self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+                // Disconnect from this peer.
+                self.router().disconnect(peer_ip);
+            }
         }
         Ok(())
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -105,13 +105,15 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
     }
 
     /// Processes a message received from the network.
-    async fn process_message(&self, peer_ip: SocketAddr, message: Self::Message) -> io::Result<()> {
+    async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
         // Process the message. Disconnect if the peer violated the protocol.
-        if let Err(error) = self.inbound(peer_ip, message).await {
-            warn!("Disconnecting from '{peer_ip}' - {error}");
-            self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
-            // Disconnect from this peer.
-            self.router().disconnect(peer_ip);
+        if let Err(error) = self.inbound(peer_addr, message).await {
+            if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
+                warn!("Disconnecting from '{peer_ip}' - {error}");
+                self.send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+                // Disconnect from this peer.
+                self.router().disconnect(peer_ip);
+            }
         }
         Ok(())
     }

--- a/node/tests/peering.rs
+++ b/node/tests/peering.rs
@@ -51,11 +51,11 @@ macro_rules! test_disconnect {
 
             // Check the peer counts.
             let node_clone = node.clone();
-            deadline!(Duration::from_secs(1), move || node_clone.router().number_of_connected_peers() == 1);
+            deadline!(Duration::from_secs(5), move || node_clone.router().number_of_connected_peers() == 1);
             let node_clone = node.clone();
-            deadline!(Duration::from_secs(1), move || node_clone.tcp().num_connected() == 1);
+            deadline!(Duration::from_secs(5), move || node_clone.tcp().num_connected() == 1);
             let peer_clone = peer.clone();
-            deadline!(Duration::from_secs(1), move || peer_clone.node().num_connected() == 1);
+            deadline!(Duration::from_secs(5), move || peer_clone.node().num_connected() == 1);
 
             // Disconnect.
             if $node_disconnects {
@@ -66,9 +66,9 @@ macro_rules! test_disconnect {
 
             // Check the peer counts have been updated.
             let node_clone = node.clone();
-            deadline!(Duration::from_secs(1), move || node_clone.router().number_of_connected_peers() == 0);
-            deadline!(Duration::from_secs(1), move || node.tcp().num_connected() == 0);
-            deadline!(Duration::from_secs(1), move || peer.node().num_connected() == 0);
+            deadline!(Duration::from_secs(5), move || node_clone.router().number_of_connected_peers() == 0);
+            deadline!(Duration::from_secs(5), move || node.tcp().num_connected() == 0);
+            deadline!(Duration::from_secs(5), move || peer.node().num_connected() == 0);
 
         }
     };


### PR DESCRIPTION
While looking into potentially introducing strong typing to avoid IP addresses from being mixed up (though that would be a large change, so it might need to wait), I found 3 more mix-ups:
- `Router::disconnect`, like all other "higher-level" (higher than `Tcp`) objects, should use the listening address as the unique connection identifier, and resolve to the actually connected address internally
- the `Disconnect` impl for the `TestRouter` was not resolving the address (missed this one last time, as no test was hitting it - I'll post such a test case soon)
- `Reading::process_message` (in the unhappy path) was not resolving the address before calling `Outbound::send`, though it was accidentally calling `Router::disconnect` correctly (though technically with the "wrong" address type, which the 1st point refers to)

This should fix the remaining occurrences of https://github.com/AleoHQ/snarkOS/issues/2102.