### PR TITLE
[Narwhal] first set of e2e tests 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ dependencies = [
  "axum-extra",
  "bincode 1.3.3",
  "bytes",
+ "deadline",
  "futures",
  "indexmap 2.0.0",
  "itertools",

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -89,6 +89,9 @@ version = "0.7.4"
 default-features = false
 features = [ "erased-json" ]
 
+[dev-dependencies.deadline]
+version = "0.2"
+
 [dev-dependencies.itertools]
 version = "0.11"
 

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -63,15 +63,12 @@ pub async fn start_n_primaries(n: u16) -> HashMap<u16, (Primary<CurrentNetwork>,
         primaries.insert(id as u16, (primary, sender));
     }
 
-    initiate_connections(&primaries).await;
-    log_connections(&primaries);
-
     primaries
 }
 
 // TODO(nkls): should be handled by the gateway or on the snarkOS level.
 /// Actively try to keep the node's connections to all nodes.
-async fn initiate_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)>) {
+pub async fn initiate_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)>) {
     for (primary, other_primary) in primaries.values().map(|(p, _)| p).tuple_combinations() {
         // Connect to the node.
         let ip = other_primary.gateway().local_ip();
@@ -82,7 +79,7 @@ async fn initiate_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>,
 }
 
 /// Logs the node's connections.
-fn log_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)>) {
+pub fn log_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)>) {
     for (primary, _) in primaries.values() {
         let node = primary.clone();
         tokio::task::spawn(async move {

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -15,17 +15,20 @@
 mod common;
 
 use crate::common::{
-    primary::start_n_primaries,
+    primary::{initiate_connections, log_connections, start_n_primaries},
     utils::{fire_unconfirmed_solutions, fire_unconfirmed_transactions},
 };
+use snarkos_node_narwhal::MAX_BATCH_DELAY;
 
 #[tokio::test]
 #[ignore = "Long-running e2e test"]
 async fn test_state_coherence() {
-    crate::common::utils::initialize_logger(0);
+    // crate::common::utils::initialize_logger(0);
 
     const N: u16 = 4;
     let primaries = start_n_primaries(N).await;
+    initiate_connections(&primaries).await;
+    log_connections(&primaries);
 
     // Start the tx cannons for each primary.
     for (id, primary) in primaries {
@@ -39,5 +42,91 @@ async fn test_state_coherence() {
     // TODO(nkls): the easiest would be to assert on the anchor or bullshark's output, once
     // implemented.
 
-    std::future::pending::<()>().await;
+    // std::future::pending::<()>().await;
+}
+
+#[tokio::test]
+async fn test_quorum_threshold() {
+    // crate::common::utils::initialize_logger(0);
+
+    // 1. Start N nodes but don't connect them.
+    const N: u16 = 4;
+    let primaries = start_n_primaries(N).await;
+    log_connections(&primaries);
+
+    // Check each node is at round 1 (0 is genesis).
+    for (primary, _sender) in primaries.values() {
+        assert_eq!(primary.current_round(), 1);
+    }
+
+    // 2. Start the cannon for node 0.
+    {
+        let (_primary_0, sender_0) = &primaries.get(&0).unwrap();
+        // Fire unconfirmed solutions.
+        fire_unconfirmed_solutions(sender_0, 0);
+        // Fire unconfirmed transactions.
+        fire_unconfirmed_transactions(sender_0, 0);
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
+
+    // Check each node is still at round 1.
+    for (primary, _sender) in primaries.values() {
+        assert_eq!(primary.current_round(), 1);
+    }
+
+    // 3. Connect the first two nodes and start the tx cannon for the second node.
+    {
+        let (primary_0, _sender_0) = &primaries.get(&0).unwrap();
+        let (primary_1, _sender_1) = &primaries.get(&1).unwrap();
+
+        // Connect node 0 to node 1.
+        let ip = primary_1.gateway().local_ip();
+        primary_0.gateway().connect(ip);
+        // Give the connection time to be established.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Fire unconfirmed solutions.
+        fire_unconfirmed_solutions(_sender_1, 1);
+        // Fire unconfirmed transactions.
+        fire_unconfirmed_transactions(_sender_1, 1);
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
+
+    // Check each node is still at round 1.
+    for (primary, _sender) in primaries.values() {
+        assert_eq!(primary.current_round(), 1);
+    }
+
+    // 4. Connect the third node and start the tx cannon for it.
+    {
+        let (primary_0, _sender_0) = &primaries.get(&0).unwrap();
+        let (primary_1, _sender_1) = &primaries.get(&1).unwrap();
+        let (primary_2, _sender_2) = &primaries.get(&2).unwrap();
+
+        // Connect node 0 and 1 to node 2.
+        let ip = primary_2.gateway().local_ip();
+        primary_0.gateway().connect(ip);
+        primary_1.gateway().connect(ip);
+        // Give the connection time to be established.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Fire unconfirmed solutions.
+        fire_unconfirmed_solutions(_sender_2, 2);
+        // Fire unconfirmed transactions.
+        fire_unconfirmed_transactions(_sender_2, 2);
+    }
+
+    // Check the nodes reach quorum and advance through the rounds.
+    deadline::deadline!(std::time::Duration::from_secs(20), move || {
+        let (primary_0, _sender_0) = &primaries.get(&0).unwrap();
+        let (primary_1, _sender_1) = &primaries.get(&1).unwrap();
+        let (primary_2, _sender_2) = &primaries.get(&2).unwrap();
+
+        const NUM_ROUNDS: u64 = 4;
+        primary_0.current_round() > NUM_ROUNDS
+            && primary_1.current_round() > NUM_ROUNDS
+            && primary_2.current_round() > NUM_ROUNDS
+    });
 }


### PR DESCRIPTION
Tests:
- basic quorum threshold (connect nodes until quorum is reached)
- basic quorum break (break enough connections so that quorum is lost)

These cases unfortunately require the use of timeouts, we might be able to further cut down on run time but I opted for safe defaults initially. Logging is commented out for now but available at the top of each case if need be. We may also be able to improve ergonomics but I'll leave that to a follow up.
