### PR TITLE
Revert "feat: increase max committee size to 100"

### DIFF
--- a/node/narwhal/committee/src/lib.rs
+++ b/node/narwhal/committee/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prop_tests;
 pub const MIN_STAKE: u64 = 1_000u64; // microcredits
 
 /// The maximum number of nodes that can be in a committee.
-pub const MAX_COMMITTEE_SIZE: u16 = 100; // members
+pub const MAX_COMMITTEE_SIZE: u16 = 4; // members
 
 use snarkvm::console::{
     prelude::*,


### PR DESCRIPTION
Reverts AleoHQ/snarkOS#2554

We need to introduce a `max_committee` variable in `Gateway` and change all constants in `Gateway` to be computed configurations if this constant is changed arbitrarily like this. Otherwise, the rate limiters are broken and we have minimal control on rate of flow for inbound and outbound messages.