### PR TITLE
Add enforcements for `Execution` fee

### DIFF
--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -398,7 +398,7 @@ fn test_ledger_execute_many() {
                 &private_key,
                 ("credits.aleo", "split"),
                 inputs.iter(),
-                Some((fee_record.clone(), 100u64)),
+                Some((fee_record.clone(), 3000u64)),
                 None,
                 rng,
             )

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -239,7 +239,7 @@ function compute:
                 assert_eq!(authorization.len(), 1);
 
                 // Execute the fee.
-                let fee = Transaction::execute_fee(vm, &caller_private_key, record, 100, None, rng).unwrap();
+                let fee = Transaction::execute_fee(vm, &caller_private_key, record, 3000, None, rng).unwrap();
 
                 // Execute.
                 let transaction = Transaction::execute_authorization(vm, authorization, Some(fee), None, rng).unwrap();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds an enforcement for execution fees where the fee in microcredits must be at least the execution size in bytes. 