### PR TITLE
Introduce OnConnect for automatic post-handshake actions

### DIFF
--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -17,7 +17,7 @@
 use crate::{Heartbeat, Inbound, Outbound};
 use snarkos_node_messages::Message;
 use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake},
+    protocols::{Disconnect, Handshake, OnConnect},
     P2P,
 };
 use snarkvm::prelude::Network;
@@ -25,7 +25,9 @@ use snarkvm::prelude::Network;
 use core::time::Duration;
 
 #[async_trait]
-pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbound<N> + Heartbeat<N> {
+pub trait Routing<N: Network>:
+    P2P + Disconnect + OnConnect + Handshake + Inbound<N> + Outbound<N> + Heartbeat<N>
+{
     /// Initialize the routing.
     async fn initialize_routing(&self) {
         // Enable the TCP protocols.
@@ -33,6 +35,7 @@ pub trait Routing<N: Network>: P2P + Disconnect + Handshake + Inbound<N> + Outbo
         self.enable_reading().await;
         self.enable_writing().await;
         self.enable_disconnect().await;
+        self.enable_on_connect().await;
         // Enable the TCP listener. Note: This must be called after the above protocols.
         self.enable_listener().await;
         // Initialize the heartbeat.

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -32,7 +32,7 @@ use snarkos_node_messages::{
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
 use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake, Reading, Writing},
+    protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
 use snarkvm::prelude::{

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -21,7 +21,7 @@ use snarkos_account::Account;
 use snarkos_node_messages::{Message, NodeType, UnconfirmedSolution};
 use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
 use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake, Reading, Writing},
+    protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
 use snarkvm::prelude::{Block, CoinbasePuzzle, ConsensusStorage, EpochChallenge, Header, Network, ProverSolution};

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -21,7 +21,7 @@ use snarkos_account::Account;
 use snarkos_node_messages::{Data, Message, NodeType, UnconfirmedSolution};
 use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
 use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake, Reading, Writing},
+    protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
 use snarkvm::prelude::{Block, CoinbasePuzzle, ConsensusStorage, EpochChallenge, Header, Network, ProverSolution};

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -16,19 +16,10 @@
 
 use super::*;
 
-use snarkos_node_messages::{
-    BlockRequest,
-    DisconnectReason,
-    Message,
-    MessageCodec,
-    Ping,
-    Pong,
-    UnconfirmedTransaction,
-};
+use snarkos_node_messages::{BlockRequest, DisconnectReason, Message, MessageCodec, Pong, UnconfirmedTransaction};
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::prelude::{Network, Transaction};
 
-use futures_util::sink::SinkExt;
 use std::{io, net::SocketAddr};
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Prover<N, C> {
@@ -47,14 +38,26 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Prover<N, C> {
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
         let genesis_header = *self.genesis.header();
-        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
-
-        // Send the first `Ping` message to the peer.
-        let message = Message::Ping(Ping::new(self.node_type(), None));
-        trace!("Sending '{}' to '{peer_ip}'", message.name());
-        framed.send(message).await?;
+        self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
 
         Ok(connection)
+    }
+}
+
+#[async_trait]
+impl<N: Network, C: ConsensusStorage<N>> OnConnect for Prover<N, C>
+where
+    Self: Outbound<N>,
+{
+    async fn on_connect(&self, peer_addr: SocketAddr) {
+        let peer_ip = if let Some(ip) = self.router.resolve_to_listener(&peer_addr) {
+            ip
+        } else {
+            return;
+        };
+
+        // Send the first `Ping` message to the peer.
+        self.send_ping(peer_ip, None);
     }
 }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -24,7 +24,7 @@ use snarkos_node_messages::{BlockRequest, Message, NodeType, PuzzleResponse, Unc
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{Heartbeat, Inbound, Outbound, Router, Routing};
 use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake, Reading, Writing},
+    protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
 use snarkvm::prelude::{Block, ConsensusStorage, Header, Network, ProverSolution};

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -24,14 +24,12 @@ use snarkos_node_messages::{
     DisconnectReason,
     Message,
     MessageCodec,
-    Ping,
     Pong,
     UnconfirmedTransaction,
 };
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::prelude::{error, EpochChallenge, Network, Transaction};
 
-use futures_util::sink::SinkExt;
 use std::{io, net::SocketAddr, time::Duration};
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Validator<N, C> {
@@ -50,23 +48,35 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Validator<N, C> {
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
         let genesis_header = self.ledger.get_header(0).map_err(|e| error(format!("{e}")))?;
-        let (peer_ip, mut framed) = self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
+        self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
+
+        Ok(connection)
+    }
+}
+
+#[async_trait]
+impl<N: Network, C: ConsensusStorage<N>> OnConnect for Validator<N, C>
+where
+    Self: Outbound<N>,
+{
+    async fn on_connect(&self, peer_addr: SocketAddr) {
+        let peer_ip = if let Some(ip) = self.router.resolve_to_listener(&peer_addr) {
+            ip
+        } else {
+            return;
+        };
 
         // Retrieve the block locators.
         let block_locators = match crate::helpers::get_block_locators(&self.ledger) {
             Ok(block_locators) => Some(block_locators),
             Err(e) => {
                 error!("Failed to get block locators: {e}");
-                return Err(error(format!("Failed to get block locators: {e}")));
+                return;
             }
         };
 
         // Send the first `Ping` message to the peer.
-        let message = Message::Ping(Ping::new(self.node_type(), block_locators));
-        trace!("Sending '{}' to '{peer_ip}'", message.name());
-        framed.send(message).await?;
-
-        Ok(connection)
+        self.send_ping(peer_ip, block_locators);
     }
 }
 

--- a/node/tcp/src/protocols/mod.rs
+++ b/node/tcp/src/protocols/mod.rs
@@ -27,11 +27,13 @@ use crate::connections::Connection;
 
 mod disconnect;
 mod handshake;
+mod on_connect;
 mod reading;
 mod writing;
 
 pub use disconnect::Disconnect;
 pub use handshake::Handshake;
+pub use on_connect::OnConnect;
 pub use reading::Reading;
 pub use writing::Writing;
 
@@ -40,6 +42,7 @@ pub(crate) struct Protocols {
     pub(crate) handshake: OnceBox<ProtocolHandler<Connection, io::Result<Connection>>>,
     pub(crate) reading: OnceBox<ProtocolHandler<Connection, io::Result<Connection>>>,
     pub(crate) writing: OnceBox<writing::WritingHandler>,
+    pub(crate) on_connect: OnceBox<ProtocolHandler<SocketAddr, ()>>,
     pub(crate) disconnect: OnceBox<ProtocolHandler<SocketAddr, ()>>,
 }
 

--- a/node/tcp/src/protocols/on_connect.rs
+++ b/node/tcp/src/protocols/on_connect.rs
@@ -1,0 +1,80 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Opt-in protocols available to the node; each protocol is expected to spawn its own task that runs throughout the
+//! node's lifetime and handles a specific functionality. The communication with these tasks is done via dedicated
+//! handler objects.
+
+use std::net::SocketAddr;
+
+use tokio::sync::{mpsc, oneshot};
+use tracing::*;
+
+use crate::{protocols::ProtocolHandler, P2P};
+#[cfg(doc)]
+use crate::{
+    protocols::{Reading, Writing},
+    Connection,
+};
+
+/// Can be used to automatically perform some initial actions once the connection with a peer is
+/// fully established.
+#[async_trait::async_trait]
+pub trait OnConnect: P2P
+where
+    Self: Clone + Send + Sync + 'static,
+{
+    /// Attaches the behavior specified in [`OnConnect::on_connect`] right after every successful
+    /// handshake.
+    async fn enable_on_connect(&self) {
+        let (from_node_sender, mut from_node_receiver) = mpsc::unbounded_channel::<(SocketAddr, oneshot::Sender<()>)>();
+
+        // use a channel to know when the on_connect task is ready
+        let (tx, rx) = oneshot::channel::<()>();
+
+        // spawn a background task dedicated to executing the desired post-handshake actions
+        let self_clone = self.clone();
+        let on_connect_task = tokio::spawn(async move {
+            trace!(parent: self_clone.tcp().span(), "spawned the OnConnect handler task");
+            if tx.send(()).is_err() {
+                error!(parent: self_clone.tcp().span(), "OnConnect handler creation interrupted! shutting down the node");
+                self_clone.tcp().shut_down().await;
+                return;
+            }
+
+            while let Some((addr, notifier)) = from_node_receiver.recv().await {
+                let self_clone2 = self_clone.clone();
+                tokio::spawn(async move {
+                    // perform the specified initial actions
+                    self_clone2.on_connect(addr).await;
+                    // notify the node that the initial actions have concluded
+                    let _ = notifier.send(()); // can't really fail
+                });
+            }
+        });
+        let _ = rx.await;
+        self.tcp().tasks.lock().push(on_connect_task);
+
+        // register the OnConnect handler with the Node
+        let hdl = Box::new(ProtocolHandler(from_node_sender));
+        assert!(self.tcp().protocols.on_connect.set(hdl).is_ok(), "the OnConnect protocol was enabled more than once!");
+    }
+
+    /// Any initial actions to be executed after the handshake is concluded; in order to be able to
+    /// communicate with the peer in the usual manner (i.e. via [`Writing`]), only its [`SocketAddr`]
+    /// (as opposed to the related [`Connection`] object) is provided as an argument.
+    async fn on_connect(&self, addr: SocketAddr);
+}

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -434,6 +434,13 @@ impl Tcp {
             let _ = tx.send(());
         }
 
+        // If enabled, enact OnConnect.
+        if let Some(handler) = self.protocols.on_connect.get() {
+            let (sender, receiver) = oneshot::channel();
+            handler.trigger((peer_addr, sender));
+            let _ = receiver.await; // can't really fail
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
This feature is designed to "tighten" the handshake and to allow the `Disconnect` actions to kick in if an initial action fails; this currently doesn't happen, which can sometimes cause a discrepancy between the low-level and high-level connected peers count