### PR TITLE
fix: reduce log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ wasm/Cargo.lock
 **/build
 **.ledger-*
 **/committee/.dev/
+.bft-storage-3/
+validator-*.log

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -49,6 +49,7 @@ impl<N: Network> Node<N> {
     }
 
     /// Initializes a new validator node.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new_validator(
         node_ip: SocketAddr,
         rest_ip: Option<SocketAddr>,

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -80,6 +80,7 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
+    #[allow(clippy::too_many_arguments)]
     /// Initializes a new validator node.
     pub async fn new(
         node_ip: SocketAddr,


### PR DESCRIPTION
This reduces log level in consensus from info! to debug! in a few cases. 

Rationale: we don't want to have 'per message' logging in info level to avoid log polution.