### PR TITLE
Register execution environment information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ version = "2.0.2"
 dependencies = [
  "anyhow",
  "clap",
+ "once_cell",
  "rusty-hook",
  "snarkos-account",
  "snarkos-cli",
@@ -2705,6 +2706,7 @@ dependencies = [
  "snarkos-node",
  "snarkos-node-cdn",
  "snarkos-node-consensus",
+ "snarkos-node-env",
  "snarkos-node-messages",
  "snarkos-node-rest",
  "snarkos-node-router",
@@ -2847,6 +2849,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkos-node-env"
+version = "2.0.2"
+dependencies = [
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "snarkos-node-messages"
 version = "2.0.2"
 dependencies = [
@@ -2889,6 +2899,7 @@ dependencies = [
  "rayon",
  "serde",
  "snarkos-node-consensus",
+ "snarkos-node-env",
  "snarkos-node-messages",
  "snarkos-node-router",
  "snarkvm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "node",
     "node/cdn",
     "node/consensus",
+    "node/env",
     "node/messages",
     "node/metrics",
     "node/rest",
@@ -50,6 +51,9 @@ version = "1.0.70"
 version = "3.2"
 features = ["derive"]
 
+[dependencies.once_cell]
+version = "1"
+
 [dependencies.snarkos-account]
 path = "./account"
 
@@ -67,6 +71,9 @@ path = "./node/cdn"
 
 [dependencies.snarkos-node-consensus]
 path = "./node/consensus"
+
+[dependencies.snarkos-node-env]
+path = "./node/env"
 
 [dependencies.snarkos-node-messages]
 path = "./node/messages"

--- a/node/env/Cargo.toml
+++ b/node/env/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "snarkos-node-env"
+version = "2.0.2"
+authors = [ "The Aleo Team <hello@aleo.org>" ]
+description = "Execution environment information for snarkOS"
+homepage = "https://aleo.org"
+repository = "https://github.com/AleoHQ/snarkOS"
+keywords = [
+  "aleo",
+  "cryptography",
+  "blockchain",
+  "decentralized",
+  "zero-knowledge"
+]
+categories = [ "cryptography", "operating-systems" ]
+license = "GPL-3.0"
+edition = "2021"
+
+[dependencies.once_cell]
+version = "1"
+
+[dependencies.serde]
+version = "1"

--- a/node/env/src/lib.rs
+++ b/node/env/src/lib.rs
@@ -1,0 +1,92 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// The snarkOS library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The snarkOS library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{env, process::Command};
+
+use once_cell::sync::OnceCell;
+use serde::Serialize;
+
+// Contains the environment information.
+pub static ENV_INFO: OnceCell<EnvInfo> = OnceCell::new();
+
+// Environment information.
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+pub struct EnvInfo {
+    package: String,
+    host: String,
+    rustc: String,
+    args: Vec<String>,
+    repo: String,
+    branch: String,
+    commit: String,
+}
+
+impl EnvInfo {
+    pub fn register() {
+        // A helper function to extract command output.
+        fn command(args: &[&str]) -> String {
+            let mut output = String::from_utf8(
+                Command::new(args[0]).args(&args[1..]).output().map(|out| out.stdout).unwrap_or_default(),
+            )
+            .unwrap_or_default();
+            output.pop(); // Strip the trailing newline.
+
+            output
+        }
+
+        // Process the rustc version information.
+        let rustc_info = command(&["rustc", "--version", "--verbose"]);
+        let rustc_info = rustc_info.split('\n').map(|line| line.split(": "));
+        let mut rustc = String::new();
+        let mut host = String::new();
+        for mut pair in rustc_info {
+            let key = pair.next();
+            let value = pair.next();
+
+            match (key, value) {
+                (Some(key), None) => {
+                    if key.starts_with("rustc ") {
+                        rustc = key.trim_start_matches("rustc ").to_owned();
+                    }
+                }
+                (Some(key), Some(value)) => {
+                    if key == "host" {
+                        host = value.to_string();
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Process the runtime arguments, omitting any private keys in the process.
+        let args = env::args().filter(|arg| !arg.starts_with("APrivateKey")).collect::<Vec<_>>();
+
+        // Collect the information.
+        let env_info = EnvInfo {
+            package: env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+            host,
+            rustc,
+            args,
+            repo: env::var("CARGO_PKG_REPOSITORY").unwrap_or_default(),
+            branch: command(&["git", "branch", "--show-current"]),
+            commit: command(&["git", "rev-parse", "HEAD"]),
+        };
+
+        // Set the static containing the information.
+        ENV_INFO.set(env_info).unwrap();
+    }
+}

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -54,6 +54,9 @@ features = [ "derive" ]
 [dependencies.snarkos-node-consensus]
 path = "../consensus"
 
+[dependencies.snarkos-node-env]
+path = "../env"
+
 [dependencies.snarkos-node-messages]
 path = "../messages"
 

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -139,6 +139,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/testnet3/statePath/:commitment", get(Self::get_state_path_for_commitment))
             .route("/testnet3/beacons", get(Self::get_beacons))
             .route("/testnet3/node/address", get(Self::get_node_address))
+            .route("/testnet3/node/env", get(Self::get_env_info))
 
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -18,6 +18,7 @@ use super::*;
 
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+use snarkos_node_env::ENV_INFO;
 use snarkvm::prelude::Transaction;
 
 /// The `get_blocks` query object.
@@ -213,6 +214,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Path(input_or_output_id): Path<Field<N>>,
     ) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.find_transition_id(&input_or_output_id)?))
+    }
+
+    // GET /testnet3/node/env
+    pub(crate) async fn get_env_info() -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(ENV_INFO.get()))
     }
 
     // POST /testnet3/transaction/broadcast

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -15,6 +15,7 @@
 // along with the snarkOS library. If not, see <https://www.gnu.org/licenses/>.
 
 use snarkos_cli::{commands::CLI, helpers::Updater};
+use snarkos_node_env::EnvInfo;
 
 use clap::Parser;
 use tikv_jemallocator::Jemalloc;
@@ -23,6 +24,9 @@ use tikv_jemallocator::Jemalloc;
 static GLOBAL: Jemalloc = Jemalloc;
 
 fn main() -> anyhow::Result<()> {
+    // Register the environment information.
+    EnvInfo::register();
+
     // Parse the given arguments.
     let cli = CLI::parse();
     // Run the updater.


### PR DESCRIPTION
This PR will allow us to get a range of information on the execution environment of snarkOS. This will be useful for the dev/testnets, as well as bug reports. At this point it is exposed as a new HTTP API route.