### PR TITLE
[Narwhal] improve e2e test tooling

### DIFF
--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -144,16 +144,8 @@ impl TestNetwork {
         }
     }
 
-    pub fn fire_unconfirmed_solutions(&mut self, id: u16) {
-        let primary = self.primaries.get_mut(&id).unwrap();
-        let handle = fire_unconfirmed_solutions(&primary.sender.as_ref().unwrap(), id);
-        primary.handles.write().push(handle);
-    }
-
-    pub fn fire_unconfirmed_transactions(&mut self, id: u16) {
-        let primary = self.primaries.get_mut(&id).unwrap();
-        let handle = fire_unconfirmed_transactions(&primary.sender.as_ref().unwrap(), id);
-        primary.handles.write().push(handle);
+    pub fn fire_cannons(&mut self, id: u16) {
+        self.primaries.get_mut(&id).unwrap().fire_cannons();
     }
 
     pub async fn connect(&self, id: u16, peer_id: u16) {

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -12,20 +12,187 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::{CurrentNetwork, MockLedgerService};
+use crate::common::{
+    utils::{fire_unconfirmed_solutions, fire_unconfirmed_transactions, initialize_logger},
+    CurrentNetwork,
+    MockLedgerService,
+};
 use snarkos_account::Account;
 use snarkos_node_narwhal::{
     helpers::{init_primary_channels, PrimarySender, Storage},
     Primary,
+    MAX_BATCH_DELAY,
     MAX_GC_ROUNDS,
 };
 use snarkos_node_narwhal_committee::{Committee, MIN_STAKE};
 use snarkvm::prelude::TestRng;
 
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+    time::Duration,
+};
+
 use indexmap::IndexMap;
 use itertools::Itertools;
-use std::collections::HashMap;
+use parking_lot::RwLock;
+use tokio::{task::JoinHandle, time::sleep};
 use tracing::*;
+
+#[derive(Clone)]
+pub struct TestNetworkConfig {
+    pub num_nodes: u16,
+    pub initiate_connections: bool,
+    pub fire_cannons: bool,
+    pub log_level: Option<u8>,
+    pub log_connections: bool,
+}
+
+#[derive(Clone)]
+pub struct TestNetwork {
+    pub config: TestNetworkConfig,
+    pub primaries: HashMap<u16, TestPrimary>,
+}
+
+#[derive(Clone)]
+pub struct TestPrimary {
+    pub id: u16,
+    pub primary: Primary<CurrentNetwork>,
+    pub sender: Option<PrimarySender<CurrentNetwork>>,
+    pub handles: Arc<RwLock<Vec<JoinHandle<()>>>>,
+}
+
+impl Deref for TestPrimary {
+    type Target = Primary<CurrentNetwork>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.primary
+    }
+}
+
+impl DerefMut for TestPrimary {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.primary
+    }
+}
+
+impl TestPrimary {
+    pub fn fire_cannons(&mut self) {
+        let solution_handle = fire_unconfirmed_solutions(self.sender.as_mut().unwrap(), self.id);
+        let transaction_handle = fire_unconfirmed_transactions(self.sender.as_mut().unwrap(), self.id);
+
+        self.handles.write().push(solution_handle);
+        self.handles.write().push(transaction_handle);
+    }
+
+    pub fn log_connections(&mut self) {
+        // let node = self.clone();
+        let self_clone = self.clone();
+        self.handles.write().push(tokio::task::spawn(async move {
+            loop {
+                let connections = self_clone.gateway().connected_peers().read().clone();
+                info!("{} connections", connections.len());
+                for connection in connections {
+                    debug!("  {}", connection);
+                }
+                sleep(Duration::from_secs(10)).await;
+            }
+        }));
+    }
+}
+
+impl TestNetwork {
+    pub fn new(config: TestNetworkConfig) -> Self {
+        if let Some(log_level) = config.log_level {
+            initialize_logger(log_level);
+        }
+
+        let (accounts, committee) = new_test_committee(config.num_nodes);
+
+        let mut primaries = HashMap::with_capacity(config.num_nodes as usize);
+        for (id, account) in accounts.into_iter().enumerate() {
+            let storage = Storage::new(committee.clone(), MAX_GC_ROUNDS);
+            let ledger = Box::new(MockLedgerService::new());
+            let primary = Primary::<CurrentNetwork>::new(account, storage, ledger, None, Some(id as u16)).unwrap();
+
+            let test_primary = TestPrimary { id: id as u16, primary, sender: None, handles: Default::default() };
+            primaries.insert(id as u16, test_primary);
+        }
+
+        Self { config, primaries }
+    }
+
+    pub async fn start(&mut self) {
+        for primary in self.primaries.values_mut() {
+            // Setup the channels and start the primary.
+            let (sender, receiver) = init_primary_channels();
+            primary.sender = Some(sender.clone());
+            primary.run(sender.clone(), receiver, None).await.unwrap();
+
+            if self.config.fire_cannons {
+                primary.fire_cannons();
+            }
+
+            if self.config.log_connections {
+                primary.log_connections();
+            }
+        }
+
+        if self.config.initiate_connections {
+            initiate_connections(&self.primaries).await;
+        }
+    }
+
+    pub fn fire_unconfirmed_solutions(&mut self, id: u16) {
+        let primary = self.primaries.get_mut(&id).unwrap();
+        let handle = fire_unconfirmed_solutions(&primary.sender.as_ref().unwrap(), id);
+        primary.handles.write().push(handle);
+    }
+
+    pub fn fire_unconfirmed_transactions(&mut self, id: u16) {
+        let primary = self.primaries.get_mut(&id).unwrap();
+        let handle = fire_unconfirmed_transactions(&primary.sender.as_ref().unwrap(), id);
+        primary.handles.write().push(handle);
+    }
+
+    pub async fn connect(&self, id: u16, peer_id: u16) {
+        let primary = self.primaries.get(&id).unwrap();
+        let peer_ip = self.primaries.get(&peer_id).unwrap().gateway().local_ip();
+        primary.gateway().connect(peer_ip);
+        // Give the connection time to be established.
+        sleep(Duration::from_millis(100)).await;
+
+        //  // TODO(nkls): maybe deadline could be used here instead?
+        //  let primary_clone = primary.clone();
+        //  deadline::deadline!(std::time::Duration::from_millis(100), move || {
+        //      primary_clone.gateway().is_connected(peer_ip)
+        //  });
+    }
+
+    pub async fn disconnect(&self, num_nodes: u16) {
+        for id in 0..num_nodes {
+            let primary = self.primaries.get(&id).unwrap();
+            for peer_ip in primary.gateway().connected_peers().read().iter() {
+                primary.gateway().disconnect(*peer_ip);
+            }
+        }
+
+        // Give the connections time to be closed.
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    pub fn is_round_reached(&self, round: u64) -> bool {
+        let quorum_threshold = self.primaries.len() / 2 + 1;
+        self.primaries.values().filter(|p| p.current_round() >= round).count() >= quorum_threshold as usize
+    }
+
+    pub async fn is_halted(&self) -> bool {
+        let halt_round = self.primaries.values().map(|p| p.current_round()).max().unwrap();
+        sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
+        self.primaries.values().all(|p| p.current_round() <= halt_round)
+    }
+}
 
 // Initializes a new test committee.
 pub fn new_test_committee(n: u16) -> (Vec<Account<CurrentNetwork>>, Committee<CurrentNetwork>) {
@@ -49,27 +216,10 @@ pub fn new_test_committee(n: u16) -> (Vec<Account<CurrentNetwork>>, Committee<Cu
     (accounts, committee)
 }
 
-pub async fn start_n_primaries(n: u16) -> HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)> {
-    let mut primaries = HashMap::with_capacity(n as usize);
-    let (accounts, committee) = new_test_committee(n);
-
-    for (id, account) in accounts.into_iter().enumerate() {
-        let storage = Storage::new(committee.clone(), MAX_GC_ROUNDS);
-        let (sender, receiver) = init_primary_channels();
-        let ledger = Box::new(MockLedgerService::new());
-        let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, None, Some(id as u16)).unwrap();
-
-        primary.run(sender.clone(), receiver, None).await.unwrap();
-        primaries.insert(id as u16, (primary, sender));
-    }
-
-    primaries
-}
-
 // TODO(nkls): should be handled by the gateway or on the snarkOS level.
 /// Actively try to keep the node's connections to all nodes.
-pub async fn initiate_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)>) {
-    for (primary, other_primary) in primaries.values().map(|(p, _)| p).tuple_combinations() {
+pub async fn initiate_connections(primaries: &HashMap<u16, TestPrimary>) {
+    for (primary, other_primary) in primaries.values().tuple_combinations() {
         // Connect to the node.
         let ip = other_primary.gateway().local_ip();
         primary.gateway().connect(ip);
@@ -78,19 +228,19 @@ pub async fn initiate_connections(primaries: &HashMap<u16, (Primary<CurrentNetwo
     }
 }
 
-/// Logs the node's connections.
-pub fn log_connections(primaries: &HashMap<u16, (Primary<CurrentNetwork>, PrimarySender<CurrentNetwork>)>) {
-    for (primary, _) in primaries.values() {
-        let node = primary.clone();
-        tokio::task::spawn(async move {
-            loop {
-                let connections = node.gateway().connected_peers().read().clone();
-                info!("{} connections", connections.len());
-                for connection in connections {
-                    debug!("  {}", connection);
-                }
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-            }
-        });
-    }
-}
+///// Logs the node's connections.
+//pub fn log_connections() {
+//    for (primary, _) in primaries.values() {
+//        let node = primary.clone();
+//        tokio::task::spawn(async move {
+//            loop {
+//                let connections = node.gateway().connected_peers().read().clone();
+//                info!("{} connections", connections.len());
+//                for connection in connections {
+//                    debug!("  {}", connection);
+//                }
+//                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+//            }
+//        });
+//    }
+//}

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -186,7 +186,7 @@ impl TestNetwork {
     // Checks a quorum of nodes have reached the given round.
     pub fn is_round_reached(&self, round: u64) -> bool {
         let quorum_threshold = self.primaries.len() / 2 + 1;
-        self.primaries.values().filter(|p| p.current_round() >= round).count() >= quorum_threshold as usize
+        self.primaries.values().filter(|p| p.current_round() >= round).count() >= quorum_threshold
     }
 
     // Checks all nodes have stopped progressing.

--- a/node/narwhal/tests/common/utils.rs
+++ b/node/narwhal/tests/common/utils.rs
@@ -26,9 +26,11 @@ use snarkvm::{
     },
 };
 
+use std::time::Duration;
+
 use ::bytes::Bytes;
 use rand::Rng;
-use tokio::{sync::oneshot, task, task::JoinHandle};
+use tokio::{sync::oneshot, task, task::JoinHandle, time::sleep};
 use tracing::*;
 use tracing_subscriber::{
     layer::{Layer, SubscriberExt},
@@ -109,7 +111,7 @@ pub fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_i
             // Increment the counter.
             counter += 1;
             // Sleep briefly.
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            sleep(Duration::from_millis(10)).await;
         }
     })
 }
@@ -153,7 +155,7 @@ pub fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, nod
             // Increment the counter.
             counter += 1;
             // Sleep briefly.
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            sleep(Duration::from_millis(10)).await;
         }
     })
 }

--- a/node/narwhal/tests/common/utils.rs
+++ b/node/narwhal/tests/common/utils.rs
@@ -28,7 +28,7 @@ use snarkvm::{
 
 use ::bytes::Bytes;
 use rand::Rng;
-use tokio::{sync::oneshot, task};
+use tokio::{sync::oneshot, task, task::JoinHandle};
 use tracing::*;
 use tracing_subscriber::{
     layer::{Layer, SubscriberExt},
@@ -69,7 +69,7 @@ pub fn initialize_logger(verbosity: u8) {
 }
 
 /// Fires *fake* unconfirmed solutions at the node.
-pub fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) {
+pub fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) -> JoinHandle<()> {
     let tx_unconfirmed_solution = sender.tx_unconfirmed_solution.clone();
     tokio::task::spawn(async move {
         // This RNG samples the *same* fake solutions for all nodes.
@@ -111,11 +111,11 @@ pub fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_i
             // Sleep briefly.
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
-    });
+    })
 }
 
 /// Fires *fake* unconfirmed transactions at the node.
-pub fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) {
+pub fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) -> JoinHandle<()> {
     let tx_unconfirmed_transaction = sender.tx_unconfirmed_transaction.clone();
     tokio::task::spawn(async move {
         // This RNG samples the *same* fake transactions for all nodes.
@@ -155,5 +155,5 @@ pub fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, nod
             // Sleep briefly.
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
-    });
+    })
 }

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -64,7 +64,7 @@ async fn test_quorum_threshold() {
     }
 
     // Start the cannons for node 0.
-    network.fire_cannons(0);
+    network.fire_cannons_at(0);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -74,8 +74,8 @@ async fn test_quorum_threshold() {
     }
 
     // Connect the first two nodes and start the cannons for node 1.
-    network.connect(0, 1).await;
-    network.fire_cannons(1);
+    network.connect_primaries(0, 1).await;
+    network.fire_cannons_at(1);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -85,9 +85,9 @@ async fn test_quorum_threshold() {
     }
 
     // Connect the third node and start the cannons for it.
-    network.connect(0, 2).await;
-    network.connect(1, 2).await;
-    network.fire_cannons(2);
+    network.connect_primaries(0, 2).await;
+    network.connect_primaries(1, 2).await;
+    network.fire_cannons_at(2);
 
     // Check the nodes reach quorum and advance through the rounds.
     const TARGET_ROUND: u64 = 4;

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -63,8 +63,7 @@ async fn test_quorum_threshold() {
     }
 
     // Start the cannons for node 0.
-    network.fire_unconfirmed_solutions(0);
-    network.fire_unconfirmed_transactions(0);
+    network.fire_cannons(0);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -75,8 +74,7 @@ async fn test_quorum_threshold() {
 
     // Connect the first two nodes and start the cannons for node 1.
     network.connect(0, 1).await;
-    network.fire_unconfirmed_solutions(1);
-    network.fire_unconfirmed_transactions(1);
+    network.fire_cannons(1);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -88,8 +86,7 @@ async fn test_quorum_threshold() {
     // Connect the third node and start the cannons for it.
     network.connect(0, 2).await;
     network.connect(1, 2).await;
-    network.fire_unconfirmed_solutions(2);
-    network.fire_unconfirmed_transactions(2);
+    network.fire_cannons(2);
 
     // Check the nodes reach quorum and advance through the rounds.
     const TARGET_ROUND: u64 = 4;

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 mod common;
-
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
-use deadline::deadline;
 use snarkos_node_narwhal::MAX_BATCH_DELAY;
+
 use std::time::Duration;
+
+use deadline::deadline;
 use tokio::time::sleep;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -26,7 +27,7 @@ async fn test_state_coherence() {
     const N: u16 = 4;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
-        initiate_connections: true,
+        connect_all: true,
         fire_cannons: true,
 
         // Set this to Some(0..=4) to see the logs.
@@ -48,7 +49,7 @@ async fn test_quorum_threshold() {
     const N: u16 = 4;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
-        initiate_connections: false,
+        connect_all: false,
         fire_cannons: false,
 
         // Set this to Some(0..=4) to see the logs.
@@ -99,7 +100,7 @@ async fn test_quorum_break() {
     const N: u16 = 4;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
-        initiate_connections: true,
+        connect_all: true,
         fire_cannons: true,
 
         // Set this to Some(0..=4) to see the logs.

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -59,8 +59,8 @@ async fn test_quorum_threshold() {
     network.start().await;
 
     // Check each node is at round 1 (0 is genesis).
-    for primary in network.primaries.values() {
-        assert_eq!(primary.current_round(), 1);
+    for validators in network.validators.values() {
+        assert_eq!(validators.primary.current_round(), 1);
     }
 
     // Start the cannons for node 0.
@@ -69,24 +69,24 @@ async fn test_quorum_threshold() {
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
     // Check each node is still at round 1.
-    for primary in network.primaries.values() {
-        assert_eq!(primary.current_round(), 1);
+    for validator in network.validators.values() {
+        assert_eq!(validator.primary.current_round(), 1);
     }
 
     // Connect the first two nodes and start the cannons for node 1.
-    network.connect_primaries(0, 1).await;
+    network.connect_validators(0, 1).await;
     network.fire_cannons_at(1);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
     // Check each node is still at round 1.
-    for primary in network.primaries.values() {
-        assert_eq!(primary.current_round(), 1);
+    for validator in network.validators.values() {
+        assert_eq!(validator.primary.current_round(), 1);
     }
 
     // Connect the third node and start the cannons for it.
-    network.connect_primaries(0, 2).await;
-    network.connect_primaries(1, 2).await;
+    network.connect_validators(0, 2).await;
+    network.connect_validators(1, 2).await;
     network.fire_cannons_at(2);
 
     // Check the nodes reach quorum and advance through the rounds.


### PR DESCRIPTION
This PR introduces a few structures to improve the ergonomics of writting e2e tests, notably`TestNetworkConfig` which can be used to construct a `TestNetwork`. Task handles (for the cannons and logging) are tracked on a per-primary basis, which will be helpful for cases requiring primary restarts. I've also introduced a few convenience methods to check for network halts and quorum reaching a certain round. 