### PR TITLE
Update `snarkos developer` to use `transfer_private`

### DIFF
--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -19,7 +19,7 @@ use snarkvm::{
     synthesizer::store::helpers::memory::ConsensusMemory,
 };
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
 use std::str::FromStr;
@@ -44,12 +44,12 @@ pub struct Deploy {
     /// The record to spend the fee from.
     #[clap(short, long)]
     record: String,
-    /// Display the generated transaction.
-    #[clap(short, long, conflicts_with = "broadcast")]
-    display: bool,
     /// The endpoint used to broadcast the generated transaction.
     #[clap(short, long, conflicts_with = "display")]
     broadcast: Option<String>,
+    /// Display the generated transaction.
+    #[clap(short, long, conflicts_with = "broadcast")]
+    display: bool,
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
@@ -58,6 +58,11 @@ pub struct Deploy {
 impl Deploy {
     /// Deploys an Aleo program.
     pub fn parse(self) -> Result<String> {
+        // Ensure that the user has specified an action.
+        if !self.display && self.broadcast.is_none() && self.store.is_none() {
+            bail!("❌ Please specify one of the following actions: --broadcast, --display, --store");
+        }
+
         // Specify the query
         let query = Query::from(self.query);
 

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -45,7 +45,7 @@ pub struct Deploy {
     #[clap(short, long)]
     record: String,
     /// The endpoint used to broadcast the generated transaction.
-    #[clap(short, long, conflicts_with = "display")]
+    #[clap(short, long, conflicts_with = "dry_run")]
     broadcast: Option<String>,
     /// Performs a dry-run of transaction generation.
     #[clap(short, long, conflicts_with = "broadcast")]

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -47,9 +47,9 @@ pub struct Deploy {
     /// The endpoint used to broadcast the generated transaction.
     #[clap(short, long, conflicts_with = "display")]
     broadcast: Option<String>,
-    /// Display the generated transaction.
+    /// Performs a dry-run of transaction generation.
     #[clap(short, long, conflicts_with = "broadcast")]
-    display: bool,
+    dry_run: bool,
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
@@ -59,8 +59,8 @@ impl Deploy {
     /// Deploys an Aleo program.
     pub fn parse(self) -> Result<String> {
         // Ensure that the user has specified an action.
-        if !self.display && self.broadcast.is_none() && self.store.is_none() {
-            bail!("❌ Please specify one of the following actions: --broadcast, --display, --store");
+        if !self.dry_run && self.broadcast.is_none() && self.store.is_none() {
+            bail!("❌ Please specify one of the following actions: --broadcast, --dry-run, --store");
         }
 
         // Specify the query
@@ -92,7 +92,7 @@ impl Deploy {
         println!("✅ Created deployment transaction for '{}'", self.program_id.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.
-        Developer::handle_transaction(self.broadcast, self.display, self.store, deployment, self.program_id.to_string())
+        Developer::handle_transaction(self.broadcast, self.dry_run, self.store, deployment, self.program_id.to_string())
     }
 }
 

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -46,7 +46,7 @@ pub struct Execute {
     #[clap(short, long)]
     record: Option<String>,
     /// The endpoint used to broadcast the generated transaction.
-    #[clap(short, long, conflicts_with = "display")]
+    #[clap(short, long, conflicts_with = "dry_run")]
     broadcast: Option<String>,
     /// Performs a dry-run of transaction generation.
     #[clap(short, long, conflicts_with = "broadcast")]

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -48,9 +48,9 @@ pub struct Execute {
     /// The endpoint used to broadcast the generated transaction.
     #[clap(short, long, conflicts_with = "display")]
     broadcast: Option<String>,
-    /// Display the generated transaction.
+    /// Performs a dry-run of transaction generation.
     #[clap(short, long, conflicts_with = "broadcast")]
-    display: bool,
+    dry_run: bool,
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
@@ -61,8 +61,8 @@ impl Execute {
     #[allow(clippy::format_in_format_args)]
     pub fn parse(self) -> Result<String> {
         // Ensure that the user has specified an action.
-        if !self.display && self.broadcast.is_none() && self.store.is_none() {
-            bail!("❌ Please specify one of the following actions: --broadcast, --display, --store");
+        if !self.dry_run && self.broadcast.is_none() && self.store.is_none() {
+            bail!("❌ Please specify one of the following actions: --broadcast, --dry-run, --store");
         }
 
         // Specify the query
@@ -125,7 +125,7 @@ impl Execute {
         println!("✅ Created execution transaction for '{}'", locator.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.
-        Developer::handle_transaction(self.broadcast, self.display, self.store, execution, locator.to_string())
+        Developer::handle_transaction(self.broadcast, self.dry_run, self.store, execution, locator.to_string())
     }
 }
 

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -45,12 +45,12 @@ pub struct Execute {
     /// The record to spend the fee from.
     #[clap(short, long)]
     record: Option<String>,
-    /// Display the generated transaction.
-    #[clap(short, long, conflicts_with = "broadcast")]
-    display: bool,
     /// The endpoint used to broadcast the generated transaction.
     #[clap(short, long, conflicts_with = "display")]
     broadcast: Option<String>,
+    /// Display the generated transaction.
+    #[clap(short, long, conflicts_with = "broadcast")]
+    display: bool,
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
@@ -60,6 +60,11 @@ impl Execute {
     /// Executes an Aleo program function with the provided inputs.
     #[allow(clippy::format_in_format_args)]
     pub fn parse(self) -> Result<String> {
+        // Ensure that the user has specified an action.
+        if !self.display && self.broadcast.is_none() && self.store.is_none() {
+            bail!("❌ Please specify one of the following actions: --broadcast, --display, --store");
+        }
+
         // Specify the query
         let query = Query::from(&self.query);
 

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -80,7 +80,8 @@ impl Execute {
             },
         };
 
-        println!("📦 Creating execution transaction for '{}'...\n", &self.program_id.to_string().bold());
+        let locator = Locator::<CurrentNetwork>::from_str(&format!("{}/{}", self.program_id, self.function))?;
+        println!("📦 Creating execution transaction for '{}'...\n", &locator.to_string().bold());
 
         // Generate the execution transaction.
         let execution = {
@@ -116,7 +117,6 @@ impl Execute {
             // Create a new transaction.
             vm.execute(&private_key, (self.program_id, self.function), self.inputs.iter(), fee, Some(query), rng)?
         };
-        let locator = Locator::<CurrentNetwork>::from_str(&format!("{}/{}", self.program_id, self.function))?;
         println!("✅ Created execution transaction for '{}'", locator.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -142,7 +142,7 @@ impl Developer {
             }
         };
 
-        // Determine if the transaction should be broadcast or displayed to user.
+        // Determine if the transaction should be broadcast to the network.
         if let Some(endpoint) = broadcast {
             // Send the deployment request to the local development node.
             match ureq::post(&endpoint).send_json(&transaction) {
@@ -212,7 +212,6 @@ impl Developer {
             // Output the transaction string.
             Ok(transaction.to_string())
         } else {
-            // TODO (raychu86): Handle the case where the user does not specify a broadcast or display flag.
             Ok("".to_string())
         }
     }

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -117,7 +117,7 @@ impl Developer {
     /// Determine if the transaction should be broadcast or displayed to user.
     fn handle_transaction(
         broadcast: Option<String>,
-        display: bool,
+        dry_run: bool,
         store: Option<String>,
         transaction: Transaction<CurrentNetwork>,
         operation: String,
@@ -208,7 +208,7 @@ impl Developer {
 
             // Output the transaction id.
             Ok(transaction_id.to_string())
-        } else if display {
+        } else if dry_run {
             // Output the transaction string.
             Ok(transaction.to_string())
         } else {

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -24,8 +24,8 @@ pub use execute::*;
 mod scan;
 pub use scan::*;
 
-mod transfer;
-pub use transfer::*;
+mod transfer_private;
+pub use transfer_private::*;
 
 use snarkvm::{
     file::{AleoFile, Manifest},
@@ -51,8 +51,8 @@ pub enum Developer {
     Execute(Execute),
     /// Scan the node for records.
     Scan(Scan),
-    /// Transfer credits.
-    Transfer(Transfer),
+    /// Execute the `credits.aleo/transfer_private` function.
+    TransferPrivate(TransferPrivate),
 }
 
 impl Developer {
@@ -62,7 +62,7 @@ impl Developer {
             Self::Deploy(deploy) => deploy.parse(),
             Self::Execute(execute) => execute.parse(),
             Self::Scan(scan) => scan.parse(),
-            Self::Transfer(transfer) => transfer.parse(),
+            Self::TransferPrivate(transfer_private) => transfer_private.parse(),
         }
     }
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -93,7 +93,7 @@ impl TransferPrivate {
             vm.execute(&private_key, ("credits.aleo", "transfer_private"), inputs.iter(), Some(fee), Some(query), rng)?
         };
         let locator = Locator::<CurrentNetwork>::from_str("credits.aleo/transfer_private")?;
-        println!("✅ Created private transfer of {} microcredits to {}...\n", &self.amount, self.recipient);
+        println!("✅ Created private transfer of {} microcredits to {}\n", &self.amount, self.recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.
         Developer::handle_transaction(self.broadcast, self.display, self.store, execution, locator.to_string())

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -48,7 +48,7 @@ pub struct TransferPrivate {
     #[clap(long)]
     fee_record: String,
     /// The endpoint used to broadcast the generated transaction.
-    #[clap(short, long, conflicts_with = "display")]
+    #[clap(short, long, conflicts_with = "dry_run")]
     broadcast: Option<String>,
     /// Performs a dry-run of transaction generation.
     #[clap(short, long, conflicts_with = "broadcast")]

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::str::FromStr;
 
-/// Executes the `transfer_public` function in the `credits.aleo` program.
+/// Executes the `transfer_private` function in the `credits.aleo` program.
 #[derive(Debug, Parser)]
 pub struct TransferPrivate {
     /// The input record used to craft the transfer.
@@ -68,7 +68,7 @@ impl TransferPrivate {
         // Retrieve the private key.
         let private_key = PrivateKey::from_str(&self.private_key)?;
 
-        println!("📦 Creating private transfer...\n");
+        println!("📦 Creating private transfer of {} microcredits to {}...\n", self.amount, self.recipient);
 
         // Generate the transfer transaction.
         let execution = {
@@ -93,7 +93,7 @@ impl TransferPrivate {
             vm.execute(&private_key, ("credits.aleo", "transfer_private"), inputs.iter(), Some(fee), Some(query), rng)?
         };
         let locator = Locator::<CurrentNetwork>::from_str("credits.aleo/transfer_private")?;
-        println!("✅ Created transfer of {} microcredits to {}...\n", &self.amount, self.recipient);
+        println!("✅ Created private transfer of {} microcredits to {}...\n", &self.amount, self.recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.
         Developer::handle_transaction(self.broadcast, self.display, self.store, execution, locator.to_string())

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -23,9 +23,9 @@ use anyhow::Result;
 use clap::Parser;
 use std::str::FromStr;
 
-/// Executes an Aleo program function.
+/// Executes the `transfer_public` function in the `credits.aleo` program.
 #[derive(Debug, Parser)]
-pub struct Transfer {
+pub struct TransferPrivate {
     /// The input record used to craft the transfer.
     #[clap(long)]
     input_record: Record<CurrentNetwork, Plaintext<CurrentNetwork>>,
@@ -58,7 +58,7 @@ pub struct Transfer {
     store: Option<String>,
 }
 
-impl Transfer {
+impl TransferPrivate {
     /// Creates an Aleo transfer with the provided inputs.
     #[allow(clippy::format_in_format_args)]
     pub fn parse(self) -> Result<String> {
@@ -68,7 +68,7 @@ impl Transfer {
         // Retrieve the private key.
         let private_key = PrivateKey::from_str(&self.private_key)?;
 
-        println!("📦 Creating transfer...\n");
+        println!("📦 Creating private transfer...\n");
 
         // Generate the transfer transaction.
         let execution = {
@@ -90,10 +90,10 @@ impl Transfer {
             ];
 
             // Create a new transaction.
-            vm.execute(&private_key, ("credits.aleo", "transfer"), inputs.iter(), Some(fee), Some(query), rng)?
+            vm.execute(&private_key, ("credits.aleo", "transfer_private"), inputs.iter(), Some(fee), Some(query), rng)?
         };
-        let locator = Locator::<CurrentNetwork>::from_str("credits.aleo/transfer")?;
-        format!("✅ Created transfer of {} microcredits to {}...\n", &self.amount, self.recipient);
+        let locator = Locator::<CurrentNetwork>::from_str("credits.aleo/transfer_private")?;
+        println!("✅ Created transfer of {} microcredits to {}...\n", &self.amount, self.recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.
         Developer::handle_transaction(self.broadcast, self.display, self.store, execution, locator.to_string())

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -19,7 +19,7 @@ use snarkvm::{
     synthesizer::store::helpers::memory::ConsensusMemory,
 };
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
 use std::str::FromStr;
 
@@ -47,12 +47,12 @@ pub struct TransferPrivate {
     /// The record to spend the fee from.
     #[clap(long)]
     fee_record: String,
-    /// Display the generated transaction.
-    #[clap(short, long, conflicts_with = "broadcast")]
-    display: bool,
     /// The endpoint used to broadcast the generated transaction.
     #[clap(short, long, conflicts_with = "display")]
     broadcast: Option<String>,
+    /// Display the generated transaction.
+    #[clap(short, long, conflicts_with = "broadcast")]
+    display: bool,
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
@@ -62,6 +62,11 @@ impl TransferPrivate {
     /// Creates an Aleo transfer with the provided inputs.
     #[allow(clippy::format_in_format_args)]
     pub fn parse(self) -> Result<String> {
+        // Ensure that the user has specified an action.
+        if !self.display && self.broadcast.is_none() && self.store.is_none() {
+            bail!("❌ Please specify one of the following actions: --broadcast, --display, --store");
+        }
+
         // Specify the query
         let query = Query::from(&self.query);
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -50,9 +50,9 @@ pub struct TransferPrivate {
     /// The endpoint used to broadcast the generated transaction.
     #[clap(short, long, conflicts_with = "display")]
     broadcast: Option<String>,
-    /// Display the generated transaction.
+    /// Performs a dry-run of transaction generation.
     #[clap(short, long, conflicts_with = "broadcast")]
-    display: bool,
+    dry_run: bool,
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
@@ -63,8 +63,8 @@ impl TransferPrivate {
     #[allow(clippy::format_in_format_args)]
     pub fn parse(self) -> Result<String> {
         // Ensure that the user has specified an action.
-        if !self.display && self.broadcast.is_none() && self.store.is_none() {
-            bail!("❌ Please specify one of the following actions: --broadcast, --display, --store");
+        if !self.dry_run && self.broadcast.is_none() && self.store.is_none() {
+            bail!("❌ Please specify one of the following actions: --broadcast, --dry-run, --store");
         }
 
         // Specify the query
@@ -101,6 +101,6 @@ impl TransferPrivate {
         println!("✅ Created private transfer of {} microcredits to {}\n", &self.amount, self.recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to user.
-        Developer::handle_transaction(self.broadcast, self.display, self.store, execution, locator.to_string())
+        Developer::handle_transaction(self.broadcast, self.dry_run, self.store, execution, locator.to_string())
     }
 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `snarkos developer transfer` command to `snarkos developer transfer-private` in accordance with the new changes to `credits.aleo`.

This should address #2444