### PR TITLE
[Narwhal] make tx cannons configurable from cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,6 +3201,7 @@ dependencies = [
  "axum-extra",
  "bincode 1.3.3",
  "bytes",
+ "clap",
  "deadline",
  "futures",
  "indexmap 2.0.0",

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -31,6 +31,9 @@ version = "1.0"
 [dependencies.bytes]
 version = "1"
 
+[dependencies.clap]
+version = "4.3"
+
 [dependencies.futures]
 version = "0.3.27"
 features = [ "thread-pool" ]

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -31,9 +31,6 @@ version = "1.0"
 [dependencies.bytes]
 version = "1"
 
-[dependencies.clap]
-version = "4.3"
-
 [dependencies.futures]
 version = "0.3.27"
 features = [ "thread-pool" ]
@@ -100,6 +97,9 @@ version = "0.6"
 version = "0.7.4"
 default-features = false
 features = [ "erased-json" ]
+
+[dev-dependencies.clap]
+version = "4.3"
 
 [dev-dependencies.deadline]
 version = "0.2"

--- a/node/narwhal/examples/README.md
+++ b/node/narwhal/examples/README.md
@@ -20,7 +20,7 @@ cargo run --release -- example monitor
 ## Development
 
 ```
-Usage: simple_node [OPTIONS] --mode <MODE> --node-id <ID> --num-nodes <N>
+Usage: simple_node [OPTIONS] --mode <MODE> --id <ID> --num-nodes <N>
 
 Options:
       --mode <MODE>
@@ -30,7 +30,7 @@ Options:
           - narwhal: Runs the node with the Narwhal memory pool protocol
           - bft:     Runs the node with the Bullshark BFT protocol (on top of Narwhal)
 
-      --node-id <ID>
+      --id <ID>
           The ID of the node
 
       --num-nodes <N>
@@ -39,8 +39,14 @@ Options:
       --config <PATH>
           If set, the path to the file containing the committee configuration
 
-      --fire-cannons [<INTERVAL_MS>]
-          Enables the tx and solution cannons, and optionally the interval in ms to run them on
+      --fire-solutions [<INTERVAL_MS>]
+          Enables the solution cannons, and optionally the interval in ms to run them on
+
+      --fire-transactions [<INTERVAL_MS>]
+          Enables the transaction cannons, and optionally the interval in ms to run them on
+
+      --fire-transmissions [<INTERVAL_MS>]
+          Enables the solution and transaction cannons, and optionally the interval in ms to run them on
 
   -h, --help
           Print help (see a summary with '-h')
@@ -49,25 +55,25 @@ Options:
 To start 4 **BFT** nodes manually, run:
 ```bash
 # Terminal 1
-cargo run --release --example simple_node --mode bft --node-id 0 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode bft --id 0 --num-nodes 4 --fire-transmissions
 # Terminal 2
-cargo run --release --example simple_node --mode bft --node-id 1 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode bft --id 1 --num-nodes 4 --fire-transmissions
 # Terminal 3
-cargo run --release --example simple_node --mode bft --node-id 2 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode bft --id 2 --num-nodes 4 --fire-transmissions
 # Terminal 4
-cargo run --release --example simple_node --mode bft --node-id 3 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode bft --id 3 --num-nodes 4 --fire-transmissions
 ```
 
 To start 4 **Narwhal** nodes manually, run:
 ```bash
 # Terminal 1
-cargo run --release --example simple_node --mode narwhal --node-id 0 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode narwhal --id 0 --num-nodes 4 --fire-transmissions
 # Terminal 2
-cargo run --release --example simple_node --mode narwhal --node-id 1 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode narwhal --id 1 --num-nodes 4 --fire-transmissions
 # Terminal 3
-cargo run --release --example simple_node --mode narwhal --node-id 2 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode narwhal --id 2 --num-nodes 4 --fire-transmissions
 # Terminal 4
-cargo run --release --example simple_node --mode narwhal --node-id 3 --num-nodes 4 --fire-cannons
+cargo run --release --example simple_node --mode narwhal --id 3 --num-nodes 4 --fire-transmissions
 ```
 
 These initialize 4 nodes, and tells each node that there are 4 validators in the committee.
@@ -75,7 +81,7 @@ These initialize 4 nodes, and tells each node that there are 4 validators in the
 ## Advanced Usage
 
 You may optionally provide a filename as an option with `--config`.
-The file must contain the peer node IDs, IP addresses and ports, in the following form `node_id=ip:port`:
+The file must contain the peer node IDs, IP addresses and ports, in the following form `id=ip:port`:
 ```
 0=192.168.1.1:5000
 1=192.168.1.2:5001
@@ -85,5 +91,5 @@ The file must contain the peer node IDs, IP addresses and ports, in the followin
 
 If this parameter is not present, all nodes are run on localhost.
 
-In addition, `--fire-cannons` will enable the transaction and solution cannons for each node.
+In addition, `--fire-transmissions` will enable the transaction and solution cannons for each node.
 If enabled, the interval in milliseconds can optionally be passed in as an argument.

--- a/node/narwhal/examples/README.md
+++ b/node/narwhal/examples/README.md
@@ -23,12 +23,27 @@ cargo run --release -- example monitor
 Usage: simple_node [OPTIONS] --mode <MODE> --node-id <ID> --num-nodes <N>
 
 Options:
-      --mode <MODE>                   The mode to run the node in [possible values: narwhal, bft]
-      --node-id <ID>                  The ID of the node
-      --num-nodes <N>                 The number of nodes in the network
-      --config <PATH>                 If set, the path to the file containing the committee configuration
-      --fire-cannons [<INTERVAL_MS>]  Enables the tx and solution cannons, and optionally the interval in ms to run them on
-  -h, --help                          Print help
+      --mode <MODE>
+          The mode to run the node in
+
+          Possible values:
+          - narwhal: Runs the node with the Narwhal memory pool protocol
+          - bft:     Runs the node with the Bullshark BFT protocol (on top of Narwhal)
+
+      --node-id <ID>
+          The ID of the node
+
+      --num-nodes <N>
+          The number of nodes in the network
+
+      --config <PATH>
+          If set, the path to the file containing the committee configuration
+
+      --fire-cannons [<INTERVAL_MS>]
+          Enables the tx and solution cannons, and optionally the interval in ms to run them on
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 To start 4 **BFT** nodes manually, run:
@@ -72,5 +87,3 @@ If this parameter is not present, all nodes are run on localhost.
 
 In addition, `--fire-cannons` will enable the transaction and solution cannons for each node.
 If enabled, the interval in milliseconds can optionally be passed in as an argument.
-
-

--- a/node/narwhal/examples/README.md
+++ b/node/narwhal/examples/README.md
@@ -19,35 +19,47 @@ cargo run --release -- example monitor
 
 ## Development
 
+```
+Usage: simple_node [OPTIONS] --mode <MODE> --node-id <ID> --num-nodes <N>
+
+Options:
+      --mode <MODE>                   The mode to run the node in [possible values: narwhal, bft]
+      --node-id <ID>                  The ID of the node
+      --num-nodes <N>                 The number of nodes in the network
+      --config <PATH>                 If set, the path to the file containing the committee configuration
+      --fire-cannons [<INTERVAL_MS>]  Enables the tx and solution cannons, and optionally the interval in ms to run them on
+  -h, --help                          Print help
+```
+
 To start 4 **BFT** nodes manually, run:
 ```bash
 # Terminal 1
-cargo run --release --example simple_node bft 0 4
+cargo run --release --example simple_node --mode bft --node-id 0 --num-nodes 4 --fire-cannons
 # Terminal 2
-cargo run --release --example simple_node bft 1 4
+cargo run --release --example simple_node --mode bft --node-id 1 --num-nodes 4 --fire-cannons
 # Terminal 3
-cargo run --release --example simple_node bft 2 4
+cargo run --release --example simple_node --mode bft --node-id 2 --num-nodes 4 --fire-cannons
 # Terminal 4
-cargo run --release --example simple_node bft 3 4
+cargo run --release --example simple_node --mode bft --node-id 3 --num-nodes 4 --fire-cannons
 ```
 
 To start 4 **Narwhal** nodes manually, run:
 ```bash
 # Terminal 1
-cargo run --release --example simple_node narwhal 0 4
+cargo run --release --example simple_node --mode narwhal --node-id 0 --num-nodes 4 --fire-cannons
 # Terminal 2
-cargo run --release --example simple_node narwhal 1 4
+cargo run --release --example simple_node --mode narwhal --node-id 1 --num-nodes 4 --fire-cannons
 # Terminal 3
-cargo run --release --example simple_node narwhal 2 4
+cargo run --release --example simple_node --mode narwhal --node-id 2 --num-nodes 4 --fire-cannons
 # Terminal 4
-cargo run --release --example simple_node narwhal 3 4
+cargo run --release --example simple_node --mode narwhal --node-id 3 --num-nodes 4 --fire-cannons
 ```
 
 These initialize 4 nodes, and tells each node that there are 4 validators in the committee.
 
 ## Advanced Usage
 
-You may optionally provide a filename as last argument.
+You may optionally provide a filename as an option with `--config`.
 The file must contain the peer node IDs, IP addresses and ports, in the following form `node_id=ip:port`:
 ```
 0=192.168.1.1:5000
@@ -57,3 +69,8 @@ The file must contain the peer node IDs, IP addresses and ports, in the followin
 ```
 
 If this parameter is not present, all nodes are run on localhost.
+
+In addition, `--fire-cannons` will enable the transaction and solution cannons for each node.
+If enabled, the interval in milliseconds can optionally be passed in as an argument.
+
+

--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -399,9 +399,12 @@ async fn start_server(bft: Option<BFT<CurrentNetwork>>, primary: Primary<Current
 
 /**************************************************************************************************/
 
+/// The operating mode of the node.
 #[derive(Debug, Clone, ValueEnum)]
 enum Mode {
+    /// Runs the node with the Narwhal memory pool protocol.
     Narwhal,
+    /// Runs the node with the Bullshark BFT protocol (on top of Narwhal).
     Bft,
 }
 

--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -469,9 +469,10 @@ async fn main() -> Result<()> {
     };
 
     // Fire unconfirmed solutions.
+    const DEFAULT_INTERVAL_MS: u64 = 450;
     let interval_ms = match args.fire_cannons {
         Some(Some(interval)) => Some(interval),
-        Some(None) => Some(450),
+        Some(None) => Some(DEFAULT_INTERVAL_MS),
         None => None,
     };
 

--- a/node/narwhal/examples/simple_node.rs
+++ b/node/narwhal/examples/simple_node.rs
@@ -37,7 +37,7 @@ use snarkvm::{
 };
 
 use ::bytes::Bytes;
-use anyhow::{anyhow, bail, ensure, Error, Result};
+use anyhow::{anyhow, ensure, Error, Result};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -46,10 +46,11 @@ use axum::{
     Router,
 };
 use axum_extra::response::ErasedJson;
+use clap::{Parser, ValueEnum};
 use indexmap::IndexMap;
 use parking_lot::RwLock;
 use rand::{Rng, SeedableRng};
-use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 use tokio::sync::oneshot;
 use tracing_subscriber::{
     layer::{Layer, SubscriberExt},
@@ -247,7 +248,7 @@ fn handle_signals(primary: &Primary<CurrentNetwork>) {
 /**************************************************************************************************/
 
 /// Fires *fake* unconfirmed solutions at the node.
-fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) {
+fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_id: u16, interval_ms: u64) {
     let tx_unconfirmed_solution = sender.tx_unconfirmed_solution.clone();
     tokio::task::spawn(async move {
         // This RNG samples the *same* fake solutions for all nodes.
@@ -283,13 +284,13 @@ fn fire_unconfirmed_solutions(sender: &PrimarySender<CurrentNetwork>, node_id: u
             // Increment the counter.
             counter += 1;
             // Sleep briefly.
-            tokio::time::sleep(std::time::Duration::from_millis(450)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(interval_ms)).await;
         }
     });
 }
 
 /// Fires *fake* unconfirmed transactions at the node.
-fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, node_id: u16) {
+fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, node_id: u16, interval_ms: u64) {
     let tx_unconfirmed_transaction = sender.tx_unconfirmed_transaction.clone();
     tokio::task::spawn(async move {
         // This RNG samples the *same* fake transactions for all nodes.
@@ -325,7 +326,7 @@ fn fire_unconfirmed_transactions(sender: &PrimarySender<CurrentNetwork>, node_id
             // Increment the counter.
             counter += 1;
             // Sleep briefly.
-            tokio::time::sleep(std::time::Duration::from_millis(450)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(interval_ms)).await;
         }
     });
 }
@@ -398,6 +399,32 @@ async fn start_server(bft: Option<BFT<CurrentNetwork>>, primary: Primary<Current
 
 /**************************************************************************************************/
 
+#[derive(Debug, Clone, ValueEnum)]
+enum Mode {
+    Narwhal,
+    Bft,
+}
+
+/// A simple CLI for the node.
+#[derive(Parser, Debug)]
+struct Args {
+    /// The mode to run the node in.
+    #[arg(long)]
+    mode: Mode,
+    /// The ID of the node.
+    #[arg(long, value_name = "ID")]
+    node_id: u16,
+    /// The number of nodes in the network.
+    #[arg(long, value_name = "N")]
+    num_nodes: u16,
+    /// If set, the path to the file containing the committee configuration.
+    #[arg(long, value_name = "PATH")]
+    config: Option<PathBuf>,
+    /// Enables the tx and solution cannons, and optionally the interval in ms to run them on.
+    #[arg(long, value_name = "INTERVAL_MS")]
+    fire_cannons: Option<Option<u64>>,
+}
+
 /// A helper method to parse the peers provided to the CLI.
 fn parse_peers(peers_string: String) -> Result<HashMap<u16, SocketAddr>, Error> {
     // Expect list of peers in the form of `node_id=ip:port`, one per line.
@@ -418,52 +445,45 @@ fn parse_peers(peers_string: String) -> Result<HashMap<u16, SocketAddr>, Error> 
 async fn main() -> Result<()> {
     initialize_logger(1);
 
-    // Retrieve the command-line arguments.
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() < 4 {
-        bail!("Please provide the commands to start a node.")
-    }
+    let args = Args::parse();
 
-    // Parse the mode.
-    let mode = args[1].as_str();
-    if mode != "bft" && mode != "narwhal" {
-        bail!("Please provide a valid mode - 'bft' or 'narwhal'.")
-    }
-    // Parse the node ID.
-    let node_id = u16::from_str(&args[2])?;
-    // Parse the number of nodes.
-    let num_nodes = u16::from_str(&args[3])?;
-
-    // (optional) Parse the peers from a file.
-    let peers = match args.len() > 4 {
-        true => parse_peers(std::fs::read_to_string(&args[4])?)?,
-        false => Default::default(),
+    let peers = match args.config {
+        Some(path) => parse_peers(std::fs::read_to_string(path)?)?,
+        None => Default::default(),
     };
 
     // Initialize an optional BFT holder.
     let mut bft_holder = None;
 
     // Start the node.
-    let (primary, sender) = match mode {
-        "bft" => {
+    let (primary, sender) = match args.mode {
+        Mode::Bft => {
             // Start the BFT.
-            let (bft, sender) = start_bft(node_id, num_nodes, peers).await?;
+            let (bft, sender) = start_bft(args.node_id, args.num_nodes, peers).await?;
             // Set the BFT holder.
             bft_holder = Some(bft.clone());
             // Return the primary and sender.
             (bft.primary().clone(), sender)
         }
-        "narwhal" => start_primary(node_id, num_nodes, peers).await?,
-        _ => unreachable!(),
+        Mode::Narwhal => start_primary(args.node_id, args.num_nodes, peers).await?,
     };
 
     // Fire unconfirmed solutions.
-    fire_unconfirmed_solutions(&sender, node_id);
-    // Fire unconfirmed transactions.
-    fire_unconfirmed_transactions(&sender, node_id);
+    let interval_ms = match args.fire_cannons {
+        Some(Some(interval)) => Some(interval),
+        Some(None) => Some(450),
+        None => None,
+    };
+
+    if let Some(interval_ms) = interval_ms {
+        // Fire unconfirmed solutions.
+        fire_unconfirmed_solutions(&sender, args.node_id, interval_ms);
+        // Fire unconfirmed transactions.
+        fire_unconfirmed_transactions(&sender, args.node_id, interval_ms);
+    }
 
     // Start the monitoring server.
-    start_server(bft_holder, primary, node_id).await;
+    start_server(bft_holder, primary, args.node_id).await;
     // // Note: Do not move this.
     // std::future::pending::<()>().await;
     Ok(())

--- a/node/narwhal/examples/start-nodes.sh
+++ b/node/narwhal/examples/start-nodes.sh
@@ -36,7 +36,7 @@ num_nodes=${2:-$default_num_nodes}
 
 # Loop to open terminal windows and execute the command
 for ((i = 0; i < num_nodes; i++)); do
-	FULL_COMMAND="$command -- --mode $mode --node-id $i --num-nodes $num_nodes --fire-cannons"
+	FULL_COMMAND="$command -- --mode $mode --id $i --num-nodes $num_nodes --fire-transmissions"
 
 	if [[ "$terminal_app" == "iTerm" ]]; then
 		osascript -e "tell application \"$terminal_app\" to create window with default profile"

--- a/node/narwhal/examples/start-nodes.sh
+++ b/node/narwhal/examples/start-nodes.sh
@@ -36,7 +36,7 @@ num_nodes=${2:-$default_num_nodes}
 
 # Loop to open terminal windows and execute the command
 for ((i = 0; i < num_nodes; i++)); do
-	FULL_COMMAND="$command $mode $i $num_nodes"
+	FULL_COMMAND="$command -- --mode $mode --node-id $i --num-nodes $num_nodes --fire-cannons"
 
 	if [[ "$terminal_app" == "iTerm" ]]; then
 		osascript -e "tell application \"$terminal_app\" to create window with default profile"


### PR DESCRIPTION
This PR introduces a basic `clap`-based CLI to make the `simple_nodes` example more configurable for devnet purposes. The tx cannons can now be enabled/disabled and configured. 
