### PR TITLE
Don't use jemalloc by default for greater compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [features]
-default = [ "jemalloc" ]
 jemalloc = [ "tikv-jemallocator" ]
 
 [workspace.dependencies.snarkvm]


### PR DESCRIPTION
Due to `tikv-jemallocator` not supporting some targets, it might be better to not have it as a default feature, even if it's documented.

Initially I considered making it non-default automatically based on the compilation target, but alas, it's [not possible yet](https://github.com/rust-lang/cargo/issues/1197). Therefore I propose that it is just removed from the list of default features, so anyone can enable it manually if they want to.