### PR TITLE
Update `snarkVM` release to 0.9.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,6 +2728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2754,6 +2755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2779,6 +2781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2792,6 +2795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2802,6 +2806,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2811,6 +2816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2820,6 +2826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2837,10 +2844,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2851,6 +2860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2863,6 +2873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2877,6 +2888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2889,6 +2901,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2897,6 +2910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2906,6 +2920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2917,6 +2932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2927,6 +2943,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2937,6 +2954,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2948,6 +2966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2960,6 +2979,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2969,6 +2989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -2980,6 +3001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -2990,6 +3012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3012,6 +3035,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3028,6 +3052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3045,6 +3070,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3059,6 +3085,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3069,6 +3096,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3076,6 +3104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3084,6 +3113,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3094,6 +3124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3103,6 +3134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3112,6 +3144,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3122,6 +3155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3134,6 +3168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3150,6 +3185,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3174,6 +3210,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3189,6 +3226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3215,6 +3253,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3232,6 +3271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.9.11"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,7 +2316,24 @@ dependencies = [
  "hyper",
  "indicatif",
  "log",
- "quick-xml",
+ "quick-xml 0.22.0",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "self_update"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e18819cd93c4799f93cd4cf0ac069ed0e615fea3af28ec78df71e0ea890628a"
+dependencies = [
+ "hyper",
+ "indicatif",
+ "log",
+ "quick-xml 0.23.1",
  "regex",
  "reqwest",
  "semver",
@@ -2542,7 +2568,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "self_update",
+ "self_update 0.34.0",
  "serde",
  "serde_json",
  "snarkos-account",
@@ -2773,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c0728150b774a986de9185e31c319861f8cd40b310ebd037533e9d649d59a2"
+checksum = "59bc826fb94e0240a58cc627d1d4795cf02856e87ea47e315c983d1c5e3e0f89"
 dependencies = [
  "anyhow",
  "clap",
@@ -2785,7 +2811,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "self_update",
+ "self_update 0.35.0",
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -2801,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea29bd35b0d5c45698a66f856225a8d0c7b966d5ab319e05d6d10ce1dbb3f23"
+checksum = "8f6bb298e5150e95e85c4658bd0f6d55c733adc5021e2f255fb90c05839cfe0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2828,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9196734dce55b69d4d764c4df07ebe78833a600944b41b71b115b9ffb926650b"
+checksum = "7624cbc7e21e73cf83311ad7618bd2fdfe11224ef6c125efb274c9ecfe2e06e0"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2843,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4db902a0adabee9bd2a6929efd69de6b41cae42a3cf7ce784f030890ff6700"
+checksum = "327bb0b8d52b13619fb3c5e2cec87d12a2891d56d38b5f415cfcde18cea80118"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2855,9 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80de37cea23d3573aa04b3d298d92cdb738d71c11b2e736700208910b6d0cfe"
+checksum = "347c010c8128840984c5f5f6a513eaa960258bee87c9ca94d577689e522c8bda"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2866,9 +2892,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d0a54513c1b75e6e4530b3ea9bdf49812670c1ce103d617249ad18164ee252"
+checksum = "85f15032bab5ebc07b04685d757d84add90f073b3a7c629f57311f9715ecd2b8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2877,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46e5db5895d350a0b5a5dc39cf10e0b152a42565faffd1ed76cc458d65d97ab"
+checksum = "cfdaee135140f27c6321c2ee32b159522331b1f0f57a55c61d85a8eef0261250"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2896,15 +2922,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f83bb5cf7b3d9360867233716ffd6a62e8e8ae75f798ebec5c18593c54aecc"
+checksum = "b84154491d3f29f739b9254cd23e6ab20868e1ea8a0c50bf70a66215195a49f7"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e1521cf9bc4714c39f8c9e41d32879933e02a633e4a4d47a3d857fe86b7eac"
+checksum = "eb53bf539d4e7a3d45b84b1a066d69b5fa211145ace42943fc55b33ed04c6886"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2914,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab54a75f46d3e8d73e6f739eaa576496821cd88b730c0029cb068b8e5778afe"
+checksum = "1b491fde294e2df38560c77f47b436eb84cda9179d1384289d48d2f0f381b75f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2928,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bd7d752f4832011a7f1d164a6fd480bbf424eaaf6bf85290c3e52ee656610f"
+checksum = "cb99c920473e96d7036761c270077da9600535f632d382a11e99ad4b67c04e0f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2944,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d507d9a84aef461e1f13232b9e900bb1436a475113342b7ac25b2285808de9d"
+checksum = "35c4c29afe50f82decf8436d9b876b595fff2e3fe69cd8e2ac57091a1936761c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2958,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b32dc28b121e8a8e9d1fa6ffa2d245ed6b4ee6a001d5a178705d7493decc8c"
+checksum = "571825663ac3ea5aa057aa2945600a646534ff9e74b4ae4f4d6fa555ac0f5897"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2968,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9b3f21795819542b026db039b8e74409386e479c67e851f61aaf15bcd9ff46"
+checksum = "79b07ae8fefb380325f3eec538457cfd386a79a9ef998a62c935081b81126b6c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2979,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d755d0bc23b58055ef956fe6f4c498d4ff1fcb7290f0811528fd8668eca494a"
+checksum = "48b04d694962e0eff5c6f1847202e9a90969c2148a4292c37aaabd68bc5ca85c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2992,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad0a54e974581cce76211bc32a7adb0dc027974b80f40a6237a652b8ed66130"
+checksum = "5c06f6ad40106e2310b27ea368993ea29a20e1c21e1eeb6b14103848ce5f67fd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3004,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5d9d53e3cb99a49a11be55ac32db33887f5bc467d823c6873a6a1d5113543a"
+checksum = "dc8d800fdc9deb77e1837aaca4b8295cb48cecbd7a888949c5196f0e828a045d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3016,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd98c46ba6c04a3caf41fd99b981479510808286c1981017f5caf847b43ab37"
+checksum = "77f462665cad0282d51572e9250aa3165214053afbb5a1d36f59c4be46cba3d4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3029,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13834f575d3f8c8aa62361f08dbb9f41ef4eafce296e6be5cae1b6966eb73c5"
+checksum = "c4873c8da377319091e6aa7f7e3ff85d82be0da1d76f48f9eee4a1c5d2d5f358"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3043,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b5a730f6c4542c6ee0907303aff3fac037f311c0874c94df6a3429560f0c2f"
+checksum = "b2f5e3ec09b3153e35e45d126aeb43484a6502ebaee9c1ff70483b77dc7d717b"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3054,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788804605492027933da6120c83460cc98eca942f1a825417c0a41f03222854e"
+checksum = "dd4c34eed9d7be1fe81d698cfb1f82807195f91dd0983bbb50e5d0b6861cc783"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3067,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ed387325f5a757473aa0d64af6ead114de31096885e58f1ceb7be31a5865da"
+checksum = "ab9949b61fb8ce05c78885803287c426d5852eefa0012d9c35b62e8e8041a008"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3079,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cf4ad08931e869198db0f39100d02fdd2d34e569f807adc8ea0bd5d218e365"
+checksum = "eac46f0cf67ea542855c7da5684d0c64c29bcf6c13dfd26cd74d170244859e54"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3103,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872cd5160b4a133055e20c9399e9bc750ea91df61a63835bbb44427499a761ba"
+checksum = "949790255a3ce43484d2d64e4019e83d377cf6e3378065e3a4dfbe95bada2d2a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3121,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e4f352a38234c3ebb66c0c5c09ca953d793c632f8bbcbebd2ee80afe87681e"
+checksum = "ed97fd6b0bc5271e2db014da2f1b6d729941545e2a8579bbc1cfad8929321683"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3141,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bec5e9e9807607cef75b15dd3fd82b125232b2e36929ea1417ce50726ed9ca"
+checksum = "a1e6a2eb8fcd2311769e8c4178d33d2d98860afb7bcf57095305d3577fc59536"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3157,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fbaf39ea6c86b6648409fb2802e38356660faecaed2c1e178a3599a84b153f"
+checksum = "8ba29808292f9aa51e64e889729632e0c08f631296812b3af21ccf9dc1eac22d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3169,18 +3195,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568ba94bec2f7f7cdb8d2f54378da632a875959d864c5dac3b8159c391ee83d4"
+checksum = "bea412df3e71f3f2ae5df39caff188807ae57769dac9202ed3cb2614952113f7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18272c987b1e0191a75f4878e766307751a4fabdf04a0b4769b2e91e2652d711"
+checksum = "00306032a99673b0aba8b8913533a4d6846c44020d593b44ffa84088bdd853dd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3188,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f461148e079732cd336478b6a2e3683bbca2e442486a71f1cec7c4dd363021d"
+checksum = "416e30243bd359ed354d8594e1f9836a6f0be8bc958778527a04c585cf28f1d5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3200,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac592e77f726ee8f0c6ad0162f25d496807b0995b39ff73eab83f6191ae4ba"
+checksum = "1db3e47a68a26d13410306e919efe2442610c1f5fc6ba259c846e39c33da3aea"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3211,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73dd95cd6cb6edfa01e26b0686deaff882321a38a103217d66f1f05aaac3e10b"
+checksum = "e204373be0ebfa1a17b166851a8f80ba4cb760799f2ad1823daefaea4b739113"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3222,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7093713b19aa004a24199dd82e8bea4e7610c46212adb0ff6582b07a3fdab06b"
+checksum = "89189d253ff3d96f646becfc15eec1314224290a1bc7dc215b71f3d38cfca0a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3234,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a26fe6de2b6096665604bda2296f981e7c34fb77b0a5707b07f7a6d79a0bf1e"
+checksum = "594d431ffc5b5811d3ae126d625f4542c010bc9e3017f882815b8ff639e69d65"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3248,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4cac728c6ce9b52952a353454429ab6c2af1954d0183db5f85a907ac481cfd"
+checksum = "e27cc43b63eec46506b8f49067413f90b6577e7b3811d659884e841898b1c306"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3266,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7d259b389681963d796321327df59775eaf407f2d0caf784619d5f8bed08ef"
+checksum = "27eab7d7b81615de7743ba615e784f851711146923caf137e7963c04da13df7e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3292,9 +3318,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090b77b059b3d6a27231400b42de6d65a51a47ed6dc9d60732c42d2d853e26f2"
+checksum = "20d349dd0c725a8b75189898d40ed67228889b0a418ccc5ea5ec68885d25f87e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3309,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0cdebc9f68b2a339565053b73fb72fa0f032519781af6fcf58ab0c5ba2adc1"
+checksum = "013d1cec9d64aa452f05a48ba3af0f1bc9598c2f220a61830c34160e4402920a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3337,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b15f33845b685fa19b18eb18705bbaaa4af72b5aaaa0f330a630135ee4dbeb"
+checksum = "34724eac8768fbc1c39b09f925b1fca52c264280c28b40137a91c09a3148b4de"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3357,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d70d67e3a5adee2e2ecb7b6eeda17b1bcc9317b5f76aaf0cdb1f67c279d1cb7"
+checksum = "7a06c52a5ceba9b9159f1b8cc3ca29bd5da16f339e4eb077cfc9024c813f2b86"
 dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,9 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0119b2b558bba04e3cce3775da77f898b5fcf08cf177e692fa6037fe3a4aeea"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -2755,9 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44717bf78752fe98f0e4228743d9384cb0abc30bf025b9d844c737b378976a3b"
+version = "0.9.11"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2782,9 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae23f5a63cf5b3bf835e577e3530d0579bf65c38dba587b904593b615a2e23a5"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2797,9 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e94a73d8a411e1cdc3a4f4bc03dc6466fe83aeaadb9266a50cdde6d687f42a4"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2809,9 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b97bf7f521574c2f2621ec1e174a89a4d795a7d7857833a7d82e026b28084ab"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2820,9 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3da410fb8e73d73a5e4a8c9c9b1d81c6f7cf6dffc1ee35a9a0d198ed36d712d"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2831,9 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a052b464f06508b82118d37047068786fa62c1087b5e87cc9a4c6602a25686"
+version = "0.9.11"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2850,15 +2836,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017fcdd952676f810a830e8d42a1444b6144f1c9282c3ca8babc26811869bb23"
+version = "0.9.11"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8993d3074498d46e29f796acd65ce1dea449edb8bbb6fb1d86a3e5fa2328829"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2868,9 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a166f49dc4b27e47cd28d79ce1b91587f07f6b76c14960fd3a4dbf434943866"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2882,9 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169d6e14aaf6618dd62c1346a8dd3f72aee99eb0c61bbb90fba10e98ca0ed6a0"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2898,9 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769d137b210ab665a2fe02d71f96deeee9122392fddb611d00a4f679068f7053"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2912,9 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875fbb8814bc05a4b174619f1f9755d41d91d85bee1ba444fb45e7036b139914"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2922,9 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef6adcde1a0e001a3f59804923ca6fbc8d28bf481aa01568f75db7c4bf5cd3d"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2933,9 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a83de038afb89793afa62c7e0141c90b595903512b6ce95457128b154214029"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2946,9 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90b73a5f8f38e0c6700122766144f46588d72a4d8cc67af4738e6b672af988f"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2958,9 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e24dd3f098b55473336370ac95e812bbaf97eb40d865ced893534d3f2133c3"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2970,9 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d941aab85e62f58ac0be502ba885c119f325811ab305e628e9574163dca47"
+version = "0.9.11"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2983,9 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f950fcb58d6ff6e965c3d79de272778a25d7dd3fd7fdf25d6e93d2e4faecc67"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2997,9 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed8b2acd1bc1e4770b14ac3042cd95c5705f6c2bf9a6bbac9917a265b778209"
+version = "0.9.11"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3008,9 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd88d7d3528537656ed13440f149103f23395423e8b5b4ce014d6f4d6e503a1"
+version = "0.9.11"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3021,9 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3f93eb4f4457a92913e19fbdd30659c46614cdcc15d78c1a010cd9b5499f6e"
+version = "0.9.11"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3033,9 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54da72a6ef1cbd290ab5a0a084d90a75582826f58a60bfddf415784ca72afc5"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3057,9 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad5d6bcd9f8ef8e40f94d4649600116f4d78342f523326d4b63a511581e0a2a"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3075,9 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7064b815282ca08d53b34df2c27d00ad380d716b305823260a7312a71e3ce08a"
+version = "0.9.11"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3094,9 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0582bdd683f021a755e846da497cc7d9c69b7b59524d1ed96487609b9e2f014"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3110,9 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb0026fbe5e3e2fbbfbbf605eb4efff2cafbec46cd4e8dda927d23485fc586d"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3122,18 +3068,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4624d2f6eb15859253859133c65c9db52a8018db3f64b62ea0a8c76ad8e70ef"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31e4ddde61ba9894b0be08cbed6e4111a1cf9099858a8bd848c89bcaacfee0f"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3141,9 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043cc4040b14289ff680281f107f9d85db7b266325d2aff1b55773b4a6553784"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3153,9 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71792e017e031c7cacf61b67823fcc19dae92f7a906caaf109d94517e47f974b"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3164,9 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e174287012d02d30e90c8ebeec1751a809e70d0f32750e7fe0ea5bd55f0157f8"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3175,9 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd1abad7a2f2e718f4c360d1f65e56d48bb647285776d3bdfec7df3f7c6b1df"
+version = "0.9.11"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3187,9 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4362d677bc2eb36077fb884cb39dfac2a0c03f86cb548b5e0439848bcc0e3d8e"
+version = "0.9.11"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3201,9 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc2ff7e15862dc0cbf2891616433a0b823d4bbcafae1e0c35d5dd11ee14e8a5"
+version = "0.9.11"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3219,9 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67857e7df8f2a5bdfbed6dde7e58295b01e51fe1258ebb6b6e52642df75e8d81"
+version = "0.9.11"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3245,9 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a734842ac8c5e994745034c6f83aaf324c3a091d830669e79bb056514f11aa"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3262,9 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5823efe283822ba821a78975078619149195df0f0cd60546c3c64ecc7ff4972e"
+version = "0.9.11"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3290,9 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10add1d9b3c360603461a9974714f7e0942280cc72df28edfe6f4f0a2b2b82d1"
+version = "0.9.11"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3309,9 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64872cc1fb4e8304881ce6838f2b2115ed82df3983e8b19ea639bbb2183f540e"
+version = "0.9.11"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayref"
@@ -436,12 +436,6 @@ dependencies = [
  "num-traits",
  "winapi",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "ci_info"
@@ -1098,9 +1092,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
@@ -1657,9 +1651,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 dependencies = [
  "parking_lot_core",
 ]
@@ -1752,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pea2pea"
@@ -2274,6 +2268,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_update"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d58e73c427061f46c801176f54349be3c1a2818cf549e1d9bcac37eef7bca"
+dependencies = [
+ "hyper",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,18 +2292,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -2305,6 +2316,7 @@ version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2500,7 +2512,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "self_update",
+ "self_update 0.32.0",
  "serde",
  "serde_json",
  "snarkos-account",
@@ -2727,8 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c0728150b774a986de9185e31c319861f8cd40b310ebd037533e9d649d59a2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2738,7 +2751,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "self_update",
+ "self_update 0.34.0",
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -2754,12 +2767,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea29bd35b0d5c45698a66f856225a8d0c7b966d5ab319e05d6d10ce1dbb3f23"
 dependencies = [
  "aleo-std",
  "anyhow",
- "hashbrown 0.13.1",
+ "hashbrown 0.13.2",
  "hex",
  "itertools",
  "parking_lot",
@@ -2780,8 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9196734dce55b69d4d764c4df07ebe78833a600944b41b71b115b9ffb926650b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2794,8 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4db902a0adabee9bd2a6929efd69de6b41cae42a3cf7ce784f030890ff6700"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2805,8 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80de37cea23d3573aa04b3d298d92cdb738d71c11b2e736700208910b6d0cfe"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2815,8 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d0a54513c1b75e6e4530b3ea9bdf49812670c1ce103d617249ad18164ee252"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2825,8 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46e5db5895d350a0b5a5dc39cf10e0b152a42565faffd1ed76cc458d65d97ab"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2843,13 +2862,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f83bb5cf7b3d9360867233716ffd6a62e8e8ae75f798ebec5c18593c54aecc"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e1521cf9bc4714c39f8c9e41d32879933e02a633e4a4d47a3d857fe86b7eac"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2859,8 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab54a75f46d3e8d73e6f739eaa576496821cd88b730c0029cb068b8e5778afe"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -2872,8 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bd7d752f4832011a7f1d164a6fd480bbf424eaaf6bf85290c3e52ee656610f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2887,8 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d507d9a84aef461e1f13232b9e900bb1436a475113342b7ac25b2285808de9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2900,8 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b32dc28b121e8a8e9d1fa6ffa2d245ed6b4ee6a001d5a178705d7493decc8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2909,8 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9b3f21795819542b026db039b8e74409386e479c67e851f61aaf15bcd9ff46"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2919,8 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d755d0bc23b58055ef956fe6f4c498d4ff1fcb7290f0811528fd8668eca494a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2931,8 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad0a54e974581cce76211bc32a7adb0dc027974b80f40a6237a652b8ed66130"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2942,8 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5d9d53e3cb99a49a11be55ac32db33887f5bc467d823c6873a6a1d5113543a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2953,8 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd98c46ba6c04a3caf41fd99b981479510808286c1981017f5caf847b43ab37"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2965,8 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13834f575d3f8c8aa62361f08dbb9f41ef4eafce296e6be5cae1b6966eb73c5"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2978,8 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b5a730f6c4542c6ee0907303aff3fac037f311c0874c94df6a3429560f0c2f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2988,8 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788804605492027933da6120c83460cc98eca942f1a825417c0a41f03222854e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3000,8 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ed387325f5a757473aa0d64af6ead114de31096885e58f1ceb7be31a5865da"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3011,8 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cf4ad08931e869198db0f39100d02fdd2d34e569f807adc8ea0bd5d218e365"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3034,8 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872cd5160b4a133055e20c9399e9bc750ea91df61a63835bbb44427499a761ba"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3051,8 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e4f352a38234c3ebb66c0c5c09ca953d793c632f8bbcbebd2ee80afe87681e"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3065,12 +3102,14 @@ dependencies = [
  "snarkvm-console-collections",
  "snarkvm-console-network",
  "snarkvm-console-types",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3bec5e9e9807607cef75b15dd3fd82b125232b2e36929ea1417ce50726ed9ca"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3084,8 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fbaf39ea6c86b6648409fb2802e38356660faecaed2c1e178a3599a84b153f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3095,16 +3135,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568ba94bec2f7f7cdb8d2f54378da632a875959d864c5dac3b8159c391ee83d4"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18272c987b1e0191a75f4878e766307751a4fabdf04a0b4769b2e91e2652d711"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3112,8 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f461148e079732cd336478b6a2e3683bbca2e442486a71f1cec7c4dd363021d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3123,8 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac592e77f726ee8f0c6ad0162f25d496807b0995b39ff73eab83f6191ae4ba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3133,8 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73dd95cd6cb6edfa01e26b0686deaff882321a38a103217d66f1f05aaac3e10b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3143,8 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7093713b19aa004a24199dd82e8bea4e7610c46212adb0ff6582b07a3fdab06b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3154,8 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a26fe6de2b6096665604bda2296f981e7c34fb77b0a5707b07f7a6d79a0bf1e"
 dependencies = [
  "rand",
  "rustc_version",
@@ -3167,8 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4cac728c6ce9b52952a353454429ab6c2af1954d0183db5f85a907ac481cfd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3184,8 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7d259b389681963d796321327df59775eaf407f2d0caf784619d5f8bed08ef"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3209,8 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090b77b059b3d6a27231400b42de6d65a51a47ed6dc9d60732c42d2d853e26f2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3225,8 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0cdebc9f68b2a339565053b73fb72fa0f032519781af6fcf58ab0c5ba2adc1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3252,8 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b15f33845b685fa19b18eb18705bbaaa4af72b5aaaa0f330a630135ee4dbeb"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3264,14 +3316,16 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "serde",
+ "serde_json",
  "snarkvm-utilities-derives",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.9.11"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f177302#f1773026e2cfbbca435ace5cdeba9ca0f7c50cc2"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d70d67e3a5adee2e2ecb7b6eeda17b1bcc9317b5f76aaf0cdb1f67c279d1cb7"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -3852,12 +3906,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.5.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
  "base64",
- "chunked_transfer",
  "flate2",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ path = "snarkos/main.rs"
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 #git = "https://github.com/AleoHQ/snarkVM.git"
-#rev = "0c20d9a"
-version = "0.9.12"
+#rev = "67f8829"
+version = "0.9.13"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
- path = "../snarkVM"
-#git = "https://github.com/AleoHQ/snarkVM.git"
-#rev = "d27939f"
+#path = "../snarkVM"
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "f177302"
 #version = "0.9.10"
 features = ["circuit", "console", "parallel"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
-# path = "../snarkvm"
+ path = "../snarkVM"
 #git = "https://github.com/AleoHQ/snarkVM.git"
 #rev = "d27939f"
-version = "0.9.10"
+#version = "0.9.10"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "f177302"
-#version = "0.9.10"
+#git = "https://github.com/AleoHQ/snarkVM.git"
+#rev = "0c20d9a"
+version = "0.9.12"
 features = ["circuit", "console", "parallel"]
 
 [dependencies.anyhow]

--- a/cli/src/commands/account.rs
+++ b/cli/src/commands/account.rs
@@ -117,7 +117,7 @@ impl Account {
                 return Ok(account.to_string());
             } else {
                 let rate = ITERATIONS / timer.elapsed().as_millis();
-                let rate = format!("[{} a/ms]", rate);
+                let rate = format!("[{rate} a/ms]");
                 println!(" {} Sampled {ITERATIONS_STR} accounts, searching...", rate.dimmed());
             }
         }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -619,9 +619,7 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
         /* Proof(s) */
 
         // Ensure the transaction is valid.
-        if !self.ledger.vm().verify(transaction) {
-            bail!("Transaction '{transaction_id}' is invalid")
-        }
+        self.ledger.vm().check_transaction(transaction)?;
 
         /* Input */
 

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -180,7 +180,7 @@ function compute:
                 )
                 .unwrap();
                 // Verify.
-                assert!(consensus.ledger.vm().verify(&transaction));
+                assert!(consensus.ledger.vm().verify_transaction(&transaction));
                 // Return the transaction.
                 transaction
             })
@@ -232,7 +232,7 @@ function compute:
                 // Execute.
                 let transaction = Transaction::execute_authorization(vm, authorization, None, rng).unwrap();
                 // Verify.
-                assert!(vm.verify(&transaction));
+                assert!(vm.verify_transaction(&transaction));
                 // Return the transaction.
                 transaction
             })

--- a/node/ledger/src/find.rs
+++ b/node/ledger/src/find.rs
@@ -39,13 +39,16 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
     }
 
     /// Returns the transaction ID that contains the given `program ID`.
-    pub fn find_deployment_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
-        self.vm.transaction_store().find_deployment_id(program_id)
+    pub fn find_transaction_id_from_program_id(&self, program_id: &ProgramID<N>) -> Result<Option<N::TransactionID>> {
+        self.vm.transaction_store().find_transaction_id_from_program_id(program_id)
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
-    pub fn find_transaction_id(&self, transition_id: &N::TransitionID) -> Result<Option<N::TransactionID>> {
-        self.vm.transaction_store().find_transaction_id(transition_id)
+    pub fn find_transaction_id_from_transition_id(
+        &self,
+        transition_id: &N::TransitionID,
+    ) -> Result<Option<N::TransactionID>> {
+        self.vm.transaction_store().find_transaction_id_from_transition_id(transition_id)
     }
 
     /// Returns the transition ID that contains the given `input ID` or `output ID`.

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -128,7 +128,7 @@ pub enum Message<N: Network> {
 
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 4;
+    pub const VERSION: u32 = 5;
 
     /// Returns the message name.
     #[inline]

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -153,21 +153,21 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .and(with(self.ledger.clone()))
             .and_then(Self::find_block_hash);
 
-        // GET /testnet3/find/deploymentID/{programID}
-        let find_deployment_id = warp::get()
-            .and(warp::path!("testnet3" / "find" / "deploymentID" / ..))
+        // GET /testnet3/find/transactionID/deployment/{programID}
+        let find_transaction_id_from_program_id = warp::get()
+            .and(warp::path!("testnet3" / "find" / "transactionID" / "deployment" / ..))
             .and(warp::path::param::<ProgramID<N>>())
             .and(warp::path::end())
             .and(with(self.ledger.clone()))
-            .and_then(Self::find_deployment_id);
+            .and_then(Self::find_transaction_id_from_program_id);
 
         // GET /testnet3/find/transactionID/{transitionID}
-        let find_transaction_id = warp::get()
+        let find_transaction_id_from_transition_id = warp::get()
             .and(warp::path!("testnet3" / "find" / "transactionID" / ..))
             .and(warp::path::param::<N::TransitionID>())
             .and(warp::path::end())
             .and(with(self.ledger.clone()))
-            .and_then(Self::find_transaction_id);
+            .and_then(Self::find_transaction_id_from_transition_id);
 
         // GET /testnet3/find/transitionID/{inputOrOutputID}
         let find_transition_id = warp::get()
@@ -206,8 +206,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .or(get_peers_all_metrics)
             .or(get_node_address)
             .or(find_block_hash)
-            .or(find_deployment_id)
-            .or(find_transaction_id)
+            .or(find_transaction_id_from_program_id)
+            .or(find_transaction_id_from_transition_id)
             .or(find_transition_id)
             .or(transaction_broadcast)
     }
@@ -341,16 +341,19 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// Returns the transaction ID that contains the given `program ID`.
-    async fn find_deployment_id(program_id: ProgramID<N>, ledger: Ledger<N, C>) -> Result<impl Reply, Rejection> {
-        Ok(reply::json(&ledger.find_deployment_id(&program_id).or_reject()?))
+    async fn find_transaction_id_from_program_id(
+        program_id: ProgramID<N>,
+        ledger: Ledger<N, C>,
+    ) -> Result<impl Reply, Rejection> {
+        Ok(reply::json(&ledger.find_transaction_id_from_program_id(&program_id).or_reject()?))
     }
 
     /// Returns the transaction ID that contains the given `transition ID`.
-    async fn find_transaction_id(
+    async fn find_transaction_id_from_transition_id(
         transition_id: N::TransitionID,
         ledger: Ledger<N, C>,
     ) -> Result<impl Reply, Rejection> {
-        Ok(reply::json(&ledger.find_transaction_id(&transition_id).or_reject()?))
+        Ok(reply::json(&ledger.find_transaction_id_from_transition_id(&transition_id).or_reject()?))
     }
 
     /// Returns the transition ID that contains the given `input ID` or `output ID`.

--- a/node/store/src/lib.rs
+++ b/node/store/src/lib.rs
@@ -98,6 +98,10 @@ pub enum DataID {
     KeyValueIDMap,
     KeyMap,
     ValueMap,
+
+    // TODO (raychu86): Move this up to Deployment for phase 3.
+    DeploymentReverseFeeMap,
+
     // Testing
     #[cfg(test)]
     Test,

--- a/node/store/src/transaction.rs
+++ b/node/store/src/transaction.rs
@@ -83,6 +83,8 @@ pub struct DeploymentDB<N: Network> {
     certificate_map: DataMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>,
     /// The fee map.
     fee_map: DataMap<N::TransactionID, (N::TransitionID, N::StateRoot, Option<Proof<N>>)>,
+    /// The reverse fee map.
+    reverse_fee_map: DataMap<N::TransitionID, N::TransactionID>,
     /// The transition store.
     transition_store: TransitionStore<N, TransitionDB<N>>,
 }
@@ -96,6 +98,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
     type VerifyingKeyMap = DataMap<(ProgramID<N>, Identifier<N>, u16), VerifyingKey<N>>;
     type CertificateMap = DataMap<(ProgramID<N>, Identifier<N>, u16), Certificate<N>>;
     type FeeMap = DataMap<N::TransactionID, (N::TransitionID, N::StateRoot, Option<Proof<N>>)>;
+    type ReverseFeeMap = DataMap<N::TransitionID, N::TransactionID>;
     type TransitionStorage = TransitionDB<N>;
 
     /// Initializes the deployment storage.
@@ -110,6 +113,7 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
             verifying_key_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentVerifyingKeyMap)?,
             certificate_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentCertificateMap)?,
             fee_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentFeeMap)?,
+            reverse_fee_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentReverseFeeMap)?,
             transition_store,
         })
     }
@@ -147,6 +151,11 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
     /// Returns the fee map.
     fn fee_map(&self) -> &Self::FeeMap {
         &self.fee_map
+    }
+
+    /// Returns the reverse fee map.
+    fn reverse_fee_map(&self) -> &Self::ReverseFeeMap {
+        &self.reverse_fee_map
     }
 
     /// Returns the transition store.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds support for finding and spending deployment fees by adding fixes from - https://github.com/AleoHQ/snarkVM/pull/1316.

This is a draft PR, since it currently relies on a specific rev of snarkVM and not an official release.
