### PR TITLE
Update documentation to clarify `start` command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,27 +153,29 @@ SUBCOMMANDS:
 
 The following are the options for the `snarkos start` command:
 ```
-snarkos-start 
-Starts the snarkOS node
-
 USAGE:
     snarkos start [OPTIONS]
 
 OPTIONS:
-        --beacon <PRIVATE KEY>           Specify this as a beacon, with the given account private key for this node as an argument
-        --client <PRIVATE KEY>           Specify this as a client, with an optional account private key for this node as an argument
-        --connect <IP ADDRESS>           Specify the IP address and port of a peer to connect to [default: ]
-        --dev <NODE ID>                  Enables development mode, specify a unique ID for this node
-    -h, --help                           Print help information
-        --logfile <PATH>                 Specify the path to the file where logs will be stored [default: /tmp/snarkos.log]
-        --network <NETWORK_ID>           Specify the network of this node [default: 3]
-        --node <IP ADDRESS>              Specify the IP address and port for the node server [default: 0.0.0.0:4133]
-        --nodisplay                      If the flag is set, the node will not render the display
-        --norest                         If the flag is set, the node will not initialize the REST server
-        --prover <PRIVATE KEY>           Specify this as a prover, with the given account private key for this node as an argument
+        --network <NETWORK_ID>           Specify the network ID of this node [default: 3]
+        
+        --beacon <PRIVATE_KEY>           Specify this node as a beacon, with the account private key as an argument
+        --validator <PRIVATE KEY>        Specify this node as a validator, with the account private key as an argument
+        --prover <PRIVATE KEY>           Specify this node as a prover, with the given account private key as an argument
+        --client <PRIVATE_KEY>           Specify this node as a client, with an optional account private key as an argument
+        
+        --node <IP:PORT>                 Specify the IP address and port for the node server [default: 0.0.0.0:4133]
+        --connect <IP:PORT>              Specify the IP address and port of a peer to connect to
+        
         --rest <REST>                    Specify the IP address and port for the REST server [default: 0.0.0.0:3033]
-        --validator <PRIVATE KEY>        Specify this as a validator, with the given account private key for this node as an argument
+        --norest                         If the flag is set, the node will not initialize the REST server
+        
+        --nodisplay                      If the flag is set, the node will not render the display
         --verbosity <VERBOSITY_LEVEL>    Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
+        --logfile <PATH>                 Specify the path to the file where logs will be stored [default: /tmp/snarkos.log]
+        
+        --dev <NODE_ID>                  Enables development mode, specify a unique ID for this node
+    -h, --help                           Print help information
 ```
 
 ## 6. Development

--- a/README.md
+++ b/README.md
@@ -160,20 +160,20 @@ USAGE:
     snarkos start [OPTIONS]
 
 OPTIONS:
-        --beacon <BEACON>          Specify this as a beacon, with the given account private key for this node
-        --client <CLIENT>          Specify this as a client, with an optional account private key for this node
-        --connect <CONNECT>        Specify the IP address and port of a peer to connect to [default: ]
-        --dev <DEV>                Enables development mode, specify a unique ID for this node
-    -h, --help                     Print help information
-        --logfile <LOGFILE>        Specify the path to the file where logs will be stored [default: /tmp/snarkos.log]
-        --network <NETWORK>        Specify the network of this node [default: 3]
-        --node <NODE>              Specify the IP address and port for the node server [default: 0.0.0.0:4133]
-        --nodisplay                If the flag is set, the node will not render the display
-        --norest                   If the flag is set, the node will not initialize the REST server
-        --prover <PROVER>          Specify this as a prover, with the given account private key for this node
-        --rest <REST>              Specify the IP address and port for the REST server [default: 0.0.0.0:3033]
-        --validator <VALIDATOR>    Specify this as a validator, with the given account private key for this node
-        --verbosity <VERBOSITY>    Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
+        --beacon <PRIVATE KEY>           Specify this as a beacon, with the given account private key for this node as an argument
+        --client <PRIVATE KEY>           Specify this as a client, with an optional account private key for this node as an argument
+        --connect <IP ADDRESS>           Specify the IP address and port of a peer to connect to [default: ]
+        --dev <NODE ID>                  Enables development mode, specify a unique ID for this node
+    -h, --help                           Print help information
+        --logfile <PATH>                 Specify the path to the file where logs will be stored [default: /tmp/snarkos.log]
+        --network <NETWORK_ID>           Specify the network of this node [default: 3]
+        --node <IP ADDRESS>              Specify the IP address and port for the node server [default: 0.0.0.0:4133]
+        --nodisplay                      If the flag is set, the node will not render the display
+        --norest                         If the flag is set, the node will not initialize the REST server
+        --prover <PRIVATE KEY>           Specify this as a prover, with the given account private key for this node as an argument
+        --rest <REST>                    Specify the IP address and port for the REST server [default: 0.0.0.0:3033]
+        --validator <PRIVATE KEY>        Specify this as a validator, with the given account private key for this node as an argument
+        --verbosity <VERBOSITY_LEVEL>    Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
 ```
 
 ## 6. Development
@@ -196,13 +196,13 @@ This procedure can be repeated to start more nodes.
 
 It is important to initialize the nodes starting from `0` and incrementing by `1` for each new node.
 
-The following is a list of options to initialize a node (replace `XX` with a number starting from `0`):
+The following is a list of options to initialize a node (replace `<NODE_ID` with a number starting from `0`):
 ```
-cargo run --release -- start --nodisplay --dev XX --beacon ""
-cargo run --release -- start --nodisplay --dev XX --validator ""
-cargo run --release -- start --nodisplay --dev XX --prover ""
-cargo run --release -- start --nodisplay --dev XX --client ""
-cargo run --release -- start --nodisplay --dev XX
+cargo run --release -- start --nodisplay --dev <NODE_ID> --beacon ""
+cargo run --release -- start --nodisplay --dev <NODE_ID> --validator ""
+cargo run --release -- start --nodisplay --dev <NODE_ID> --prover ""
+cargo run --release -- start --nodisplay --dev <NODE_ID> --client ""
+cargo run --release -- start --nodisplay --dev <NODE_ID>
 ```
 
 When no node type is specified, the node will default to `--client`.
@@ -211,7 +211,7 @@ When no node type is specified, the node will default to `--client`.
 
 To clean up the node storage, run:
 ```
-cargo run --release -- clean --dev XX
+cargo run --release -- clean --dev <NODE_ID>
 ```
 
 ## 7. License

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This procedure can be repeated to start more nodes.
 
 It is important to initialize the nodes starting from `0` and incrementing by `1` for each new node.
 
-The following is a list of options to initialize a node (replace `<NODE_ID` with a number starting from `0`):
+The following is a list of options to initialize a node (replace `<NODE_ID>` with a number starting from `0`):
 ```
 cargo run --release -- start --nodisplay --dev <NODE_ID> --beacon ""
 cargo run --release -- start --nodisplay --dev <NODE_ID> --validator ""

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -40,52 +40,53 @@ const RECOMMENDED_MIN_NOFILES_LIMIT_VALIDATOR: u64 = 1024;
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
 pub struct Start {
-    /// Specify the network of this node [default: 3].
+    /// Specify the network of this node
     #[clap(default_value = "3", long = "network")]
     pub network: u16,
-    /// Enables development mode, specify a unique ID for this node.
-    #[clap(long)]
-    pub dev: Option<u16>,
 
-    /// Specify this as a beacon, with the given account private key for this node as an argument
+    /// Specify this node as a beacon, with the account private key as an argument
     #[clap(long = "beacon")]
     pub beacon: Option<String>,
-    /// Specify this as a validator, with the given account private key for this node as an
-    /// argument
+    /// Specify this node as a validator, with the account private key as an argument
     #[clap(long = "validator")]
     pub validator: Option<String>,
-    /// Specify this as a prover, with the given account private key for this node as an argument
+    /// Specify this node as a prover, with the account private key as an argument
     #[clap(long = "prover")]
     pub prover: Option<String>,
-    /// Specify this as a client, with an optional account private key for this node as an argument
+    /// Specify this node as a client, with an optional account private key as an argument
     #[clap(long = "client")]
     pub client: Option<String>,
 
-    /// Specify the IP address and port of a peer to connect to.
-    #[clap(default_value = "", long = "connect")]
-    pub connect: String,
-    /// Specify the IP address and port for the node server.
+    /// Specify the IP address and port for the node server
     #[clap(default_value = "0.0.0.0:4133", long = "node")]
     pub node: SocketAddr,
-    /// Specify the IP address and port for the REST server.
+    /// Specify the IP address and port of a peer to connect to
+    #[clap(default_value = "", long = "connect")]
+    pub connect: String,
+    
+    /// Specify the IP address and port for the REST server
     #[clap(default_value = "0.0.0.0:3033", long = "rest")]
     pub rest: SocketAddr,
-    /// If the flag is set, the node will not initialize the REST server.
+    /// If the flag is set, the node will not initialize the REST server
     #[clap(long)]
     pub norest: bool,
 
+    /// If the flag is set, the node will not render the display
+    #[clap(long)]
+    pub nodisplay: bool,
     /// Specify the verbosity of the node [options: 0, 1, 2, 3, 4]
     #[clap(default_value = "2", long = "verbosity")]
     pub verbosity: u8,
-    /// If the flag is set, the node will not render the display.
-    #[clap(long)]
-    pub nodisplay: bool,
-    /// Enables the node to prefetch initial blocks from a CDN.
-    #[clap(default_value = "https://testnet3.blocks.aleo.org/phase2", long = "cdn")]
-    pub cdn: String,
-    /// Specify the path to the file where logs will be stored.
+    /// Specify the path to the file where logs will be stored
     #[clap(default_value_os_t = std::env::temp_dir().join("snarkos.log"), long = "logfile")]
     pub logfile: PathBuf,
+    
+    /// Enables the node to prefetch initial blocks from a CDN
+    #[clap(default_value = "https://testnet3.blocks.aleo.org/phase2", long = "cdn")]
+    pub cdn: String,
+    /// Enables development mode, specify a unique ID for this node
+    #[clap(long)]
+    pub dev: Option<u16>,
 }
 
 impl Start {

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -40,7 +40,7 @@ const RECOMMENDED_MIN_NOFILES_LIMIT_VALIDATOR: u64 = 1024;
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
 pub struct Start {
-    /// Specify the network of this node
+    /// Specify the network ID of this node
     #[clap(default_value = "3", long = "network")]
     pub network: u16,
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -63,7 +63,7 @@ pub struct Start {
     /// Specify the IP address and port of a peer to connect to
     #[clap(default_value = "", long = "connect")]
     pub connect: String,
-    
+
     /// Specify the IP address and port for the REST server
     #[clap(default_value = "0.0.0.0:3033", long = "rest")]
     pub rest: SocketAddr,
@@ -80,7 +80,7 @@ pub struct Start {
     /// Specify the path to the file where logs will be stored
     #[clap(default_value_os_t = std::env::temp_dir().join("snarkos.log"), long = "logfile")]
     pub logfile: PathBuf,
-    
+
     /// Enables the node to prefetch initial blocks from a CDN
     #[clap(default_value = "https://testnet3.blocks.aleo.org/phase2", long = "cdn")]
     pub cdn: String,

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -40,23 +40,24 @@ const RECOMMENDED_MIN_NOFILES_LIMIT_VALIDATOR: u64 = 1024;
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
 pub struct Start {
-    /// Specify the network of this node.
+    /// Specify the network of this node [default: 3].
     #[clap(default_value = "3", long = "network")]
     pub network: u16,
     /// Enables development mode, specify a unique ID for this node.
     #[clap(long)]
     pub dev: Option<u16>,
 
-    /// Specify this as a beacon, with the given account private key for this node.
+    /// Specify this as a beacon, with the given account private key for this node as an argument
     #[clap(long = "beacon")]
     pub beacon: Option<String>,
-    /// Specify this as a validator, with the given account private key for this node.
+    /// Specify this as a validator, with the given account private key for this node as an
+    /// argument
     #[clap(long = "validator")]
     pub validator: Option<String>,
-    /// Specify this as a prover, with the given account private key for this node.
+    /// Specify this as a prover, with the given account private key for this node as an argument
     #[clap(long = "prover")]
     pub prover: Option<String>,
-    /// Specify this as a client, with an optional account private key for this node.
+    /// Specify this as a client, with an optional account private key for this node as an argument
     #[clap(long = "client")]
     pub client: Option<String>,
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

The existing README.md in snarkOS does not adequately specify the argument to be passed for the various command line options for the `start` command. This PR adds more verbiage to help developers understand exactly how they are meant to use the various options when starting a snarkOS node. 

## Test Plan

Can be verified directly by viewing the source of README.md, or by running `snarkos start --help`

## Related PRs

None
