### PR TITLE
[Narwhal] test duplicates in ready queue

### DIFF
--- a/node/narwhal/src/helpers/ready.rs
+++ b/node/narwhal/src/helpers/ready.rs
@@ -202,10 +202,13 @@ mod tests {
 
     #[test]
     fn test_ready_duplicate() {
+        use rand::RngCore;
         let rng = &mut TestRng::default();
 
         // Sample random fake bytes.
-        let data = |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>()));
+        let mut vec = vec![0u8; 512];
+        rng.fill_bytes(&mut vec);
+        let data = Data::Buffer(Bytes::from(vec));
 
         // Initialize the ready queue.
         let ready = Ready::<CurrentNetwork>::new(Storage::new(1));
@@ -214,7 +217,7 @@ mod tests {
         let commitment = TransmissionID::Solution(PuzzleCommitment::from_g1_affine(rng.gen()));
 
         // Initialize the solutions.
-        let solution = Transmission::Solution(data(rng));
+        let solution = Transmission::Solution(data);
 
         // Insert the commitments.
         assert!(ready.insert(commitment, solution.clone()).unwrap());

--- a/node/narwhal/src/helpers/ready.rs
+++ b/node/narwhal/src/helpers/ready.rs
@@ -199,4 +199,28 @@ mod tests {
                 .collect::<IndexMap<_, _>>()
         );
     }
+
+    #[test]
+    fn test_ready_duplicate() {
+        let rng = &mut TestRng::default();
+
+        // Sample random fake bytes.
+        let data = |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>()));
+
+        // Initialize the ready queue.
+        let ready = Ready::<CurrentNetwork>::new(Storage::new(1));
+
+        // Initialize the commitments.
+        let commitment = TransmissionID::Solution(PuzzleCommitment::from_g1_affine(rng.gen()));
+
+        // Initialize the solutions.
+        let solution = Transmission::Solution(data(rng));
+
+        // Insert the commitments.
+        assert!(ready.insert(commitment, solution.clone()).unwrap());
+        assert!(!ready.insert(commitment, solution).unwrap());
+
+        // Check the number of transmissions.
+        assert_eq!(ready.len(), 1);
+    }
 }


### PR DESCRIPTION
Adds a test case to cover a duplicate insert in the ready queue. This gives the module decently complete test coverage. 
