### PR TITLE
Correct the capacity for block locator checkpoints

### DIFF
--- a/node/src/helpers.rs
+++ b/node/src/helpers.rs
@@ -35,7 +35,7 @@ pub fn get_block_locators<N: Network, C: ConsensusStorage<N>>(ledger: &Ledger<N,
     }
 
     // Initialize the checkpoints map.
-    let mut checkpoints = IndexMap::with_capacity((latest_height % CHECKPOINT_INTERVAL).try_into()?);
+    let mut checkpoints = IndexMap::with_capacity((latest_height / CHECKPOINT_INTERVAL + 1).try_into()?);
 
     // Retrieve the checkpoint block hashes.
     for height in (0..=latest_height).step_by(CHECKPOINT_INTERVAL as usize) {


### PR DESCRIPTION
There is a bug in the calculation of capacity for the collection of block locator checkpoints: right now it uses modulo (`%`), even though the loop that populates it performs `latest_height / CHECKPOINT_INTERVAL + 1` steps, leading to mismatched allocations.