### PR TITLE
Enforce a 1s raw TCP connection timeout

### DIFF
--- a/node/tcp/src/helpers/config.rs
+++ b/node/tcp/src/helpers/config.rs
@@ -52,6 +52,8 @@ pub struct Config {
     /// note: This number can very briefly be breached by 1 in case of inbound connection attempts. It can never be
     /// breached by outbound connection attempts, though.
     pub max_connections: u16,
+    /// The maximum time (in milliseconds) allowed to establish a raw (before the [`Handshake`] protocol) TCP connection.
+    pub connection_timeout_ms: u16,
 }
 
 impl Config {
@@ -87,6 +89,7 @@ impl Default for Config {
             allow_random_port: true,
             fatal_io_errors: vec![ConnectionReset, ConnectionAborted, BrokenPipe, InvalidData, UnexpectedEof],
             max_connections: 100,
+            connection_timeout_ms: 1_000,
         }
     }
 }


### PR DESCRIPTION
While we already impose a limit on the duration of the handshake, we currently rely on the OS to impose a time limit on raw TCP connections, and that time can be rather long.

This PR introduces a way to configure it, and sets it to a default value of 1 second.