### PR TITLE
Fix flakiness in disconnect tests

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -101,6 +101,10 @@ version = "0.2"
 [dev-dependencies.pea2pea]
 version = "0.46"
 
+[dev-dependencies.snarkos-node-router]
+path = "./router"
+features = [ "test" ]
+
 [dev-dependencies.tracing-subscriber]
 version = "0.3"
 features = [ "env-filter", "fmt" ]

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -135,15 +135,15 @@ impl<N: Network> Router<N> {
     }
 
     /// Attempts to connect to the given peer IP.
-    pub fn connect(&self, peer_ip: SocketAddr) {
+    pub fn connect(&self, peer_ip: SocketAddr) -> Option<JoinHandle<()>> {
         // Return early if the attempt is against the protocol rules.
         if let Err(forbidden_message) = self.check_connection_attempt(peer_ip) {
             warn!("{forbidden_message}");
-            return;
+            return None;
         }
 
         let router = self.clone();
-        tokio::spawn(async move {
+        Some(tokio::spawn(async move {
             // Attempt to connect to the candidate peer.
             match router.tcp.connect(peer_ip).await {
                 // Remove the peer from the candidate peers.
@@ -154,7 +154,7 @@ impl<N: Network> Router<N> {
                     warn!("Unable to connect to '{peer_ip}' - {error}")
                 }
             }
-        });
+        }))
     }
 
     /// Ensure we are allowed to connect to the given peer.
@@ -183,7 +183,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Disconnects from the given peer IP, if the peer is connected.
-    pub fn disconnect(&self, peer_ip: SocketAddr) {
+    pub fn disconnect(&self, peer_ip: SocketAddr) -> JoinHandle<()> {
         let router = self.clone();
         tokio::spawn(async move {
             if let Some(peer_addr) = router.resolve_to_ambiguous(&peer_ip) {
@@ -191,7 +191,7 @@ impl<N: Network> Router<N> {
                 let _disconnected = router.tcp.disconnect(peer_addr).await;
                 debug_assert!(_disconnected);
             }
-        });
+        })
     }
 
     /// Returns the IP address of this node.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -45,6 +45,7 @@ use snarkos_node_tcp::{Config, Tcp};
 use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 
 use anyhow::{bail, Result};
+#[cfg(not(feature = "test"))]
 use core::str::FromStr;
 use indexmap::{IndexMap, IndexSet};
 use parking_lot::{Mutex, RwLock};
@@ -375,6 +376,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Returns the list of bootstrap peers.
+    #[cfg(not(feature = "test"))]
     pub fn bootstrap_peers(&self) -> Vec<SocketAddr> {
         if self.is_dev {
             // In development mode, connect to the dedicated local beacon.
@@ -397,6 +399,12 @@ impl<N: Network> Router<N> {
                 SocketAddr::from_str("143.244.211.239:4133").unwrap(),
             ]
         }
+    }
+
+    /// Returns the list of bootstrap peers.
+    #[cfg(feature = "test")]
+    pub fn bootstrap_peers(&self) -> Vec<SocketAddr> {
+        vec![]
     }
 
     /// Returns the list of metrics for the connected peers.

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -41,6 +41,7 @@ pub trait Routing<N: Network>:
         // Initialize the heartbeat.
         self.initialize_heartbeat();
         // Initialize the report.
+        #[cfg(not(feature = "test"))]
         self.initialize_report();
     }
 

--- a/node/tests/peering.rs
+++ b/node/tests/peering.rs
@@ -47,7 +47,7 @@ macro_rules! test_disconnect {
             let peer_addr = peer.node().listening_addr().unwrap();
 
             // Connect the node to the test peer.
-            node.router().connect(peer_addr);
+            node.router().connect(peer_addr).unwrap().await.unwrap();
 
             // Check the peer counts.
             let node_clone = node.clone();
@@ -59,7 +59,7 @@ macro_rules! test_disconnect {
 
             // Disconnect.
             if $node_disconnects {
-                node.router().disconnect(node.tcp().connected_addrs()[0]);
+                node.router().disconnect(node.tcp().connected_addrs()[0]).await.unwrap();
             } else {
                 peer.node().disconnect(peer.node().connected_addrs()[0]).await;
             }


### PR DESCRIPTION
Our current `Router::{connect, disconnect}` methods spawn background tasks and return near-immediately, without giving the caller any means to verify if these have concluded. While it is not essential in regular runtime, it's something that's very useful in tests.

This PR returns the handles to the aforementioned background tasks, allowing us to `await` them in tests. No non-test callsite or behavior is affected.