### PR TITLE
Update clap to 4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,29 +592,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.0",
+ "clap_derive",
  "once_cell",
 ]
 
@@ -627,21 +610,8 @@ dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.5.0",
+ "clap_lex",
  "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote 1.0.26",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -654,15 +624,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.26",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -2038,12 +1999,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,30 +2179,6 @@ checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
  "proc-macro2",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote 1.0.26",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote 1.0.26",
- "version_check",
 ]
 
 [[package]]
@@ -2802,7 +2733,7 @@ name = "snarkos"
 version = "2.0.2"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "once_cell",
  "rusty-hook",
  "snarkos-account",
@@ -2835,8 +2766,9 @@ name = "snarkos-cli"
 version = "2.0.2"
 dependencies = [
  "aleo-std",
+ "anstyle",
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "crossterm 0.26.1",
  "indexmap",
@@ -3070,7 +3002,7 @@ checksum = "4e7b0ba80caad1b2e0c2b032b972addd37d516157a00b8e9237466871158222d"
 dependencies = [
  "anstyle",
  "anyhow",
- "clap 4.3.0",
+ "clap",
  "colored",
  "indexmap",
  "num-format",
@@ -3836,12 +3768,6 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = ["circuit", "console", "rocks"]
 version = "1.0.70"
 
 [dependencies.clap]
-version = "3.2"
+version = "4.3"
 features = ["derive"]
 
 [dependencies.once_cell]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,12 +20,15 @@ edition = "2021"
 version = "0.1.18"
 default-features = false
 
+[dependencies.anstyle]
+version = "1"
+
 [dependencies.anyhow]
 version = "1.0.70"
 
 [dependencies.clap]
-version = "3.2"
-features = ["derive"]
+version = "4.3"
+features = ["derive", "color", "unstable-styles"]
 
 [dependencies.colored]
 version = "2"

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -28,7 +28,6 @@ use std::str::FromStr;
 #[derive(Debug, Parser)]
 pub struct Deploy {
     /// The name of the program to deploy.
-    #[clap(parse(try_from_str))]
     program_id: ProgramID<CurrentNetwork>,
     /// A path to a directory containing a manifest file. Defaults to the current working directory.
     #[clap(long)]

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -90,3 +90,38 @@ impl Deploy {
         Developer::handle_transaction(self.broadcast, self.display, self.store, deployment, self.program_id.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{Command, CLI};
+
+    #[test]
+    fn clap_snarkos_deploy() {
+        let arg_vec = vec![
+            "snarkos",
+            "developer",
+            "deploy",
+            "--private-key",
+            "PRIVATE_KEY",
+            "--query",
+            "QUERY",
+            "--fee",
+            "77",
+            "--record",
+            "RECORD",
+            "hello.aleo",
+        ];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Developer(Developer::Deploy(deploy)) = cli.command {
+            assert_eq!(deploy.program_id, "hello.aleo".try_into().unwrap());
+            assert_eq!(deploy.private_key, "PRIVATE_KEY");
+            assert_eq!(deploy.query, "QUERY");
+            assert_eq!(deploy.fee, 77);
+            assert_eq!(deploy.record, "RECORD");
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
+    }
+}

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -28,13 +28,10 @@ use std::str::FromStr;
 #[derive(Debug, Parser)]
 pub struct Execute {
     /// The program identifier.
-    #[clap(parse(try_from_str))]
     program_id: ProgramID<CurrentNetwork>,
     /// The function name.
-    #[clap(parse(try_from_str))]
     function: Identifier<CurrentNetwork>,
     /// The function inputs.
-    #[clap(parse(try_from_str))]
     inputs: Vec<Value<CurrentNetwork>>,
     /// The private key used to generate the execution.
     #[clap(short, long)]

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -113,3 +113,43 @@ impl Execute {
         Developer::handle_transaction(self.broadcast, self.display, self.store, execution, locator.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{Command, CLI};
+
+    #[test]
+    fn clap_snarkos_execute() {
+        let arg_vec = vec![
+            "snarkos",
+            "developer",
+            "execute",
+            "--private-key",
+            "PRIVATE_KEY",
+            "--query",
+            "QUERY",
+            "--fee",
+            "77",
+            "--record",
+            "RECORD",
+            "hello.aleo",
+            "hello",
+            "1u32",
+            "2u32",
+        ];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Developer(Developer::Execute(execute)) = cli.command {
+            assert_eq!(execute.private_key, "PRIVATE_KEY");
+            assert_eq!(execute.query, "QUERY");
+            assert_eq!(execute.fee, Some(77));
+            assert_eq!(execute.record, Some("RECORD".into()));
+            assert_eq!(execute.program_id, "hello.aleo".try_into().unwrap());
+            assert_eq!(execute.function, "hello".try_into().unwrap());
+            assert_eq!(execute.inputs, vec!["1u32".try_into().unwrap(), "2u32".try_into().unwrap()]);
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
+    }
+}

--- a/cli/src/commands/developer/transfer.rs
+++ b/cli/src/commands/developer/transfer.rs
@@ -27,13 +27,13 @@ use std::str::FromStr;
 #[derive(Debug, Parser)]
 pub struct Transfer {
     /// The input record used to craft the transfer.
-    #[clap(parse(try_from_str), long)]
+    #[clap(long)]
     input_record: Record<CurrentNetwork, Plaintext<CurrentNetwork>>,
     /// The recipient address.
-    #[clap(parse(try_from_str), long)]
+    #[clap(long)]
     recipient: Address<CurrentNetwork>,
     /// The number of microcredits to transfer.
-    #[clap(parse(try_from_str), long)]
+    #[clap(long)]
     amount: u64,
     /// The private key used to generate the execution.
     #[clap(short, long)]

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -27,11 +27,19 @@ pub use start::*;
 mod update;
 pub use update::*;
 
+use anstyle::{AnsiColor, Color, Style};
 use anyhow::Result;
-use clap::Parser;
+use clap::{builder::Styles, Parser};
+
+const HEADER_COLOR: Option<Color> = Some(Color::Ansi(AnsiColor::Yellow));
+const LITERAL_COLOR: Option<Color> = Some(Color::Ansi(AnsiColor::Green));
+const STYLES: Styles = Styles::plain()
+    .header(Style::new().bold().fg_color(HEADER_COLOR))
+    .usage(Style::new().bold().fg_color(HEADER_COLOR))
+    .literal(Style::new().bold().fg_color(LITERAL_COLOR));
 
 #[derive(Debug, Parser)]
-#[clap(name = "snarkOS", author = "The Aleo Team <hello@aleo.org>", setting = clap::AppSettings::ColoredHelp)]
+#[clap(name = "snarkOS", author = "The Aleo Team <hello@aleo.org>", styles = STYLES)]
 pub struct CLI {
     /// Specify the verbosity [options: 0, 1, 2, 3]
     #[clap(default_value = "2", short, long)]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -340,6 +340,7 @@ impl Start {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::{Command, CLI};
     use snarkvm::prelude::Testnet3;
 
     type CurrentNetwork = Testnet3;
@@ -528,5 +529,37 @@ mod tests {
         assert!(config.prover.is_none());
         assert!(config.client.is_some());
         assert_eq!(genesis, expected_genesis);
+    }
+
+    #[test]
+    fn clap_snarkos_start() {
+        let arg_vec = vec![
+            "snarkos",
+            "start",
+            "--nodisplay",
+            "--dev",
+            "2",
+            "--validator",
+            "PRIVATE_KEY",
+            "--cdn",
+            "CDN",
+            "--connect",
+            "IP1,IP2,IP3",
+            "--rest",
+            "127.0.0.1:3033",
+        ];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Start(start) = cli.command {
+            assert!(start.nodisplay);
+            assert_eq!(start.dev, Some(2));
+            assert_eq!(start.validator.as_deref(), Some("PRIVATE_KEY"));
+            assert_eq!(start.cdn, "CDN");
+            assert_eq!(start.rest, "127.0.0.1:3033".parse().unwrap());
+            assert_eq!(start.network, 3);
+            assert_eq!(start.connect, "IP1,IP2,IP3");
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
     }
 }


### PR DESCRIPTION
This is the snarkOS counterpart to https://github.com/AleoHQ/snarkVM/pull/1583.