### PR TITLE
Fix error in `program/{programID}` endpoint

### DIFF
--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -138,7 +138,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(id): Path<ProgramID<N>>,
     ) -> Result<ErasedJson, RestError> {
-        let program = if id == ProgramID::<N>::from_str("creadits.aleo")? {
+        let program = if id == ProgramID::<N>::from_str("credits.aleo")? {
             Program::<N>::credits()?
         } else {
             rest.ledger.get_program(id)?


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This is a minor fix for the `program/{programID}` endpoint. `credits.aleo` was misspelled here. 
