### PR TITLE
Deduplicate peer IP in logs

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -54,22 +54,17 @@ macro_rules! expect_message {
                 data
             }
             // Received a disconnect message, abort.
-            Some(Message::Disconnect(reason)) => {
-                return Err(error(format!("'{}' disconnected: {reason:?}", $peer_addr)))
-            }
+            Some(Message::Disconnect(reason)) => return Err(error(format!("Peer disconnected: {reason:?}"))),
             // Received an unexpected message, abort.
             Some(ty) => {
                 return Err(error(format!(
-                    "'{}' did not follow the handshake protocol: received {:?} instead of {}",
-                    $peer_addr,
+                    "Handshake protocol violated: received {:?} instead of {}",
                     ty.name(),
                     stringify!($msg_ty),
                 )))
             }
             // Received nothing.
-            None => {
-                return Err(error(format!("'{}' disconnected before sending {:?}", $peer_addr, stringify!($msg_ty),)))
-            }
+            None => return Err(error(format!("Didn't receive {:?}", stringify!($msg_ty),))),
         }
     };
 }


### PR DESCRIPTION
I've noticed that the logs related to handshake and inbound messages currently contain the peer IP twice; examples:
```
WARN Unable to connect to '<IP>' - '<IP>' disconnected before sending "Message::ChallengeResponse"
WARN Disconnecting from '<IP>' - Disconnecting peer '<IP>' for the following reason: PeerRefresh
```
This PR removes the duplicate instances of the peer IP.