### PR TITLE
Narwhal tweaks

### DIFF
--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -131,7 +131,7 @@ fn keep_connections(primary: &Primary<CurrentNetwork>, node_id: u16, num_nodes: 
                 // Initialize the gateway IP.
                 let ip = SocketAddr::from_str(&format!("127.0.0.1:{}", MEMORY_POOL_PORT + i)).unwrap();
                 // Check if the node is connected.
-                if i != node_id && !node.gateway().is_connected(&ip) {
+                if i != node_id && !node.gateway().is_connected(ip) {
                     // Connect to the node.
                     node.gateway().connect(ip);
                 }

--- a/node/narwhal/src/committee.rs
+++ b/node/narwhal/src/committee.rs
@@ -68,7 +68,7 @@ impl<N: Network> Committee<N> {
     /// Adds a validator to the committee.
     pub fn add_validator(&self, address: Address<N>, stake: u64) -> Result<()> {
         // Check if the validator is already in the committee.
-        if self.is_committee_member(&address) {
+        if self.is_committee_member(address) {
             bail!("Validator already in committee");
         }
         // Add the validator to the committee.
@@ -87,13 +87,13 @@ impl<N: Network> Committee<N> {
     }
 
     /// Returns `true` if the given address is in the committee.
-    pub fn is_committee_member(&self, address: &Address<N>) -> bool {
-        self.committee.read().contains_key(address)
+    pub fn is_committee_member(&self, address: Address<N>) -> bool {
+        self.committee.read().contains_key(&address)
     }
 
     /// Returns the amount of stake for the given address.
-    pub fn get_stake(&self, address: &Address<N>) -> u64 {
-        self.committee.read().get(address).copied().unwrap_or_default()
+    pub fn get_stake(&self, address: Address<N>) -> u64 {
+        self.committee.read().get(&address).copied().unwrap_or_default()
     }
 
     /// Returns the total amount of stake in the committee.
@@ -127,13 +127,13 @@ impl<N: Network> Committee<N> {
 
 impl<N: Network> Committee<N> {
     /// Returns the peer IP for the given address.
-    pub fn get_peer_ip(&self, address: &Address<N>) -> Option<SocketAddr> {
-        self.address_peers.read().get(address).copied()
+    pub fn get_peer_ip(&self, address: Address<N>) -> Option<SocketAddr> {
+        self.address_peers.read().get(&address).copied()
     }
 
     /// Returns the address for the given peer IP.
-    pub fn get_address(&self, peer_ip: &SocketAddr) -> Option<Address<N>> {
-        self.peer_addresses.read().get(peer_ip).copied()
+    pub fn get_address(&self, peer_ip: SocketAddr) -> Option<Address<N>> {
+        self.peer_addresses.read().get(&peer_ip).copied()
     }
 
     /// Inserts the given peer.
@@ -143,8 +143,8 @@ impl<N: Network> Committee<N> {
     }
 
     /// Removes the given peer.
-    pub(crate) fn remove_peer(&self, peer_ip: &SocketAddr) {
-        if let Some(address) = self.peer_addresses.write().remove(peer_ip) {
+    pub(crate) fn remove_peer(&self, peer_ip: SocketAddr) {
+        if let Some(address) = self.peer_addresses.write().remove(&peer_ip) {
             self.address_peers.write().remove(&address);
         }
     }

--- a/node/narwhal/src/helpers/resolver.rs
+++ b/node/narwhal/src/helpers/resolver.rs
@@ -37,13 +37,13 @@ impl Resolver {
     }
 
     /// Returns the listener address for the given (ambiguous) peer address, if it exists.
-    pub fn get_listener(&self, peer_addr: &SocketAddr) -> Option<SocketAddr> {
-        self.to_listener.read().get(peer_addr).copied()
+    pub fn get_listener(&self, peer_addr: SocketAddr) -> Option<SocketAddr> {
+        self.to_listener.read().get(&peer_addr).copied()
     }
 
     /// Returns the (ambiguous) peer address for the given listener address, if it exists.
-    pub fn get_ambiguous(&self, peer_ip: &SocketAddr) -> Option<SocketAddr> {
-        self.from_listener.read().get(peer_ip).copied()
+    pub fn get_ambiguous(&self, peer_ip: SocketAddr) -> Option<SocketAddr> {
+        self.from_listener.read().get(&peer_ip).copied()
     }
 
     /// Inserts a bidirectional mapping of the listener address and the (ambiguous) peer address.
@@ -53,8 +53,8 @@ impl Resolver {
     }
 
     /// Removes the bidirectional mapping of the listener address and the (ambiguous) peer address.
-    pub fn remove_peer(&self, listener_ip: &SocketAddr) {
-        if let Some(peer_addr) = self.from_listener.write().remove(listener_ip) {
+    pub fn remove_peer(&self, listener_ip: SocketAddr) {
+        if let Some(peer_addr) = self.from_listener.write().remove(&listener_ip) {
             self.to_listener.write().remove(&peer_addr);
         }
     }

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -220,12 +220,12 @@ impl<N: Network> Primary<N> {
             return Ok(());
         }
         // Retrieve the address of the peer.
-        let Some(address) = self.committee.get_address(&peer_ip) else {
+        let Some(address) = self.committee.get_address(peer_ip) else {
             warn!("Received a batch signature from a disconnected peer '{peer_ip}'");
             return Ok(());
         };
         // Ensure the address is in the committee.
-        if !self.committee.is_committee_member(&address) {
+        if !self.committee.is_committee_member(address) {
             warn!("Received a batch signature from a non-committee peer '{peer_ip}'");
             return Ok(());
         }
@@ -251,7 +251,7 @@ impl<N: Network> Primary<N> {
             // Compute the cumulative amount of stake, thus far.
             let mut stake = 0u64;
             for signature in signatures.keys().chain([batch.signature()].into_iter()) {
-                stake = stake.saturating_add(self.committee.get_stake(&signature.to_address()));
+                stake = stake.saturating_add(self.committee.get_stake(signature.to_address()));
             }
             // Check if the batch has reached the threshold.
             if stake >= self.committee.quorum_threshold()? {


### PR DESCRIPTION
Passes `Copy` types by value and scopes locks instead of using `drop`. 