### PR TITLE
modified atomic::ordering about shutdown and puzzle_instances

### DIFF
--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -120,7 +120,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Prover<N, C> {
 
         // Shut down the coinbase puzzle.
         trace!("Shutting down the coinbase puzzle...");
-        self.shutdown.store(true, Ordering::SeqCst);
+        self.shutdown.store(true, Ordering::Relaxed);
 
         // Abort the tasks.
         trace!("Shutting down the prover...");
@@ -244,19 +244,19 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
 
     /// Returns the current number of puzzle instances.
     fn num_puzzle_instances(&self) -> u8 {
-        self.puzzle_instances.load(Ordering::SeqCst)
+        self.puzzle_instances.load(Ordering::Relaxed)
     }
 
     /// Increments the number of puzzle instances.
     fn increment_puzzle_instances(&self) {
-        self.puzzle_instances.fetch_add(1, Ordering::SeqCst);
+        self.puzzle_instances.fetch_add(1, Ordering::Relaxed);
         #[cfg(debug_assertions)]
         trace!("Number of Instances - {}", self.num_puzzle_instances());
     }
 
     /// Decrements the number of puzzle instances.
     fn decrement_puzzle_instances(&self) {
-        self.puzzle_instances.fetch_sub(1, Ordering::SeqCst);
+        self.puzzle_instances.fetch_sub(1, Ordering::Relaxed);
         #[cfg(debug_assertions)]
         trace!("Number of Instances - {}", self.num_puzzle_instances());
     }


### PR DESCRIPTION
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L123
Here shutdown is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L247
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L252
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L259
Here puzzle_instance is used here for counting, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.