### PR TITLE
[Narwhal] Return a &'static str from EventTrait::name

### DIFF
--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -36,8 +36,8 @@ impl<N: Network> From<BatchCertificate<N>> for BatchCertified<N> {
 impl<N: Network> EventTrait for BatchCertified<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "BatchCertified".to_string()
+    fn name(&self) -> &'static str {
+        "BatchCertified"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -37,8 +37,8 @@ impl<N: Network> From<BatchHeader<N>> for BatchPropose<N> {
 impl<N: Network> EventTrait for BatchPropose<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "BatchPropose".to_string()
+    fn name(&self) -> &'static str {
+        "BatchPropose"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -31,8 +31,8 @@ impl<N: Network> BatchSignature<N> {
 impl<N: Network> EventTrait for BatchSignature<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "BatchSignature".to_string()
+    fn name(&self) -> &'static str {
+        "BatchSignature"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -36,8 +36,8 @@ impl<N: Network> From<Field<N>> for CertificateRequest<N> {
 impl<N: Network> EventTrait for CertificateRequest<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "CertificateRequest".to_string()
+    fn name(&self) -> &'static str {
+        "CertificateRequest"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -36,8 +36,8 @@ impl<N: Network> From<BatchCertificate<N>> for CertificateResponse<N> {
 impl<N: Network> EventTrait for CertificateResponse<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "CertificateResponse".to_string()
+    fn name(&self) -> &'static str {
+        "CertificateResponse"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -32,8 +32,8 @@ impl<N: Network> ChallengeRequest<N> {
 impl<N: Network> EventTrait for ChallengeRequest<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "ChallengeRequest".to_string()
+    fn name(&self) -> &'static str {
+        "ChallengeRequest"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/challenge_response.rs
+++ b/node/narwhal/src/event/challenge_response.rs
@@ -22,8 +22,8 @@ pub struct ChallengeResponse<N: Network> {
 impl<N: Network> EventTrait for ChallengeResponse<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "ChallengeResponse".to_string()
+    fn name(&self) -> &'static str {
+        "ChallengeResponse"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/disconnect.rs
+++ b/node/narwhal/src/event/disconnect.rs
@@ -41,8 +41,8 @@ impl From<DisconnectReason> for Disconnect {
 impl EventTrait for Disconnect {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "Disconnect".to_string()
+    fn name(&self) -> &'static str {
+        "Disconnect"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/mod.rs
+++ b/node/narwhal/src/event/mod.rs
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 
 pub trait EventTrait {
     /// Returns the event name.
-    fn name(&self) -> String;
+    fn name(&self) -> &'static str;
     /// Serializes the event into the buffer.
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()>;
     /// Deserializes the given buffer into a event.
@@ -94,7 +94,7 @@ impl<N: Network> Event<N> {
 
     /// Returns the event name.
     #[inline]
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &'static str {
         match self {
             Self::BatchPropose(event) => event.name(),
             Self::BatchSignature(event) => event.name(),

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -36,8 +36,8 @@ impl<N: Network> From<TransmissionID<N>> for TransmissionRequest<N> {
 impl<N: Network> EventTrait for TransmissionRequest<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "TransmissionRequest".to_string()
+    fn name(&self) -> &'static str {
+        "TransmissionRequest"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -37,8 +37,8 @@ impl<N: Network> From<(TransmissionID<N>, Transmission<N>)> for TransmissionResp
 impl<N: Network> EventTrait for TransmissionResponse<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "TransmissionResponse".to_string()
+    fn name(&self) -> &'static str {
+        "TransmissionResponse"
     }
 
     /// Serializes the event into the buffer.

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -36,8 +36,8 @@ impl<N: Network> From<IndexSet<TransmissionID<N>>> for WorkerPing<N> {
 impl<N: Network> EventTrait for WorkerPing<N> {
     /// Returns the event name.
     #[inline]
-    fn name(&self) -> String {
-        "WorkerPing".to_string()
+    fn name(&self) -> &'static str {
+        "WorkerPing"
     }
 
     /// Serializes the event into the buffer.


### PR DESCRIPTION
`EventTrait::name` doesn't need to return allocated strings, it can just use static ones instead.