### PR TITLE
Add functionality to the renaming suggestions in PR [#2262]

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This procedure can be repeated to start more nodes.
 
 It is important to initialize the nodes starting from `0` and incrementing by `1` for each new node.
 
-The following is a list of options to initialize a node (replace `XX` with a number starting from `0`):
+The following is a list of options to initialize a node (replace `<NODE_ID>` with a number starting from `0`):
 ```
 cargo run --release -- start --nodisplay --dev <NODE_ID> --beacon ""
 cargo run --release -- start --nodisplay --dev <NODE_ID> --validator ""

--- a/README.md
+++ b/README.md
@@ -160,21 +160,21 @@ USAGE:
     snarkos start [OPTIONS]
 
 OPTIONS:
-        --beacon Specify this node to run as a beacon
-        --cdn <URL> Enables the node to prefetch initial blocks from a CDN [default: https://testnet3.blocks.aleo.org/phase2]
-        --client Specify this node to run as a client
-        --dev <NODE_ID> Enables development mode, specify a unique ID for this node
-    -h, --help Print help information
-        --logfile <PATH> Path to file where logs will be stored [default: /path/to/snarkos.log]
-        --network <NETWORK_ID> The network this node should operate on [default: 3] [default: 3]
-        --node <IP:PORT> IP address and port for the node server [default: 0.0.0.0:4133]
-        --nodisplay If this flag is set, the node will not render the display
-        --norest If this flag is set, the node will not initialize the REST server
-        --connect <IP:PORT> IP address and port of a peer to connect to [default: ]
-        --private_key <PRIVATE_KEY> The private key to be used for this node. If left blank in development mode, a new key will be generated
-        --prover Specify this node to run as a prover
-        --rest <IP:PORT> IP address and port for the REST server [default: 0.0.0.0:3033]
-        --validator Specify this node to run as a validator
+        --beacon                      Specify this node to run as a beacon
+        --cdn <URL>                   Enables the node to prefetch initial blocks from a CDN [default: https://testnet3.blocks.aleo.org/phase2]
+        --client                      Specify this node to run as a client
+        --dev <NODE_ID>               Enables development mode, specify a unique ID for this node
+    -h, --help                        Print help information
+        --logfile <PATH>              Path to file where logs will be stored [default: /path/to/snarkos.log]
+        --network <NETWORK_ID>        The network this node should operate on [default: 3] [default: 3]
+        --node <IP:PORT>              IP address and port for the node server [default: 0.0.0.0:4133]
+        --nodisplay                   If this flag is set, the node will not render the display
+        --norest                      If this flag is set, the node will not initialize the REST server
+        --connect <IP:PORT>           IP address and port of a peer to connect to [default: ]
+        --private_key <PRIVATE_KEY>   The private key to be used for this node. If left blank in development mode, a new key will be generated
+        --prover                      Specify this node to run as a prover
+        --rest <IP:PORT>              IP address and port for the REST server [default: 0.0.0.0:3033]
+        --validator                   Specify this node to run as a validator
         --verbosity <VERBOSITY_LEVEL> The verbosity of the node [options: 0, 1, 2, 3, 4] [default: 2]
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,20 +160,22 @@ USAGE:
     snarkos start [OPTIONS]
 
 OPTIONS:
-        --beacon <BEACON>          Specify this as a beacon, with the given account private key for this node
-        --client <CLIENT>          Specify this as a client, with an optional account private key for this node
-        --connect <CONNECT>        Specify the IP address and port of a peer to connect to [default: ]
-        --dev <DEV>                Enables development mode, specify a unique ID for this node
-    -h, --help                     Print help information
-        --logfile <LOGFILE>        Specify the path to the file where logs will be stored [default: /tmp/snarkos.log]
-        --network <NETWORK>        Specify the network of this node [default: 3]
-        --node <NODE>              Specify the IP address and port for the node server [default: 0.0.0.0:4133]
-        --nodisplay                If the flag is set, the node will not render the display
-        --norest                   If the flag is set, the node will not initialize the REST server
-        --prover <PROVER>          Specify this as a prover, with the given account private key for this node
-        --rest <REST>              Specify the IP address and port for the REST server [default: 0.0.0.0:3033]
-        --validator <VALIDATOR>    Specify this as a validator, with the given account private key for this node
-        --verbosity <VERBOSITY>    Specify the verbosity of the node [options: 0, 1, 2, 3] [default: 2]
+        --beacon Specify this node to run as a beacon
+        --cdn <URL> Enables the node to prefetch initial blocks from a CDN [default: https://testnet3.blocks.aleo.org/phase2]
+        --client Specify this node to run as a client
+        --dev <NODE_ID> Enables development mode, specify a unique ID for this node
+    -h, --help Print help information
+        --logfile <PATH> Path to file where logs will be stored [default: /path/to/snarkos.log]
+        --network <NETWORK_ID> The network this node should operate on [default: 3] [default: 3]
+        --node <IP:PORT> IP address and port for the node server [default: 0.0.0.0:4133]
+        --nodisplay If this flag is set, the node will not render the display
+        --norest If this flag is set, the node will not initialize the REST server
+        --connect <IP:PORT> IP address and port of a peer to connect to [default: ]
+        --private_key <PRIVATE_KEY> The private key to be used for this node. If left blank in development mode, a new key will be generated
+        --prover Specify this node to run as a prover
+        --rest <IP:PORT> IP address and port for the REST server [default: 0.0.0.0:3033]
+        --validator Specify this node to run as a validator
+        --verbosity <VERBOSITY_LEVEL> The verbosity of the node [options: 0, 1, 2, 3, 4] [default: 2]
 ```
 
 ## 6. Development
@@ -198,11 +200,11 @@ It is important to initialize the nodes starting from `0` and incrementing by `1
 
 The following is a list of options to initialize a node (replace `XX` with a number starting from `0`):
 ```
-cargo run --release -- start --nodisplay --dev XX --beacon ""
-cargo run --release -- start --nodisplay --dev XX --validator ""
-cargo run --release -- start --nodisplay --dev XX --prover ""
-cargo run --release -- start --nodisplay --dev XX --client ""
-cargo run --release -- start --nodisplay --dev XX
+cargo run --release -- start --nodisplay --dev <NODE_ID> --beacon ""
+cargo run --release -- start --nodisplay --dev <NODE_ID> --validator ""
+cargo run --release -- start --nodisplay --dev <NODE_ID> --prover ""
+cargo run --release -- start --nodisplay --dev <NODE_ID> --client ""
+cargo run --release -- start --nodisplay --dev <NODE_ID>
 ```
 
 When no node type is specified, the node will default to `--client`.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -43,7 +43,7 @@ pub struct Start {
     /// Specify the network ID of this node.
     #[clap(default_value = "3", long = "network", value_name = "NETWORK_ID")]
     pub network: u16,
-    /// Enables development mode, specify a unique ID for this node
+    /// Enables development mode, specify a unique ID for this node.
     #[clap(long, value_name = "NODE_ID")]
     pub dev: Option<u16>,
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -40,7 +40,7 @@ const RECOMMENDED_MIN_NOFILES_LIMIT_VALIDATOR: u64 = 1024;
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
 pub struct Start {
-    /// The network this node should operate on [default: 3]
+    /// Specify the network ID of this node.
     #[clap(default_value = "3", long = "network", value_name = "NETWORK_ID")]
     pub network: u16,
     /// Enables development mode, specify a unique ID for this node

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -47,7 +47,7 @@ pub struct Start {
     #[clap(long, value_name = "NODE_ID")]
     pub dev: Option<u16>,
 
-    /// Specify this node to run as a beacon
+    /// Specify this node to run as a beacon.
     #[clap(long = "beacon", conflicts_with_all = &["client", "prover", "validator"])]
     pub beacon: bool,
     /// Specify this node to run as a validator

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -569,27 +569,58 @@ mod tests {
     #[test]
     fn test_conflicting_flags() {
         // Test starting the SnarkOS node with the sigma algebra of conflicting flags, ensure they conflict
-        let err = Start::try_parse_from(["snarkos", "--beacon", "--validator", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(["snarkos", "--beacon", "--validator", "--private_key", "aleo1xx"].iter())
+            .unwrap_err()
+            .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--beacon", "--prover", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(["snarkos", "--beacon", "--prover", "--private_key", "aleo1xx"].iter())
+            .unwrap_err()
+            .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos","--beacon", "--client", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(["snarkos", "--beacon", "--client", "--private_key", "aleo1xx"].iter())
+            .unwrap_err()
+            .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0", "--validator", "--prover", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(["snarkos", "--validator", "--prover", "--private_key", "aleo1xx"].iter())
+            .unwrap_err()
+            .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0", "--validator", "--client", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(["snarkos", "--validator", "--client", "--private_key", "aleo1xx"].iter())
+            .unwrap_err()
+            .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0", "--prover", "--client", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(["snarkos", "--prover", "--client", "--private_key", "aleo1xx"].iter())
+            .unwrap_err()
+            .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0", "--prover", "--client", "--beacon", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err =
+            Start::try_parse_from(["snarkos", "--prover", "--client", "--beacon", "--private_key", "aleo1xx"].iter())
+                .unwrap_err()
+                .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0", "--prover", "--client", "--validator", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(
+            ["snarkos", "--prover", "--client", "--validator", "--private_key", "aleo1xx"].iter(),
+        )
+        .unwrap_err()
+        .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0", "--beacon", "--client", "--validator", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(
+            ["snarkos", "--beacon", "--client", "--validator", "--private_key", "aleo1xx"].iter(),
+        )
+        .unwrap_err()
+        .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0",  "--beacon", "--prover", "--validator", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(
+            ["snarkos", "--beacon", "--prover", "--validator", "--private_key", "aleo1xx"].iter(),
+        )
+        .unwrap_err()
+        .kind();
         assert_eq!(err, ArgumentConflict);
-        let err = Start::try_parse_from(["snarkos", "--dev", "0",  "--client", "--beacon", "--prover", "--validator", "--private_key", "aleo1xx"].iter()).unwrap_err().kind();
+        let err = Start::try_parse_from(
+            ["snarkos", "--client", "--beacon", "--prover", "--validator", "--private_key", "aleo1xx"].iter(),
+        )
+        .unwrap_err()
+        .kind();
         assert_eq!(err, ArgumentConflict);
     }
 }

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -50,7 +50,7 @@ pub struct Start {
     /// Specify this node to run as a beacon.
     #[clap(long = "beacon", conflicts_with_all = &["client", "prover", "validator"])]
     pub beacon: bool,
-    /// Specify this node to run as a validator
+    /// Specify this node to run as a validator.
     #[clap(long = "validator", conflicts_with_all = &["beacon", "client", "prover"])]
     pub validator: bool,
     /// Specify this node to run as a prover

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -53,13 +53,13 @@ pub struct Start {
     /// Specify this node to run as a validator.
     #[clap(long = "validator", conflicts_with_all = &["beacon", "client", "prover"])]
     pub validator: bool,
-    /// Specify this node to run as a prover
+    /// Specify this node to run as a prover.
     #[clap(long = "prover", conflicts_with_all = &["beacon", "client", "validator"])]
     pub prover: bool,
-    /// Specify this node to run as a client
+    /// Specify this node to run as a client.
     #[clap(long = "client", conflicts_with_all = &["beacon", "prover", "validator"])]
     pub client: bool,
-    /// The private key to be used for this node. If left blank in development mode, a new key will be generated
+    /// Specify the private key of this node.
     #[clap(long = "private_key")]
     pub private_key: Option<String>,
 


### PR DESCRIPTION
## Motivation

PR #2262 suggests that documentation be updated to be more clear. This PR adds the suggested documentation into the CLI tool.

## Changelog
* Refactors the node configuration options as flags
* Adds a separate command line option for --private_key to disambiguate where the private key should be specified
* Adds renaming suggestions in the documentation & cli suggested in #2262 

## Test Plan
* All unit tests currently pass, added a test to ensure the tool is not allowed to start with conflicting `node type` flags
* If these changes are philosophically accepted, further test coverage will be written to cover further edge cases of the start command

## Related PRs
#2262 
