### PR TITLE
Use generic instead of hard coded MapID for `open_map`

### DIFF
--- a/node/store/src/rocksdb/map.rs
+++ b/node/store/src/rocksdb/map.rs
@@ -260,7 +260,7 @@ impl<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> fmt::Debu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{rocksdb::tests::temp_dir, TestMap};
+    use crate::{rocksdb::tests::temp_dir, MapID, TestMap};
     use snarkvm::prelude::{Address, FromStr, Testnet3};
 
     use serial_test::serial;

--- a/node/store/src/rocksdb/tests.rs
+++ b/node/store/src/rocksdb/tests.rs
@@ -47,7 +47,7 @@ fn test_open() {
 #[test]
 #[serial]
 fn test_open_map() {
-    let _map = RocksDB::open_map_testing::<u32, String>(temp_dir(), None, MapID::Test(TestMapID::Test))
+    let _map = RocksDB::open_map_testing::<u32, String, _>(temp_dir(), None, MapID::Test(TestMapID::Test))
         .expect("Failed to open data map");
 }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `mapID` type in `RocksDB::open_map` to a generic. This purpose of this, is that external repos that use the `DataMap` and `RocksDB` can define their own custom MapIDs instead of using the hard-coded snarkOS ones.
