### PR TITLE
[Narwhal] proptest worker initialisation

### DIFF
--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -859,6 +859,7 @@ pub mod prop_tests {
     pub struct GatewayInput {
         #[filter(CommitteeInput::is_valid)]
         pub committee_input: CommitteeInput,
+        #[filter(Validator::is_valid)]
         pub node_validator: Validator,
         pub dev: Option<u8>,
         #[strategy(0..MAX_WORKERS)]

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -873,6 +873,10 @@ pub mod prop_tests {
             Gateway::new(account, self.worker_storage.to_storage(), dev).unwrap()
         }
 
+        pub fn is_valid(&self) -> bool {
+            self.committee_input.is_valid() && self.workers_count < MAX_WORKERS
+        }
+
         pub async fn generate_workers(
             &self,
             gateway: &Gateway<CurrentNetwork>,

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -839,6 +839,7 @@ pub mod prop_tests {
 
     #[derive(Arbitrary, Debug, Clone)]
     pub struct StorageInput {
+        #[filter(CommitteeInput::is_valid)]
         pub committee: CommitteeInput,
         pub gc_rounds: u64,
     }

--- a/node/narwhal/src/worker.rs
+++ b/node/narwhal/src/worker.rs
@@ -381,7 +381,7 @@ mod prop_tests {
 
     impl WorkerInput {
         fn to_worker(&self) -> Result<Worker<CurrentNetwork>> {
-            Worker::new(self.id, self.gateway.to_gateway(), self.storage.to_storage())
+            Worker::new(self.id, self.gateway.to_gateway(), self.storage.to_storage(), Default::default())
         }
 
         fn is_valid(&self) -> bool {

--- a/node/narwhal/src/worker.rs
+++ b/node/narwhal/src/worker.rs
@@ -364,13 +364,42 @@ impl<N: Network> Worker<N> {
 
 #[cfg(test)]
 mod prop_tests {
-    use crate::helpers::storage::prop_tests::StorageInput;
+    use super::*;
 
-    use test_strategy::Arbitrary;
+    use crate::{helpers::storage::prop_tests::StorageInput, prop_tests::GatewayInput};
+    use test_strategy::{proptest, Arbitrary};
+
+    type CurrentNetwork = snarkvm::prelude::Testnet3;
 
     #[derive(Arbitrary, Debug, Clone)]
     pub struct WorkerInput {
         pub id: u8,
+        #[filter(GatewayInput::is_valid)]
+        pub gateway: GatewayInput,
         pub storage: StorageInput,
+    }
+
+    impl WorkerInput {
+        fn to_worker(&self) -> Result<Worker<CurrentNetwork>> {
+            Worker::new(self.id, self.gateway.to_gateway(), self.storage.to_storage())
+        }
+
+        fn is_valid(&self) -> bool {
+            self.id < MAX_WORKERS
+        }
+    }
+
+    #[proptest]
+    fn worker_initialization(input: WorkerInput) {
+        match input.to_worker() {
+            Ok(worker) => {
+                assert!(input.is_valid());
+                assert_eq!(worker.id(), input.id);
+            }
+            Err(e) => {
+                assert!(!input.is_valid());
+                assert_eq!(e.to_string().as_str(), format!("Invalid worker ID '{}'", input.id));
+            }
+        }
     }
 }


### PR DESCRIPTION
Sets up property-based testing for workers and checks their initialisation. 

Also includes some modifications to proptest plumbing:
- `CommitteInput` is now guaranteed to generate validators with different account seeds. Previously, they'd be deduplicated upon insert when creating the `Committee`, resulting in an mismatch. 
- `GatewayInput` now has an `is_valid` method. 