### PR TITLE
Correctly set the post-handshake codec limit

### DIFF
--- a/node/messages/src/helpers/codec.rs
+++ b/node/messages/src/helpers/codec.rs
@@ -34,19 +34,17 @@ pub struct MessageCodec<N: Network> {
 }
 
 impl<N: Network> MessageCodec<N> {
-    /// Increases the maximum permitted message size post-handshake.
-    pub fn update_max_message_len(&mut self) {
-        self.codec.set_max_frame_length(MAXIMUM_MESSAGE_SIZE);
+    pub fn handshake() -> Self {
+        let mut codec = Self::default();
+        codec.codec.set_max_frame_length(MAXIMUM_HANDSHAKE_MESSAGE_SIZE);
+        codec
     }
 }
 
 impl<N: Network> Default for MessageCodec<N> {
     fn default() -> Self {
         Self {
-            codec: LengthDelimitedCodec::builder()
-                .max_frame_length(MAXIMUM_HANDSHAKE_MESSAGE_SIZE)
-                .little_endian()
-                .new_codec(),
+            codec: LengthDelimitedCodec::builder().max_frame_length(MAXIMUM_MESSAGE_SIZE).little_endian().new_codec(),
             _phantom: Default::default(),
         }
     }


### PR DESCRIPTION
While the change in https://github.com/AleoHQ/snarkOS/pull/2343 is fine, it was insufficient, as the original issue was more complex.

We are not persisting the handshake codec, so the ones created for the purposes of reading and writing messages need to have their maximum frame size adjusted separately.