### PR TITLE
Filter bogon addresses from the peer lists

### DIFF
--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -26,7 +26,7 @@ use snarkos_node_messages::{
     UnconfirmedSolution,
     UnconfirmedTransaction,
 };
-use snarkos_node_tcp::protocols::Reading;
+use snarkos_node_tcp::{is_bogon_address, protocols::Reading};
 use snarkvm::prelude::{Block, EpochChallenge, Header, Network, ProverSolution, Transaction};
 
 use anyhow::{bail, ensure, Result};
@@ -293,6 +293,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
     fn peer_request(&self, peer_ip: SocketAddr) -> bool {
         // Retrieve the connected peers.
         let peers = self.router().connected_peers();
+        // Filter out bogon addresses.
+        let peers = peers.into_iter().filter(|addr| !is_bogon_address(addr.ip())).collect();
         // Send a `PeerResponse` message to the peer.
         self.send(peer_ip, Message::PeerResponse(PeerResponse { peers }));
         true
@@ -300,8 +302,10 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
 
     /// Handles a `PeerResponse` message.
     fn peer_response(&self, _peer_ip: SocketAddr, peers: &[SocketAddr]) -> bool {
+        // Filter out bogon addresses.
+        let peers = peers.iter().copied().filter(|addr| !is_bogon_address(addr.ip())).collect::<Vec<_>>();
         // Adds the given peer IPs to the list of candidate peers.
-        self.router().insert_candidate_peers(peers);
+        self.router().insert_candidate_peers(&peers);
         true
     }
 

--- a/node/tcp/src/lib.rs
+++ b/node/tcp/src/lib.rs
@@ -27,8 +27,21 @@ pub mod protocols;
 mod tcp;
 pub use tcp::Tcp;
 
+use std::net::IpAddr;
+
 /// A trait for objects containing a [`Tcp`]; it is required to implement protocols.
 pub trait P2P {
     /// Returns a reference to the TCP instance.
     fn tcp(&self) -> &Tcp;
+}
+
+/// Checks if the given IP address is a bogon address.
+///
+/// A bogon address is an IP address that should not appear on the public Internet.
+/// This includes private addresses, loopback addresses, and link-local addresses.
+pub fn is_bogon_address(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ipv4) => ipv4.is_loopback() || ipv4.is_private() || ipv4.is_link_local(),
+        IpAddr::V6(ipv6) => ipv6.is_loopback(),
+    }
 }


### PR DESCRIPTION
We don't want them to be shared with others; local setups can point to other nodes via trusted peers.