### PR TITLE
Guard against overallocation when deserializing with bincode

### DIFF
--- a/node/messages/src/challenge_request.rs
+++ b/node/messages/src/challenge_request.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use bincode::Options;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChallengeRequest<N: Network> {
     pub version: u32,
@@ -42,7 +44,9 @@ impl<N: Network> MessageTrait for ChallengeRequest<N> {
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let (version, listener_port, node_type, address, nonce) = bincode::deserialize_from(&mut bytes.reader())?;
+        let options =
+            bincode::options().with_limit(MAXIMUM_MESSAGE_SIZE as u64).with_fixint_encoding().allow_trailing_bytes();
+        let (version, listener_port, node_type, address, nonce) = options.deserialize_from(&mut bytes.reader())?;
         Ok(Self { version, listener_port, node_type, address, nonce })
     }
 }

--- a/node/messages/src/helpers/codec.rs
+++ b/node/messages/src/helpers/codec.rs
@@ -23,7 +23,7 @@ use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 const MAXIMUM_HANDSHAKE_MESSAGE_SIZE: usize = 1024 * 1024; // 1 MiB
 
 /// The maximum size of a message that can be transmitted in the network.
-const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
+pub(crate) const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
 
 /// The codec used to decode and encode network `Message`s.
 pub struct MessageCodec<N: Network> {

--- a/node/messages/src/helpers/mod.rs
+++ b/node/messages/src/helpers/mod.rs
@@ -17,6 +17,7 @@ pub use block_locators::*;
 
 mod codec;
 pub use codec::MessageCodec;
+pub(crate) use codec::MAXIMUM_MESSAGE_SIZE;
 
 #[allow(unused)]
 mod noise_codec;

--- a/node/messages/src/peer_response.rs
+++ b/node/messages/src/peer_response.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use bincode::Options;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerResponse {
     pub peers: Vec<SocketAddr>,
@@ -35,6 +37,8 @@ impl MessageTrait for PeerResponse {
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
-        Ok(Self { peers: bincode::deserialize_from(&mut bytes.reader())? })
+        let options =
+            bincode::options().with_limit(MAXIMUM_MESSAGE_SIZE as u64).with_fixint_encoding().allow_trailing_bytes();
+        Ok(Self { peers: options.deserialize_from(&mut bytes.reader())? })
     }
 }

--- a/node/messages/src/ping.rs
+++ b/node/messages/src/ping.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use bincode::Options;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Ping<N: Network> {
     pub version: u32,
@@ -37,8 +39,10 @@ impl<N: Network> MessageTrait for Ping<N> {
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
+        let options =
+            bincode::options().with_limit(MAXIMUM_MESSAGE_SIZE as u64).with_fixint_encoding().allow_trailing_bytes();
         let mut reader = bytes.reader();
-        let (version, node_type, block_locators) = bincode::deserialize_from(&mut reader)?;
+        let (version, node_type, block_locators) = options.deserialize_from(&mut reader)?;
         Ok(Self { version, node_type, block_locators })
     }
 }


### PR DESCRIPTION
This change applies to network messages that involve collections.