### PR TITLE
Categorize DataMap IDs, introduce MapID

### DIFF
--- a/node/store/src/block.rs
+++ b/node/store/src/block.rs
@@ -16,7 +16,8 @@
 
 use crate::{
     rocksdb::{self, DataMap, Database},
-    DataID,
+    BlockMap,
+    MapID,
     TransactionDB,
     TransitionDB,
 };
@@ -72,17 +73,17 @@ impl<N: Network> BlockStorage<N> for BlockDB<N> {
         let transaction_store = TransactionStore::<N, TransactionDB<N>>::open(transition_store)?;
         // Return the block storage.
         Ok(Self {
-            state_root_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockStateRootMap)?,
-            reverse_state_root_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockReverseStateRootMap)?,
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockIDMap)?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockReverseIDMap)?,
-            header_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockHeaderMap)?,
-            transactions_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockTransactionsMap)?,
-            reverse_transactions_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockReverseTransactionsMap)?,
+            state_root_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::StateRoot))?,
+            reverse_state_root_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::ReverseStateRoot))?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::ReverseID))?,
+            header_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::Header))?,
+            transactions_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::Transactions))?,
+            reverse_transactions_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::ReverseTransactions))?,
             transaction_store,
-            coinbase_solution_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockCoinbaseSolutionMap)?,
-            coinbase_puzzle_commitment_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockCoinbasePuzzleCommitmentMap)?,
-            signature_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::BlockSignatureMap)?,
+            coinbase_solution_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::CoinbaseSolution))?,
+            coinbase_puzzle_commitment_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::CoinbasePuzzleCommitment))?,
+            signature_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Block(BlockMap::Signature))?,
         })
     }
 

--- a/node/store/src/lib.rs
+++ b/node/store/src/lib.rs
@@ -47,6 +47,25 @@ pub enum MapID {
     Transaction(TransactionMap),
     Transition(TransitionMap),
     Program(ProgramMap),
+    #[cfg(test)]
+    Test(TestMap),
+}
+
+impl From<MapID> for u16 {
+    fn from(id: MapID) -> u16 {
+        match id {
+            MapID::Block(id) => id as u16,
+            MapID::Deployment(id) => id as u16,
+            MapID::Execution(id) => id as u16,
+            MapID::Input(id) => id as u16,
+            MapID::Output(id) => id as u16,
+            MapID::Transaction(id) => id as u16,
+            MapID::Transition(id) => id as u16,
+            MapID::Program(id) => id as u16,
+            #[cfg(test)]
+            MapID::Test(id) => id as u16,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -139,6 +158,13 @@ pub enum ProgramMap {
     KeyValueID = DataID::KeyValueIDMap as u16,
     Key = DataID::KeyMap as u16,
     Value = DataID::ValueMap as u16,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum TestMap {
+    Test = DataID::Test as u16,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/node/store/src/lib.rs
+++ b/node/store/src/lib.rs
@@ -42,10 +42,10 @@ pub enum MapID {
     Block(BlockMap),
     Deployment(DeploymentMap),
     Execution(ExecutionMap),
-    Input(InputMap),
-    Output(OutputMap),
     Transaction(TransactionMap),
     Transition(TransitionMap),
+    TransitionInput(TransitionInputMap),
+    TransitionOutput(TransitionOutputMap),
     Program(ProgramMap),
     #[cfg(test)]
     Test(TestMap),
@@ -57,10 +57,10 @@ impl From<MapID> for u16 {
             MapID::Block(id) => id as u16,
             MapID::Deployment(id) => id as u16,
             MapID::Execution(id) => id as u16,
-            MapID::Input(id) => id as u16,
-            MapID::Output(id) => id as u16,
             MapID::Transaction(id) => id as u16,
             MapID::Transition(id) => id as u16,
+            MapID::TransitionInput(id) => id as u16,
+            MapID::TransitionOutput(id) => id as u16,
             MapID::Program(id) => id as u16,
             #[cfg(test)]
             MapID::Test(id) => id as u16,
@@ -107,7 +107,7 @@ pub enum ExecutionMap {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(u16)]
-pub enum InputMap {
+pub enum TransitionInputMap {
     ID = DataID::InputIDMap as u16,
     ReverseID = DataID::InputReverseIDMap as u16,
     Constant = DataID::InputConstantMap as u16,
@@ -120,7 +120,7 @@ pub enum InputMap {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(u16)]
-pub enum OutputMap {
+pub enum TransitionOutputMap {
     ID = DataID::OutputIDMap as u16,
     ReverseID = DataID::OutputReverseIDMap as u16,
     Constant = DataID::OutputConstantMap as u16,

--- a/node/store/src/lib.rs
+++ b/node/store/src/lib.rs
@@ -36,9 +36,114 @@ pub use transaction::*;
 mod transition;
 pub use transition::*;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum MapID {
+    Block(BlockMap),
+    Deployment(DeploymentMap),
+    Execution(ExecutionMap),
+    Input(InputMap),
+    Output(OutputMap),
+    Transaction(TransactionMap),
+    Transition(TransitionMap),
+    Program(ProgramMap),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum BlockMap {
+    StateRoot = DataID::BlockStateRootMap as u16,
+    ReverseStateRoot = DataID::BlockReverseStateRootMap as u16,
+    ID = DataID::BlockIDMap as u16,
+    ReverseID = DataID::BlockReverseIDMap as u16,
+    Header = DataID::BlockHeaderMap as u16,
+    Transactions = DataID::BlockTransactionsMap as u16,
+    ReverseTransactions = DataID::BlockReverseTransactionsMap as u16,
+    CoinbaseSolution = DataID::BlockCoinbaseSolutionMap as u16,
+    CoinbasePuzzleCommitment = DataID::BlockCoinbasePuzzleCommitmentMap as u16,
+    Signature = DataID::BlockSignatureMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum DeploymentMap {
+    ID = DataID::DeploymentIDMap as u16,
+    Edition = DataID::DeploymentEditionMap as u16,
+    ReverseID = DataID::DeploymentReverseIDMap as u16,
+    Program = DataID::DeploymentProgramMap as u16,
+    VerifyingKey = DataID::DeploymentVerifyingKeyMap as u16,
+    Certificate = DataID::DeploymentCertificateMap as u16,
+    Fee = DataID::DeploymentFeeMap as u16,
+    ReverseFee = DataID::DeploymentReverseFeeMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum ExecutionMap {
+    ID = DataID::ExecutionIDMap as u16,
+    ReverseID = DataID::ExecutionReverseIDMap as u16,
+    Inclusion = DataID::ExecutionInclusionMap as u16,
+    Fee = DataID::ExecutionFeeMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum InputMap {
+    ID = DataID::InputIDMap as u16,
+    ReverseID = DataID::InputReverseIDMap as u16,
+    Constant = DataID::InputConstantMap as u16,
+    Public = DataID::InputPublicMap as u16,
+    Private = DataID::InputPrivateMap as u16,
+    Record = DataID::InputRecordMap as u16,
+    RecordTag = DataID::InputRecordTagMap as u16,
+    ExternalRecord = DataID::InputExternalRecordMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum OutputMap {
+    ID = DataID::OutputIDMap as u16,
+    ReverseID = DataID::OutputReverseIDMap as u16,
+    Constant = DataID::OutputConstantMap as u16,
+    Public = DataID::OutputPublicMap as u16,
+    Private = DataID::OutputPrivateMap as u16,
+    Record = DataID::OutputRecordMap as u16,
+    RecordNonce = DataID::OutputRecordNonceMap as u16,
+    ExternalRecord = DataID::OutputExternalRecordMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum TransactionMap {
+    ID = DataID::TransactionIDMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum TransitionMap {
+    Locator = DataID::TransitionLocatorMap as u16,
+    Finalize = DataID::TransitionFinalizeMap as u16,
+    Proof = DataID::TransitionProofMap as u16,
+    TPK = DataID::TransitionTPKMap as u16,
+    ReverseTPK = DataID::TransitionReverseTPKMap as u16,
+    TCM = DataID::TransitionTCMMap as u16,
+    ReverseTCM = DataID::TransitionReverseTCMMap as u16,
+    Fee = DataID::TransitionFeeMap as u16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum ProgramMap {
+    ID = DataID::ProgramIDMap as u16,
+    MappingID = DataID::MappingIDMap as u16,
+    KeyValueID = DataID::KeyValueIDMap as u16,
+    Key = DataID::KeyMap as u16,
+    Value = DataID::ValueMap as u16,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u16)]
-pub enum DataID {
+enum DataID {
     // Block
     BlockStateRootMap,
     BlockReverseStateRootMap,

--- a/node/store/src/lib.rs
+++ b/node/store/src/lib.rs
@@ -189,6 +189,7 @@ enum DataID {
     DeploymentVerifyingKeyMap,
     DeploymentCertificateMap,
     DeploymentFeeMap,
+    DeploymentReverseFeeMap,
     // Execution
     ExecutionIDMap,
     ExecutionReverseIDMap,
@@ -229,9 +230,6 @@ enum DataID {
     KeyValueIDMap,
     KeyMap,
     ValueMap,
-
-    // TODO (raychu86): Move this up to Deployment for phase 3.
-    DeploymentReverseFeeMap,
 
     // Testing
     #[cfg(test)]

--- a/node/store/src/program.rs
+++ b/node/store/src/program.rs
@@ -16,7 +16,8 @@
 
 use crate::{
     rocksdb::{self, DataMap, Database},
-    DataID,
+    MapID,
+    ProgramMap,
 };
 use snarkvm::prelude::*;
 
@@ -50,11 +51,11 @@ impl<N: Network> ProgramStorage<N> for ProgramDB<N> {
     /// Initializes the program state storage.
     fn open(dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            program_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::ProgramIDMap)?,
-            mapping_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::MappingIDMap)?,
-            key_value_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::KeyValueIDMap)?,
-            key_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::KeyMap)?,
-            value_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::ValueMap)?,
+            program_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Program(ProgramMap::ID))?,
+            mapping_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Program(ProgramMap::MappingID))?,
+            key_value_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Program(ProgramMap::KeyValueID))?,
+            key_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Program(ProgramMap::Key))?,
+            value_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Program(ProgramMap::Value))?,
             dev,
         })
     }

--- a/node/store/src/rocksdb/map.rs
+++ b/node/store/src/rocksdb/map.rs
@@ -260,7 +260,7 @@ impl<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> fmt::Debu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rocksdb::tests::temp_dir;
+    use crate::{rocksdb::tests::temp_dir, TestMap};
     use snarkvm::prelude::{Address, FromStr, Testnet3};
 
     use serial_test::serial;
@@ -278,7 +278,7 @@ mod tests {
 
         // Initialize a map.
         let map: DataMap<Address<CurrentNetwork>, ()> =
-            RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
         map.insert(address, ()).expect("Failed to insert into data map");
         assert!(map.contains_key(&address).unwrap());
     }
@@ -289,7 +289,7 @@ mod tests {
     fn test_insert_and_get_speculative() {
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter().next().is_none());
@@ -342,7 +342,7 @@ mod tests {
     fn test_remove_and_get_speculative() {
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter().next().is_none());
@@ -405,7 +405,7 @@ mod tests {
 
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter().next().is_none());
@@ -466,7 +466,7 @@ mod tests {
 
         // Initialize a map.
         let map: DataMap<usize, String> =
-            RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+            RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMap::Test)).expect("Failed to open data map");
 
         // Sanity check.
         assert!(map.iter().next().is_none());

--- a/node/store/src/rocksdb/tests.rs
+++ b/node/store/src/rocksdb/tests.rs
@@ -16,7 +16,8 @@
 
 use crate::{
     rocksdb::{DataMap, RocksDB},
-    DataID,
+    MapID,
+    TestMap as TestMapID,
 };
 use snarkvm::{
     console::{network::Testnet3, types::Scalar},
@@ -46,14 +47,15 @@ fn test_open() {
 #[test]
 #[serial]
 fn test_open_map() {
-    let _map =
-        RocksDB::open_map_testing::<u32, String>(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let _map = RocksDB::open_map_testing::<u32, String>(temp_dir(), None, MapID::Test(TestMapID::Test))
+        .expect("Failed to open data map");
 }
 
 #[test]
 #[serial]
 fn test_insert_and_contains_key() {
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     assert!(map.contains_key(&123456789).expect("Failed to call contains key"));
@@ -63,7 +65,8 @@ fn test_insert_and_contains_key() {
 #[test]
 #[serial]
 fn test_insert_and_get() {
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     assert_eq!(Some("123456789".to_string()), map.get(&123456789).expect("Failed to get").map(|v| v.to_string()));
@@ -74,7 +77,8 @@ fn test_insert_and_get() {
 #[test]
 #[serial]
 fn test_insert_and_remove() {
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     assert_eq!(map.get(&123456789).expect("Failed to get").map(|v| v.to_string()), Some("123456789".to_string()));
@@ -86,7 +90,8 @@ fn test_insert_and_remove() {
 #[test]
 #[serial]
 fn test_insert_and_iter() {
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
 
@@ -98,7 +103,8 @@ fn test_insert_and_iter() {
 #[test]
 #[serial]
 fn test_insert_and_keys() {
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
 
@@ -110,7 +116,8 @@ fn test_insert_and_keys() {
 #[test]
 #[serial]
 fn test_insert_and_values() {
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
 
@@ -124,11 +131,13 @@ fn test_insert_and_values() {
 fn test_reopen() {
     let directory = temp_dir();
     {
-        let map = RocksDB::open_map_testing(directory.clone(), None, DataID::Test).expect("Failed to open data map");
+        let map = RocksDB::open_map_testing(directory.clone(), None, MapID::Test(TestMapID::Test))
+            .expect("Failed to open data map");
         map.insert(123456789, "123456789".to_string()).expect("Failed to insert");
     }
     {
-        let map: TestMap = RocksDB::open_map_testing(directory, None, DataID::Test).expect("Failed to open data map");
+        let map: TestMap =
+            RocksDB::open_map_testing(directory, None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
         match map.get(&123456789).expect("Failed to get") {
             Some(Cow::Borrowed(value)) => assert_eq!(value.to_string(), "123456789".to_string()),
             Some(Cow::Owned(value)) => assert_eq!(value, "123456789".to_string()),
@@ -142,7 +151,7 @@ fn test_reopen() {
 // fn test_export_import() {
 //     let file = temp_file();
 //     {
-//         let mut map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+//         let mut map = RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 //
 //         for i in 0..100 {
 //             map.insert(i, i.to_string()).expect("Failed to insert");
@@ -154,7 +163,7 @@ fn test_reopen() {
 //     let storage = RocksDB::open_temporary(temp_dir(), None).expect("Failed to open storage");
 //     storage.import(&file).expect("Failed to import storage");
 //
-//     let map = storage.open_map::<u32, String>(DataID::Test).expect("Failed to open data map");
+//     let map = storage.open_map::<u32, String>(MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 //
 //     for i in 0..100 {
 //         assert_eq!(map.get(&i).expect("Failed to get").map(|v| v.to_string()), Some(i.to_string()));
@@ -170,7 +179,8 @@ fn test_scalar_mul() {
 
     const ITERATIONS: u32 = 1_000_000u32;
 
-    let map = RocksDB::open_map_testing(temp_dir(), None, DataID::Test).expect("Failed to open data map");
+    let map =
+        RocksDB::open_map_testing(temp_dir(), None, MapID::Test(TestMapID::Test)).expect("Failed to open data map");
 
     // Sample `ITERATION` random field elements to store.
     for i in 0..ITERATIONS {

--- a/node/store/src/transaction.rs
+++ b/node/store/src/transaction.rs
@@ -16,7 +16,10 @@
 
 use crate::{
     rocksdb::{self, DataMap, Database},
-    DataID,
+    DeploymentMap,
+    ExecutionMap,
+    MapID,
+    TransactionMap,
     TransitionDB,
 };
 use snarkvm::prelude::*;
@@ -46,7 +49,7 @@ impl<N: Network> TransactionStorage<N> for TransactionDB<N> {
         // Initialize the execution store.
         let execution_store = ExecutionStore::<N, ExecutionDB<N>>::open(transition_store)?;
         // Return the transaction storage.
-        Ok(Self { id_map: rocksdb::RocksDB::open_map(N::ID, execution_store.dev(), DataID::TransactionIDMap)?, deployment_store, execution_store })
+        Ok(Self { id_map: rocksdb::RocksDB::open_map(N::ID, execution_store.dev(), MapID::Transaction(TransactionMap::ID))?, deployment_store, execution_store })
     }
 
     /// Returns the ID map.
@@ -106,14 +109,14 @@ impl<N: Network> DeploymentStorage<N> for DeploymentDB<N> {
         // Retrieve the optional development ID.
         let dev = transition_store.dev();
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentIDMap)?,
-            edition_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentEditionMap)?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentReverseIDMap)?,
-            program_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentProgramMap)?,
-            verifying_key_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentVerifyingKeyMap)?,
-            certificate_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentCertificateMap)?,
-            fee_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentFeeMap)?,
-            reverse_fee_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::DeploymentReverseFeeMap)?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::ID))?,
+            edition_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::Edition))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::ReverseID))?,
+            program_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::Program))?,
+            verifying_key_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::VerifyingKey))?,
+            certificate_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::Certificate))?,
+            fee_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::Fee))?,
+            reverse_fee_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Deployment(DeploymentMap::ReverseFee))?,
             transition_store,
         })
     }
@@ -193,11 +196,11 @@ impl<N: Network> ExecutionStorage<N> for ExecutionDB<N> {
         // Retrieve the optional development ID.
         let dev = transition_store.dev();
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::ExecutionIDMap)?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::ExecutionReverseIDMap)?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Execution(ExecutionMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Execution(ExecutionMap::ReverseID))?,
             transition_store,
-            inclusion_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::ExecutionInclusionMap)?,
-            fee_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::ExecutionFeeMap)?,
+            inclusion_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Execution(ExecutionMap::Inclusion))?,
+            fee_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Execution(ExecutionMap::Fee))?,
         })
     }
 

--- a/node/store/src/transition.rs
+++ b/node/store/src/transition.rs
@@ -16,10 +16,10 @@
 
 use crate::{
     rocksdb::{self, DataMap, Database},
-    InputMap,
     MapID,
-    OutputMap,
+    TransitionInputMap,
     TransitionMap,
+    TransitionOutputMap,
 };
 use snarkvm::prelude::*;
 
@@ -165,14 +165,14 @@ impl<N: Network> InputStorage<N> for InputDB<N> {
     /// Initializes the transition input storage.
     fn open(dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::ID))?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::ReverseID))?,
-            constant: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Constant))?,
-            public: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Public))?,
-            private: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Private))?,
-            record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Record))?,
-            record_tag: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::RecordTag))?,
-            external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::ExternalRecord))?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::ReverseID))?,
+            constant: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::Constant))?,
+            public: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::Public))?,
+            private: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::Private))?,
+            record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::Record))?,
+            record_tag: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::RecordTag))?,
+            external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionInput(TransitionInputMap::ExternalRecord))?,
             dev,
         })
     }
@@ -261,14 +261,14 @@ impl<N: Network> OutputStorage<N> for OutputDB<N> {
     /// Initializes the transition output storage.
     fn open(dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::ID))?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::ReverseID))?,
-            constant: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Constant))?,
-            public: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Public))?,
-            private: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Private))?,
-            record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Record))?,
-            record_nonce: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::RecordNonce))?,
-            external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::ExternalRecord))?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::ReverseID))?,
+            constant: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::Constant))?,
+            public: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::Public))?,
+            private: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::Private))?,
+            record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::Record))?,
+            record_nonce: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::RecordNonce))?,
+            external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::TransitionOutput(TransitionOutputMap::ExternalRecord))?,
             dev,
         })
     }

--- a/node/store/src/transition.rs
+++ b/node/store/src/transition.rs
@@ -16,7 +16,10 @@
 
 use crate::{
     rocksdb::{self, DataMap, Database},
-    DataID,
+    InputMap,
+    MapID,
+    OutputMap,
+    TransitionMap,
 };
 use snarkvm::prelude::*;
 
@@ -61,16 +64,16 @@ impl<N: Network> TransitionStorage<N> for TransitionDB<N> {
     /// Initializes the transition storage.
     fn open(dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            locator_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionLocatorMap)?,
+            locator_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::Locator))?,
             input_store: InputStore::open(dev)?,
             output_store: OutputStore::open(dev)?,
-            finalize_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionFinalizeMap)?,
-            proof_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionProofMap)?,
-            tpk_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionTPKMap)?,
-            reverse_tpk_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionReverseTPKMap)?,
-            tcm_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionTCMMap)?,
-            reverse_tcm_map: rocksdb::RocksDB::open_map(N::ID, dev,  DataID::TransitionReverseTCMMap)?,
-            fee_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::TransitionFeeMap)?,
+            finalize_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::Finalize))?,
+            proof_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::Proof))?,
+            tpk_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::TPK))?,
+            reverse_tpk_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::ReverseTPK))?,
+            tcm_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::TCM))?,
+            reverse_tcm_map: rocksdb::RocksDB::open_map(N::ID, dev,  MapID::Transition(TransitionMap::ReverseTCM))?,
+            fee_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Transition(TransitionMap::Fee))?,
         })
     }
 
@@ -162,14 +165,14 @@ impl<N: Network> InputStorage<N> for InputDB<N> {
     /// Initializes the transition input storage.
     fn open(dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputIDMap)?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputReverseIDMap)?,
-            constant: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputConstantMap)?,
-            public: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputPublicMap)?,
-            private: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputPrivateMap)?,
-            record: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputRecordMap)?,
-            record_tag: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputRecordTagMap)?,
-            external_record: rocksdb::RocksDB::open_map(N::ID, dev, DataID::InputExternalRecordMap)?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::ReverseID))?,
+            constant: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Constant))?,
+            public: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Public))?,
+            private: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Private))?,
+            record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::Record))?,
+            record_tag: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::RecordTag))?,
+            external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Input(InputMap::ExternalRecord))?,
             dev,
         })
     }
@@ -258,14 +261,14 @@ impl<N: Network> OutputStorage<N> for OutputDB<N> {
     /// Initializes the transition output storage.
     fn open(dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputIDMap)?,
-            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputReverseIDMap)?,
-            constant: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputConstantMap)?,
-            public: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputPublicMap)?,
-            private: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputPrivateMap)?,
-            record: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputRecordMap)?,
-            record_nonce: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputRecordNonceMap)?,
-            external_record: rocksdb::RocksDB::open_map(N::ID, dev, DataID::OutputExternalRecordMap)?,
+            id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::ID))?,
+            reverse_id_map: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::ReverseID))?,
+            constant: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Constant))?,
+            public: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Public))?,
+            private: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Private))?,
+            record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::Record))?,
+            record_nonce: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::RecordNonce))?,
+            external_record: rocksdb::RocksDB::open_map(N::ID, dev, MapID::Output(OutputMap::ExternalRecord))?,
             dev,
         })
     }


### PR DESCRIPTION
This PR introduces a new `enum MapID` and a few associated `enum`s in order to split the now-private lower-level `enum DataID` into more readable "chunks" whose order can be changed if need be.

The rules regarding `DataID` remain the same - the order of its variants - once a storage has been initialized - should never change, and new ones should only ever be appended to the end.