### PR TITLE
Bump `snarkvm-utilities` to v0.10.2 and update report frequency

### DIFF
--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -119,7 +119,7 @@ path = "."
 features = [ "test" ]
 
 [dev-dependencies.snarkvm-utilities]
-version = "0.10.1"
+version = "0.10.2"
 
 [dev-dependencies.tracing-subscriber]
 version = "0.3"

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -75,7 +75,7 @@ pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbo
                 let url = "https://vm.aleo.org/testnet3/report";
                 let _ = reqwest::Client::new().post(url).json(&report).send().await;
                 // Sleep for a fixed duration in seconds.
-                tokio::time::sleep(Duration::from_secs(600)).await;
+                tokio::time::sleep(Duration::from_secs(6 * 60 * 60)).await;
             }
         });
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps the `snarkvm-utilities` dev-dependency version to `v0.10.2` and updates the report frequency from 10 minutes to 6 hours.

