### PR TITLE
feat: support simple_node on multiple IP addresses

### DIFF
--- a/node/narwhal/examples/README.md
+++ b/node/narwhal/examples/README.md
@@ -3,15 +3,19 @@
 ## Quick Start
 
 To start 4 **BFT** nodes, run:
+
 ```bash
 ./start-nodes.sh bft
 ```
+
 To start 4 **Narwhal** nodes, run:
+
 ```bash
 ./start-nodes.sh narwhal
 ```
 
 (WIP - not ready) To monitor the nodes, run:
+
 ```bash
 cargo run --release -- example monitor
 ```
@@ -19,6 +23,7 @@ cargo run --release -- example monitor
 ## Development
 
 To start 4 **BFT** nodes manually, run:
+
 ```bash
 # Terminal 1
 cargo run --release --example simple_node bft 0 4
@@ -31,6 +36,7 @@ cargo run --release --example simple_node bft 3 4
 ```
 
 To start 4 **Narwhal** nodes manually, run:
+
 ```bash
 # Terminal 1
 cargo run --release --example simple_node narwhal 0 4
@@ -43,3 +49,15 @@ cargo run --release --example simple_node narwhal 3 4
 ```
 
 These initialize 4 nodes, and tells each node that there are 4 validators in the committee.
+
+You can optionally pass in a filename as last argument. This file should contain the peer node ids, IP addresses and ports.
+It should be in the following form `node_id=ip:port`:
+
+```
+0=192.168.1.1:5000
+1=192.168.1.2:5001
+2=192.168.1.3:5002
+3=192.168.1.4:5003
+```
+
+If this parameter is not present, all nodes are run on localhost.

--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -158,7 +158,7 @@ pub async fn start_primary(
     Ok((primary, sender))
 }
 
-/// Initializes the components of the node
+/// Initializes the components of the node.
 fn initialize_components(node_id: u16, num_nodes: u16) -> Result<(Storage<CurrentNetwork>, Account<CurrentNetwork>)> {
     // Ensure that the node ID is valid.
     ensure!(node_id < num_nodes, "Node ID {node_id} must be less than {num_nodes}");

--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -36,7 +36,7 @@ use snarkvm::{
 };
 
 use ::bytes::Bytes;
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Error, Result};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -48,7 +48,7 @@ use axum_extra::response::ErasedJson;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng};
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc};
 use tracing_subscriber::{
     layer::{Layer, SubscriberExt},
     util::SubscriberInitExt,
@@ -94,21 +94,27 @@ pub fn initialize_logger(verbosity: u8) {
 /**************************************************************************************************/
 
 /// Starts the BFT instance.
-pub async fn start_bft(node_id: u16, num_nodes: u16) -> Result<(BFT<CurrentNetwork>, PrimarySender<CurrentNetwork>)> {
+pub async fn start_bft(
+    node_id: u16,
+    num_nodes: u16,
+    peers: HashMap<u16, SocketAddr>,
+) -> Result<(BFT<CurrentNetwork>, PrimarySender<CurrentNetwork>)> {
     // Initialize the primary channels.
     let (sender, receiver) = init_primary_channels();
     // Initialize the components.
     let (storage, account) = initialize_components(node_id, num_nodes)?;
     // Initialize the mock ledger service.
     let ledger = Box::new(MockLedgerService::new());
+    // Initialize the gateway IP.
+    let ip = peers.get(&node_id).ok_or(anyhow!("Invalid node ID"))?;
     // Initialize the BFT instance.
-    let mut bft = BFT::<CurrentNetwork>::new(account, storage, ledger, Some(node_id))?;
+    let mut bft = BFT::<CurrentNetwork>::new(account, storage, ledger, Some(node_id), *ip)?;
     // Run the BFT instance.
     bft.run(sender.clone(), receiver).await?;
     // Retrieve the BFT's primary.
     let primary = bft.primary();
     // Keep the node's connections.
-    keep_connections(primary, node_id, num_nodes);
+    keep_connections(primary, node_id, num_nodes, peers);
     // Handle the log connections.
     log_connections(primary);
     // Handle OS signals.
@@ -121,6 +127,7 @@ pub async fn start_bft(node_id: u16, num_nodes: u16) -> Result<(BFT<CurrentNetwo
 pub async fn start_primary(
     node_id: u16,
     num_nodes: u16,
+    peers: HashMap<u16, SocketAddr>,
 ) -> Result<(Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)> {
     // Initialize the primary channels.
     let (sender, receiver) = init_primary_channels();
@@ -128,12 +135,14 @@ pub async fn start_primary(
     let (storage, account) = initialize_components(node_id, num_nodes)?;
     // Initialize the mock ledger service.
     let ledger = Box::new(MockLedgerService::new());
+    // Initialize the gateway IP.
+    let ip = peers.get(&node_id).ok_or(anyhow!("Invalid node ID"))?;
     // Initialize the primary instance.
-    let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, Some(node_id))?;
+    let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, Some(node_id), *ip)?;
     // Run the primary instance.
     primary.run(sender.clone(), receiver, None).await?;
     // Keep the node's connections.
-    keep_connections(&primary, node_id, num_nodes);
+    keep_connections(&primary, node_id, num_nodes, peers);
     // Handle the log connections.
     log_connections(&primary);
     // Handle OS signals.
@@ -172,7 +181,7 @@ fn initialize_components(node_id: u16, num_nodes: u16) -> Result<(Storage<Curren
 }
 
 /// Actively try to keep the node's connections to all nodes.
-fn keep_connections(primary: &Primary<CurrentNetwork>, node_id: u16, num_nodes: u16) {
+fn keep_connections(primary: &Primary<CurrentNetwork>, node_id: u16, num_nodes: u16, peers: HashMap<u16, SocketAddr>) {
     let node = primary.clone();
     tokio::task::spawn(async move {
         // Sleep briefly to ensure the other nodes are ready to connect.
@@ -181,10 +190,11 @@ fn keep_connections(primary: &Primary<CurrentNetwork>, node_id: u16, num_nodes: 
         loop {
             for i in 0..num_nodes {
                 // Initialize the gateway IP.
-                let ip = SocketAddr::from_str(&format!("127.0.0.1:{}", MEMORY_POOL_PORT + i)).unwrap();
+                let ip = *peers.get(&i).unwrap();
                 // Check if the node is connected.
                 if i != node_id && !node.gateway().is_connected(ip) {
                     // Connect to the node.
+                    debug!("Connecting to {}", ip);
                     node.gateway().connect(ip);
                 }
             }
@@ -369,6 +379,19 @@ async fn start_server(bft: Option<BFT<CurrentNetwork>>, primary: Primary<Current
         .unwrap();
 }
 
+fn parse_peers(peers_string: String) -> Result<HashMap<u16, SocketAddr>, Error> {
+    // Expect list of peers in the form of `node_id=ip:port`, one per line.
+    let mut peers = HashMap::new();
+    for peer in peers_string.lines() {
+        let mut split = peer.split('=');
+        let node_id = u16::from_str(split.next().ok_or_else(|| anyhow!("Bad Format"))?)?;
+        let addr: String = split.next().ok_or_else(|| anyhow!("Bad Format"))?.parse()?;
+        let ip = SocketAddr::from_str(addr.as_str())?;
+        peers.insert(node_id, ip);
+    }
+    Ok(peers)
+}
+
 /**************************************************************************************************/
 
 #[tokio::main]
@@ -391,6 +414,20 @@ async fn main() -> Result<()> {
     // Parse the number of nodes.
     let num_nodes = u16::from_str(&args[3])?;
 
+    let peers = if args.len() > 4 {
+        // read peers from a file
+        let peers_string = std::fs::read_to_string(&args[4])?;
+        parse_peers(peers_string)?
+    } else {
+        // All nodes running locally.
+        let mut peers = HashMap::new();
+        for i in 0..num_nodes {
+            let ip = SocketAddr::from_str(format!("127.0.0.1:{:?}", MEMORY_POOL_PORT + i).as_str())?;
+            peers.insert(i, ip);
+        }
+        peers
+    };
+
     // Initialize an optional BFT holder.
     let mut bft_holder = None;
 
@@ -398,13 +435,13 @@ async fn main() -> Result<()> {
     let (primary, sender) = match mode {
         "bft" => {
             // Start the BFT.
-            let (bft, sender) = start_bft(node_id, num_nodes).await?;
+            let (bft, sender) = start_bft(node_id, num_nodes, peers).await?;
             // Set the BFT holder.
             bft_holder = Some(bft.clone());
             // Return the primary and sender.
             (bft.primary().clone(), sender)
         }
-        "narwhal" => start_primary(node_id, num_nodes).await?,
+        "narwhal" => start_primary(node_id, num_nodes, peers).await?,
         _ => unreachable!(),
     };
 
@@ -418,4 +455,43 @@ async fn main() -> Result<()> {
     // // Note: Do not move this.
     // std::future::pending::<()>().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_peers_empty() -> Result<(), Error> {
+        let peers = parse_peers("".to_owned())?;
+        assert_eq!(peers.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_peers_ok() -> Result<(), Error> {
+        let s = r#"0=192.168.1.176:5000
+1=192.168.1.176:5001
+2=192.168.1.176:5002
+3=192.168.1.176:5003"#;
+        let peers = parse_peers(s.to_owned())?;
+        assert_eq!(peers.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_peers_bad_id() -> Result<(), Error> {
+        let s = "A=192.168.1.176:5000";
+        let peers = parse_peers(s.to_owned());
+        assert!(peers.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn parse_peers_bad_format() -> Result<(), Error> {
+        let s = "foo";
+        let peers = parse_peers(s.to_owned());
+        assert!(peers.is_err());
+        Ok(())
+    }
 }

--- a/node/narwhal/examples/start-nodes.sh
+++ b/node/narwhal/examples/start-nodes.sh
@@ -1,4 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+if [ $# -lt 1 ]; then
+	echo "Usage: $0 <mode> [num_nodes]"
+	echo "mode: bft or narwhal"
+	echo "num_nodes: number of nodes to spin up (default: 4)"
+	exit
+fi
 
 # The mode - bft or narwhal
 mode=$1
@@ -25,21 +32,23 @@ case "$TERM_PROGRAM" in
 esac
 
 # Get the number of nodes from the command-line argument
-num_nodes=${1:-$default_num_nodes}
+num_nodes=${2:-$default_num_nodes}
 
 # Loop to open terminal windows and execute the command
 for ((i = 0; i < num_nodes; i++)); do
+	FULL_COMMAND="$command $mode $i $num_nodes"
+
 	if [[ "$terminal_app" == "iTerm" ]]; then
 		osascript -e "tell application \"$terminal_app\" to create window with default profile"
 		sleep 0.5
-		osascript -e "tell application \"$terminal_app\" to tell current window to tell current session to write text \"cd $path && $command $i $num_nodes\""
+		osascript -e "tell application \"$terminal_app\" to tell current window to tell current session to write text \"cd $path && $FULL_COMMAND\""
 	elif [[ "$terminal_app" == "Terminal" ]]; then
-		osascript -e "tell application \"$terminal_app\" to do script \"cd $path; $command $i $num_nodes\""
+		osascript -e "tell application \"$terminal_app\" to do script \"cd $path; $FULL_COMMAND\""
 	else
 		if ! command -v xterm &>/dev/null; then
 			echo "xterm could not be found, please install it"
 			exit
 		fi
-		xterm -e "cd $path; $command $mode $i $num_nodes" &
+		xterm -e "cd $path; $FULL_COMMAND" &
 	fi
 done

--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -30,6 +30,7 @@ use parking_lot::{Mutex, RwLock};
 use std::{
     collections::{BTreeMap, HashSet},
     future::Future,
+    net::SocketAddr,
     sync::{
         atomic::{AtomicI64, Ordering},
         Arc,
@@ -53,9 +54,15 @@ pub struct BFT<N: Network> {
 
 impl<N: Network> BFT<N> {
     /// Initializes a new instance of the BFT.
-    pub fn new(account: Account<N>, storage: Storage<N>, ledger: Ledger<N>, dev: Option<u16>) -> Result<Self> {
+    pub fn new(
+        account: Account<N>,
+        storage: Storage<N>,
+        ledger: Ledger<N>,
+        dev: Option<u16>,
+        ip: SocketAddr,
+    ) -> Result<Self> {
         Ok(Self {
-            primary: Primary::new(account, storage, ledger, dev)?,
+            primary: Primary::new(account, storage, ledger, dev, ip)?,
             dag: Default::default(),
             leader_certificate: Default::default(),
             leader_certificate_timer: Default::default(),

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -30,7 +30,6 @@ use crate::{
     MAX_COMMITTEE_SIZE,
     MAX_GC_ROUNDS,
     MAX_TRANSMISSIONS_PER_BATCH,
-    MEMORY_POOL_PORT,
 };
 use snarkos_account::Account;
 use snarkos_node_tcp::{
@@ -103,13 +102,8 @@ pub struct Gateway<N: Network> {
 
 impl<N: Network> Gateway<N> {
     /// Initializes a new gateway.
-    pub fn new(account: Account<N>, storage: Storage<N>, dev: Option<u16>) -> Result<Self> {
-        // Initialize the gateway IP.
-        let ip = match dev {
-            // TODO change dev to Option<u8>, otherwise there is potential overflow
-            Some(dev) => SocketAddr::from_str(&format!("127.0.0.1:{}", MEMORY_POOL_PORT + dev)),
-            None => SocketAddr::from_str(&format!("0.0.0.0:{}", MEMORY_POOL_PORT)),
-        }?;
+    #[allow(unused_variables)]
+    pub fn new(account: Account<N>, storage: Storage<N>, dev: Option<u16>, ip: SocketAddr) -> Result<Self> {
         // Initialize the TCP stack.
         let tcp = Tcp::new(Config::new(ip, MAX_COMMITTEE_SIZE));
         // Return the gateway.
@@ -854,6 +848,7 @@ pub mod prop_tests {
     use indexmap::IndexMap;
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        str::FromStr,
         sync::Arc,
     };
     use test_strategy::{proptest, Arbitrary};
@@ -866,7 +861,7 @@ pub mod prop_tests {
         pub committee_input: CommitteeInput,
         #[filter(Validator::is_valid)]
         pub node_validator: Validator,
-        pub dev: Option<u8>,
+        pub dev: Option<u16>,
         #[strategy(0..MAX_WORKERS)]
         pub workers_count: u8,
         pub worker_storage: StorageInput,
@@ -875,8 +870,11 @@ pub mod prop_tests {
     impl GatewayInput {
         pub fn to_gateway(&self) -> Gateway<CurrentNetwork> {
             let account = self.node_validator.get_account();
-            let dev = self.dev.map(|dev| dev as u16);
-            Gateway::new(account, self.worker_storage.to_storage(), dev).unwrap()
+            let ip = self
+                .dev
+                .map(|dev| SocketAddr::from_str(format!("127.0.0.1:{}", MEMORY_POOL_PORT + dev).as_str()).unwrap())
+                .unwrap_or(SocketAddr::from_str(format!("0.0.0.0:{}", MEMORY_POOL_PORT).as_str()).unwrap());
+            Gateway::new(account, self.worker_storage.to_storage(), self.dev, ip).unwrap()
         }
 
         pub fn is_valid(&self) -> bool {
@@ -925,7 +923,7 @@ pub mod prop_tests {
                 let gateway = input.to_gateway();
                 let tcp_config = gateway.tcp().config();
                 assert_eq!(tcp_config.listener_ip, Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));
-                assert_eq!(tcp_config.desired_listening_port, Some(MEMORY_POOL_PORT + (dev as u16)));
+                assert_eq!(tcp_config.desired_listening_port, Some(MEMORY_POOL_PORT + dev));
                 gateway
             }
             None => {
@@ -947,14 +945,11 @@ pub mod prop_tests {
         let gateway = input.to_gateway();
         let tcp_config = gateway.tcp().config();
         assert_eq!(tcp_config.listener_ip, Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));
-        assert_eq!(tcp_config.desired_listening_port, Some(MEMORY_POOL_PORT + (dev as u16)));
+        assert_eq!(tcp_config.desired_listening_port, Some(MEMORY_POOL_PORT + dev));
 
         let (workers, worker_senders) = input.generate_workers(&gateway).await;
         gateway.run(worker_senders).await;
-        assert_eq!(
-            gateway.local_ip(),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), MEMORY_POOL_PORT + (dev as u16))
-        );
+        assert_eq!(gateway.local_ip(), SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), MEMORY_POOL_PORT + dev));
         assert_eq!(gateway.num_workers(), workers.len() as u8);
     }
 }

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -84,9 +84,15 @@ pub struct Primary<N: Network> {
 
 impl<N: Network> Primary<N> {
     /// Initializes a new primary instance.
-    pub fn new(account: Account<N>, storage: Storage<N>, ledger: Ledger<N>, dev: Option<u16>) -> Result<Self> {
+    pub fn new(
+        account: Account<N>,
+        storage: Storage<N>,
+        ledger: Ledger<N>,
+        dev: Option<u16>,
+        ip: SocketAddr,
+    ) -> Result<Self> {
         Ok(Self {
-            gateway: Gateway::new(account, storage.clone(), dev)?,
+            gateway: Gateway::new(account, storage.clone(), dev, ip)?,
             storage,
             ledger: Arc::from(ledger),
             workers: Default::default(),

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -18,13 +18,14 @@ use snarkos_node_narwhal::{
     helpers::{init_primary_channels, Committee, PrimarySender, Storage},
     Primary,
     MAX_GC_ROUNDS,
+    MEMORY_POOL_PORT,
     MIN_STAKE,
 };
 
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rand::SeedableRng;
-use std::collections::HashMap;
+use std::{collections::HashMap, net::SocketAddr, str::FromStr};
 use tracing::*;
 
 // Initializes a new test committee.
@@ -57,7 +58,8 @@ pub async fn start_n_primaries(n: u16) -> HashMap<u16, (Primary<CurrentNetwork>,
         let storage = Storage::new(committee.clone(), MAX_GC_ROUNDS);
         let (sender, receiver) = init_primary_channels();
         let ledger = Box::new(MockLedgerService::new());
-        let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, Some(id as u16)).unwrap();
+        let ip = SocketAddr::from_str(format!("127.0.0.1:{}", MEMORY_POOL_PORT + id as u16).as_str()).unwrap();
+        let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, Some(id as u16), ip).unwrap();
 
         primary.run(sender.clone(), receiver, None).await.unwrap();
         primaries.insert(id as u16, (primary, sender));

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -330,6 +330,7 @@ impl Tcp {
 
     /// Creates an instance of `TcpListener` based on the node's configuration.
     async fn create_listener(&self, listener_ip: IpAddr) -> io::Result<TcpListener> {
+        debug!("Creating a TCP listener on {}", listener_ip);
         let listener = if let Some(port) = self.config().desired_listening_port {
             // Construct the desired listening IP address.
             let desired_listening_addr = SocketAddr::new(listener_ip, port);
@@ -494,7 +495,7 @@ impl Tcp {
 
 impl fmt::Debug for Tcp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "The TCP stack")
+        write!(f, "The TCP stack config: {:?}", self.config)
     }
 }
 


### PR DESCRIPTION
Support running on multiple hosts.
Usage:
Create a file with all peers (one per line) in this form: 0=192.168.1.176:5000 (node_id=ip:port). You can check the provided `peers.txt`.
Pass this filename as extra parameter on the command line:
`cargo +stable r --release --example simple_node bft 0 4 peers.txt`
