### PR TITLE
Update the MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = [
 categories = [ "cryptography", "operating-systems" ]
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.66"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please note to run an Aleo Prover that is **competitive**, the machine will requ
 
 ### 2.2 Installation
 
-Before beginning, please ensure your machine has `Rust v1.65+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
+Before beginning, please ensure your machine has `Rust v1.66+` installed. Instructions to [install Rust can be found here.](https://www.rust-lang.org/tools/install)
 
 Start by cloning this Github repository:
 ```


### PR DESCRIPTION
Due to the use of `BTreeMap::last_key_value` in snarkVM, the MSRV of snarkOS has increased as well.

In addition to updating the README, the `rust-version` key is added to the `Cargo.toml` of the project in order for the users to immediately know if their compiler is unable to compile it.