### PR TITLE
modified atomic::ordering about SEQUENTIAL_NODE_ID

### DIFF
--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -86,7 +86,7 @@ impl Tcp {
     pub fn new(mut config: Config) -> Self {
         // If there is no pre-configured name, assign a sequential numeric identifier.
         if config.name.is_none() {
-            config.name = Some(SEQUENTIAL_NODE_ID.fetch_add(1, SeqCst).to_string());
+            config.name = Some(SEQUENTIAL_NODE_ID.fetch_add(1, Relaxed).to_string());
         }
 
         // Create a tracing span containing the node's name.


### PR DESCRIPTION
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/tcp/src/tcp.rs#L89
I think the use of ordering here is irregular, SEQUENTIAL_NODE_ID is used here for counting, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.