### PR TITLE
feat: bind on wildcard if an IP address was given

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -89,7 +89,8 @@ impl<N: Network, C: ConsensusStorage<N>> Consensus<N, C> {
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone()));
         // Initialize the BFT.
-        let bft = BFT::new(account, storage, ledger_service, ip, dev)?;
+        // Note that ip is always passed in as None by the validator.
+        let bft = BFT::new(account, storage, ledger_service, ip.map(|ip| ip.port()), dev)?;
         // Return the consensus.
         Ok(Self { ledger, bft, primary_sender: Default::default(), handles: Default::default() })
     }

--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -109,12 +109,12 @@ pub async fn start_bft(
     // Initialize the mock ledger service.
     let ledger = Arc::new(MockLedgerService::new());
     // Initialize the gateway IP and dev mode.
-    let (ip, dev) = match peers.get(&node_id) {
-        Some(ip) => (Some(*ip), None),
+    let (port, dev) = match peers.get(&node_id) {
+        Some(ip) => (Some(ip.port()), None),
         None => (None, Some(node_id)),
     };
     // Initialize the BFT instance.
-    let mut bft = BFT::<CurrentNetwork>::new(account, storage, ledger, ip, dev)?;
+    let mut bft = BFT::<CurrentNetwork>::new(account, storage, ledger, port, dev)?;
     // Run the BFT instance.
     bft.run(sender.clone(), receiver, None).await?;
     // Retrieve the BFT's primary.
@@ -142,12 +142,12 @@ pub async fn start_primary(
     // Initialize the mock ledger service.
     let ledger = Arc::new(MockLedgerService::new());
     // Initialize the gateway IP and dev mode.
-    let (ip, dev) = match peers.get(&node_id) {
-        Some(ip) => (Some(*ip), None),
+    let (port, dev) = match peers.get(&node_id) {
+        Some(ip) => (Some(ip.port()), None),
         None => (None, Some(node_id)),
     };
     // Initialize the primary instance.
-    let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, ip, dev)?;
+    let mut primary = Primary::<CurrentNetwork>::new(account, storage, ledger, port, dev)?;
     // Run the primary instance.
     primary.run(sender.clone(), receiver, None).await?;
     // Keep the node's connections.

--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -45,7 +45,6 @@ use parking_lot::{Mutex, RwLock};
 use std::{
     collections::{BTreeMap, HashSet},
     future::Future,
-    net::SocketAddr,
     sync::{
         atomic::{AtomicI64, Ordering},
         Arc,
@@ -75,11 +74,11 @@ impl<N: Network> BFT<N> {
         account: Account<N>,
         storage: Storage<N>,
         ledger: Ledger<N>,
-        ip: Option<SocketAddr>,
+        port: Option<u16>,
         dev: Option<u16>,
     ) -> Result<Self> {
         Ok(Self {
-            primary: Primary::new(account, storage, ledger, ip, dev)?,
+            primary: Primary::new(account, storage, ledger, port, dev)?,
             dag: Default::default(),
             leader_certificate: Default::default(),
             leader_certificate_timer: Default::default(),

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -94,11 +94,11 @@ impl<N: Network> Primary<N> {
         account: Account<N>,
         storage: Storage<N>,
         ledger: Ledger<N>,
-        ip: Option<SocketAddr>,
+        port: Option<u16>,
         dev: Option<u16>,
     ) -> Result<Self> {
         Ok(Self {
-            gateway: Gateway::new(account, storage.clone(), ip, dev)?,
+            gateway: Gateway::new(account, storage.clone(), port, dev)?,
             storage,
             ledger,
             workers: Arc::from(vec![]),


### PR DESCRIPTION
This changes the logic for selecting the binding ip/port so that if an IP address was given, bind to the wildcard (0.0.0.0) and given port. This is to facilitate devnet efforts.