### PR TITLE
Add fee to beacon transfers

### DIFF
--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -313,7 +313,7 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
                     beacon.account.private_key(),
                     ("credits.aleo", "transfer"),
                     inputs.iter(),
-                    Some((fee_record.clone(), 1000)),
+                    Some((fee_record.clone(), 1)),
                     None,
                     rng,
                 );


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds fees to the transfer functions created by the beacon. 

Currently the fee is set to the minimum of 1 microcredit, however will need to be updated once rules for execution fees are established.
