### PR TITLE
Precompute total stake on committee changes 

### DIFF
--- a/node/narwhal/src/helpers/committee.rs
+++ b/node/narwhal/src/helpers/committee.rs
@@ -124,6 +124,7 @@ impl<N: Network> Committee<N> {
 pub mod prop_tests {
     use crate::helpers::Committee;
     use snarkos_account::Account;
+    use std::collections::HashSet;
 
     use anyhow::Result;
     use indexmap::IndexMap;
@@ -167,7 +168,7 @@ pub mod prop_tests {
         }
 
         pub fn is_valid(&self) -> bool {
-            self.round > 0 && self.validators.len() >= 4
+            self.round > 0 && HashSet::<u64>::from_iter(self.validators.iter().map(|v| v.account_seed)).len() >= 4
         }
     }
 

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -190,7 +190,7 @@ impl<N: Network> Primary<N> {
             // Construct a set over the authors.
             let authors = previous_certificates.iter().map(BatchCertificate::author).collect();
             // Check if the previous certificates have reached the quorum threshold.
-            if committee.is_quorum_threshold_reached(&authors)? {
+            if committee.is_quorum_threshold_reached(&authors) {
                 is_ready = true;
             }
         }
@@ -316,7 +316,7 @@ impl<N: Network> Primary<N> {
             // Construct an iterator over the addresses.
             let addresses = signatures.keys().chain([batch.signature()].into_iter()).map(Signature::to_address);
             // Check if the batch has reached the quorum threshold.
-            if self.committee.read().is_quorum_threshold_reached(&addresses.collect())? {
+            if self.committee.read().is_quorum_threshold_reached(&addresses.collect()) {
                 is_ready = true;
             }
         }
@@ -616,7 +616,7 @@ impl<N: Network> Primary<N> {
                 bail!("Missing the committee for the previous round {previous_round}")
             };
             // Ensure the previous certificates have reached the quorum threshold.
-            if !previous_committee.is_quorum_threshold_reached(&previous_authors)? {
+            if !previous_committee.is_quorum_threshold_reached(&previous_authors) {
                 bail!("Previous certificates for the proposed batch did not reach quorum threshold");
             }
         }


### PR DESCRIPTION
This PR changes the internal behavior of `Committee` by precomputing `total_stake` only on membership changes and storing it in memory. This saves us from redundant computing and overflow checking, and removes a couple of `Result`s from the API.