### PR TITLE
[Narwhal] Proptests for BFT events

### DIFF
--- a/node/narwhal/committee/src/prop_tests.rs
+++ b/node/narwhal/committee/src/prop_tests.rs
@@ -108,7 +108,8 @@ impl Arbitrary for ValidatorSet {
     type Strategy = BoxedStrategy<ValidatorSet>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        validator_set(any_valid_validator(), size_range(4..=MAX_COMMITTEE_SIZE as usize)).boxed()
+        // use minimal validator set to speed up tests that require signing from the committee members
+        validator_set(any_valid_validator(), size_range(4..=4usize)).boxed()
     }
 }
 

--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -75,7 +75,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_batch_certified())] original: BatchCertified<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         BatchCertified::serialize(&original, &mut buf).unwrap();
 
         let deserialized: BatchCertified<CurrentNetwork> = BatchCertified::deserialize(buf.get_ref().clone()).unwrap();

--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -74,15 +74,14 @@ mod prop_tests {
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_batch_certified())] batch_certified: BatchCertified<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_batch_certified())] original: BatchCertified<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
-        BatchCertified::serialize(&batch_certified, &mut buf).unwrap();
+        BatchCertified::serialize(&original, &mut buf).unwrap();
 
-        let deserialized_batch_certified: BatchCertified<CurrentNetwork> =
-            BatchCertified::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized: BatchCertified<CurrentNetwork> = BatchCertified::deserialize(buf.get_ref().clone()).unwrap();
         assert_eq!(
-            batch_certified.certificate.deserialize_blocking().unwrap(),
-            deserialized_batch_certified.certificate.deserialize_blocking().unwrap()
+            original.certificate.deserialize_blocking().unwrap(),
+            deserialized.certificate.deserialize_blocking().unwrap()
         );
     }
 }

--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -58,7 +58,7 @@ impl<N: Network> EventTrait for BatchCertified<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{
         event::{certificate_response::prop_tests::any_batch_certificate, EventTrait},
         BatchCertified,
@@ -69,7 +69,7 @@ mod prop_tests {
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_batch_certified() -> BoxedStrategy<BatchCertified<CurrentNetwork>> {
+    pub fn any_batch_certified() -> BoxedStrategy<BatchCertified<CurrentNetwork>> {
         any_batch_certificate().prop_map(BatchCertified::from).boxed()
     }
 

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -83,7 +83,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_batch_propose())] original: BatchPropose<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         BatchPropose::serialize(&original, &mut buf).unwrap();
 
         let deserialized: BatchPropose<CurrentNetwork> = BatchPropose::deserialize(buf.get_ref().clone()).unwrap();

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -86,8 +86,7 @@ mod prop_tests {
         let mut buf = BytesMut::with_capacity(64).writer();
         BatchPropose::serialize(&original, &mut buf).unwrap();
 
-        let deserialized: BatchPropose<CurrentNetwork> =
-            BatchPropose::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized: BatchPropose<CurrentNetwork> = BatchPropose::deserialize(buf.get_ref().clone()).unwrap();
         // because of the Data enum, we cannot compare the structs directly even though it derives PartialEq
         assert_eq!(original.round, deserialized.round);
         assert_eq!(

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -82,17 +82,17 @@ mod prop_tests {
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_batch_propose())] propose: BatchPropose<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_batch_propose())] original: BatchPropose<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
-        BatchPropose::serialize(&propose, &mut buf).unwrap();
+        BatchPropose::serialize(&original, &mut buf).unwrap();
 
-        let deserialized_propose: BatchPropose<CurrentNetwork> =
+        let deserialized: BatchPropose<CurrentNetwork> =
             BatchPropose::deserialize(buf.get_ref().clone()).unwrap();
         // because of the Data enum, we cannot compare the structs directly even though it derives PartialEq
-        assert_eq!(propose.round, deserialized_propose.round);
+        assert_eq!(original.round, deserialized.round);
         assert_eq!(
-            propose.batch_header.deserialize_blocking().unwrap(),
-            deserialized_propose.batch_header.deserialize_blocking().unwrap()
+            original.batch_header.deserialize_blocking().unwrap(),
+            deserialized.batch_header.deserialize_blocking().unwrap()
         );
     }
 }

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -61,7 +61,7 @@ impl<N: Network> EventTrait for BatchPropose<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{
         event::{certificate_response::prop_tests::any_batch_header, EventTrait},
         BatchPropose,
@@ -74,7 +74,7 @@ mod prop_tests {
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_batch_propose() -> BoxedStrategy<BatchPropose<CurrentNetwork>> {
+    pub fn any_batch_propose() -> BoxedStrategy<BatchPropose<CurrentNetwork>> {
         any::<CommitteeContext>()
             .prop_flat_map(|committee| (any::<u64>(), any_batch_header(&committee)))
             .prop_map(|(round, batch_header)| BatchPropose::new(round, Data::Object(batch_header)))

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -82,12 +82,12 @@ mod prop_tests {
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_batch_signature())] signature: BatchSignature<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_batch_signature())] original: BatchSignature<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
-        BatchSignature::serialize(&signature, &mut buf).unwrap();
+        BatchSignature::serialize(&original, &mut buf).unwrap();
 
-        let deserialized_signature: BatchSignature<CurrentNetwork> =
+        let deserialized: BatchSignature<CurrentNetwork> =
             BatchSignature::deserialize(buf.get_ref().clone()).unwrap();
-        assert_eq!(signature, deserialized_signature);
+        assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -57,7 +57,7 @@ impl<N: Network> EventTrait for BatchSignature<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{
         event::{
             certificate_request::prop_tests::any_field,
@@ -73,7 +73,7 @@ mod prop_tests {
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_batch_signature() -> BoxedStrategy<BatchSignature<CurrentNetwork>> {
+    pub fn any_batch_signature() -> BoxedStrategy<BatchSignature<CurrentNetwork>> {
         (any_field(), any_signature(), Just(now()), -10..10i64)
             .prop_map(|(certificate_id, signature, timestamp, drift)| {
                 BatchSignature::new(certificate_id, signature, timestamp + drift)

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -86,8 +86,7 @@ mod prop_tests {
         let mut buf = BytesMut::with_capacity(64).writer();
         BatchSignature::serialize(&original, &mut buf).unwrap();
 
-        let deserialized: BatchSignature<CurrentNetwork> =
-            BatchSignature::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized: BatchSignature<CurrentNetwork> = BatchSignature::deserialize(buf.get_ref().clone()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -83,7 +83,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_batch_signature())] original: BatchSignature<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         BatchSignature::serialize(&original, &mut buf).unwrap();
 
         let deserialized: BatchSignature<CurrentNetwork> = BatchSignature::deserialize(buf.get_ref().clone()).unwrap();

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -55,3 +55,39 @@ impl<N: Network> EventTrait for BatchSignature<N> {
         })
     }
 }
+
+#[cfg(test)]
+mod prop_tests {
+    use crate::{
+        event::{
+            certificate_request::prop_tests::any_field,
+            challenge_response::prop_tests::any_signature,
+            EventTrait,
+        },
+        helpers::now,
+        BatchSignature,
+    };
+    use bytes::{BufMut, BytesMut};
+    use proptest::prelude::{BoxedStrategy, Just, Strategy};
+    use test_strategy::proptest;
+
+    type CurrentNetwork = snarkvm::prelude::Testnet3;
+
+    fn any_batch_signature() -> BoxedStrategy<BatchSignature<CurrentNetwork>> {
+        (any_field(), any_signature(), Just(now()), -10..10i64)
+            .prop_map(|(certificate_id, signature, timestamp, drift)| {
+                BatchSignature::new(certificate_id, signature, timestamp + drift)
+            })
+            .boxed()
+    }
+
+    #[proptest]
+    fn serialize_deserialize(#[strategy(any_batch_signature())] signature: BatchSignature<CurrentNetwork>) {
+        let mut buf = BytesMut::with_capacity(64).writer();
+        BatchSignature::serialize(&signature, &mut buf).unwrap();
+
+        let deserialized_signature: BatchSignature<CurrentNetwork> =
+            BatchSignature::deserialize(buf.get_ref().clone()).unwrap();
+        assert_eq!(signature, deserialized_signature);
+    }
+}

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -77,12 +77,12 @@ pub mod prop_tests {
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_challenge_request())] request: CertificateRequest<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_challenge_request())] original: CertificateRequest<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
-        CertificateRequest::serialize(&request, &mut buf).unwrap();
+        CertificateRequest::serialize(&original, &mut buf).unwrap();
 
-        let deserialized_request: CertificateRequest<CurrentNetwork> =
+        let deserialized: CertificateRequest<CurrentNetwork> =
             CertificateRequest::deserialize(buf.get_ref().clone()).unwrap();
-        assert_eq!(request, deserialized_request);
+        assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -78,7 +78,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_certificate_request())] original: CertificateRequest<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         CertificateRequest::serialize(&original, &mut buf).unwrap();
 
         let deserialized: CertificateRequest<CurrentNetwork> =

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -59,7 +59,7 @@ impl<N: Network> EventTrait for CertificateRequest<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{event::EventTrait, helpers::storage::prop_tests::CryptoTestRng, CertificateRequest};
     use bytes::{BufMut, BytesMut};
     use proptest::prelude::{any, BoxedStrategy, Strategy};
@@ -68,7 +68,7 @@ mod prop_tests {
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_field() -> BoxedStrategy<Field<CurrentNetwork>> {
+    pub fn any_field() -> BoxedStrategy<Field<CurrentNetwork>> {
         any::<CryptoTestRng>().prop_map(|mut rng| Field::rand(&mut rng)).boxed()
     }
 

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -72,12 +72,12 @@ pub mod prop_tests {
         any::<CryptoTestRng>().prop_map(|mut rng| Field::rand(&mut rng)).boxed()
     }
 
-    fn any_challenge_request() -> BoxedStrategy<CertificateRequest<CurrentNetwork>> {
+    pub fn any_certificate_request() -> BoxedStrategy<CertificateRequest<CurrentNetwork>> {
         any_field().prop_map(CertificateRequest::new).boxed()
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_challenge_request())] original: CertificateRequest<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_certificate_request())] original: CertificateRequest<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
         CertificateRequest::serialize(&original, &mut buf).unwrap();
 

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -73,7 +73,7 @@ pub mod prop_tests {
     }
 
     fn any_challenge_request() -> BoxedStrategy<CertificateRequest<CurrentNetwork>> {
-        any_field().prop_map(|certificate_id| CertificateRequest::new(certificate_id)).boxed()
+        any_field().prop_map(CertificateRequest::new).boxed()
     }
 
     #[proptest]

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -117,12 +117,12 @@ pub mod prop_tests {
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_certificate_response())] response: CertificateResponse<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_certificate_response())] original: CertificateResponse<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
-        CertificateResponse::serialize(&response, &mut buf).unwrap();
+        CertificateResponse::serialize(&original, &mut buf).unwrap();
 
-        let deserialized_response: CertificateResponse<CurrentNetwork> =
+        let deserialized: CertificateResponse<CurrentNetwork> =
             CertificateResponse::deserialize(buf.get_ref().clone()).unwrap();
-        assert_eq!(response, deserialized_response);
+        assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -101,19 +101,19 @@ pub mod prop_tests {
             .boxed()
     }
 
-    fn any_certificate_response() -> BoxedStrategy<CertificateResponse<CurrentNetwork>> {
+    pub fn any_batch_certificate() -> BoxedStrategy<BatchCertificate<CurrentNetwork>> {
         any::<CommitteeContext>()
             .prop_flat_map(|committee| (Just(committee.clone()), any_batch_header(&committee), any::<CryptoTestRng>()))
             .prop_map(|(committee, batch_header, mut rng)| {
                 let CommitteeContext(_, validator_set) = committee;
-                let certificate = BatchCertificate::new(
-                    batch_header.clone(),
-                    sign_batch_header(&validator_set, &batch_header, &mut rng),
-                )
-                .unwrap();
-                CertificateResponse::new(certificate)
+                BatchCertificate::new(batch_header.clone(), sign_batch_header(&validator_set, &batch_header, &mut rng))
+                    .unwrap()
             })
             .boxed()
+    }
+
+    fn any_certificate_response() -> BoxedStrategy<CertificateResponse<CurrentNetwork>> {
+        any_batch_certificate().prop_map(CertificateResponse::new).boxed()
     }
 
     #[proptest]

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -110,7 +110,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_certificate_response())] original: CertificateResponse<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         CertificateResponse::serialize(&original, &mut buf).unwrap();
 
         let deserialized: CertificateResponse<CurrentNetwork> =

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -83,20 +83,12 @@ pub mod prop_tests {
     pub fn any_batch_header(committee: &CommitteeContext) -> BoxedStrategy<BatchHeader<CurrentNetwork>> {
         (Just(committee.clone()), any::<Selector>(), any::<CryptoTestRng>(), vec(any_transmission(), 0..16))
             .prop_map(|(committee, selector, mut rng, transmissions)| {
-                let CommitteeContext(_, validator_set) = committee;
-                let ValidatorSet(validators) = validator_set.clone();
+                let CommitteeContext(_, ValidatorSet(validators)) = committee;
                 let signer = selector.select(validators);
                 let transmission_ids = transmissions.into_iter().map(|(id, _)| id).collect();
 
-                BatchHeader::new(
-                    &signer.account.private_key(),
-                    0,
-                    now(),
-                    transmission_ids,
-                    Default::default(),
-                    &mut rng,
-                )
-                .unwrap()
+                BatchHeader::new(signer.account.private_key(), 0, now(), transmission_ids, Default::default(), &mut rng)
+                    .unwrap()
             })
             .boxed()
     }

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -104,7 +104,7 @@ pub mod prop_tests {
             .boxed()
     }
 
-    fn any_certificate_response() -> BoxedStrategy<CertificateResponse<CurrentNetwork>> {
+    pub fn any_certificate_response() -> BoxedStrategy<CertificateResponse<CurrentNetwork>> {
         any_batch_certificate().prop_map(CertificateResponse::new).boxed()
     }
 

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -73,7 +73,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_challenge_request())] original: ChallengeRequest<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         ChallengeRequest::serialize(&original, &mut buf).unwrap();
 
         let deserialized: ChallengeRequest<CurrentNetwork> =

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -51,7 +51,7 @@ impl<N: Network> EventTrait for ChallengeRequest<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{event::EventTrait, ChallengeRequest};
     use bytes::{BufMut, BytesMut};
     use proptest::prelude::{any, BoxedStrategy, Strategy};
@@ -60,7 +60,7 @@ mod prop_tests {
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_challenge_request() -> BoxedStrategy<ChallengeRequest<CurrentNetwork>> {
+    pub fn any_challenge_request() -> BoxedStrategy<ChallengeRequest<CurrentNetwork>> {
         (any_valid_account(), any::<u64>(), any::<u32>(), any::<u16>())
             .prop_map(|(account, nonce, version, listener_port)| ChallengeRequest {
                 address: account.address(),

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -72,12 +72,12 @@ mod prop_tests {
     }
 
     #[proptest]
-    fn serialize_deserialize(#[strategy(any_challenge_request())] request: ChallengeRequest<CurrentNetwork>) {
+    fn serialize_deserialize(#[strategy(any_challenge_request())] original: ChallengeRequest<CurrentNetwork>) {
         let mut buf = BytesMut::with_capacity(64).writer();
-        ChallengeRequest::serialize(&request, &mut buf).unwrap();
+        ChallengeRequest::serialize(&original, &mut buf).unwrap();
 
-        let deserialized_request: ChallengeRequest<CurrentNetwork> =
+        let deserialized: ChallengeRequest<CurrentNetwork> =
             ChallengeRequest::deserialize(buf.get_ref().clone()).unwrap();
-        assert_eq!(request, deserialized_request);
+        assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/challenge_response.rs
+++ b/node/narwhal/src/event/challenge_response.rs
@@ -41,7 +41,7 @@ impl<N: Network> EventTrait for ChallengeResponse<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{event::EventTrait, helpers::storage::prop_tests::CryptoTestRng, ChallengeResponse};
     use bytes::{BufMut, BytesMut};
     use proptest::prelude::{any, BoxedStrategy, Strategy};
@@ -54,7 +54,7 @@ mod prop_tests {
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_signature() -> BoxedStrategy<Signature<CurrentNetwork>> {
+    pub fn any_signature() -> BoxedStrategy<Signature<CurrentNetwork>> {
         (any::<CryptoTestRng>(), 0..64)
             .prop_map(|(mut rng, message_size)| {
                 let message: Vec<_> = (0..message_size).map(|_| Uniform::rand(&mut rng)).collect();

--- a/node/narwhal/src/event/challenge_response.rs
+++ b/node/narwhal/src/event/challenge_response.rs
@@ -70,7 +70,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_challenge_response())] original: ChallengeResponse<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         ChallengeResponse::serialize(&original, &mut buf).unwrap();
 
         let deserialized: ChallengeResponse<CurrentNetwork> =

--- a/node/narwhal/src/event/challenge_response.rs
+++ b/node/narwhal/src/event/challenge_response.rs
@@ -64,7 +64,7 @@ pub mod prop_tests {
             .boxed()
     }
 
-    fn any_challenge_response() -> BoxedStrategy<ChallengeResponse<CurrentNetwork>> {
+    pub fn any_challenge_response() -> BoxedStrategy<ChallengeResponse<CurrentNetwork>> {
         any_signature().prop_map(|sig| ChallengeResponse { signature: Data::Object(sig) }).boxed()
     }
 

--- a/node/narwhal/src/event/disconnect.rs
+++ b/node/narwhal/src/event/disconnect.rs
@@ -81,7 +81,7 @@ mod tests {
 
         for reason in all_reasons.iter() {
             let disconnect = Disconnect::from(*reason);
-            let mut buf = BytesMut::with_capacity(64).writer();
+            let mut buf = BytesMut::default().writer();
             Disconnect::serialize(&disconnect, &mut buf).unwrap();
 
             let disconnect = Disconnect::deserialize(buf.get_ref().clone()).unwrap();
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn deserializing_empty_defaults_no_reason() {
-        let buf = BytesMut::with_capacity(64).writer();
+        let buf = BytesMut::default().writer();
         let disconnect = Disconnect::deserialize(buf.get_ref().clone()).unwrap();
         assert_eq!(disconnect.reason, DisconnectReason::NoReasonGiven);
     }
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Invalid 'Disconnect' event")]
     fn deserializing_invalid_data_panics() {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         bincode::serialize_into(&mut buf, "not a DisconnectReason-value").unwrap();
         let _disconnect = Disconnect::deserialize(buf.get_ref().clone()).unwrap();
     }

--- a/node/narwhal/src/event/disconnect.rs
+++ b/node/narwhal/src/event/disconnect.rs
@@ -63,3 +63,44 @@ impl EventTrait for Disconnect {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{event::EventTrait, Disconnect, DisconnectReason};
+    use bytes::{BufMut, BytesMut};
+
+    #[test]
+    fn serialize_deserialize() {
+        // TODO switch to an iteration method that doesn't require manually updating this vec if enums are added
+        let all_reasons = vec![
+            DisconnectReason::ProtocolViolation,
+            DisconnectReason::NoReasonGiven,
+            DisconnectReason::InvalidChallengeResponse,
+            DisconnectReason::OutdatedClientVersion,
+        ];
+
+        for reason in all_reasons.iter() {
+            let disconnect = Disconnect::from(*reason);
+            let mut buf = BytesMut::with_capacity(64).writer();
+            Disconnect::serialize(&disconnect, &mut buf).unwrap();
+
+            let disconnect = Disconnect::deserialize(buf.get_ref().clone()).unwrap();
+            assert_eq!(reason, &disconnect.reason);
+        }
+    }
+
+    #[test]
+    fn deserializing_empty_defaults_no_reason() {
+        let buf = BytesMut::with_capacity(64).writer();
+        let disconnect = Disconnect::deserialize(buf.get_ref().clone()).unwrap();
+        assert_eq!(disconnect.reason, DisconnectReason::NoReasonGiven);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid 'Disconnect' event")]
+    fn deserializing_invalid_data_panics() {
+        let mut buf = BytesMut::with_capacity(64).writer();
+        bincode::serialize_into(&mut buf, "not a DisconnectReason-value").unwrap();
+        let _disconnect = Disconnect::deserialize(buf.get_ref().clone()).unwrap();
+    }
+}

--- a/node/narwhal/src/event/mod.rs
+++ b/node/narwhal/src/event/mod.rs
@@ -236,7 +236,7 @@ mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_event())] original: Event<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         Event::serialize(&original, &mut buf).unwrap();
 
         let deserialized: Event<CurrentNetwork> = Event::deserialize(buf.get_ref().clone()).unwrap();
@@ -254,14 +254,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Missing event ID")]
     fn deserializing_empty_defaults_no_reason() {
-        let buf = BytesMut::with_capacity(64).writer();
+        let buf = BytesMut::default().writer();
         Event::<CurrentNetwork>::deserialize(buf.get_ref().clone()).unwrap();
     }
 
     #[test]
     fn deserializing_invalid_data_panics() {
-        let mut buf = BytesMut::with_capacity(64).writer();
-        let invalid_id = 11u16;
+        let mut buf = BytesMut::default().writer();
+        let invalid_id = u16::MAX;
         bincode::serialize_into(&mut buf, &invalid_id).unwrap();
         assert_eq!(
             Event::<CurrentNetwork>::deserialize(buf.get_ref().clone()).unwrap_err().to_string(),

--- a/node/narwhal/src/event/mod.rs
+++ b/node/narwhal/src/event/mod.rs
@@ -178,3 +178,94 @@ impl<N: Network> Event<N> {
         Ok(event)
     }
 }
+
+#[cfg(test)]
+mod prop_tests {
+    use crate::{
+        event::{
+            batch_certified::prop_tests::any_batch_certified,
+            batch_propose::prop_tests::any_batch_propose,
+            batch_signature::prop_tests::any_batch_signature,
+            certificate_request::prop_tests::any_certificate_request,
+            certificate_response::prop_tests::any_certificate_response,
+            challenge_request::prop_tests::any_challenge_request,
+            challenge_response::prop_tests::any_challenge_response,
+            transmission_request::prop_tests::any_transmission_request,
+            transmission_response::prop_tests::any_transmission_response,
+            worker_ping::prop_tests::any_worker_ping,
+        },
+        Disconnect,
+        DisconnectReason,
+        Event,
+    };
+    use bytes::{BufMut, BytesMut};
+    use proptest::{
+        prelude::{any, BoxedStrategy, Just, Strategy},
+        prop_oneof,
+        sample::Selector,
+    };
+    use test_strategy::proptest;
+
+    type CurrentNetwork = snarkvm::prelude::Testnet3;
+
+    fn any_event() -> BoxedStrategy<Event<CurrentNetwork>> {
+        prop_oneof![
+            any_batch_certified().prop_map(Event::BatchCertified),
+            any_batch_propose().prop_map(Event::BatchPropose),
+            any_batch_signature().prop_map(Event::BatchSignature),
+            any_certificate_request().prop_map(Event::CertificateRequest),
+            any_certificate_response().prop_map(Event::CertificateResponse),
+            any_challenge_request().prop_map(Event::ChallengeRequest),
+            any_challenge_response().prop_map(Event::ChallengeResponse),
+            (
+                Just(vec![
+                    DisconnectReason::ProtocolViolation,
+                    DisconnectReason::NoReasonGiven,
+                    DisconnectReason::InvalidChallengeResponse,
+                    DisconnectReason::OutdatedClientVersion,
+                ]),
+                any::<Selector>()
+            )
+                .prop_map(|(reasons, selector)| Event::Disconnect(Disconnect::from(selector.select(reasons)))),
+            any_transmission_request().prop_map(Event::TransmissionRequest),
+            any_transmission_response().prop_map(Event::TransmissionResponse),
+            any_worker_ping().prop_map(Event::WorkerPing)
+        ]
+        .boxed()
+    }
+
+    #[proptest]
+    fn serialize_deserialize(#[strategy(any_event())] original: Event<CurrentNetwork>) {
+        let mut buf = BytesMut::with_capacity(64).writer();
+        Event::serialize(&original, &mut buf).unwrap();
+
+        let deserialized: Event<CurrentNetwork> = Event::deserialize(buf.get_ref().clone()).unwrap();
+        assert_eq!(original.id(), deserialized.id());
+        assert_eq!(original.name(), deserialized.name());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Event;
+    use bytes::{BufMut, BytesMut};
+    type CurrentNetwork = snarkvm::prelude::Testnet3;
+
+    #[test]
+    #[should_panic(expected = "Missing event ID")]
+    fn deserializing_empty_defaults_no_reason() {
+        let buf = BytesMut::with_capacity(64).writer();
+        Event::<CurrentNetwork>::deserialize(buf.get_ref().clone()).unwrap();
+    }
+
+    #[test]
+    fn deserializing_invalid_data_panics() {
+        let mut buf = BytesMut::with_capacity(64).writer();
+        let invalid_id = 11u16;
+        bincode::serialize_into(&mut buf, &invalid_id).unwrap();
+        assert_eq!(
+            Event::<CurrentNetwork>::deserialize(buf.get_ref().clone()).unwrap_err().to_string(),
+            format!("Unknown event ID {invalid_id}")
+        );
+    }
+}

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -59,7 +59,7 @@ impl<N: Network> EventTrait for TransmissionRequest<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{
         event::EventTrait,
         helpers::storage::prop_tests::{any_puzzle_commitment, any_transaction_id},
@@ -82,7 +82,7 @@ mod prop_tests {
         .boxed()
     }
 
-    fn any_transmission_request() -> BoxedStrategy<TransmissionRequest<CurrentNetwork>> {
+    pub fn any_transmission_request() -> BoxedStrategy<TransmissionRequest<CurrentNetwork>> {
         any_transmission_id().prop_map(TransmissionRequest::new).boxed()
     }
 

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -88,7 +88,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_transmission_request())] original: TransmissionRequest<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         TransmissionRequest::serialize(&original, &mut buf).unwrap();
 
         let deserialized = TransmissionRequest::deserialize(buf.get_ref().clone()).unwrap();

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -62,7 +62,7 @@ impl<N: Network> EventTrait for TransmissionResponse<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{
         event::EventTrait,
         helpers::storage::prop_tests::{any_puzzle_commitment, any_transaction_id},
@@ -79,7 +79,7 @@ mod prop_tests {
     use test_strategy::proptest;
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_transmission() -> BoxedStrategy<(TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>)> {
+    pub fn any_transmission() -> BoxedStrategy<(TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>)> {
         prop_oneof![
             (any_puzzle_commitment(), collection::vec(any::<u8>(), 256..=256)).prop_map(|(pc, bytes)| (
                 TransmissionID::Solution(pc),

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -60,3 +60,51 @@ impl<N: Network> EventTrait for TransmissionResponse<N> {
         Ok(Self { transmission_id, transmission })
     }
 }
+
+#[cfg(test)]
+mod prop_tests {
+    use crate::{
+        event::EventTrait,
+        helpers::storage::prop_tests::{any_puzzle_commitment, any_transaction_id},
+        TransmissionResponse,
+    };
+    use ::bytes::Bytes;
+    use bytes::{BufMut, BytesMut};
+    use proptest::{
+        collection,
+        prelude::{any, BoxedStrategy, Strategy},
+        prop_oneof,
+    };
+    use snarkvm::ledger::narwhal::{Data, Transmission, TransmissionID};
+    use test_strategy::proptest;
+    type CurrentNetwork = snarkvm::prelude::Testnet3;
+
+    fn any_transmission() -> BoxedStrategy<(TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>)> {
+        prop_oneof![
+            (any_puzzle_commitment(), collection::vec(any::<u8>(), 256..=256)).prop_map(|(pc, bytes)| (
+                TransmissionID::Solution(pc),
+                Transmission::Solution(Data::Buffer(Bytes::from(bytes)))
+            )),
+            (any_transaction_id(), collection::vec(any::<u8>(), 512..=512)).prop_map(|(tid, bytes)| (
+                TransmissionID::Transaction(tid),
+                Transmission::Transaction(Data::Buffer(Bytes::from(bytes)))
+            )),
+        ]
+        .boxed()
+    }
+
+    #[proptest]
+    fn serialize_deserialize(
+        #[strategy(any_transmission())] input: (TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>),
+    ) {
+        let (id, transmission) = input;
+        let response = TransmissionResponse::new(id, transmission.clone());
+
+        let mut buf = BytesMut::with_capacity(64).writer();
+        TransmissionResponse::serialize(&response, &mut buf).unwrap();
+
+        let response = TransmissionResponse::deserialize(buf.get_ref().clone()).unwrap();
+        assert_eq!(id, response.transmission_id);
+        assert_eq!(transmission, response.transmission);
+    }
+}

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -100,7 +100,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_transmission_response())] original: TransmissionResponse<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         TransmissionResponse::serialize(&original, &mut buf).unwrap();
 
         let deserialized = TransmissionResponse::deserialize(buf.get_ref().clone()).unwrap();

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -66,7 +66,7 @@ impl<N: Network> EventTrait for WorkerPing<N> {
 }
 
 #[cfg(test)]
-mod prop_tests {
+pub mod prop_tests {
     use crate::{event::EventTrait, helpers::storage::prop_tests::any_transmission_id, WorkerPing};
     use bytes::{BufMut, BytesMut};
     use proptest::{
@@ -76,7 +76,7 @@ mod prop_tests {
     use test_strategy::proptest;
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
-    fn any_worker_ping() -> BoxedStrategy<WorkerPing<CurrentNetwork>> {
+    pub fn any_worker_ping() -> BoxedStrategy<WorkerPing<CurrentNetwork>> {
         hash_set(any_transmission_id(), 1..16).prop_map(|ids| WorkerPing::new(ids.into_iter().collect())).boxed()
     }
 

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -64,3 +64,34 @@ impl<N: Network> EventTrait for WorkerPing<N> {
         Ok(Self { transmission_ids })
     }
 }
+
+#[cfg(test)]
+mod prop_tests {
+    use crate::{event::EventTrait, helpers::storage::prop_tests::any_transmission_id, WorkerPing};
+    use bytes::{BufMut, BytesMut};
+    use indexmap::IndexSet;
+    use proptest::{
+        collection::hash_set,
+        prelude::{BoxedStrategy, Strategy},
+    };
+    use snarkvm::ledger::narwhal::TransmissionID;
+    use std::collections::HashSet;
+    use test_strategy::proptest;
+    type CurrentNetwork = snarkvm::prelude::Testnet3;
+
+    fn any_ids() -> BoxedStrategy<HashSet<TransmissionID<CurrentNetwork>>> {
+        hash_set(any_transmission_id(), 1..16).boxed()
+    }
+
+    #[proptest]
+    fn serialize_deserialize(#[strategy(any_ids())] ids: HashSet<TransmissionID<CurrentNetwork>>) {
+        let input: IndexSet<TransmissionID<CurrentNetwork>> = ids.into_iter().collect();
+        let worker_ping = WorkerPing::new(input.clone());
+
+        let mut buf = BytesMut::with_capacity(64).writer();
+        WorkerPing::serialize(&worker_ping, &mut buf).unwrap();
+
+        let output = WorkerPing::deserialize(buf.get_ref().clone()).unwrap().transmission_ids;
+        assert_eq!(input, output);
+    }
+}

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -82,7 +82,7 @@ pub mod prop_tests {
 
     #[proptest]
     fn serialize_deserialize(#[strategy(any_worker_ping())] original: WorkerPing<CurrentNetwork>) {
-        let mut buf = BytesMut::with_capacity(64).writer();
+        let mut buf = BytesMut::default().writer();
         WorkerPing::serialize(&original, &mut buf).unwrap();
 
         let deserialized = WorkerPing::deserialize(buf.get_ref().clone()).unwrap();

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -899,11 +899,11 @@ pub mod prop_tests {
         .boxed()
     }
 
-    fn any_puzzle_commitment() -> BoxedStrategy<PuzzleCommitment<CurrentNetwork>> {
+    pub fn any_puzzle_commitment() -> BoxedStrategy<PuzzleCommitment<CurrentNetwork>> {
         Just(0).prop_perturb(|_, rng| PuzzleCommitment::from_g1_affine(CryptoTestRng(rng).gen())).boxed()
     }
 
-    fn any_transaction_id() -> BoxedStrategy<<CurrentNetwork as Network>::TransactionID> {
+    pub fn any_transaction_id() -> BoxedStrategy<<CurrentNetwork as Network>::TransactionID> {
         Just(0)
             .prop_perturb(|_, rng| {
                 <CurrentNetwork as Network>::TransactionID::from(Field::rand(&mut CryptoTestRng(rng)))

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -911,7 +911,7 @@ pub mod prop_tests {
             .boxed()
     }
 
-    fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
+    pub fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
         prop_oneof![
             any_transaction_id().prop_map(TransmissionID::Transaction),
             any_puzzle_commitment().prop_map(TransmissionID::Solution),

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -919,7 +919,7 @@ pub mod prop_tests {
         .boxed()
     }
 
-    fn sign_batch_header<R: Rng + CryptoRng>(
+    pub fn sign_batch_header<R: Rng + CryptoRng>(
         validator_set: &ValidatorSet,
         batch_header: &BatchHeader<CurrentNetwork>,
         rng: &mut R,


### PR DESCRIPTION
This PR adds property tests to BFT events in `snarkos-node-narwhal`-crate. Most of the event implementation is deserialization and serialization logic, which lends itself well for proptesting. 