### PR TITLE
Use blocking tasks for some heavy inbound operations

### DIFF
--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -31,6 +31,7 @@ use snarkvm::prelude::{Block, EpochChallenge, Header, Network, ProverSolution, T
 
 use anyhow::{bail, ensure, Result};
 use std::{net::SocketAddr, time::Instant};
+use tokio::task::spawn_blocking;
 
 #[async_trait]
 pub trait Inbound<N: Network>: Reading + Outbound<N> {
@@ -117,7 +118,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                     bail!("Block request from '{peer_ip}' has an excessive range ({start_height}..{end_height})")
                 }
 
-                match self.block_request(peer_ip, message) {
+                let node = self.clone();
+                match spawn_blocking(move || node.block_request(peer_ip, message)).await? {
                     true => Ok(()),
                     false => bail!("Peer '{peer_ip}' sent an invalid block request"),
                 }
@@ -152,7 +154,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
 
                 // Process the block response.
-                match self.block_response(peer_ip, blocks.0) {
+                let node = self.clone();
+                match spawn_blocking(move || node.block_response(peer_ip, blocks.0)).await? {
                     true => Ok(()),
                     false => bail!("Peer '{peer_ip}' sent an invalid block response"),
                 }

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -22,6 +22,7 @@ use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::prelude::{error, EpochChallenge, Header};
 
 use std::{io, net::SocketAddr};
+use tokio::task::spawn_blocking;
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Beacon<N, C> {
     /// Returns a reference to the TCP instance.
@@ -236,9 +237,17 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Beacon<N, C> {
         solution: ProverSolution<N>,
     ) -> bool {
         // Add the unconfirmed solution to the memory pool.
-        if let Err(error) = self.consensus.add_unconfirmed_solution(&solution) {
-            trace!("[UnconfirmedSolution] {error}");
-            return true; // Maintain the connection.
+        let node = self.clone();
+        match spawn_blocking(move || node.consensus.add_unconfirmed_solution(&solution)).await {
+            Ok(Err(error)) => {
+                trace!("[UnconfirmedSolution] {error}");
+                return true; // Maintain the connection.
+            }
+            Err(error) => {
+                trace!("[UnconfirmedSolution] {error}");
+                return true; // Maintain the connection.
+            }
+            _ => {}
         }
         let message = Message::UnconfirmedSolution(serialized);
         // Propagate the "UnconfirmedSolution" to the connected beacons.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -31,6 +31,7 @@ use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::prelude::{error, EpochChallenge, Network, Transaction};
 
 use std::{io, net::SocketAddr, time::Duration};
+use tokio::task::spawn_blocking;
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Validator<N, C> {
     /// Returns a reference to the TCP instance.
@@ -228,9 +229,17 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         solution: ProverSolution<N>,
     ) -> bool {
         // Add the unconfirmed solution to the memory pool.
-        if let Err(error) = self.consensus.add_unconfirmed_solution(&solution) {
-            trace!("[UnconfirmedSolution] {error}");
-            return true; // Maintain the connection.
+        let node = self.clone();
+        match spawn_blocking(move || node.consensus.add_unconfirmed_solution(&solution)).await {
+            Ok(Err(error)) => {
+                trace!("[UnconfirmedSolution] {error}");
+                return true; // Maintain the connection.
+            }
+            Err(error) => {
+                trace!("[UnconfirmedSolution] {error}");
+                return true; // Maintain the connection.
+            }
+            _ => {}
         }
         let message = Message::UnconfirmedSolution(serialized);
         // Propagate the "UnconfirmedSolution" to the connected beacons.


### PR DESCRIPTION
Any operation that can take multiple milliseconds should be considered blocking, and processed in the context of a dedicated blocking task. I performed some measurements and applied those to the methods applicable to a few inbound message types: `BlockRequest`, `BlockResponse`, and `UnconfirmedSolution` (`UnconfirmedTransaction` is a likely future candidate too).

This should improve the overall responsiveness of the node.

API consideration: in the future we might want to make `Inbound::unconfirmed_solution` non-`async`, and to move the call to the blocking task to `Inbound::inbound` (like with e.g. `::block_request`).