### PR TITLE
Generate timestamp for the batch proposal externally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "indexmap 2.0.0",
  "itertools",
@@ -3300,12 +3300,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-collections",
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3344,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3388,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3542,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3561,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3570,7 +3570,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "rand",
  "rayon",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "bytes",
  "indexmap 2.0.0",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "indexmap 2.0.0",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "indexmap 2.0.0",
  "paste",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "bincode 1.3.3",
  "once_cell",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.14.1"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=3819ffa42#3819ffa42557a56bbdc2065494034f95bca1debe"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=bb295b7cb#bb295b7cbd36ea342529c807561faf7edbc737ad"
 dependencies = [
  "proc-macro2",
  "quote 1.0.29",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "3819ffa42"
+rev = "bb295b7cb"
 #version = "=0.14.1"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -264,8 +264,10 @@ impl<N: Network> Primary<N> {
         let rng = &mut rand::thread_rng();
         // Retrieve the private key.
         let private_key = self.gateway.account().private_key();
+        // Generate the local timestamp for batch
+        let timestamp = now();
         // Sign the batch.
-        let batch = Batch::new(private_key, round, transmissions, previous_certificates, rng)?;
+        let batch = Batch::new(private_key, round, timestamp, transmissions, previous_certificates, rng)?;
         // Construct the batch header.
         let batch_header = batch.to_header()?;
         // Construct the proposal.


### PR DESCRIPTION
This PR fixes the `propose_batch()` after API change in https://github.com/AleoHQ/snarkVM/pull/1774.
