### PR TITLE
[Fix] Migrate integration test to run on a schedule to unblock CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,26 @@ commands:
       - clear_environment:
           cache_key: << parameters.cache_key >>
 
+  run_serial_long:
+    description: "Build and run long running tests"
+    parameters:
+      workspace_member:
+        type: string
+      cache_key:
+        type: string
+      flags:
+        type: string
+        default: ""
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: << parameters.cache_key >>
+      - run:
+          no_output_timeout: 300m
+          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
+      - clear_environment:
+          cache_key: << parameters.cache_key >>
+
   run_parallel:
     description: "Build and run tests (in parallel)"
     parameters:
@@ -139,7 +159,7 @@ jobs:
       - image: cimg/rust:1.65
     resource_class: 2xlarge
     steps:
-      - run_serial:
+      - run_serial_long:
           workspace_member: .integration
           cache_key: snarkos-integration-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,6 @@ jobs:
       - image: cimg/rust:1.65
     resource_class: 2xlarge
     steps:
-      - no_output_timeout: 300m
       - run_serial:
           workspace_member: .integration
           cache_key: snarkos-integration-cache
@@ -340,7 +339,7 @@ workflows:
                 node
               ]
 
-  nightly-workflow:
+  scheduled-workflow:
     triggers:
       - schedule:
           cron: "0 0,12 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
       - image: cimg/rust:1.65
     resource_class: 2xlarge
     steps:
+      - no_output_timeout: 300m
       - run_serial:
           workspace_member: .integration
           cache_key: snarkos-integration-cache
@@ -311,7 +312,6 @@ workflows:
 
   main-workflow:
     jobs:
-      - integration
       - snarkos
       - account
       - cli
@@ -339,3 +339,14 @@ workflows:
                 display,
                 node
               ]
+
+  nightly-workflow:
+    triggers:
+      - schedule:
+          cron: "0 0,12 * * *"
+          filters:
+            branches:
+              only:
+                - testnet3
+    jobs:
+      - integration


### PR DESCRIPTION
## Motivation

The integration test is currently configured to run on every push, which is timing out and causing ci to fail. 

Although this test SHOULD be run regularly, it is more of a healthcheck than a unit test and thus, more suited to run at regular intervals instead of on every push.

## Changelog
* Moved integration test to run on scheduled runs twice daily
* Created a `- run_serial_long` command with a timeout of `300m` designed for tests that are known/designed to be long running. This param could've been changed in `run_serial` directly, but it would mean that any tests not designed to be long running would hang for hours, hurting iteration time against PRs & costing ci time.

## Test Plan
* The integration test should be triggered in SnarkOS to ensure it runs correctly