### PR TITLE
Bump snarkVM version to `v0.10.1`

### DIFF
--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -26,7 +26,7 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase2";
+    const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase3";
 
     #[test]
     #[traced_test]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-tcp",
  "snarkvm",
- "snarkvm-utilities 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.9.16",
  "time",
  "tokio",
  "tokio-stream",
@@ -2987,8 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2589bfe5607284df8265545401c47c6c735bec146d4eefdcc3f68c3c8eb29625"
 dependencies = [
  "anyhow",
  "clap",
@@ -3005,7 +3006,7 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-parameters",
  "snarkvm-synthesizer",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "thiserror",
  "ureq",
  "walkdir",
@@ -3013,8 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a8bcf91cdc753318ccc8ad3c86b33f92e847b7e803e2581c965a2b752e8fff"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3033,14 +3035,15 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-r1cs",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bc7c79d95e53153d9b9f789636165d074ecba163faf18bb03033207c41a193"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3053,8 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222d1a51c9724ff8044c3fc1c64eef61089e77af2ce48c9ab778a1164140ff07"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3064,8 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f055bc681423a2171c1f1ea155c9bb0a8a38d743e65561db36520889e6c2ee"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3074,8 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c29a50d3c6c0c87868e5a720feb27aa3077fcc0d4e5fa1a98c61680f24f8eff"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3084,8 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31e87c199e9468ae2052b8494279992cc86ff9bbf823d91797872a05d696dc3"
 dependencies = [
  "indexmap",
  "itertools",
@@ -3097,18 +3104,20 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-r1cs",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06a40a3455028428c56c10b981375026220563b82ff948d8889ac05dd82b0f9"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9ae05e72adf38fe1f8eac5f86f33493041d9e6a0d56b77319f76ae3ab7d53"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3118,21 +3127,23 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807d334344dd60402c28a567ff58da3d1eb1e3a994383c89703ccddf12ad8135"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
  "snarkvm-console-program",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06be7fe7fc121bb8a95e09c4c8828acff4c5c05b64e2e5640c4fdd8c3b0d4f8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3146,8 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eac07d9566ade7795ddfd770d177ed132ecca298e09121f983d40d11361a6f2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3159,8 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69aa39b811368134840d4d28c1908136be388fea7a561440788edcfd4df8909f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3168,8 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d95b78f70869190abd6f5e2f3caddf0152d19590426e18e7d098500675ceb"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3178,8 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186617cb49950cf289acdc214bc080bda541ba9036ae926d2ed79823d6edd434"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3190,8 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd99af3efc713ec23462dbab93251eedd47d295ff61ff376dd69094b1848058"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3201,8 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7ac6ccd751b6f8d95223406334cd07e9e2da4bce32f293876a75db68e4036d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3212,8 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50938e1ea5d8a29885ea3936cbf61b6cce5f3aaf0627432905fc3f62ecd49ea"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3224,8 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86271c1f924a931b2999715b36099944d8794b6ca13027708c36223b1f7d307c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3237,8 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b326a01d2a842c41d4bd97693fd2ed02706ecdf046fcf6565b1fd0070de3c5f5"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3247,20 +3267,22 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea07751b4b1154f24c654075076fad6f827964b7bbfc347c581c7ad5289067a2"
 dependencies = [
  "blake2s_simd",
  "smallvec",
  "snarkvm-console-types",
  "snarkvm-fields",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
 ]
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb81af330472b53b9628f56b6befcea16117ca5d3f5d3db3da0881e2da38a91"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3270,8 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ccfe1c79e528cc55a9eca19a7465e8620a91e4ca3ebb9ab9f5df52b25ef2f6d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3288,13 +3311,14 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-parameters",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
 ]
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b429e334fe182436975bc75b66243b23fe1b01a9fb315d96b5934dfa00f0be56"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3305,13 +3329,14 @@ dependencies = [
  "serde",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
 ]
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091421abe0121d453b4944a11cb31ee8876f0fad4a45371c78a3392d6d3f27ca"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3324,13 +3349,14 @@ dependencies = [
  "snarkvm-console-collections",
  "snarkvm-console-network",
  "snarkvm-console-types",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
 ]
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af11b97d30052d071bce20c78f8694154f719f846726324d811ac3b7515f9a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3344,8 +3370,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ab6fbbf078b39a028c06e47628542deb5b49920bde981abbc26170de1c16e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3355,16 +3382,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ad7b828a7ee93a1c947eeb299c3ee87c76bb582799079e65de1eb404966f0f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705671cc02ff00d4b06ae9dfc35bed1ad9d432ee78f9fc399a00cd56802c1cf5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3372,8 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6a63ab4245b43b85eb338edb07c93de3f9e29e6c2b12e278f46241872a579d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3383,8 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf88c80a88cd51f5653b6a32d248a5926079328129c73505e78a7faa429ac41"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3393,8 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cb8b078d209faa655dd07f1437e3ed1494251e84a50c9d74e349d631d4b309"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3403,8 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88410ad088cbe227f4b07d2078126a47bd411092548e6bf488d3678e739f24f6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3414,22 +3447,24 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd712ef6f44d3319efbbe4f761ba63107feba37f0b232069caf89db993ba986c"
 dependencies = [
  "rand",
  "rayon",
  "rustc_version",
  "serde",
  "snarkvm-fields",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95e172fbbc7465fae2f310e04a702cb6936a836cbd847f02730067fd7a6567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3439,14 +3474,15 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fc9208050134c096a27164dfddbbaf6755bd9ed8e31890d37c64677a775fa6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3464,14 +3500,15 @@ dependencies = [
  "serde_json",
  "sha2",
  "snarkvm-curves",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c99e79ced68fab9f93054e30c1e7bd7fe01498a76e701d70c24d44c07e7d3e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3480,14 +3517,15 @@ dependencies = [
  "itertools",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4e12eb05795c556d5c214e71e3dc2c0a0361610c64b5ef3ace1aa57f068acf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3508,7 +3546,7 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-utilities 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities 0.10.1",
  "tracing",
  "ureq",
 ]
@@ -3529,14 +3567,15 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-utilities-derives 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities-derives 0.9.16",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8e257ef9fb07b1c7397511b915b5e264c22a715ca7eaf33d3241fed1e94e8d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3548,7 +3587,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-utilities-derives 0.9.16 (git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f)",
+ "snarkvm-utilities-derives 0.10.1",
  "thiserror",
 ]
 
@@ -3565,8 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.9.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=e51660f#e51660ff7b24ea2629475befd3ad796d4ad80ffe"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c89ae994d1a7472ff56d04adb802b326ae3c6bf98bbfb447601ce0524da314d"
 dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-tcp",
  "snarkvm",
- "snarkvm-utilities 0.9.16",
+ "snarkvm-utilities",
  "time",
  "tokio",
  "tokio-stream",
@@ -3006,7 +3006,7 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-parameters",
  "snarkvm-synthesizer",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "thiserror",
  "ureq",
  "walkdir",
@@ -3035,7 +3035,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-r1cs",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3104,7 +3104,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-r1cs",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3136,7 +3136,7 @@ dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
  "snarkvm-console-program",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3275,7 +3275,7 @@ dependencies = [
  "smallvec",
  "snarkvm-console-types",
  "snarkvm-fields",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3311,7 +3311,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-parameters",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3329,7 +3329,7 @@ dependencies = [
  "serde",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3349,7 +3349,7 @@ dependencies = [
  "snarkvm-console-collections",
  "snarkvm-console-network",
  "snarkvm-console-types",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
 ]
 
 [[package]]
@@ -3456,7 +3456,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "snarkvm-fields",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3474,7 +3474,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3500,7 +3500,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "snarkvm-curves",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3517,7 +3517,7 @@ dependencies = [
  "itertools",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
@@ -3546,29 +3546,9 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
- "snarkvm-utilities 0.10.1",
+ "snarkvm-utilities",
  "tracing",
  "ureq",
-]
-
-[[package]]
-name = "snarkvm-utilities"
-version = "0.9.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34038d6351815ade16f1d7fe6d34fc723b990a9e200ee7dda5c8e3785f914f8"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode 1.3.3",
- "num-bigint",
- "num_cpus",
- "rand",
- "rand_xorshift",
- "rayon",
- "serde",
- "serde_json",
- "snarkvm-utilities-derives 0.9.16",
- "thiserror",
 ]
 
 [[package]]
@@ -3587,19 +3567,8 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-utilities-derives 0.10.1",
+ "snarkvm-utilities-derives",
  "thiserror",
-]
-
-[[package]]
-name = "snarkvm-utilities-derives"
-version = "0.9.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541b2488455c3194799b66349714f7891c47d7a7d16413c3b46c0ab280102d4f"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ path = "snarkos/main.rs"
 
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "e51660f"
-#version = "0.10.0"
+#git = "https://github.com/AleoHQ/snarkVM.git"
+#rev = "e51660f"
+version = "0.10.1"
 features = ["circuit", "console"]
 
 [dependencies.anyhow]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -82,7 +82,7 @@ pub struct Start {
     pub logfile: PathBuf,
 
     /// Enables the node to prefetch initial blocks from a CDN
-    #[clap(default_value = "https://testnet3.blocks.aleo.org/phase2", long = "cdn")]
+    #[clap(default_value = "https://testnet3.blocks.aleo.org/phase3", long = "cdn")]
     pub cdn: String,
     /// Enables development mode, specify a unique ID for this node
     #[clap(long)]

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -382,7 +382,7 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase2";
+    const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase3";
 
     fn check_load_blocks(start: u32, end: Option<u32>, expected: usize) {
         let blocks = Arc::new(RwLock::new(Vec::new()));

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -19,7 +19,7 @@ use snarkvm::{
     console::{
         account::{Address, PrivateKey, ViewKey},
         network::{prelude::*, Testnet3},
-        program::{Entry, Identifier, Literal, Plaintext, ProgramID, Value},
+        program::{Entry, Identifier, Literal, Plaintext, Value},
     },
     prelude::TestRng,
     synthesizer::{

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -119,7 +119,7 @@ path = "."
 features = [ "test" ]
 
 [dev-dependencies.snarkvm-utilities]
-version = "0.9.16"
+version = "0.10.1"
 
 [dev-dependencies.tracing-subscriber]
 version = "0.3"

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -43,7 +43,6 @@ use snarkvm::prelude::{
     Literal,
     Network,
     Plaintext,
-    ProgramID,
     ProverSolution,
     Transaction,
     Value,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps the snarkVM version to `v0.10.1`.
