### PR TITLE
[Narwhal] set up BFT e2e test tooling

### DIFF
--- a/node/narwhal/src/helpers/channels.rs
+++ b/node/narwhal/src/helpers/channels.rs
@@ -58,7 +58,7 @@ pub fn init_consensus_channels<N: Network>() -> (ConsensusSender<N>, ConsensusRe
     (sender, receiver)
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BFTSender<N: Network> {
     pub tx_primary_round: mpsc::Sender<(u64, oneshot::Sender<Result<()>>)>,
     pub tx_primary_certificate: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,

--- a/node/narwhal/tests/bft_e2e.rs
+++ b/node/narwhal/tests/bft_e2e.rs
@@ -15,6 +15,10 @@
 mod common;
 
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
+use deadline::deadline;
+use snarkos_node_narwhal::MAX_BATCH_DELAY;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "long-running e2e test"]
@@ -33,4 +37,84 @@ async fn test_state_coherence() {
     network.start().await;
 
     std::future::pending::<()>().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_quorum_threshold() {
+    // Start N nodes but don't connect them.
+    const N: u16 = 4;
+    let mut network = TestNetwork::new(TestNetworkConfig {
+        num_nodes: N,
+        bft: true,
+        connect_all: false,
+        fire_cannons: false,
+        // Set this to Some(0..=4) to see the logs.
+        log_level: None,
+        log_connections: true,
+    });
+    network.start().await;
+
+    // Check each node is at round 1 (0 is genesis).
+    for validators in network.validators.values() {
+        assert_eq!(validators.primary.current_round(), 1);
+    }
+
+    // Start the cannons for node 0.
+    network.fire_cannons_at(0);
+
+    sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
+
+    // Check each node is still at round 1.
+    for validator in network.validators.values() {
+        assert_eq!(validator.primary.current_round(), 1);
+    }
+
+    // Connect the first two nodes and start the cannons for node 1.
+    network.connect_validators(0, 1).await;
+    network.fire_cannons_at(1);
+
+    sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
+
+    // Check each node is still at round 1.
+    for validator in network.validators.values() {
+        assert_eq!(validator.primary.current_round(), 1);
+    }
+
+    // Connect the third node and start the cannons for it.
+    network.connect_validators(0, 2).await;
+    network.connect_validators(1, 2).await;
+    network.fire_cannons_at(2);
+
+    // Check the nodes reach quorum and advance through the rounds.
+    const TARGET_ROUND: u64 = 4;
+    deadline!(Duration::from_secs(20), move || { network.is_round_reached(TARGET_ROUND) });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_quorum_break() {
+    // Start N nodes, connect them and start the cannons for each.
+    const N: u16 = 4;
+    let mut network = TestNetwork::new(TestNetworkConfig {
+        num_nodes: N,
+        bft: true,
+        connect_all: true,
+        fire_cannons: true,
+        // Set this to Some(0..=4) to see the logs.
+        log_level: None,
+        log_connections: true,
+    });
+    network.start().await;
+
+    // Check the nodes have started advancing through the rounds.
+    const TARGET_ROUND: u64 = 4;
+    // Note: cloning the network is fine because the primaries it wraps are `Arc`ed.
+    let network_clone = network.clone();
+    deadline!(Duration::from_secs(20), move || { network_clone.is_round_reached(TARGET_ROUND) });
+
+    // Break the quorum by disconnecting two nodes.
+    const NUM_NODES: u16 = 2;
+    network.disconnect(NUM_NODES).await;
+
+    // Check the nodes have stopped advancing through the rounds.
+    assert!(network.is_halted().await);
 }

--- a/node/narwhal/tests/bft_e2e.rs
+++ b/node/narwhal/tests/bft_e2e.rs
@@ -24,11 +24,13 @@ use tokio::time::sleep;
 #[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
+    const CANNON_INTERVAL_MS: u64 = 10;
+
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: true,
         connect_all: true,
-        fire_cannons: true,
+        fire_cannons: Some(CANNON_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: Some(0),
         log_connections: true,
@@ -43,11 +45,13 @@ async fn test_state_coherence() {
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;
+    const CANNON_INTERVAL_MS: u64 = 10;
+
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: true,
         connect_all: false,
-        fire_cannons: false,
+        fire_cannons: None,
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,
@@ -60,7 +64,7 @@ async fn test_quorum_threshold() {
     }
 
     // Start the cannons for node 0.
-    network.fire_cannons_at(0);
+    network.fire_cannons_at(0, CANNON_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -71,7 +75,7 @@ async fn test_quorum_threshold() {
 
     // Connect the first two nodes and start the cannons for node 1.
     network.connect_validators(0, 1).await;
-    network.fire_cannons_at(1);
+    network.fire_cannons_at(1, CANNON_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -83,7 +87,7 @@ async fn test_quorum_threshold() {
     // Connect the third node and start the cannons for it.
     network.connect_validators(0, 2).await;
     network.connect_validators(1, 2).await;
-    network.fire_cannons_at(2);
+    network.fire_cannons_at(2, CANNON_INTERVAL_MS);
 
     // Check the nodes reach quorum and advance through the rounds.
     const TARGET_ROUND: u64 = 4;
@@ -94,11 +98,12 @@ async fn test_quorum_threshold() {
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
+    const CANNON_INTERVAL_MS: u64 = 10;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: true,
         connect_all: true,
-        fire_cannons: true,
+        fire_cannons: Some(CANNON_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,

--- a/node/narwhal/tests/bft_e2e.rs
+++ b/node/narwhal/tests/bft_e2e.rs
@@ -1,0 +1,36 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use crate::common::primary::{TestNetwork, TestNetworkConfig};
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "long-running e2e test"]
+async fn test_state_coherence() {
+    const N: u16 = 4;
+    let mut network = TestNetwork::new(TestNetworkConfig {
+        num_nodes: N,
+        bft: true,
+        connect_all: true,
+        fire_cannons: true,
+        // Set this to Some(0..=4) to see the logs.
+        log_level: Some(0),
+        log_connections: true,
+    });
+
+    network.start().await;
+
+    std::future::pending::<()>().await;
+}

--- a/node/narwhal/tests/common/utils.rs
+++ b/node/narwhal/tests/common/utils.rs
@@ -71,7 +71,11 @@ pub fn initialize_logger(verbosity: u8) {
 }
 
 /// Fires *fake* unconfirmed solutions at the node.
-pub fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) -> JoinHandle<()> {
+pub fn fire_unconfirmed_solutions(
+    sender: &PrimarySender<CurrentNetwork>,
+    node_id: u16,
+    interval_ms: u64,
+) -> JoinHandle<()> {
     let tx_unconfirmed_solution = sender.tx_unconfirmed_solution.clone();
     tokio::task::spawn(async move {
         // This RNG samples the *same* fake solutions for all nodes.
@@ -111,13 +115,17 @@ pub fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_i
             // Increment the counter.
             counter += 1;
             // Sleep briefly.
-            sleep(Duration::from_millis(10)).await;
+            sleep(Duration::from_millis(interval_ms)).await;
         }
     })
 }
 
 /// Fires *fake* unconfirmed transactions at the node.
-pub fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) -> JoinHandle<()> {
+pub fn fire_unconfirmed_transactions(
+    sender: &PrimarySender<CurrentNetwork>,
+    node_id: u16,
+    interval_ms: u64,
+) -> JoinHandle<()> {
     let tx_unconfirmed_transaction = sender.tx_unconfirmed_transaction.clone();
     tokio::task::spawn(async move {
         // This RNG samples the *same* fake transactions for all nodes.
@@ -155,7 +163,7 @@ pub fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, nod
             // Increment the counter.
             counter += 1;
             // Sleep briefly.
-            sleep(Duration::from_millis(10)).await;
+            sleep(Duration::from_millis(interval_ms)).await;
         }
     })
 }

--- a/node/narwhal/tests/e2e.rs
+++ b/node/narwhal/tests/e2e.rs
@@ -43,7 +43,7 @@ async fn test_state_coherence() {
     std::future::pending::<()>().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;
@@ -94,7 +94,7 @@ async fn test_quorum_threshold() {
     deadline!(Duration::from_secs(20), move || { network.is_round_reached(TARGET_ROUND) });
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;

--- a/node/narwhal/tests/narwhal_e2e.rs
+++ b/node/narwhal/tests/narwhal_e2e.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod common;
+
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
 use snarkos_node_narwhal::MAX_BATCH_DELAY;
 
@@ -22,14 +23,14 @@ use deadline::deadline;
 use tokio::time::sleep;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Long-running e2e test"]
+#[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
+        bft: false,
         connect_all: true,
         fire_cannons: true,
-
         // Set this to Some(0..=4) to see the logs.
         log_level: Some(0),
         log_connections: true,
@@ -49,9 +50,9 @@ async fn test_quorum_threshold() {
     const N: u16 = 4;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
+        bft: false,
         connect_all: false,
         fire_cannons: false,
-
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,
@@ -100,9 +101,9 @@ async fn test_quorum_break() {
     const N: u16 = 4;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
+        bft: false,
         connect_all: true,
         fire_cannons: true,
-
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,

--- a/node/narwhal/tests/narwhal_e2e.rs
+++ b/node/narwhal/tests/narwhal_e2e.rs
@@ -26,11 +26,13 @@ use tokio::time::sleep;
 #[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
+    const CANNON_INTERVAL_MS: u64 = 10;
+
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: true,
-        fire_cannons: true,
+        fire_cannons: Some(CANNON_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: Some(0),
         log_connections: true,
@@ -48,11 +50,13 @@ async fn test_state_coherence() {
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;
+    const CANNON_INTERVAL_MS: u64 = 10;
+
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: false,
-        fire_cannons: false,
+        fire_cannons: None,
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,
@@ -65,7 +69,7 @@ async fn test_quorum_threshold() {
     }
 
     // Start the cannons for node 0.
-    network.fire_cannons_at(0);
+    network.fire_cannons_at(0, CANNON_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -76,7 +80,7 @@ async fn test_quorum_threshold() {
 
     // Connect the first two nodes and start the cannons for node 1.
     network.connect_validators(0, 1).await;
-    network.fire_cannons_at(1);
+    network.fire_cannons_at(1, CANNON_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -88,7 +92,7 @@ async fn test_quorum_threshold() {
     // Connect the third node and start the cannons for it.
     network.connect_validators(0, 2).await;
     network.connect_validators(1, 2).await;
-    network.fire_cannons_at(2);
+    network.fire_cannons_at(2, CANNON_INTERVAL_MS);
 
     // Check the nodes reach quorum and advance through the rounds.
     const TARGET_ROUND: u64 = 4;
@@ -99,11 +103,12 @@ async fn test_quorum_threshold() {
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
+    const CANNON_INTERVAL_MS: u64 = 10;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: true,
-        fire_cannons: true,
+        fire_cannons: Some(CANNON_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,


### PR DESCRIPTION
This PR adapts the existing test tooling to optionally spin up BFT instances on top of Narwhal. 

The only non-test change is adding `Clone` to the `BFTSender`. 