### PR TITLE
Initial property test support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,7 +3073,6 @@ dependencies = [
  "proptest",
  "rand",
  "rand_chacha",
- "rand_xorshift",
  "serde",
  "sha2",
  "snarkos-account",
@@ -3898,25 +3897,25 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structmeta"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
  "structmeta-derive",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "structmeta-derive"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3990,13 +3989,12 @@ dependencies = [
 [[package]]
 name = "test-strategy"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61348cf95c0dfa12f0b6155f5b564d2806f518620a28263280ae357b41c96b4a"
+source = "git+https://github.com/frozenlib/test-strategy/?branch=master#885013160c1431970a80faa43a5c96a9e05385ce"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",
  "structmeta",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +1975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm 0.2.7",
 ]
 
 [[package]]
@@ -2064,7 +2086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
- "libm",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -2244,6 +2266,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2300,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -2551,6 +2599,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rusty-hook"
@@ -3010,14 +3070,17 @@ dependencies = [
  "indexmap 2.0.0",
  "open",
  "parking_lot",
+ "proptest",
  "rand",
  "rand_chacha",
+ "rand_xorshift",
  "serde",
  "sha2",
  "snarkos-account",
  "snarkos-node-messages",
  "snarkos-node-tcp",
  "snarkvm",
+ "test-strategy",
  "time",
  "tokio",
  "tokio-stream",
@@ -3834,6 +3897,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "structmeta"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.29",
+ "structmeta-derive",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.29",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3985,18 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix 0.37.22",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61348cf95c0dfa12f0b6155f5b564d2806f518620a28263280ae357b41c96b4a"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.29",
+ "structmeta",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4301,6 +4399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,6 +4532,15 @@ name = "virtue"
 version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -107,3 +107,8 @@ features = [ "fs", "trace" ]
 [dev-dependencies.tracing-subscriber]
 version = "0.3"
 features = [ "env-filter" ]
+
+[dev-dependencies]
+test-strategy = "0.3.0"
+proptest = "1.0.0"
+rand_xorshift = "0.3.0"

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -109,6 +109,5 @@ version = "0.3"
 features = [ "env-filter" ]
 
 [dev-dependencies]
-test-strategy = "0.3.0"
+test-strategy = { git = "https://github.com/frozenlib/test-strategy/", branch = "master"}
 proptest = "1.0.0"
-rand_xorshift = "0.3.0"

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -837,10 +837,7 @@ pub mod gateway_tests {
         pub fn to_gateway(&self) -> Gateway<N> {
             let committee = self.committee_input.to_committee().unwrap();
             let account = self.node_validator.get_account();
-            let dev = match self.dev {
-                None => None,
-                Some(dev) => Some(dev as u16),
-            };
+            let dev = self.dev.map(|dev| dev as u16);
             Gateway::new(Arc::new(RwLock::new(committee)), account, dev).unwrap()
         }
 
@@ -913,7 +910,7 @@ pub mod gateway_tests {
                 assert_eq!(gateway.num_workers(), workers.len() as u8);
             }
             Err(err) => {
-                panic!("Shouldn't fail because of {err}");
+                unreachable!("Unexpected {err}");
             }
         }
     }

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -898,7 +898,6 @@ pub mod gateway_tests {
     #[proptest(async = "tokio")]
     async fn gateway_start(#[filter(|x| x.dev.is_some())] input: GatewayInput) {
         let Some(dev) = input.dev else { unreachable!() };
-        println!("{input:?}");
         let mut gateway = input.to_gateway();
         let tcp_config = gateway.tcp().config();
         assert_eq!(tcp_config.listener_ip, Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));

--- a/node/narwhal/src/helpers/committee.rs
+++ b/node/narwhal/src/helpers/committee.rs
@@ -170,6 +170,18 @@ pub mod tests {
     }
 
     #[proptest]
+    fn committee_advance(#[filter(CommitteeInput::is_valid)] input: CommitteeInput) {
+        let committee = input.to_committee().unwrap();
+        let current_round = input.round;
+        let current_members = committee.members();
+        assert_eq!(committee.round(), current_round);
+
+        let committee = committee.to_next_round().unwrap();
+        assert_eq!(committee.round(), current_round + 1);
+        assert_eq!(committee.members(), current_members);
+    }
+
+    #[proptest]
     fn committee_members(input: CommitteeInput) {
         let committee = match input.to_committee() {
             Ok(committee) => {

--- a/node/narwhal/src/helpers/committee.rs
+++ b/node/narwhal/src/helpers/committee.rs
@@ -119,7 +119,7 @@ impl<N: Network> Committee<N> {
 }
 
 #[cfg(test)]
-pub mod tests {
+pub mod committee_tests {
     use crate::helpers::Committee;
     use anyhow::Result;
     use indexmap::IndexMap;
@@ -131,7 +131,7 @@ pub mod tests {
 
     type N = Testnet3;
 
-    #[derive(Arbitrary, Debug)]
+    #[derive(Arbitrary, Debug, Clone)]
     pub struct CommitteeInput {
         #[strategy(0u64..)]
         pub round: u64,

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -406,7 +406,7 @@ impl<N: Network> Storage<N> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod storage_tests {
     use super::*;
     use snarkvm::{
         ledger::narwhal::Data,
@@ -416,6 +416,7 @@ mod tests {
     use ::bytes::Bytes;
 
     use indexmap::indexset;
+    use test_strategy::Arbitrary;
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
@@ -559,5 +560,16 @@ mod tests {
         assert!(!storage.contains_certificate(certificate_id));
         // Ensure the certificate is no longer stored in the round.
         assert!(storage.get_certificates_for_round(round).is_empty());
+    }
+
+    #[derive(Arbitrary, Debug, Clone)]
+    pub struct StorageInput {
+        pub gc_rounds: u64,
+    }
+
+    impl StorageInput {
+        pub fn to_storage(&self) -> Storage<CurrentNetwork> {
+            Storage::new(self.gc_rounds)
+        }
     }
 }

--- a/node/narwhal/src/worker.rs
+++ b/node/narwhal/src/worker.rs
@@ -266,3 +266,18 @@ impl<N: Network> Worker<N> {
         self.handles.lock().iter().for_each(|handle| handle.abort());
     }
 }
+
+#[cfg(test)]
+mod worker_tests {
+    use crate::{gateway_tests::GatewayInput, helpers::storage_tests::StorageInput, Gateway, Worker, MAX_WORKERS};
+    use snarkvm::prelude::Testnet3;
+    use test_strategy::Arbitrary;
+
+    type N = Testnet3;
+
+    #[derive(Arbitrary, Debug, Clone)]
+    pub struct WorkerInput {
+        pub id: u8,
+        pub storage: StorageInput,
+    }
+}

--- a/node/narwhal/src/worker.rs
+++ b/node/narwhal/src/worker.rs
@@ -269,11 +269,8 @@ impl<N: Network> Worker<N> {
 
 #[cfg(test)]
 mod worker_tests {
-    use crate::{gateway_tests::GatewayInput, helpers::storage_tests::StorageInput, Gateway, Worker, MAX_WORKERS};
-    use snarkvm::prelude::Testnet3;
+    use crate::helpers::storage_tests::StorageInput;
     use test_strategy::Arbitrary;
-
-    type N = Testnet3;
 
     #[derive(Arbitrary, Debug, Clone)]
     pub struct WorkerInput {


### PR DESCRIPTION
This PR adds the `test-strategy` and `proptest` dependencies for convenient property testing, and initial proptests for `Committee` and `Gateway` structs. More tests will be added in following PRs, so this is ready for review.

Note that `test-strategy` has not yet officially released the support for async proptests, so the dependency points directly to Github for now (I haven't bumped into any quality issues).