### PR TITLE
Update message queue depth to 1024

### DIFF
--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -51,14 +51,14 @@ where
     /// messages the node can enqueue, but setting it to a large value can make the node more susceptible to DoS
     /// attacks.
     ///
-    /// The default value is 64.
-    const MESSAGE_QUEUE_DEPTH: usize = 64;
+    /// The default value is 1024.
+    const MESSAGE_QUEUE_DEPTH: usize = 1024;
 
     /// The initial size of a per-connection buffer for reading inbound messages. Can be set to the maximum expected size
     /// of the inbound message in order to only allocate it once.
     ///
-    /// The default value is 64KiB.
-    const INITIAL_BUFFER_SIZE: usize = 64 * 1024;
+    /// The default value is 1024KiB.
+    const INITIAL_BUFFER_SIZE: usize = 1024 * 1024;
 
     /// The final (deserialized) type of inbound messages.
     type Message: Send;

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -48,8 +48,8 @@ where
     /// messages the node can enqueue. Setting it to a large value is not recommended, as doing it might
     /// obscure potential issues with your implementation (like slow serialization) or network.
     ///
-    /// The default value is 64.
-    const MESSAGE_QUEUE_DEPTH: usize = 64;
+    /// The default value is 1024.
+    const MESSAGE_QUEUE_DEPTH: usize = 1024;
 
     /// The type of the outbound messages; unless their serialization is expensive and the message
     /// is broadcasted (in which case it would get serialized multiple times), serialization should


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR increases the message queue depth for `reading` and `writing` from `64` to `1024`. Though we may want to tune the number down, as `1024` might be a little high.

This change was necessary as we saw 
`ERROR tcp{name=\"0\"}: snarkos_node_tcp::protocols::reading: can't process a message from <IP_ADDRESS>: no available capacity` messages when the number of incoming coinbase solutions spiked. 
