### PR TITLE
Avoid cloning PuzzleResponse/EpochChallenge

### DIFF
--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -22,7 +22,6 @@ use snarkos_node_messages::{
     MessageCodec,
     Ping,
     Pong,
-    PuzzleResponse,
     UnconfirmedSolution,
     UnconfirmedTransaction,
 };
@@ -34,7 +33,7 @@ use snarkos_node_tcp::{
     Tcp,
     P2P,
 };
-use snarkvm::prelude::{Block, Header, Network, ProverSolution, Transaction};
+use snarkvm::prelude::{Block, EpochChallenge, Header, Network, ProverSolution, Transaction};
 
 use async_trait::async_trait;
 use futures_util::sink::SinkExt;
@@ -170,7 +169,7 @@ impl<N: Network> Inbound<N> for TestRouter<N> {
     }
 
     /// Handles an `PuzzleResponse` message.
-    fn puzzle_response(&self, _peer_ip: SocketAddr, _serialized: PuzzleResponse<N>, _header: Header<N>) -> bool {
+    fn puzzle_response(&self, _peer_ip: SocketAddr, _epoch_challenge: EpochChallenge<N>, _header: Header<N>) -> bool {
         true
     }
 

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -28,7 +28,7 @@ use snarkos_node_messages::{
 };
 use snarkos_node_router::Routing;
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{error, Header};
+use snarkvm::prelude::{error, EpochChallenge, Header};
 
 use futures_util::sink::SinkExt;
 use std::{io, net::SocketAddr};
@@ -222,7 +222,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Beacon<N, C> {
     }
 
     /// Disconnects on receipt of a `PuzzleResponse` message.
-    fn puzzle_response(&self, peer_ip: SocketAddr, _serialized: PuzzleResponse<N>, _header: Header<N>) -> bool {
+    fn puzzle_response(&self, peer_ip: SocketAddr, _epoch_challenge: EpochChallenge<N>, _header: Header<N>) -> bool {
         debug!("Disconnecting '{peer_ip}' for the following reason - {:?}", DisconnectReason::ProtocolViolation);
         false
     }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -18,7 +18,7 @@ mod router;
 
 use crate::traits::NodeInterface;
 use snarkos_account::Account;
-use snarkos_node_messages::{Message, NodeType, PuzzleResponse, UnconfirmedSolution};
+use snarkos_node_messages::{Message, NodeType, UnconfirmedSolution};
 use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
 use snarkos_node_tcp::{
     protocols::{Disconnect, Handshake, Reading, Writing},

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -152,9 +152,9 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
     }
 
     /// Saves the latest epoch challenge and latest block header in the node.
-    fn puzzle_response(&self, peer_ip: SocketAddr, serialized: PuzzleResponse<N>, header: Header<N>) -> bool {
+    fn puzzle_response(&self, peer_ip: SocketAddr, epoch_challenge: EpochChallenge<N>, header: Header<N>) -> bool {
         // Retrieve the epoch number.
-        let epoch_number = serialized.epoch_challenge.epoch_number();
+        let epoch_number = epoch_challenge.epoch_number();
         // Retrieve the block height.
         let block_height = header.height();
 
@@ -165,7 +165,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         );
 
         // Save the latest epoch challenge in the node.
-        self.latest_epoch_challenge.write().replace(serialized.epoch_challenge);
+        self.latest_epoch_challenge.write().replace(epoch_challenge);
         // Save the latest block header in the node.
         self.latest_block_header.write().replace(header);
 

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -18,7 +18,7 @@ mod router;
 
 use crate::traits::NodeInterface;
 use snarkos_account::Account;
-use snarkos_node_messages::{Data, Message, NodeType, PuzzleResponse, UnconfirmedSolution};
+use snarkos_node_messages::{Data, Message, NodeType, UnconfirmedSolution};
 use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
 use snarkos_node_tcp::{
     protocols::{Disconnect, Handshake, Reading, Writing},

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -172,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
         );
 
         // Save the latest epoch challenge in the node.
-        self.latest_epoch_challenge.write().replace(epoch_challenge);
+        self.latest_epoch_challenge.write().replace(Arc::new(epoch_challenge));
         // Save the latest block header in the node.
         self.latest_block_header.write().replace(header);
 

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -159,9 +159,9 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
     }
 
     /// Saves the latest epoch challenge and latest block header in the node.
-    fn puzzle_response(&self, peer_ip: SocketAddr, serialized: PuzzleResponse<N>, header: Header<N>) -> bool {
+    fn puzzle_response(&self, peer_ip: SocketAddr, epoch_challenge: EpochChallenge<N>, header: Header<N>) -> bool {
         // Retrieve the epoch number.
-        let epoch_number = serialized.epoch_challenge.epoch_number();
+        let epoch_number = epoch_challenge.epoch_number();
         // Retrieve the block height.
         let block_height = header.height();
 
@@ -172,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
         );
 
         // Save the latest epoch challenge in the node.
-        self.latest_epoch_challenge.write().replace(serialized.epoch_challenge);
+        self.latest_epoch_challenge.write().replace(epoch_challenge);
         // Save the latest block header in the node.
         self.latest_block_header.write().replace(header);
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -29,7 +29,7 @@ use snarkos_node_messages::{
     UnconfirmedTransaction,
 };
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{error, Network, Transaction};
+use snarkvm::prelude::{error, EpochChallenge, Network, Transaction};
 
 use futures_util::sink::SinkExt;
 use std::{io, net::SocketAddr, time::Duration};
@@ -206,7 +206,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
     }
 
     /// Disconnects on receipt of a `PuzzleResponse` message.
-    fn puzzle_response(&self, peer_ip: SocketAddr, _serialized: PuzzleResponse<N>, _header: Header<N>) -> bool {
+    fn puzzle_response(&self, peer_ip: SocketAddr, _epoch_challenge: EpochChallenge<N>, _header: Header<N>) -> bool {
         debug!("Disconnecting '{peer_ip}' for the following reason - {:?}", DisconnectReason::ProtocolViolation);
         false
     }


### PR DESCRIPTION
While there are some inbound messages where it's beneficial to preserve their (semi-)serialized form for the purposes of relaying them further, this is not needed with `PuzzleResponse`; this was found via memory profiling, where the associated clone operation turned out to be quite significant.