### PR TITLE
Fine-tune the Ordering for all the atomics

### DIFF
--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -120,7 +120,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Prover<N, C> {
 
         // Shut down the coinbase puzzle.
         trace!("Shutting down the coinbase puzzle...");
-        self.shutdown.store(true, Ordering::SeqCst);
+        self.shutdown.store(true, Ordering::Relaxed);
 
         // Abort the tasks.
         trace!("Shutting down the prover...");
@@ -244,19 +244,19 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
 
     /// Returns the current number of puzzle instances.
     fn num_puzzle_instances(&self) -> u8 {
-        self.puzzle_instances.load(Ordering::SeqCst)
+        self.puzzle_instances.load(Ordering::Relaxed)
     }
 
     /// Increments the number of puzzle instances.
     fn increment_puzzle_instances(&self) {
-        self.puzzle_instances.fetch_add(1, Ordering::SeqCst);
+        self.puzzle_instances.fetch_add(1, Ordering::Relaxed);
         #[cfg(debug_assertions)]
         trace!("Number of Instances - {}", self.num_puzzle_instances());
     }
 
     /// Decrements the number of puzzle instances.
     fn decrement_puzzle_instances(&self) {
-        self.puzzle_instances.fetch_sub(1, Ordering::SeqCst);
+        self.puzzle_instances.fetch_sub(1, Ordering::Relaxed);
         #[cfg(debug_assertions)]
         trace!("Number of Instances - {}", self.num_puzzle_instances());
     }

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -136,7 +136,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
 
         // Shut down the sync pool.
         trace!("Shutting down the sync pool...");
-        self.shutdown.store(true, Ordering::SeqCst);
+        self.shutdown.store(true, Ordering::Relaxed);
 
         // Abort the tasks.
         trace!("Shutting down the validator...");

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -86,7 +86,7 @@ impl Tcp {
     pub fn new(mut config: Config) -> Self {
         // If there is no pre-configured name, assign a sequential numeric identifier.
         if config.name.is_none() {
-            config.name = Some(SEQUENTIAL_NODE_ID.fetch_add(1, SeqCst).to_string());
+            config.name = Some(SEQUENTIAL_NODE_ID.fetch_add(1, Relaxed).to_string());
         }
 
         // Create a tracing span containing the node's name.


### PR DESCRIPTION
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/beacon/mod.rs#L234
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/beacon/mod.rs#L252
I think block_generation_time needs to be synchronized with consensus. The read operation of produce_next_block needs to see the next block produced by the produce_next_block function. Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.


https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L247
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L252
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L259
Here puzzle_instance is used here for counting, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.

https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/tcp/src/tcp.rs#L89
I think the use of ordering here is irregular, SEQUENTIAL_NODE_ID is used here for counting, not to synchronize access to other shared variables. Although Ordering::SeqCst ensures the correctness of the program, it affects the performance of the program. Therefore, just Ordering::Relaxed needs to be used here to ensure the correctness of the program.

https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/store/src/rocksdb/map.rs#L95
I think the use of ordering here is irregular. In the start_atomic function, batch_in_progress is not synchronized with other variables, so Relaxed can be used for batch_in_progress.

https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/store/src/rocksdb/map.rs#L116
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/store/src/rocksdb/map.rs#L149
In the finish_atomic and abort_atomic functions, batch_in_progress is used to synchronize the atomic_batch variable. Therefore, the read operation of batch_in_progress needs to see the changes of the atomic_batch variable.  Using Ordering::SeqCst is unnecessary and may impact program performance, I think just Acquire/Release needs to be used here to ensure the correctness of the program.

https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/beacon/mod.rs#L186
https://github.com/AleoHQ/snarkOS/blob/8cfa1657746bcdc372207f788f093b3060aac350/node/src/prover/mod.rs#L123
Here shutdown is just a signal and doesn't synchronize with other variables. Therefore, Relaxed can be used in both single-threaded and multi-threaded environments.