### PR TITLE
Bump snarkVM to `v0.14.4`

### DIFF
--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -17,9 +17,13 @@
 #[cfg(test)]
 mod tests {
     use snarkos_node_cdn::sync_ledger_with_cdn;
-    use snarkvm::{
-        prelude::{Block, FromBytes, Ledger, Network, Testnet3},
-        synthesizer::store::helpers::memory::ConsensusMemory,
+    use snarkvm::prelude::{
+        block::Block,
+        store::helpers::memory::ConsensusMemory,
+        FromBytes,
+        Ledger,
+        Network,
+        Testnet3,
     };
 
     use tracing_test::traced_test;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,7 +114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f2a841f04c2eaeb5a95312e5201a9e4b7c95b64ca99870d6bd2e2376df540a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -116,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6118baab6285accf088b31d5ea5029c37bbf9d98e62b4d8720a0a5a66bc2e427"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -244,19 +253,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -364,6 +373,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,11 +447,11 @@ dependencies = [
  "peeking_take_while",
  "prettyplease",
  "proc-macro2",
- "quote 1.0.28",
+ "quote 1.0.29",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -438,9 +462,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "blake2"
@@ -639,8 +663,8 @@ checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -657,9 +681,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "17bfac9400fe632590700de801b5dfbdca8b6944073832d1284bdbeef7f00e45"
 dependencies = [
  "atty",
  "lazy_static",
@@ -882,7 +906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1108,8 +1132,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1192,6 +1216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,9 +1254,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
  "ahash",
 ]
@@ -1466,13 +1496,12 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
 
@@ -1487,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jobserver"
@@ -1613,6 +1642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
  "ahash",
  "metrics-macros",
@@ -1731,19 +1766,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.13.2",
+ "hashbrown 0.13.1",
  "metrics",
  "num_cpus",
  "quanta",
@@ -1854,13 +1889,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 1.0.109",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1909,6 +1944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,8 +1989,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2003,7 +2047,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2057,29 +2101,29 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -2141,7 +2185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2186,9 +2230,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -2387,6 +2431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,15 +2453,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -2457,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "same-file"
@@ -2472,11 +2535,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2544,22 +2607,22 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2576,10 +2639,11 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
 dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2960,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb55d3117b1cb5f4ecba3afaede11536171f212aa1b4082dacb58cc5b198323"
+checksum = "7dd4ce6ebf1840dbe0d08fbc951b89166c30ccd42cfc0179cb56bb896a6dc8c5"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2989,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3a127a0ea10ed55a63753c77b172bccf26f360de5a98bcfd9844429ee7e3b4"
+checksum = "b5efd91be6c3dc1430c1a4d5777a2ddbb137c07dff3c012910ee3df83ed73b8e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3019,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9d6c6ca5b7676b7965c2cee631def41ab96bc9f2fe324907f248231501fa12"
+checksum = "7476470d6f6db2c537bc581dafd157449b26f7bfc75247be779223a8732d371b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3034,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0897e3d6130d098121d1798bbc8a08f734de4efe234abed5c01ebb588f6099ec"
+checksum = "533ecc224724a70191af6ffc52a632f9515b4e24d052921ff727c71e86b04e90"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3046,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c57658a5aa1effcef7c93a08af4c87ce7bdbd46fb2208f86358e2053555b81c"
+checksum = "1db3085023870da4cd635b25f94e7dd17fa57803d6ad349c697d4db107483c8a"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3057,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d412403bb467901f7de68c76ff9bf53ed88b5391de2e68a04071af88b780f10f"
+checksum = "01701d35df6f6ce4fbbab70468eb8e498732203197672ee74431993cf1fd2bf5"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3068,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58a810f21aca59ee903e9db2bea29dc3fb7af82fde0bb50ec01e95359569226"
+checksum = "b355c7a54e4a2ac3e40abd2d6b1d47b5fedab9b753152eb23570961731add60a"
 dependencies = [
  "indexmap 2.0.0",
  "itertools",
@@ -3087,15 +3151,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ac826726517bd503a375fce4d616f192bca407b0130ca14b5aa7ae1a901421"
+checksum = "6374845011f48efcba24bf7c567d34376ad8c2bbcab7d058569cf659bc5b59f0"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b3fc9b80f027b0a55f84f56719305fd9dc89e9bfcff198afe5a4c48ee3cbfe"
+checksum = "35a9bec67659e105ad1f0a522ff826e11678646eadc3eee7f2d5b612ce5eec2d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3105,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb64cee93771eb27ed58cabf286642e4ac33b0158a7b42431a751f8dd850303"
+checksum = "aa78d19308618fbf6dbc8505cb7406aef67000c04c0f15f7228dddfd39d4e860"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -3119,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed4a945c7745e10fe67be911bb33cfed77e6b5a47b33a3c7dda2291cb206049"
+checksum = "ecd7d432cf0a41ffece7cbc1a6be58d0572c024ce45ea58bddf2eaed626f5610"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3135,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c84f049bd3503611bbf38f10e1a552cba2e480fb1913845d59ee23a173a8e86"
+checksum = "3fce8f0c7f063f189a26352fcc876f6600b8aa4aed5964660a6c9e4ebe86778b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3149,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7152b425a06f672d813fa5e6a729440def1f28e6823232317b14dbcdb2bf288f"
+checksum = "e59a39ab84ce4f061056be292ecbb186492985a727e5c4f8e4ecd8062e599e58"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3159,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26560433b704e4df9828a94b68564b234d5ce0cb548e42c544d828892d879766"
+checksum = "d5cb2ff3044fcfc983fe4b7568ac9645ece8d92cf89820f0449bf096937e4840"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3170,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eb1f406e97d5e5c7703a8c9cc9bc4a261c7bdb8d2d553a87f41637001e37dd"
+checksum = "cb81f5a0d7d5333acabedf9376078f9b10cde60969130e01c815b8da2707d146"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3183,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2230bc28497448c9841013ba6e22daff53161e417616e8661d70e87de59faa4c"
+checksum = "04de8d6f43babec68473a06590c2d10275db0d7468597d4e8e7229b81836f594"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3195,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3692e5a3f14bc8a9cdf470e4eb8e128d6fcca51bfc4b321c798aa61913c72ea2"
+checksum = "0abe7dd082ea9096e3856ddc239ddee3accb109e8cc845bc19c944509a683ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3207,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe0a730257aad4e7e1db33cbd1e804aeb636ca86113d381b09d62c468e74207"
+checksum = "2d5c019e2494c755c1bbe9d23f51f2d98be40ba491dded34bd8c636507186a87"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3220,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a52e5c7a899899edb585e206f54a364949e0dd4a0595427934a3949e260c0ed"
+checksum = "1f180828d1217d783b6dd91b8c3a02f8f0c341bd09019a32eefd0b3b41b2e6bd"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3234,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adbb5299fd6958ba24c043e67208a95db1aa148c7d4febd66aba16eb79264e7"
+checksum = "7d2e3b5fcd416814ae4f3497295858366601ad4809696b6f3cf4e36eb8a73586"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3245,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf84caf1eaac04f06a14f7818e519e6b4f5d9b4a26a62227d6cff1e9b5b5774"
+checksum = "bcb876c5be5048625ec1d85038af7d673616af305539b3b17aeef026405b9025"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3258,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce43d1d2ef86839cb24362004bcc70c90ba4247dd2cc43ea8fdc6ccf16633dc2"
+checksum = "b78dbf5afd964ac3fbc4460aacc8cf48ceea12eb5e86b974ebb2bb0c82c7f245"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3270,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2837afb34a60e09bada60e3d164f8fc54f80029656e258d09a8ef9a749cc11"
+checksum = "26a8c150eba8f5aca647a0f1c09ff5c9923866ecd863b798b9a8ff5300553437"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -3294,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135fbd42d96c09670d6f6a90cf5bfaf3f59bb076f016d43e1f9752094d469c4"
+checksum = "1688615caa3321808fe56df2e7f66a5493b906286f695b2c73d45713febb11ed"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3312,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317c3637bdd3057498629779132b65e75290ee32930a3866519b4313783cc40f"
+checksum = "82dd101991db1533b0dfb2fa8358de50a5d50bc4857a4a6a1ca9b2ced3b2a178"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3332,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b82379c642dc8bcaeef24715dc197495c44a46b37942c33fd2f7dd101c8539b"
+checksum = "7c789ab29dbbb40aab9580ce103ebfbbc8751a79ea6af1fa9e60eea83bc6523e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3348,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b434896f9f30a559adaf72c1d3e389d55fc5b6f7c81b1436c90832836dc6d2"
+checksum = "31d0a9fe2afb1e378ce3963cb3ece3b464593d2b010b7387f48222f7d5da4042"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3360,18 +3424,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb76ad8a178faf0808cc1ea050e73856f776707c1b764a5192740a2f79b863"
+checksum = "a7f1c66f8a9e9d0620b882d681f24251901d523a0d94759e1331a296b25c211f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f787d254d43ea4aa962ac6930340f09e640ec70a4baa8795b51472539e1036"
+checksum = "4b759d0023a689956832a9b664204b11a6ad96c40f3020161901bea26ecd0082"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3379,9 +3443,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8f1e859c83f2a4e1ebd4a9805680497a7fbfe0615681c18311131a3ed47451"
+checksum = "1bc7199f8c243939231f99afc06a7904958b01deb72363484e7e03535f096ce2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3391,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c6bb27e84d0b375a985cfbb27188615609d8faa986cb78ec298a1ad6752b21"
+checksum = "876ab23eb4894979ecf5a85f5d75e68601e023d52ab515c5963cd30de63429a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3402,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ca9aff825a47be71a85091f716512d8779d9ccad2d4443327de952ed18d4c7"
+checksum = "10dcd9d8edd0e1f1aad714e47851a0a8d13bc83b4151744ca2545c63eb6078c6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3413,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb4a67c4557ddbe258f22754379f22a57d8b3826ddf1c293b04ab23dcae14a9"
+checksum = "4657683afc0c1a0e7617c90d22e13833bed3d3d3174c6c9a876b69a4052887d1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3425,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a7aae73e06e3af3f5fc3a477628b215e9867a27949010bc38294c535f29f1a"
+checksum = "cb187d828c2a0a726f56fed7b7b0ea0012f7a98d9b7048ddb384bc67acbb288d"
 dependencies = [
  "rand",
  "rayon",
@@ -3440,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a364585eba401aa7a3e0b530720113afce8a1675603b32b119b8226d1a9903"
+checksum = "e0f5ef0c5c673de3bf38abd50a81094ddf3128e9e57a5ebc7e850fe77c8ed099"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3458,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4385f62cc5e84a376376f63f89ba20a19a61c68d513985cb1b2cb70869423e99"
+checksum = "552f482745d17d25769fa3aa144804e9ef5f0e1df44296c3e68c992a3dc88935"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3469,16 +3533,92 @@ dependencies = [
  "rand",
  "rayon",
  "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-synthesizer",
  "time",
  "tracing",
 ]
 
 [[package]]
-name = "snarkvm-parameters"
-version = "0.12.6"
+name = "snarkvm-ledger-block"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d7b05d31785576ad85ef2789dc8fc90329ec0a1f02bd61c7d544f3f54bffde"
+checksum = "98de8ca88c1df9c6f7aea301f0923ea41ddf4dd61fafc6d2732c463177867c18"
+dependencies = [
+ "indexmap 2.0.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+]
+
+[[package]]
+name = "snarkvm-ledger-coinbase"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312d590332d4155a4a1a5fb17892918451cc34382d2a4a5bac780a73a69a3d0f"
+dependencies = [
+ "anyhow",
+ "bincode 1.3.3",
+ "blake2",
+ "itertools",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms",
+ "snarkvm-console",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
+]
+
+[[package]]
+name = "snarkvm-ledger-query"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d726d16266bb6e22c2081397aee1589a335f181fd6680cb384eaf4d700ad56d9"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "snarkvm-console",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "ureq",
+]
+
+[[package]]
+name = "snarkvm-ledger-store"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "040b06417bb332fcb9edf72cc13dde9be4bcb52822428e7f9fe7d41c02988f34"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode 1.3.3",
+ "indexmap 2.0.0",
+ "once_cell",
+ "parking_lot",
+ "rayon",
+ "rocksdb",
+ "serde",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42029b74e853b94e6bbbc6e5333fc53ac8a8511b44130e1f46337ed7e6dd1621"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3501,75 +3641,66 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2628224ef7ee761ec0f2c77cbb7efc971f915d2c01883cc6f7089e063f5d5119"
+checksum = "073db75a7f6c4c5a37480336cff44cb23a90cfbd5c74143fcf873bd6782dcd8e"
 dependencies = [
  "aleo-std",
- "anyhow",
- "bincode 1.3.3",
- "blake2",
- "colored",
  "indexmap 2.0.0",
- "itertools",
- "once_cell",
  "parking_lot",
- "paste",
  "rand",
- "rand_chacha",
- "rayon",
- "reqwest",
- "rocksdb",
- "serde",
- "serde_json",
- "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-synthesizer-coinbase",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
- "snarkvm-utilities",
  "tracing",
- "ureq",
 ]
 
 [[package]]
-name = "snarkvm-synthesizer-coinbase"
-version = "0.12.6"
+name = "snarkvm-synthesizer-process"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e702f8f13f8aa3ba1fc89e6c760f22358b1b3f0e9d4535bedd8a8c481819ba"
+checksum = "8d3fd82ee7b73c3363b0c1602ec89ebc0b56a1c1853080e720c4fbbe7b4187b6"
 dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "blake2",
- "itertools",
- "rayon",
- "serde_json",
- "snarkvm-algorithms",
+ "aleo-std",
+ "colored",
+ "indexmap 2.0.0",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "snarkvm-circuit",
  "snarkvm-console",
- "snarkvm-curves",
- "snarkvm-fields",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
- "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0bec7c66086c2fa8eceb18467dd0692c07b38e16a8a2aa74ab82d2a684e868"
+checksum = "2bd9a06fac1c8de4bf4d2e209c301b74b73111f6cf1ff34d2ec5801538f189c9"
 dependencies = [
  "indexmap 2.0.0",
+ "paste",
+ "rand",
+ "rand_chacha",
+ "serde_json",
+ "snarkvm-circuit",
  "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1721c7b2e4da47c355ed48efcae208dc46885a3a65290db80e4845814dd2ce14"
+checksum = "65a3cb27ec6bc122542def3d2c505edc038406aeb8bcd583ae59f5f7710180ce"
 dependencies = [
  "bincode 1.3.3",
  "once_cell",
@@ -3581,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16329751e82faca0c9ae2e14f9951e77669f28c488194bdae90a2d7905b5f55"
+checksum = "0e6dc11adb255fd369b9375ce1d80c1f8d8022b582a8b3c344d7e4c1c94a1a51"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3601,13 +3732,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.12.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90f007329c4b49ed72e92267e8722c96a1b2e5461d4d2bfe0bbb44b46b3f9ec"
+checksum = "e3c7b85b20396061be79f8746f03251ed9504ccf7de18910bfe7d4eab6355b46"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3678,18 +3809,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -3718,7 +3849,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.22",
  "windows-sys 0.48.0",
 ]
 
@@ -3738,8 +3869,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3816,11 +3947,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -3840,8 +3972,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3923,7 +4055,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.3.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3968,8 +4100,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -4074,7 +4206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
 dependencies = [
  "lazy_static",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -4085,7 +4217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
- "quote 1.0.28",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -4122,9 +4254,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -4279,8 +4411,8 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -4302,7 +4434,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.28",
+ "quote 1.0.29",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4313,8 +4445,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.28",
- "syn 2.0.22",
+ "quote 1.0.29",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4381,22 +4513,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4414,7 +4531,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -4434,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -254,29 +254,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.69"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -451,7 +440,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -634,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -645,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -657,14 +646,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -681,13 +670,13 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bfac9400fe632590700de801b5dfbdca8b6944073832d1284bdbeef7f00e45"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -727,9 +716,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -990,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1133,7 +1122,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1304,18 +1293,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1483,7 +1463,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1496,12 +1476,12 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "rustix 0.38.2",
+ "hermit-abi",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -1688,7 +1668,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1697,7 +1677,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1767,7 +1747,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1895,7 +1875,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1933,7 +1913,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1990,7 +1970,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2052,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "pea2pea"
@@ -2116,7 +2096,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2168,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
+checksum = "d220334a184db82b31b83f5ff093e3315280fb2b6bbc032022b2304a509aab7a"
 
 [[package]]
 name = "ppv-lite86"
@@ -2180,19 +2160,19 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2338,13 +2318,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2357,6 +2338,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,9 +2356,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -2453,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.22"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2467,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -2480,13 +2472,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.1",
  "sct",
 ]
 
@@ -2501,10 +2493,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
+name = "rustls-webpki"
+version = "0.101.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "rusty-hook"
@@ -2607,29 +2609,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -2639,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
+checksum = "8acc4422959dd87a76cb117c191dcbffc20467f06c9100b76721dab370f24d3a"
 dependencies = [
  "itoa",
  "serde",
@@ -2755,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "snarkos"
@@ -3024,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd4ce6ebf1840dbe0d08fbc951b89166c30ccd42cfc0179cb56bb896a6dc8c5"
+checksum = "c90801ecdcfc2510ab60cabf34ad20b611ea45a706bf53cd2bcb3fe5916fbf46"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3053,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5efd91be6c3dc1430c1a4d5777a2ddbb137c07dff3c012910ee3df83ed73b8e"
+checksum = "215c452596f574b26961de0f58ba874c5ba04526d4a670b6604d75812fbe19c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3083,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7476470d6f6db2c537bc581dafd157449b26f7bfc75247be779223a8732d371b"
+checksum = "babb1eb9f6947d415677b8b7e40f5b2400e11c468718b2975accfce98c789156"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3098,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533ecc224724a70191af6ffc52a632f9515b4e24d052921ff727c71e86b04e90"
+checksum = "4bf97177a7caf5251fa62524d8d81288d278ff7726d47cd60fb299ee16ffff92"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3110,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db3085023870da4cd635b25f94e7dd17fa57803d6ad349c697d4db107483c8a"
+checksum = "207f5a4390ae5d35f8c5fd3e9a979592b057abd4d0badc372d3210dcb8a35686"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3121,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01701d35df6f6ce4fbbab70468eb8e498732203197672ee74431993cf1fd2bf5"
+checksum = "2add37be44da1d18f835538dcfab24fb2143838d73570d1c4f37ea1ec8e1f5aa"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3132,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b355c7a54e4a2ac3e40abd2d6b1d47b5fedab9b753152eb23570961731add60a"
+checksum = "b6479bfb7019cedaf7818c72ed063be2a66662b0a6814745b31c78579d8184f6"
 dependencies = [
  "indexmap 2.0.0",
  "itertools",
@@ -3151,15 +3153,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6374845011f48efcba24bf7c567d34376ad8c2bbcab7d058569cf659bc5b59f0"
+checksum = "851941e4fe924456301a7cbdd4c7c49a9e1166a85b3f8077c1716159a17ee613"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a9bec67659e105ad1f0a522ff826e11678646eadc3eee7f2d5b612ce5eec2d"
+checksum = "ce26b2a91dfddc1e6c5e0fb3b5f8a1c205646a488293900608af9b521eb94a94"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3169,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa78d19308618fbf6dbc8505cb7406aef67000c04c0f15f7228dddfd39d4e860"
+checksum = "39a9c43ab80dbd0fa9a38c9977d25b87206eae1e1009fcbc5fd4211be914254d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -3183,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd7d432cf0a41ffece7cbc1a6be58d0572c024ce45ea58bddf2eaed626f5610"
+checksum = "358929df1f4054f38a5d5b5c7e6fd6d18a415e604e327d1d2346397d83c4bdd0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3199,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8f0c7f063f189a26352fcc876f6600b8aa4aed5964660a6c9e4ebe86778b"
+checksum = "094f01703c3325872d2ae296bba643ab287200a6521f09fa8089cff505b01a4f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3213,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59a39ab84ce4f061056be292ecbb186492985a727e5c4f8e4ecd8062e599e58"
+checksum = "9a3b9cf78160a7ced32e6f63c42c1164d80e7311637bad17acf0a414cf43e97a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3223,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cb2ff3044fcfc983fe4b7568ac9645ece8d92cf89820f0449bf096937e4840"
+checksum = "9cf7f362edef6367fe8ff05dac6119e7d3ad6ef1499afde4b4500c6440d2fdbc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3234,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb81f5a0d7d5333acabedf9376078f9b10cde60969130e01c815b8da2707d146"
+checksum = "caa9f180e981ea7eca175a8ec05828de9bb90b1f79de6d7e6104656246473ba2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3247,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04de8d6f43babec68473a06590c2d10275db0d7468597d4e8e7229b81836f594"
+checksum = "9112edd964907f9b15f1cf716f33af44f4518eb4128706c8614b9c8d3bd2a5cd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3259,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abe7dd082ea9096e3856ddc239ddee3accb109e8cc845bc19c944509a683ca6"
+checksum = "e1e4d1c4ad3d71a24aee62671280aaed8470b9f848df578dee012b80d8a65653"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3271,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5c019e2494c755c1bbe9d23f51f2d98be40ba491dded34bd8c636507186a87"
+checksum = "9ba5d2b6e0230d8418ee66425497afa02fee308aea6495a3c37c6407528f411c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3284,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f180828d1217d783b6dd91b8c3a02f8f0c341bd09019a32eefd0b3b41b2e6bd"
+checksum = "3bdd291f6e725b75d08de643fd2a282911c789dab9dba54b2fc461432f0dc063"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3298,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2e3b5fcd416814ae4f3497295858366601ad4809696b6f3cf4e36eb8a73586"
+checksum = "2692913aa794e6512631bbd6d0ae299eb22d88abd1e5925cf23d55e156cf7153"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3309,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb876c5be5048625ec1d85038af7d673616af305539b3b17aeef026405b9025"
+checksum = "268e64aea3f7363a69190d576ef5bef5481d5871435395020427e825f0c53f01"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3322,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78dbf5afd964ac3fbc4460aacc8cf48ceea12eb5e86b974ebb2bb0c82c7f245"
+checksum = "b3ff370bb2818e856af98184bdf25e4cfc2e9d31b42a54833e4ee14b41c62b08"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3334,9 +3336,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a8c150eba8f5aca647a0f1c09ff5c9923866ecd863b798b9a8ff5300553437"
+checksum = "065c3cda7a06b02b20cde9074d93fb3c705f29bd7a73664acb52c8450cc0bee0"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -3358,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1688615caa3321808fe56df2e7f66a5493b906286f695b2c73d45713febb11ed"
+checksum = "b9ad7682945d1a9f07f1dc98aad409f58a1c0e93effc3c11cb89953350fb5c1c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3376,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82dd101991db1533b0dfb2fa8358de50a5d50bc4857a4a6a1ca9b2ced3b2a178"
+checksum = "1eb7bd174c0eff4c226cb6525e539a77756bc58097656582e376d75601d20248"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3396,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c789ab29dbbb40aab9580ce103ebfbbc8751a79ea6af1fa9e60eea83bc6523e"
+checksum = "27ff2d5b175a48091778b94209d531b518c8dfdd2314fbf8a7de4c2abf08d0f3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3412,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d0a9fe2afb1e378ce3963cb3ece3b464593d2b010b7387f48222f7d5da4042"
+checksum = "2b72fa668a428383a0ea242f707447ec58b9b1fcc038e96d699b932839ce2f21"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3424,18 +3426,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1c66f8a9e9d0620b882d681f24251901d523a0d94759e1331a296b25c211f"
+checksum = "50ff4fdb80ccf7598a26164062f16eff23adb4ac8cff655376056ae3439e4550"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b759d0023a689956832a9b664204b11a6ad96c40f3020161901bea26ecd0082"
+checksum = "4b548e7c900f1f0a9302937d9ec38e2b2b608f5da30925912fdc31d83f15abf4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3443,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc7199f8c243939231f99afc06a7904958b01deb72363484e7e03535f096ce2"
+checksum = "4a7656f00619b40f7a08ad66719e4c2e04e6c1e9e1097b400ab0870efb0241fb"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3455,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab23eb4894979ecf5a85f5d75e68601e023d52ab515c5963cd30de63429a8"
+checksum = "150e32c228ccf7a1154f1e8d52c40dd12d83df4b4890020df1f1e0747a457751"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3466,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10dcd9d8edd0e1f1aad714e47851a0a8d13bc83b4151744ca2545c63eb6078c6"
+checksum = "dddc3ee109b723aab5c5329319d08d41bf63050365047045ebf5de2d996b6738"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3477,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4657683afc0c1a0e7617c90d22e13833bed3d3d3174c6c9a876b69a4052887d1"
+checksum = "c20f7cd48a69571f7cdc157e78576d12f8e3f213a8bc6caaaf51f49dfd997a07"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3489,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb187d828c2a0a726f56fed7b7b0ea0012f7a98d9b7048ddb384bc67acbb288d"
+checksum = "e793bbc08d7952b18fe63d3b9d7811ab1068bc8b2d2f2ca6344f8491b879f52b"
 dependencies = [
  "rand",
  "rayon",
@@ -3504,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f5ef0c5c673de3bf38abd50a81094ddf3128e9e57a5ebc7e850fe77c8ed099"
+checksum = "13be0ead7da66a07e64324a34b3a9a7420a2b9184777f6e50667280fd1593c9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3522,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552f482745d17d25769fa3aa144804e9ef5f0e1df44296c3e68c992a3dc88935"
+checksum = "f83fc809ddcf179cddd560e454905f868b5817753fc732ddb0ea5dd583d0ff54"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3544,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de8ca88c1df9c6f7aea301f0923ea41ddf4dd61fafc6d2732c463177867c18"
+checksum = "981ff6912ecfb3450de5f04a8a8803ff7475abda67b43e1968f1531ac51034e1"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -3559,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-coinbase"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312d590332d4155a4a1a5fb17892918451cc34382d2a4a5bac780a73a69a3d0f"
+checksum = "6492e17cc884c318f61e97e109f5e3ccc7d8e1ce704b7d1f2d8aa24e0322eca8"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -3579,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726d16266bb6e22c2081397aee1589a335f181fd6680cb384eaf4d700ad56d9"
+checksum = "98c3adef9c2dab90913465140c0759efc8ce9fa8f42c795a336683c8f18cc81f"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3593,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040b06417bb332fcb9edf72cc13dde9be4bcb52822428e7f9fe7d41c02988f34"
+checksum = "99ef614037842fd47375f89f40f20a7c37b001a04cc030570b535999b358a241"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3616,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42029b74e853b94e6bbbc6e5333fc53ac8a8511b44130e1f46337ed7e6dd1621"
+checksum = "b136116c7e09d48733694553eb0d3a248aac8787af6a9a1f71c2fb56dc8d255e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3641,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073db75a7f6c4c5a37480336cff44cb23a90cfbd5c74143fcf873bd6782dcd8e"
+checksum = "a8ed13cafe7e450b95a3056c743f5cf446d4b1506dd8a0405194742d157030dd"
 dependencies = [
  "aleo-std",
  "indexmap 2.0.0",
@@ -3662,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3fd82ee7b73c3363b0c1602ec89ebc0b56a1c1853080e720c4fbbe7b4187b6"
+checksum = "00c788735f6a75a92a909f32120335170e505dbb26e504891e03eda598d14619"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3672,6 +3674,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
  "snarkvm-ledger-block",
@@ -3683,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd9a06fac1c8de4bf4d2e209c301b74b73111f6cf1ff34d2ec5801538f189c9"
+checksum = "f27aa6c225ec8b063ea79909b5c54b32aa01597ce75e166b6131a8da9c953f1e"
 dependencies = [
  "indexmap 2.0.0",
  "paste",
@@ -3698,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a3cb27ec6bc122542def3d2c505edc038406aeb8bcd583ae59f5f7710180ce"
+checksum = "97ae154b2011346683302da51220e35f5709783d2ef4172b5e67056758fbb961"
 dependencies = [
  "bincode 1.3.3",
  "once_cell",
@@ -3712,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e6dc11adb255fd369b9375ce1d80c1f8d8022b582a8b3c344d7e4c1c94a1a51"
+checksum = "03f4caa23d2b983a0e8ddaffd55fde3e28888cb78fac2dde31e7d10f2dc114c6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3732,13 +3735,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.14.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c7b85b20396061be79f8746f03251ed9504ccf7de18910bfe7d4eab6355b46"
+checksum = "38853133bb727b5ad195580085f207d92a7b7c0f819ecbe213674048273a260f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3815,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
@@ -3849,28 +3852,28 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3905,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "serde",
@@ -3923,9 +3926,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -3973,7 +3976,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4101,7 +4104,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4312,7 +4315,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
  "serde",
  "serde_json",
  "url",
@@ -4412,7 +4415,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -4446,7 +4449,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4473,7 +4476,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-version = "=0.12.6"
+version = "=0.14.0"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-version = "=0.14.0"
+version = "=0.14.4"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -14,9 +14,14 @@
 
 use super::{CurrentNetwork, Developer};
 
-use snarkvm::{
-    prelude::{ConsensusStore, Plaintext, PrivateKey, ProgramID, Query, Record, VM},
-    synthesizer::store::helpers::memory::ConsensusMemory,
+use snarkvm::prelude::{
+    query::Query,
+    store::{helpers::memory::ConsensusMemory, ConsensusStore},
+    Plaintext,
+    PrivateKey,
+    ProgramID,
+    Record,
+    VM,
 };
 
 use anyhow::{bail, Result};

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -14,9 +14,17 @@
 
 use super::{CurrentNetwork, Developer, Program};
 
-use snarkvm::{
-    prelude::{ConsensusStore, Identifier, Locator, Plaintext, PrivateKey, ProgramID, Query, Record, Value, VM},
-    synthesizer::store::helpers::memory::ConsensusMemory,
+use snarkvm::prelude::{
+    query::Query,
+    store::{helpers::memory::ConsensusMemory, ConsensusStore},
+    Identifier,
+    Locator,
+    Plaintext,
+    PrivateKey,
+    ProgramID,
+    Record,
+    Value,
+    VM,
 };
 
 use anyhow::{bail, Result};

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -30,7 +30,7 @@ pub use transfer_private::*;
 use snarkvm::{
     file::{AleoFile, Manifest},
     package::Package,
-    prelude::{Program, ProgramID, ToBytes, Transaction},
+    prelude::{block::Transaction, Program, ProgramID, ToBytes},
 };
 
 use anyhow::{bail, ensure, Result};

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -14,7 +14,7 @@
 
 use super::CurrentNetwork;
 
-use snarkvm::prelude::{Block, Ciphertext, Field, Network, Plaintext, PrivateKey, Record, ViewKey};
+use snarkvm::prelude::{block::Block, Ciphertext, Field, Network, Plaintext, PrivateKey, Record, ViewKey};
 
 use anyhow::{bail, ensure, Result};
 use clap::Parser;

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -14,9 +14,16 @@
 
 use super::{CurrentNetwork, Developer};
 
-use snarkvm::{
-    prelude::{Address, ConsensusStore, Locator, Plaintext, PrivateKey, Query, Record, Value, VM},
-    synthesizer::store::helpers::memory::ConsensusMemory,
+use snarkvm::prelude::{
+    query::Query,
+    store::{helpers::memory::ConsensusMemory, ConsensusStore},
+    Address,
+    Locator,
+    Plaintext,
+    PrivateKey,
+    Record,
+    Value,
+    VM,
 };
 
 use anyhow::{bail, Result};

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -15,9 +15,14 @@
 use snarkos_account::Account;
 use snarkos_display::Display;
 use snarkos_node::{messages::NodeType, Node};
-use snarkvm::{
-    prelude::{Block, ConsensusStore, FromBytes, Network, PrivateKey, Testnet3, VM},
-    synthesizer::store::helpers::memory::ConsensusMemory,
+use snarkvm::prelude::{
+    block::Block,
+    store::{helpers::memory::ConsensusMemory, ConsensusStore},
+    FromBytes,
+    Network,
+    PrivateKey,
+    Testnet3,
+    VM,
 };
 
 use anyhow::{bail, Result};

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use snarkvm::prelude::{
-    cow_to_copied,
-    Block,
-    ConsensusStorage,
+    block::Block,
+    store::{cow_to_copied, ConsensusStorage},
     Deserialize,
     DeserializeOwned,
     Ledger,
@@ -384,7 +383,7 @@ mod tests {
         blocks::{cdn_get, cdn_height, handle_dispatch_error, log_progress, BLOCKS_PER_FILE},
         load_blocks,
     };
-    use snarkvm::prelude::{Block, Testnet3};
+    use snarkvm::prelude::{block::Block, Testnet3};
 
     use anyhow::{anyhow, Result};
     use parking_lot::RwLock;

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -23,7 +23,12 @@ pub use memory_pool::*;
 #[cfg(test)]
 mod tests;
 
-use snarkvm::prelude::*;
+use snarkvm::prelude::{
+    block::{Block, Transaction},
+    coinbase::{CoinbasePuzzle, ProverSolution},
+    store::ConsensusStorage,
+    *,
+};
 
 use anyhow::Result;
 

--- a/node/consensus/src/memory_pool/mod.rs
+++ b/node/consensus/src/memory_pool/mod.rs
@@ -16,9 +16,13 @@ mod solutions;
 mod transactions;
 
 use crate::Consensus;
-use snarkvm::{
-    ledger::anchor_block_height,
-    prelude::{ConsensusStorage, Itertools, Network, ProverSolution, PuzzleCommitment, Transaction},
+use snarkvm::prelude::{
+    anchor_block_height,
+    block::Transaction,
+    coinbase::{ProverSolution, PuzzleCommitment},
+    store::ConsensusStorage,
+    Itertools,
+    Network,
 };
 
 use anyhow::{anyhow, Result};

--- a/node/consensus/src/tests.rs
+++ b/node/consensus/src/tests.rs
@@ -19,12 +19,14 @@ use snarkvm::{
         network::{prelude::*, Testnet3},
         program::{Entry, Identifier, Literal, Plaintext, Value},
     },
-    prelude::{Ledger, RecordsFilter, TestRng},
-    synthesizer::{
+    prelude::{
         block::{Block, Transaction},
-        process::Program,
         store::ConsensusStore,
-        vm::VM,
+        Ledger,
+        Program,
+        RecordsFilter,
+        TestRng,
+        VM,
     },
 };
 
@@ -40,8 +42,7 @@ pub(crate) mod test_helpers {
     use crate::Consensus;
     use snarkvm::{
         console::{account::PrivateKey, network::Testnet3, program::Value},
-        prelude::TestRng,
-        synthesizer::{process::FinalizeGlobalState, store::helpers::memory::ConsensusMemory, Block},
+        prelude::{block::Block, store::helpers::memory::ConsensusMemory, FinalizeGlobalState, TestRng},
     };
 
     use once_cell::sync::OnceCell;

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -69,18 +69,14 @@ mod unconfirmed_transaction;
 pub use unconfirmed_transaction::UnconfirmedTransaction;
 
 use snarkvm::prelude::{
+    block::{Block, Header, Transaction},
+    coinbase::{EpochChallenge, ProverSolution, PuzzleCommitment},
     error,
     Address,
-    Block,
-    EpochChallenge,
     FromBytes,
-    Header,
     Network,
-    ProverSolution,
-    PuzzleCommitment,
     Signature,
     ToBytes,
-    Transaction,
 };
 
 use ::bytes::{Buf, BytesMut};

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -122,7 +122,7 @@ pub enum Message<N: Network> {
 
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 7;
+    pub const VERSION: u32 = 8;
 
     /// Returns the message name.
     #[inline]

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -27,8 +27,7 @@ use snarkos_node_messages::{Data, Message, UnconfirmedTransaction};
 use snarkos_node_router::Routing;
 use snarkvm::{
     console::{program::ProgramID, types::Field},
-    prelude::{cfg_into_iter, Ledger, Network},
-    synthesizer::ConsensusStorage,
+    prelude::{cfg_into_iter, store::ConsensusStorage, Ledger, Network},
 };
 
 use anyhow::Result;

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -17,7 +17,7 @@ use super::*;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use snarkos_node_env::ENV_INFO;
-use snarkvm::prelude::{Identifier, Plaintext, Transaction};
+use snarkvm::prelude::{block::Transaction, Identifier, Plaintext};
 
 /// The `get_blocks` query object.
 #[derive(Deserialize, Serialize)]

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -24,7 +24,7 @@ use snarkos_node_messages::{
     MessageTrait,
 };
 use snarkos_node_tcp::{ConnectionSide, Tcp, P2P};
-use snarkvm::prelude::{error, Address, Header, Network};
+use snarkvm::prelude::{block::Header, error, Address, Network};
 
 use anyhow::{bail, Result};
 use futures::SinkExt;

--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use snarkos_node_messages::BlockRequest;
-use snarkvm::prelude::{Network, PuzzleCommitment};
+use snarkvm::prelude::{coinbase::PuzzleCommitment, Network};
 
 use core::hash::Hash;
 use indexmap::{IndexMap, IndexSet};

--- a/node/router/src/helpers/sync.rs
+++ b/node/router/src/helpers/sync.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use snarkos_node_messages::BlockLocators;
-use snarkvm::prelude::{Block, Network};
+use snarkvm::prelude::{block::Block, Network};
 
 use anyhow::{bail, ensure, Result};
 use colored::Colorize;

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -25,7 +25,11 @@ use snarkos_node_messages::{
     UnconfirmedTransaction,
 };
 use snarkos_node_tcp::{is_bogon_address, protocols::Reading};
-use snarkvm::prelude::{Block, EpochChallenge, Header, Network, ProverSolution, Transaction};
+use snarkvm::prelude::{
+    block::{Block, Header, Transaction},
+    coinbase::{EpochChallenge, ProverSolution},
+    Network,
+};
 
 use anyhow::{bail, ensure, Result};
 use std::{net::SocketAddr, time::Instant};

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -25,7 +25,7 @@ use std::{
 use snarkos_account::Account;
 use snarkos_node_messages::NodeType;
 use snarkos_node_router::Router;
-use snarkvm::prelude::{Block, FromBytes, Network, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{block::Block, FromBytes, Network, Testnet3 as CurrentNetwork};
 
 /// A helper macro to print the TCP listening address, along with the connected and connecting peers.
 #[macro_export]

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -30,7 +30,11 @@ use snarkos_node_tcp::{
     Tcp,
     P2P,
 };
-use snarkvm::prelude::{Block, EpochChallenge, Header, Network, ProverSolution, Transaction};
+use snarkvm::prelude::{
+    block::{Block, Header, Transaction},
+    coinbase::{EpochChallenge, ProverSolution},
+    Network,
+};
 
 use async_trait::async_trait;
 use std::{io, net::SocketAddr};

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -33,17 +33,16 @@ use snarkos_node_tcp::{
     P2P,
 };
 use snarkvm::prelude::{
-    Block,
-    ConsensusStorage,
+    block::{Block, Transaction},
+    coinbase::ProverSolution,
+    store::ConsensusStorage,
     Entry,
     Identifier,
     Ledger,
     Literal,
     Network,
     Plaintext,
-    ProverSolution,
     RecordMap,
-    Transaction,
     Value,
     Zero,
 };
@@ -444,9 +443,10 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::{
-        prelude::{ConsensusStore, Testnet3, VM},
-        synthesizer::store::helpers::memory::ConsensusMemory,
+    use snarkvm::prelude::{
+        store::{helpers::memory::ConsensusMemory, ConsensusStore},
+        Testnet3,
+        VM,
     };
 
     use rand::SeedableRng;

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -17,7 +17,7 @@ use super::*;
 use snarkos_node_messages::{BlockRequest, BlockResponse, DataBlocks, DisconnectReason, Message, MessageCodec, Pong};
 use snarkos_node_router::Routing;
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{error, EpochChallenge, Header};
+use snarkvm::prelude::{block::Header, coinbase::EpochChallenge, error};
 
 use std::{io, net::SocketAddr};
 use tokio::task::spawn_blocking;

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -22,7 +22,12 @@ use snarkos_node_tcp::{
     protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
-use snarkvm::prelude::{Block, CoinbasePuzzle, ConsensusStorage, EpochChallenge, Header, Network, ProverSolution};
+use snarkvm::prelude::{
+    block::{Block, Header},
+    coinbase::{CoinbasePuzzle, EpochChallenge, ProverSolution},
+    store::ConsensusStorage,
+    Network,
+};
 
 use anyhow::Result;
 use core::marker::PhantomData;

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -17,7 +17,7 @@ use super::*;
 use snarkos_node_messages::{BlockRequest, DisconnectReason, MessageCodec, Pong, UnconfirmedTransaction};
 use snarkos_node_router::Routing;
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{Network, Transaction};
+use snarkvm::prelude::{block::Transaction, Network};
 
 use std::{io, net::SocketAddr, time::Duration};
 

--- a/node/src/helpers.rs
+++ b/node/src/helpers.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use snarkos_node_messages::{BlockLocators, CHECKPOINT_INTERVAL, NUM_RECENTS};
-use snarkvm::prelude::{ConsensusStorage, Ledger, Network};
+use snarkvm::prelude::{store::ConsensusStorage, Ledger, Network};
 
 use anyhow::Result;
 use indexmap::IndexMap;

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -15,9 +15,13 @@
 use crate::{traits::NodeInterface, Beacon, Client, Prover, Validator};
 use snarkos_account::Account;
 use snarkos_node_messages::NodeType;
-use snarkvm::{
-    prelude::{Address, Block, Network, PrivateKey, ViewKey},
-    synthesizer::store::helpers::{memory::ConsensusMemory, rocksdb::ConsensusDB},
+use snarkvm::prelude::{
+    block::Block,
+    store::helpers::{memory::ConsensusMemory, rocksdb::ConsensusDB},
+    Address,
+    Network,
+    PrivateKey,
+    ViewKey,
 };
 
 use anyhow::Result;

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -22,7 +22,12 @@ use snarkos_node_tcp::{
     protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
-use snarkvm::prelude::{Block, CoinbasePuzzle, ConsensusStorage, EpochChallenge, Header, Network, ProverSolution};
+use snarkvm::prelude::{
+    block::{Block, Header},
+    coinbase::{CoinbasePuzzle, EpochChallenge, ProverSolution},
+    store::ConsensusStorage,
+    Network,
+};
 
 use anyhow::Result;
 use colored::Colorize;

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -16,7 +16,7 @@ use super::*;
 
 use snarkos_node_messages::{BlockRequest, DisconnectReason, Message, MessageCodec, Pong, UnconfirmedTransaction};
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{Network, Transaction};
+use snarkvm::prelude::{block::Transaction, Network};
 
 use std::{io, net::SocketAddr};
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -24,7 +24,13 @@ use snarkos_node_tcp::{
     protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
     P2P,
 };
-use snarkvm::prelude::{Block, ConsensusStorage, Header, Ledger, Network, ProverSolution};
+use snarkvm::prelude::{
+    block::{Block, Header},
+    coinbase::ProverSolution,
+    store::ConsensusStorage,
+    Ledger,
+    Network,
+};
 
 use anyhow::Result;
 use parking_lot::Mutex;

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -26,7 +26,7 @@ use snarkos_node_messages::{
     UnconfirmedTransaction,
 };
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{error, EpochChallenge, Network, Transaction};
+use snarkvm::prelude::{block::Transaction, coinbase::EpochChallenge, error, Network};
 
 use std::{io, net::SocketAddr, time::Duration};
 use tokio::task::spawn_blocking;

--- a/node/tests/common/mod.rs
+++ b/node/tests/common/mod.rs
@@ -18,7 +18,7 @@ pub mod test_peer;
 use std::{env, str::FromStr};
 
 use snarkos_account::Account;
-use snarkvm::prelude::{Block, FromBytes, Network, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{block::Block, FromBytes, Network, Testnet3 as CurrentNetwork};
 
 /// Returns a fixed account.
 pub fn sample_account() -> Account<CurrentNetwork> {

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -15,7 +15,7 @@
 use crate::common::test_peer::sample_genesis_block;
 use snarkos_account::Account;
 use snarkos_node::{Beacon, Client, Prover, Validator};
-use snarkvm::{prelude::Testnet3 as CurrentNetwork, synthesizer::store::helpers::memory::ConsensusMemory};
+use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, Testnet3 as CurrentNetwork};
 
 use std::str::FromStr;
 

--- a/node/tests/common/test_peer.rs
+++ b/node/tests/common/test_peer.rs
@@ -15,7 +15,7 @@
 use snarkos_account::Account;
 use snarkos_node_messages::{ChallengeRequest, ChallengeResponse, Data, Message, MessageCodec, MessageTrait, NodeType};
 use snarkos_node_router::expect_message;
-use snarkvm::prelude::{error, Address, Block, FromBytes, Network, TestRng, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{block::Block, error, Address, FromBytes, Network, TestRng, Testnet3 as CurrentNetwork};
 
 use std::{
     io,

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -20,7 +20,7 @@ use common::{node::*, test_peer::TestPeer};
 
 use snarkos_node::{Beacon, Client, Prover, Validator};
 use snarkos_node_tcp::P2P;
-use snarkvm::{prelude::Testnet3 as CurrentNetwork, synthesizer::store::helpers::memory::ConsensusMemory};
+use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, Testnet3 as CurrentNetwork};
 
 use pea2pea::Pea2Pea;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps the snarkVM version to `v0.14.4` and updates the imports to match the new crate structure in snarkVM.
