### PR TITLE
Make the handshake asymmetric

### DIFF
--- a/node/messages/src/challenge_request.rs
+++ b/node/messages/src/challenge_request.rs
@@ -48,3 +48,9 @@ impl<N: Network> MessageTrait for ChallengeRequest<N> {
         Ok(Self { version, listener_port, node_type, address, nonce })
     }
 }
+
+impl<N: Network> ChallengeRequest<N> {
+    pub fn new(listener_port: u16, node_type: NodeType, address: Address<N>, nonce: u64) -> Self {
+        Self { version: Message::<N>::VERSION, listener_port, node_type, address, nonce }
+    }
+}

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -90,6 +90,7 @@ impl<N: Network> Router<N> {
             debug!("Received a connection request from '{peer_addr}'");
             None
         } else {
+            debug!("Connecting to {peer_addr}...");
             Some(peer_addr)
         };
 

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -186,6 +186,9 @@ impl<N: Network> Router<N> {
         self.insert_connected_peer(peer, peer_addr);
         info!("Connected to '{peer_ip}'");
 
+        // Increase the maximum permitted message size.
+        framed.codec_mut().update_max_message_len();
+
         Ok((peer_ip, framed))
     }
 

--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkos_node_messages::NodeType;
+use snarkos_node_messages::{ChallengeRequest, NodeType};
 use snarkvm::prelude::{Address, Network};
 
 use parking_lot::RwLock;
@@ -39,12 +39,12 @@ pub struct Peer<N: Network> {
 
 impl<N: Network> Peer<N> {
     /// Initializes a new instance of `Peer`.
-    pub fn new(listening_ip: SocketAddr, address: Address<N>, node_type: NodeType, version: u32) -> Self {
+    pub fn new(listening_ip: SocketAddr, challenge_request: &ChallengeRequest<N>) -> Self {
         Self {
             peer_ip: listening_ip,
-            address,
-            node_type,
-            version,
+            address: challenge_request.address,
+            node_type: challenge_request.node_type,
+            version: challenge_request.version,
             first_seen: Instant::now(),
             last_seen: Arc::new(RwLock::new(Instant::now())),
         }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -145,7 +145,6 @@ impl<N: Network> Router<N> {
         let router = self.clone();
         tokio::spawn(async move {
             // Attempt to connect to the candidate peer.
-            debug!("Connecting to {peer_ip}...");
             match router.tcp.connect(peer_ip).await {
                 // Remove the peer from the candidate peers.
                 Ok(()) => router.remove_candidate_peer(peer_ip),

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -23,8 +23,6 @@ use core::time::Duration;
 
 #[tokio::test]
 async fn test_connect_without_handshake() {
-    initialize_logger(3);
-
     // Create 2 routers.
     let node0 = validator(0, 2).await;
     let node1 = client(0, 2).await;
@@ -81,8 +79,6 @@ async fn test_connect_without_handshake() {
 
 #[tokio::test]
 async fn test_connect_with_handshake() {
-    initialize_logger(3);
-
     // Create 2 routers.
     let node0 = validator(0, 2).await;
     let node1 = client(0, 2).await;
@@ -159,8 +155,6 @@ async fn test_connect_with_handshake() {
 #[ignore]
 #[tokio::test]
 async fn test_connect_simultaneously_with_handshake() {
-    initialize_logger(3);
-
     // Create 2 routers.
     let node0 = validator(0, 2).await;
     let node1 = client(0, 2).await;

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -23,8 +23,6 @@ use core::time::Duration;
 
 #[tokio::test]
 async fn test_disconnect_without_handshake() {
-    initialize_logger(3);
-
     // Create 2 routers.
     let node0 = validator(0, 1).await;
     let node1 = client(0, 1).await;
@@ -67,8 +65,6 @@ async fn test_disconnect_without_handshake() {
 
 #[tokio::test]
 async fn test_disconnect_with_handshake() {
-    initialize_logger(3);
-
     // Create 2 routers.
     let node0 = validator(0, 1).await;
     let node1 = client(0, 1).await;


### PR DESCRIPTION
This PR addresses https://github.com/AleoHQ/snarkOS/issues/2184 with one difference - the messages are not bundled together (this can happen later on if desired). In addition, the handshake message size is now restricted to 1MiB, which could probably be made even smaller.

As a drive-by, some logs are disabled in tests (as they are only useful for debugging), and the connection initiation logs are unified.

Closes #2184.
Closes #2149.