### PR TITLE
fix: gateway proptest

### DIFF
--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -866,6 +866,7 @@ pub mod prop_tests {
         pub committee_input: CommitteeInput,
         #[filter(Validator::is_valid)]
         pub node_validator: Validator,
+        #[filter(#dev.is_none() || *#dev.as_ref().unwrap() < 10000)]
         pub dev: Option<u16>,
         #[strategy(0..MAX_WORKERS)]
         pub workers_count: u8,


### PR DESCRIPTION
Fixed the failing Gateway proptest. The proptests are putting a too large value for the dev parameter. This causes an overflow when 5000 + dev is done (u16).

Constrain the `dev` field to < 10_000. (I tried a lower value, but then proptest complains there are too many rejects for this field).