### PR TITLE
Read the node's private key from the filesystem

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -61,8 +61,8 @@ pub struct Start {
     /// Specify the node's account private key.
     #[clap(long = "private-key")]
     pub private_key: Option<String>,
-    /// Specify the path to the node's account private key.
-    #[clap(long = "private-key-path")]
+    /// Specify the path to a file containing the node's account private key.
+    #[clap(long = "private-key-file")]
     pub private_key_path: Option<PathBuf>,
 
     /// Specify the IP address and port for the node server
@@ -170,6 +170,11 @@ impl Start {
 
     /// Read the private key directly from an argument or from a filesystem location.
     fn parse_private_key(&mut self) -> Result<()> {
+        // Ensure only one private key flag is provided to the CLI.
+        if self.private_key.is_some() && self.private_key_path.is_some() {
+            bail!("Both the private key string and file path flags were specified, please pick only one");
+        }
+
         // If the private key is provided directly, don't do anything else.
         if self.private_key.is_some() {
             return Ok(());

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -148,6 +148,7 @@ impl Start {
     }
 
     /// Returns the CDN to prefetch initial blocks from, from the given configurations.
+    #[allow(clippy::if_same_then_else)]
     fn parse_cdn(&self) -> Option<String> {
         // Disable CDN if:
         //  1. The node is in development mode.

--- a/run-prover.sh
+++ b/run-prover.sh
@@ -16,7 +16,7 @@ then
   exit
 fi
 
-COMMAND="cargo run --release -- start --nodisplay --prover ${PROVER_PRIVATE_KEY}"
+COMMAND="cargo run --release -- start --nodisplay --prover --private-key ${PROVER_PRIVATE_KEY}"
 
 for word in $*;
 do

--- a/run-validator.sh
+++ b/run-validator.sh
@@ -16,7 +16,7 @@ then
   exit
 fi
 
-COMMAND="cargo run --release -- start --nodisplay --validator ${VALIDATOR_PRIVATE_KEY}"
+COMMAND="cargo run --release -- start --nodisplay --validator --private-key ${VALIDATOR_PRIVATE_KEY}"
 
 for word in $*;
 do


### PR DESCRIPTION
This PR is a proposal to address the community requests to allow the node's private key to be loaded from the filesystem in addition to being passed as a runtime argument or input from the command line.

The main change is as follows:
```sh
# Using a private key string
--beacon --private-key "{private_key_string}"
--validator --private-key "{private_key_string}"
--prover --private-key "{private_key_string}"
--client --private-key "{private_key_string}"

# Using a private key file
--beacon --private-key-file "{file_path}"
--validator --private-key-file "{file_path}"
--prover --private-key-file "{file_path}"
--client --private-key-file "{file_path}"
```

This setup, while a bit more verbose, provides better optionality for the user.