### PR TITLE
Updates the logic for `cdn_height` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reqwest",
+ "serde",
  "snarkos-node-ledger",
  "snarkvm",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "serde",
+ "serde_json",
  "snarkos-node-ledger",
  "snarkvm",
  "tokio",

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -46,6 +46,9 @@ optional = true
 [dependencies.reqwest]
 version = "0.11"
 
+[dependencies.serde]
+version = "1"
+
 [dependencies.snarkos-node-ledger]
 path = "../ledger"
 

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -49,6 +49,9 @@ version = "0.11"
 [dependencies.serde]
 version = "1"
 
+[dependencies.serde_json]
+version = "1"
+
 [dependencies.snarkos-node-ledger]
 path = "../ledger"
 

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -15,7 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkos_node_ledger::Ledger;
-use snarkvm::prelude::{cow_to_copied, Block, ConsensusStorage, DeserializeOwned, Network};
+use snarkvm::prelude::{cow_to_copied, Block, ConsensusStorage, Deserialize, DeserializeOwned, Network, Serialize};
 
 use anyhow::{anyhow, bail, Result};
 use colored::Colorize;
@@ -92,7 +92,7 @@ pub async fn load_blocks<N: Network>(
     }
 
     // Fetch the CDN height.
-    let cdn_height = match cdn_height::<BLOCKS_PER_FILE>().await {
+    let cdn_height = match cdn_height::<BLOCKS_PER_FILE>(base_url).await {
         Ok(cdn_height) => cdn_height,
         Err(error) => return Err((start_height, error)),
     };
@@ -254,30 +254,35 @@ pub async fn load_blocks<N: Network>(
 ///
 /// Note: This function decrements the tip by a few blocks, to ensure the
 /// tip is not on a block that is not yet available on the CDN.
-async fn cdn_height<const BLOCKS_PER_FILE: u32>() -> Result<u32> {
-    const BASE_URL: &str = "https://vm.aleo.org/api";
-
+async fn cdn_height<const BLOCKS_PER_FILE: u32>(base_url: &str) -> Result<u32> {
+    // A representation of the 'latest.json' file object.
+    #[derive(Deserialize, Serialize, Debug)]
+    struct LatestState {
+        exclusive_height: u32,
+        inclusive_height: u32,
+        hash: String,
+    }
     // Create a request client.
     let client = match reqwest::Client::builder().build() {
         Ok(client) => client,
         Err(error) => bail!("Failed to create a CDN request client: {error}"),
     };
     // Prepare the URL.
-    let height_url = format!("{BASE_URL}/testnet3/latest/height");
+    let latest_json_url = format!("{base_url}/latest.json");
     // Send the request.
-    let response = match client.get(height_url).send().await {
+    let response = match client.get(latest_json_url).send().await {
         Ok(response) => response,
         Err(error) => bail!("Failed to fetch the CDN height: {error}"),
     };
     // Parse the response.
-    let text = match response.text().await {
-        Ok(text) => text,
+    let bytes = match response.bytes().await {
+        Ok(bytes) => bytes,
         Err(error) => bail!("Failed to parse the CDN height response: {error}"),
     };
-    // Parse the tip.
-    let tip = match text.parse::<u32>() {
-        Ok(tip) => tip,
-        Err(error) => bail!("Failed to parse the CDN tip: {error}"),
+    // Parse the bytes for the tip.
+    let tip = match bincode::deserialize::<LatestState>(&bytes) {
+        Ok(latest) => latest.exclusive_height,
+        Err(error) => bail!("Failed to deserialize the CDN height respone: {error}"),
     };
     // Decrement the tip by a few blocks to ensure the CDN is caught up.
     let tip = tip.saturating_sub(10);
@@ -382,7 +387,7 @@ mod tests {
 
     type CurrentNetwork = Testnet3;
 
-    const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase3";
+    const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase2";
 
     fn check_load_blocks(start: u32, end: Option<u32>, expected: usize) {
         let blocks = Arc::new(RwLock::new(Vec::new()));
@@ -438,7 +443,7 @@ mod tests {
     fn test_cdn_height() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let height = cdn_height::<BLOCKS_PER_FILE>().await.unwrap();
+            let height = cdn_height::<BLOCKS_PER_FILE>(TEST_BASE_URL).await.unwrap();
             assert!(height > 0);
         });
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Updates the logic for `cdn_height` method.

The new approach decouples `snarkOS` from `vm.aleo.org` completely, now only relying purely on the `CDN` when needed.