### PR TITLE
modified atomic::ordering about shutdown

### DIFF
--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -136,7 +136,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
 
         // Shut down the sync pool.
         trace!("Shutting down the sync pool...");
-        self.shutdown.store(true, Ordering::SeqCst);
+        self.shutdown.store(true, Ordering::Relaxed);
 
         // Abort the tasks.
         trace!("Shutting down the validator...");


### PR DESCRIPTION
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/validator/mod.rs#L139
Here shutdown is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
