### PR TITLE
Add a connection cleanup test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689894c2db1ea643a50834b999abf1c110887402542955ff5451dab8f861f9ed"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2 1.0.50",
  "quote 1.0.23",
@@ -1804,6 +1804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peak_alloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae5ca2a4f36e9bba393e6711350dde5d11f5aacca3660fcca7877fe6b6e9d98"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2721,6 +2727,7 @@ dependencies = [
  "bincode 1.3.3",
  "bytes",
  "colored",
+ "deadline",
  "futures",
  "futures-util",
  "indexmap",
@@ -2728,13 +2735,16 @@ dependencies = [
  "linked-hash-map",
  "once_cell",
  "parking_lot",
+ "peak_alloc",
  "rand",
  "reqwest",
  "serde",
  "snarkos-account",
  "snarkos-node-messages",
+ "snarkos-node-router",
  "snarkos-node-tcp",
  "snarkvm",
+ "snarkvm-utilities",
  "time",
  "tokio",
  "tokio-stream",
@@ -3872,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "operating-systems" ]
 license = "GPL-3.0"
 edition = "2021"
 
+[features]
+test = []
+
 [dependencies.anyhow]
 version = "1"
 
@@ -97,13 +100,26 @@ version = "=0.1"
 [dependencies.tracing]
 version = "0.1"
 
+[dev-dependencies.deadline]
+version = "0.2"
+
 [dev-dependencies.futures-util]
 version = "0.3"
 features = ["sink"]
 
+[dev-dependencies.peak_alloc]
+version = "0.1"
+
 [dev-dependencies.snarkos-node-messages]
 path = "../messages"
 features = [ "test" ]
+
+[dev-dependencies.snarkos-node-router]
+path = "."
+features = [ "test" ]
+
+[dev-dependencies.snarkvm-utilities]
+version = "0.9"
 
 [dev-dependencies.tracing-subscriber]
 version = "0.3"

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -143,7 +143,7 @@ impl<N: Network> Router<N> {
         }
 
         let router = self.clone();
-        self.spawn(async move {
+        tokio::spawn(async move {
             // Attempt to connect to the candidate peer.
             debug!("Connecting to {peer_ip}...");
             match router.tcp.connect(peer_ip).await {
@@ -186,7 +186,7 @@ impl<N: Network> Router<N> {
     /// Disconnects from the given peer IP, if the peer is connected.
     pub fn disconnect(&self, peer_ip: SocketAddr) {
         let router = self.clone();
-        self.spawn(async move {
+        tokio::spawn(async move {
             if let Some(peer_addr) = router.resolve_to_ambiguous(&peer_ip) {
                 // Disconnect from this peer.
                 let _disconnected = router.tcp.disconnect(peer_addr).await;

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -487,7 +487,7 @@ impl<N: Network> Router<N> {
         self.candidate_peers.write().remove(&peer_ip);
     }
 
-    /// Spawns a task with the given future.
+    /// Spawns a task with the given future; it should only be used for long-running tasks.
     pub fn spawn<T: Future<Output = ()> + Send + 'static>(&self, future: T) {
         self.handles.write().push(tokio::spawn(future));
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -150,7 +150,10 @@ impl<N: Network> Router<N> {
                 // Remove the peer from the candidate peers.
                 Ok(()) => router.remove_candidate_peer(peer_ip),
                 // If the connection was not allowed, log the error.
-                Err(error) => warn!("Unable to connect to '{peer_ip}' - {error}"),
+                Err(error) => {
+                    router.connecting_peers.lock().remove(&peer_ip);
+                    warn!("Unable to connect to '{peer_ip}' - {error}")
+                }
             }
         });
     }
@@ -165,10 +168,6 @@ impl<N: Network> Router<N> {
         if self.number_of_connected_peers() >= self.max_connected_peers() {
             bail!("Dropping connection attempt to '{peer_ip}' (maximum peers reached)")
         }
-        // Ensure the node is not already connecting to this peer.
-        if !self.connecting_peers.lock().insert(peer_ip) {
-            bail!("Dropping connection attempt to '{peer_ip}' (already shaking hands as the initiator)")
-        }
         // Ensure the node is not already connected to this peer.
         if self.is_connected(&peer_ip) {
             bail!("Dropping connection attempt to '{peer_ip}' (already connected)")
@@ -176,6 +175,10 @@ impl<N: Network> Router<N> {
         // Ensure the peer is not restricted.
         if self.is_restricted(&peer_ip) {
             bail!("Dropping connection attempt to '{peer_ip}' (restricted)")
+        }
+        // Ensure the node is not already connecting to this peer.
+        if !self.connecting_peers.lock().insert(peer_ip) {
+            bail!("Dropping connection attempt to '{peer_ip}' (already shaking hands as the initiator)")
         }
         Ok(())
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -474,6 +474,11 @@ impl<N: Network> Router<N> {
         self.candidate_peers.write().insert(peer_ip);
     }
 
+    #[cfg(feature = "test")]
+    pub fn clear_candidate_peers(&self) {
+        self.candidate_peers.write().clear();
+    }
+
     /// Removes the given address from the candidate peers, if it exists.
     pub fn remove_candidate_peer(&self, peer_ip: SocketAddr) {
         self.candidate_peers.write().remove(&peer_ip);

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -1,0 +1,101 @@
+// Copyright (C) 2019-2022 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+mod common;
+use common::*;
+
+use deadline::deadline;
+use peak_alloc::PeakAlloc;
+use snarkos_node_router::Routing;
+use snarkos_node_tcp::{
+    protocols::{Disconnect, Handshake},
+    P2P,
+};
+use snarkvm::prelude::Rng;
+use snarkvm_utilities::TestRng;
+
+use core::time::Duration;
+
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+#[tokio::test]
+async fn test_connection_cleanups() {
+    // The number of connections to start and close.
+    const NUM_CONNECTIONS: usize = 10;
+
+    // Initialize an Rng.
+    let mut rng = TestRng::default();
+
+    // Create 2 routers of random types.
+    let mut nodes = Vec::with_capacity(2);
+    for _ in 0..2 {
+        let node = match rng.gen_range(0..4) % 4 {
+            0 => beacon(0, 1).await,
+            1 => client(0, 1).await,
+            2 => prover(0, 1).await,
+            3 => validator(0, 1).await,
+            _ => unreachable!(),
+        };
+
+        nodes.push(node);
+    }
+
+    // Enable handshake handling.
+    nodes[0].enable_handshake().await;
+    nodes[1].enable_handshake().await;
+
+    nodes[0].enable_disconnect().await;
+    nodes[1].enable_disconnect().await;
+
+    nodes[0].enable_listener().await;
+    nodes[1].enable_listener().await;
+
+    // We'll want to register heap use after a single connection, after the related collections are initialized.
+    let mut heap_after_one_conn = None;
+
+    // Connect and disconnect in a loop.
+    for i in 0..NUM_CONNECTIONS {
+        // Connect one of the nodes to the other one.
+        nodes[1].connect(nodes[0].local_ip());
+
+        // Wait until the connection is complete.
+        let tcp0 = nodes[0].tcp().clone();
+        let tcp1 = nodes[1].tcp().clone();
+        deadline!(Duration::from_secs(3), move || tcp0.num_connected() == 1 && tcp1.num_connected() == 1);
+
+        // Since the connectee doesn't read from the connector, it can't tell that the connector disconnected
+        // from it, so it needs to disconnect from it manually.
+        nodes[0].disconnect(nodes[1].local_ip());
+        nodes[1].disconnect(nodes[0].local_ip());
+
+        // Wait until the disconnect is complete.
+        let tcp0 = nodes[0].tcp().clone();
+        let tcp1 = nodes[1].tcp().clone();
+        deadline!(Duration::from_secs(3), move || tcp0.num_connected() == 0 && tcp1.num_connected() == 0);
+
+        // Register heap use after a single connection.
+        if i == 0 {
+            heap_after_one_conn = Some(PEAK_ALLOC.current_usage());
+        }
+    }
+
+    // Register final heap use.
+    let heap_after_loop = PEAK_ALLOC.current_usage();
+
+    // Final heap use should equal that after the first connection.
+    assert_eq!(heap_after_one_conn.unwrap(), heap_after_loop);
+}


### PR DESCRIPTION
This PR contains a test ensuring that our connections don't leak memory. Other than aiding the earlier disconnect-related fixes, it already helped detect the two following issues in `staging`:
- `Router::spawn` should **not** be used for short, "self-destructing" tasks (at least not in its current shape); this was reverted
- the accounting of connecting peers needs to be tighter for outbound connections; this was adjusted as a drive-by

`cargo update` was also run, because this PR alters the lockfile and there's already a pending dependabot PR which this will take care of.