### PR TITLE
Increase `testnet3/transaction/broadcast` request size to 16 MB

### DIFF
--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -180,7 +180,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // POST /testnet3/transaction/broadcast
         let transaction_broadcast = warp::post()
             .and(warp::path!("testnet3" / "transaction" / "broadcast"))
-            .and(warp::body::content_length_limit(10 * 1024 * 1024))
+            .and(warp::body::content_length_limit(16 * 1024 * 1024))
             .and(warp::body::json())
             .and(with(self.consensus.clone()))
             .and(with(self.routing.clone()))


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR increases the node's transaction broadcast endpoint size restriction from 10MB to 16MB. 