### PR TITLE
Fix CI fmt issues

### DIFF
--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -136,7 +136,7 @@ impl<N: Network> BFT<N> {
         // Retrieve the leader certificate.
         let Some(leader_certificate) = self.leader_certificate.read().clone() else {
             // If there is no leader certificate for the previous round, return 'true'.
-            return Ok(true)
+            return Ok(true);
         };
         // Retrieve the leader certificate ID.
         let leader_certificate_id = leader_certificate.certificate_id();

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -713,7 +713,7 @@ impl<N: Network> Gateway<N> {
 
         // Sign the counterparty nonce.
         let Ok(our_signature) = self.account.sign_bytes(&peer_request.nonce.to_le_bytes(), rng) else {
-            return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")))
+            return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
         let our_response = ChallengeResponse { signature: Data::Object(our_signature) };


### PR DESCRIPTION
This PR fixes CI issues caused by Rust nightly 1.73 `cargo fmt` changes.

### Context

CI runs `cargo +nightly fmt --all -- --check` and started failing as of `cargo 1.73.0-nightly`.

> Example: https://app.circleci.com/pipelines/github/AleoHQ/snarkOS/8812/workflows/029369e6-7652-499c-ac51-31a9adca2820/jobs/66457