### PR TITLE
Ignore e2e tests

### DIFF
--- a/node/narwhal/src/lib.rs
+++ b/node/narwhal/src/lib.rs
@@ -45,7 +45,7 @@ pub const MAX_BATCH_DELAY: u64 = 2500; // ms
 pub const MAX_COMMITTEE_SIZE: u16 = 4; // members
 /// The maximum number of seconds before a proposed batch is considered expired.
 pub const MAX_EXPIRATION_TIME_IN_SECS: i64 = 10; // seconds
-/// The maximum number of round to store before garbage collecting.
+/// The maximum number of rounds to store before garbage collecting.
 pub const MAX_GC_ROUNDS: u64 = 50; // rounds
 /// The maximum number of seconds before the timestamp is considered expired.
 pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -20,6 +20,7 @@ use crate::common::{
 };
 
 #[tokio::test]
+#[ignore = "Long-running e2e test"]
 async fn test_state_coherence() {
     crate::common::utils::initialize_logger(0);
 


### PR DESCRIPTION
- Fix a small typo in lib.rs docs
- Ignore long-running e2e tests