### PR TITLE
[Narwhal] e2e storage coherence cases

### DIFF
--- a/node/narwhal/tests/bft_e2e.rs
+++ b/node/narwhal/tests/bft_e2e.rs
@@ -25,13 +25,13 @@ use tokio::time::sleep;
 #[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
 
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: true,
         connect_all: true,
-        fire_cannons: Some(CANNON_INTERVAL_MS),
+        fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: Some(0),
         log_connections: true,
@@ -46,13 +46,13 @@ async fn test_state_coherence() {
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
 
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: true,
         connect_all: false,
-        fire_cannons: None,
+        fire_transmissions: None,
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,
@@ -65,7 +65,7 @@ async fn test_quorum_threshold() {
     }
 
     // Start the cannons for node 0.
-    network.fire_cannons_at(0, CANNON_INTERVAL_MS);
+    network.fire_transmissions_at(0, TRANSMISSION_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -76,7 +76,7 @@ async fn test_quorum_threshold() {
 
     // Connect the first two nodes and start the cannons for node 1.
     network.connect_validators(0, 1).await;
-    network.fire_cannons_at(1, CANNON_INTERVAL_MS);
+    network.fire_transmissions_at(1, TRANSMISSION_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -88,7 +88,7 @@ async fn test_quorum_threshold() {
     // Connect the third node and start the cannons for it.
     network.connect_validators(0, 2).await;
     network.connect_validators(1, 2).await;
-    network.fire_cannons_at(2, CANNON_INTERVAL_MS);
+    network.fire_transmissions_at(2, TRANSMISSION_INTERVAL_MS);
 
     // Check the nodes reach quorum and advance through the rounds.
     const TARGET_ROUND: u64 = 4;
@@ -99,12 +99,12 @@ async fn test_quorum_threshold() {
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: true,
         connect_all: true,
-        fire_cannons: Some(CANNON_INTERVAL_MS),
+        fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,

--- a/node/narwhal/tests/bft_e2e.rs
+++ b/node/narwhal/tests/bft_e2e.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(dead_code)]
 mod common;
 
 use crate::common::primary::{TestNetwork, TestNetworkConfig};

--- a/node/narwhal/tests/bft_e2e.rs
+++ b/node/narwhal/tests/bft_e2e.rs
@@ -141,7 +141,7 @@ async fn test_leader_election_consistency() {
         num_nodes: N,
         bft: true,
         connect_all: true,
-        fire_cannons: Some(CANNON_INTERVAL_MS),
+        fire_transmissions: Some(CANNON_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -210,12 +210,29 @@ impl TestNetwork {
         self.validators.values().all(|v| v.primary.current_round() <= halt_round)
     }
 
+    // Checks if the committee is coherent in storage for all nodes (not quorum).
     pub fn is_committee_coherent<T>(&self, rounds_range: T) -> bool
     where
         T: RangeBounds<u64> + IntoIterator<Item = u64>,
     {
         rounds_range.into_iter().fold(true, |acc, round| {
             acc && self.validators.values().map(|v| v.primary.storage().get_committee(round).unwrap()).dedup().count()
+                == 1
+        })
+    }
+
+    // Checks if the certificates are coherent in storage for all nodes (not quorum).
+    pub fn is_certificate_round_coherent<T>(&self, rounds_range: T) -> bool
+    where
+        T: RangeBounds<u64> + IntoIterator<Item = u64>,
+    {
+        rounds_range.into_iter().fold(true, |acc, round| {
+            acc && self
+                .validators
+                .values()
+                .map(|v| v.primary.storage().get_certificates_for_round(round))
+                .dedup()
+                .count()
                 == 1
         })
     }

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -47,7 +47,7 @@ pub struct TestNetworkConfig {
     /// started).
     pub connect_all: bool,
     /// If `Some(i)` is set, the cannons will fire every `i` milliseconds.
-    pub fire_cannons: Option<u64>,
+    pub fire_transmissions: Option<u64>,
     /// The log level to use for the test.
     pub log_level: Option<u8>,
     /// If this is set to `true`, the number of connections is logged every 5 seconds.
@@ -79,7 +79,7 @@ pub struct TestValidator {
 }
 
 impl TestValidator {
-    pub fn fire_cannons(&mut self, interval_ms: u64) {
+    pub fn fire_transmissions(&mut self, interval_ms: u64) {
         let solution_handle = fire_unconfirmed_solutions(self.primary_sender.as_mut().unwrap(), self.id, interval_ms);
         let transaction_handle =
             fire_unconfirmed_transactions(self.primary_sender.as_mut().unwrap(), self.id, interval_ms);
@@ -146,8 +146,8 @@ impl TestNetwork {
                 validator.primary.run(primary_sender, primary_receiver, None).await.unwrap();
             }
 
-            if let Some(interval_ms) = self.config.fire_cannons {
-                validator.fire_cannons(interval_ms);
+            if let Some(interval_ms) = self.config.fire_transmissions {
+                validator.fire_transmissions(interval_ms);
             }
 
             if self.config.log_connections {
@@ -161,8 +161,8 @@ impl TestNetwork {
     }
 
     // Starts the solution and trasnaction cannons for node.
-    pub fn fire_cannons_at(&mut self, id: u16, interval_ms: u64) {
-        self.validators.get_mut(&id).unwrap().fire_cannons(interval_ms);
+    pub fn fire_transmissions_at(&mut self, id: u16, interval_ms: u64) {
+        self.validators.get_mut(&id).unwrap().fire_transmissions(interval_ms);
     }
 
     // Connects a node to another node.

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -210,7 +210,8 @@ impl TestNetwork {
         self.validators.values().all(|v| v.primary.current_round() <= halt_round)
     }
 
-    // Checks if the committee is coherent in storage for all nodes (not quorum).
+    // Checks if the committee is coherent in storage for all nodes (not quorum) over a range of
+    // rounds.
     pub fn is_committee_coherent<T>(&self, rounds_range: T) -> bool
     where
         T: RangeBounds<u64> + IntoIterator<Item = u64>,
@@ -220,7 +221,8 @@ impl TestNetwork {
         })
     }
 
-    // Checks if the certificates are coherent in storage for all nodes (not quorum).
+    // Checks if the certificates are coherent in storage for all nodes (not quorum) over a range
+    // of rounds.
     pub fn is_certificate_round_coherent<T>(&self, rounds_range: T) -> bool
     where
         T: RangeBounds<u64> + IntoIterator<Item = u64>,

--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -215,9 +215,8 @@ impl TestNetwork {
     where
         T: RangeBounds<u64> + IntoIterator<Item = u64>,
     {
-        rounds_range.into_iter().fold(true, |acc, round| {
-            acc && self.validators.values().map(|v| v.primary.storage().get_committee(round).unwrap()).dedup().count()
-                == 1
+        rounds_range.into_iter().all(|round| {
+            self.validators.values().map(|v| v.primary.storage().get_committee(round).unwrap()).dedup().count() == 1
         })
     }
 
@@ -226,14 +225,8 @@ impl TestNetwork {
     where
         T: RangeBounds<u64> + IntoIterator<Item = u64>,
     {
-        rounds_range.into_iter().fold(true, |acc, round| {
-            acc && self
-                .validators
-                .values()
-                .map(|v| v.primary.storage().get_certificates_for_round(round))
-                .dedup()
-                .count()
-                == 1
+        rounds_range.into_iter().all(|round| {
+            self.validators.values().map(|v| v.primary.storage().get_certificates_for_round(round)).dedup().count() == 1
         })
     }
 }

--- a/node/narwhal/tests/narwhal_e2e.rs
+++ b/node/narwhal/tests/narwhal_e2e.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(dead_code)]
 mod common;
 
 use crate::common::primary::{TestNetwork, TestNetworkConfig};

--- a/node/narwhal/tests/narwhal_e2e.rs
+++ b/node/narwhal/tests/narwhal_e2e.rs
@@ -130,7 +130,7 @@ async fn test_quorum_break() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_committee_coherence() {
+async fn test_storage_coherence() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
     const CANNON_INTERVAL_MS: u64 = 10;
@@ -154,4 +154,10 @@ async fn test_committee_coherence() {
     // Check the committee is coherent across the network up to the target round. We skip the
     // genesis round.
     assert!(network.is_committee_coherent(1..TARGET_ROUND));
+
+    // Check the round certificates are coherent across the network. We skip the genesis round and
+    // check up to 2 rounds before the the target round as the round preceding the target round
+    // might still be incomplete since the network advances when quorum is reached, not when all
+    // the nodes have completed the round.
+    assert!(network.is_certificate_round_coherent(1..TARGET_ROUND - 1));
 }

--- a/node/narwhal/tests/narwhal_e2e.rs
+++ b/node/narwhal/tests/narwhal_e2e.rs
@@ -26,13 +26,13 @@ use tokio::time::sleep;
 #[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
 
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: true,
-        fire_cannons: Some(CANNON_INTERVAL_MS),
+        fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: Some(0),
         log_connections: true,
@@ -50,13 +50,13 @@ async fn test_state_coherence() {
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
 
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: false,
-        fire_cannons: None,
+        fire_transmissions: None,
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,
@@ -69,7 +69,7 @@ async fn test_quorum_threshold() {
     }
 
     // Start the cannons for node 0.
-    network.fire_cannons_at(0, CANNON_INTERVAL_MS);
+    network.fire_transmissions_at(0, TRANSMISSION_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -80,7 +80,7 @@ async fn test_quorum_threshold() {
 
     // Connect the first two nodes and start the cannons for node 1.
     network.connect_validators(0, 1).await;
-    network.fire_cannons_at(1, CANNON_INTERVAL_MS);
+    network.fire_transmissions_at(1, TRANSMISSION_INTERVAL_MS);
 
     sleep(Duration::from_millis(MAX_BATCH_DELAY * 2)).await;
 
@@ -92,7 +92,7 @@ async fn test_quorum_threshold() {
     // Connect the third node and start the cannons for it.
     network.connect_validators(0, 2).await;
     network.connect_validators(1, 2).await;
-    network.fire_cannons_at(2, CANNON_INTERVAL_MS);
+    network.fire_transmissions_at(2, TRANSMISSION_INTERVAL_MS);
 
     // Check the nodes reach quorum and advance through the rounds.
     const TARGET_ROUND: u64 = 4;
@@ -103,12 +103,12 @@ async fn test_quorum_threshold() {
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: true,
-        fire_cannons: Some(CANNON_INTERVAL_MS),
+        fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,
@@ -133,12 +133,12 @@ async fn test_quorum_break() {
 async fn test_storage_coherence() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
-    const CANNON_INTERVAL_MS: u64 = 10;
+    const TRANSMISSION_INTERVAL_MS: u64 = 10;
     let mut network = TestNetwork::new(TestNetworkConfig {
         num_nodes: N,
         bft: false,
         connect_all: true,
-        fire_cannons: Some(CANNON_INTERVAL_MS),
+        fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
         // Set this to Some(0..=4) to see the logs.
         log_level: None,
         log_connections: true,


### PR DESCRIPTION
This PR adds a e2e test case to check storage coherence over mulitple rounds in the network (narwhal only). It verifies the committee each node has the same committee for each round and verifies the certificates, batches and authors are coherent over the network. 

I have also renamed `fire_cannons` to `fire_transmissions` to be consistent with the changes in #2560. 