### PR TITLE
Fix `.integration` CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
     steps:
       - run_serial:
           workspace_member: .integration
+          no_output_timeout: 60m
           cache_key: snarkos-integration-cache
 
   snarkos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,12 +91,15 @@ commands:
       flags:
         type: string
         default: ""
+      timeout:
+        type: string
+        default: "30m"
     steps:
       - checkout
       - setup_environment:
           cache_key: << parameters.cache_key >>
       - run:
-          no_output_timeout: 30m
+          no_output_timeout: << parameters.timeout >>
           command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
       - clear_environment:
           cache_key: << parameters.cache_key >>
@@ -141,8 +144,8 @@ jobs:
     steps:
       - run_serial:
           workspace_member: .integration
-          no_output_timeout: 60m
           cache_key: snarkos-integration-cache
+          timeout: "60m"
 
   snarkos:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
       - run_serial:
           workspace_member: .integration
           cache_key: snarkos-integration-cache
-          timeout: "60m"
+          timeout: "120m"
 
   snarkos:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
       - run_serial:
           workspace_member: .integration
           cache_key: snarkos-integration-cache
-          timeout: "120m"
+          timeout: "180m"
 
   snarkos:
     docker:

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022 Aleo Systems Inc.
+// Copyright (C) 2019-2023 Aleo Systems Inc.
 // This file is part of the snarkOS library.
 
 // The snarkOS library is free software: you can redistribute it and/or modify


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `no_output_timeout` to 60 minutes for the `.integration` CI job (sync CDN to tip).
