### PR TITLE
REST rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -81,6 +81,7 @@ version = "1"
 
 [dependencies.tower]
 version = "0.4"
+features = ["buffer", "limit"]
 
 [dependencies.tower_governor]
 version = "0.3"


### PR DESCRIPTION
This PR introduces a rate limiting service (with a limit of 5 reqs/s) to the REST server.