### PR TITLE
Provide error messages when executing programs

### DIFF
--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -69,9 +69,19 @@ impl Execute {
         // Retrieve the private key.
         let private_key = PrivateKey::from_str(&self.private_key)?;
 
-        // Fetch the program from query node.
-        let program: Program<CurrentNetwork> =
-            ureq::get(&format!("{}/testnet3/program/{}", self.query, self.program_id)).call()?.into_json()?;
+        // Send a request to the query node.
+        let response = ureq::get(&format!("{}/testnet3/program/{}", self.query, self.program_id)).call();
+
+        // Deserialize the program.
+        let program: Program<CurrentNetwork> = match response {
+            Ok(response) => response.into_json()?,
+            Err(err) => match err {
+                ureq::Error::Status(_status, response) => {
+                    bail!(response.into_string().unwrap_or("Response too large!".to_owned()))
+                }
+                err => bail!(err),
+            },
+        };
 
         println!("📦 Creating execution transaction for '{}'...\n", &self.program_id.to_string().bold());
 


### PR DESCRIPTION
This PR changes the way error responses are displayed when running `snarkos developer execute`: instead of providing only the status code, the specific error message is displayed now. I tested it with the case from #2417, and it changed the output from
```
https://vm.aleo.org/api/testnet3/program/the_liolik_1.aleo: status code 500
```
to
```
Something went wrong: Missing program for ID the_liolik_1.aleo
```
which is more user-friendly. This applies to all other possible errors that would now only return a `500` when using this command.

Closes #2417.