### PR TITLE
[Narwhal] Event serialization tweaks

### DIFF
--- a/node/messages/src/beacon_propose.rs
+++ b/node/messages/src/beacon_propose.rs
@@ -43,10 +43,10 @@ impl<N: Network> MessageTrait for BeaconPropose<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.version.to_le_bytes())?;
-        writer.write_all(&self.round.to_le_bytes())?;
-        writer.write_all(&self.block_height.to_le_bytes())?;
-        writer.write_all(&self.block_hash.to_bytes_le()?)?;
+        self.version.write_le(&mut *writer)?;
+        self.round.write_le(&mut *writer)?;
+        self.block_height.write_le(&mut *writer)?;
+        self.block_hash.write_le(&mut *writer)?;
         self.block.serialize_blocking_into(writer)
     }
 

--- a/node/messages/src/beacon_propose.rs
+++ b/node/messages/src/beacon_propose.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BeaconPropose<N: Network> {
     pub version: u8,
@@ -36,8 +38,8 @@ impl<N: Network> BeaconPropose<N> {
 impl<N: Network> MessageTrait for BeaconPropose<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        format!("BeaconPropose {}", self.block_height)
+    fn name(&self) -> Cow<'static, str> {
+        format!("BeaconPropose {}", self.block_height).into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/beacon_timeout.rs
+++ b/node/messages/src/beacon_timeout.rs
@@ -43,10 +43,10 @@ impl<N: Network> MessageTrait for BeaconTimeout<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.version.to_le_bytes())?;
-        writer.write_all(&self.round.to_le_bytes())?;
-        writer.write_all(&self.block_height.to_le_bytes())?;
-        writer.write_all(&self.block_hash.to_bytes_le()?)?;
+        self.version.write_le(&mut *writer)?;
+        self.round.write_le(&mut *writer)?;
+        self.block_height.write_le(&mut *writer)?;
+        self.block_hash.write_le(&mut *writer)?;
         self.signature.serialize_blocking_into(writer)
     }
 

--- a/node/messages/src/beacon_timeout.rs
+++ b/node/messages/src/beacon_timeout.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BeaconTimeout<N: Network> {
     pub version: u8,
@@ -36,8 +38,8 @@ impl<N: Network> BeaconTimeout<N> {
 impl<N: Network> MessageTrait for BeaconTimeout<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        format!("BeaconTimeout {}", self.block_height)
+    fn name(&self) -> Cow<'static, str> {
+        format!("BeaconTimeout {}", self.block_height).into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/beacon_vote.rs
+++ b/node/messages/src/beacon_vote.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BeaconVote<N: Network> {
     pub version: u8,
@@ -43,8 +45,8 @@ impl<N: Network> BeaconVote<N> {
 impl<N: Network> MessageTrait for BeaconVote<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        format!("BeaconVote {}", self.block_height)
+    fn name(&self) -> Cow<'static, str> {
+        format!("BeaconVote {}", self.block_height).into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/beacon_vote.rs
+++ b/node/messages/src/beacon_vote.rs
@@ -50,11 +50,11 @@ impl<N: Network> MessageTrait for BeaconVote<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.version.to_le_bytes())?;
-        writer.write_all(&self.round.to_le_bytes())?;
-        writer.write_all(&self.block_height.to_le_bytes())?;
-        writer.write_all(&self.block_hash.to_bytes_le()?)?;
-        writer.write_all(&self.timestamp.to_le_bytes())?;
+        self.version.write_le(&mut *writer)?;
+        self.round.write_le(&mut *writer)?;
+        self.block_height.write_le(&mut *writer)?;
+        self.block_hash.write_le(&mut *writer)?;
+        self.timestamp.write_le(&mut *writer)?;
         self.signature.serialize_blocking_into(writer)
     }
 

--- a/node/messages/src/block_request.rs
+++ b/node/messages/src/block_request.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BlockRequest {
     /// The starting block height (inclusive).
@@ -25,13 +27,14 @@ pub struct BlockRequest {
 impl MessageTrait for BlockRequest {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
+    fn name(&self) -> Cow<'static, str> {
         let start = self.start_height;
         let end = self.end_height;
         match start + 1 == end {
             true => format!("BlockRequest {start}"),
             false => format!("BlockRequest {start}..{end}"),
         }
+        .into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/block_response.rs
+++ b/node/messages/src/block_response.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockResponse<N: Network> {
     /// The original block request.
@@ -25,13 +27,14 @@ pub struct BlockResponse<N: Network> {
 impl<N: Network> MessageTrait for BlockResponse<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
+    fn name(&self) -> Cow<'static, str> {
         let start = self.request.start_height;
         let end = self.request.end_height;
         match start + 1 == end {
             true => format!("BlockResponse {start}"),
             false => format!("BlockResponse {start}..{end}"),
         }
+        .into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/challenge_request.rs
+++ b/node/messages/src/challenge_request.rs
@@ -15,6 +15,7 @@
 use super::*;
 
 use bincode::Options;
+use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChallengeRequest<N: Network> {
@@ -28,8 +29,8 @@ pub struct ChallengeRequest<N: Network> {
 impl<N: Network> MessageTrait for ChallengeRequest<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "ChallengeRequest".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "ChallengeRequest".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/challenge_response.rs
+++ b/node/messages/src/challenge_response.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChallengeResponse<N: Network> {
     pub genesis_header: Header<N>,
@@ -23,8 +25,8 @@ pub struct ChallengeResponse<N: Network> {
 impl<N: Network> MessageTrait for ChallengeResponse<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "ChallengeResponse".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "ChallengeResponse".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/challenge_response.rs
+++ b/node/messages/src/challenge_response.rs
@@ -30,7 +30,7 @@ impl<N: Network> MessageTrait for ChallengeResponse<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.genesis_header.to_bytes_le()?)?;
+        self.genesis_header.write_le(&mut *writer)?;
         self.signature.serialize_blocking_into(writer)
     }
 

--- a/node/messages/src/disconnect.rs
+++ b/node/messages/src/disconnect.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Disconnect {
     pub reason: DisconnectReason,
@@ -28,8 +30,8 @@ impl From<DisconnectReason> for Disconnect {
 impl MessageTrait for Disconnect {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "Disconnect".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "Disconnect".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -179,7 +179,7 @@ impl<N: Network> Message<N> {
     /// Serializes the message into the buffer.
     #[inline]
     pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.id().to_le_bytes()[..])?;
+        self.id().write_le(&mut *writer)?;
 
         match self {
             Self::BeaconPropose(message) => message.serialize(writer),

--- a/node/messages/src/lib.rs
+++ b/node/messages/src/lib.rs
@@ -82,6 +82,7 @@ use snarkvm::prelude::{
 use ::bytes::{Buf, BytesMut};
 use anyhow::{bail, Result};
 use std::{
+    borrow::Cow,
     fmt,
     fmt::{Display, Formatter},
     io::{Read, Result as IoResult, Write},
@@ -91,7 +92,7 @@ use std::{
 
 pub trait MessageTrait {
     /// Returns the message name.
-    fn name(&self) -> String;
+    fn name(&self) -> Cow<'static, str>;
     /// Serializes the message into the buffer.
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()>;
     /// Deserializes the given buffer into a message.
@@ -132,7 +133,7 @@ impl<N: Network> Message<N> {
 
     /// Returns the message name.
     #[inline]
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> Cow<'static, str> {
         match self {
             Self::BeaconPropose(message) => message.name(),
             Self::BeaconTimeout(message) => message.name(),

--- a/node/messages/src/peer_request.rs
+++ b/node/messages/src/peer_request.rs
@@ -14,14 +14,16 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerRequest;
 
 impl MessageTrait for PeerRequest {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "PeerRequest".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "PeerRequest".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/peer_response.rs
+++ b/node/messages/src/peer_response.rs
@@ -15,6 +15,7 @@
 use super::*;
 
 use bincode::Options;
+use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PeerResponse {
@@ -24,8 +25,8 @@ pub struct PeerResponse {
 impl MessageTrait for PeerResponse {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "PeerResponse".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "PeerResponse".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/ping.rs
+++ b/node/messages/src/ping.rs
@@ -15,6 +15,7 @@
 use super::*;
 
 use bincode::Options;
+use std::borrow::Cow;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Ping<N: Network> {
@@ -26,8 +27,8 @@ pub struct Ping<N: Network> {
 impl<N: Network> MessageTrait for Ping<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "Ping".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "Ping".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/pong.rs
+++ b/node/messages/src/pong.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Pong {
     pub is_fork: Option<bool>,
@@ -22,8 +24,8 @@ pub struct Pong {
 impl MessageTrait for Pong {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "Pong".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "Pong".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/puzzle_request.rs
+++ b/node/messages/src/puzzle_request.rs
@@ -14,14 +14,16 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PuzzleRequest;
 
 impl MessageTrait for PuzzleRequest {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "PuzzleRequest".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "PuzzleRequest".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/puzzle_response.rs
+++ b/node/messages/src/puzzle_response.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PuzzleResponse<N: Network> {
     pub epoch_challenge: EpochChallenge<N>,
@@ -23,8 +25,8 @@ pub struct PuzzleResponse<N: Network> {
 impl<N: Network> MessageTrait for PuzzleResponse<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "PuzzleResponse".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "PuzzleResponse".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/puzzle_response.rs
+++ b/node/messages/src/puzzle_response.rs
@@ -30,7 +30,7 @@ impl<N: Network> MessageTrait for PuzzleResponse<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.epoch_challenge.to_bytes_le()?)?;
+        self.epoch_challenge.write_le(&mut *writer)?;
         self.block_header.serialize_blocking_into(writer)
     }
 

--- a/node/messages/src/unconfirmed_solution.rs
+++ b/node/messages/src/unconfirmed_solution.rs
@@ -30,7 +30,7 @@ impl<N: Network> MessageTrait for UnconfirmedSolution<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.puzzle_commitment.to_bytes_le()?)?;
+        self.puzzle_commitment.write_le(&mut *writer)?;
         self.solution.serialize_blocking_into(writer)
     }
 

--- a/node/messages/src/unconfirmed_solution.rs
+++ b/node/messages/src/unconfirmed_solution.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnconfirmedSolution<N: Network> {
     pub puzzle_commitment: PuzzleCommitment<N>,
@@ -23,8 +25,8 @@ pub struct UnconfirmedSolution<N: Network> {
 impl<N: Network> MessageTrait for UnconfirmedSolution<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "UnconfirmedSolution".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "UnconfirmedSolution".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/unconfirmed_transaction.rs
+++ b/node/messages/src/unconfirmed_transaction.rs
@@ -14,6 +14,8 @@
 
 use super::*;
 
+use std::borrow::Cow;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnconfirmedTransaction<N: Network> {
     pub transaction_id: N::TransactionID,
@@ -23,8 +25,8 @@ pub struct UnconfirmedTransaction<N: Network> {
 impl<N: Network> MessageTrait for UnconfirmedTransaction<N> {
     /// Returns the message name.
     #[inline]
-    fn name(&self) -> String {
-        "UnconfirmedTransaction".to_string()
+    fn name(&self) -> Cow<'static, str> {
+        "UnconfirmedTransaction".into()
     }
 
     /// Serializes the message into the buffer.

--- a/node/messages/src/unconfirmed_transaction.rs
+++ b/node/messages/src/unconfirmed_transaction.rs
@@ -30,7 +30,7 @@ impl<N: Network> MessageTrait for UnconfirmedTransaction<N> {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.transaction_id.to_bytes_le()?)?;
+        self.transaction_id.write_le(&mut *writer)?;
         self.transaction.serialize_blocking_into(writer)
     }
 

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -44,7 +44,7 @@ impl<N: Network> EventTrait for BatchPropose<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.round.to_le_bytes())?;
+        self.round.write_le(&mut *writer)?;
         self.batch_header.serialize_blocking_into(writer)
     }
 

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -38,9 +38,9 @@ impl<N: Network> EventTrait for BatchSignature<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.batch_id.to_bytes_le()?)?;
-        writer.write_all(&self.signature.to_bytes_le()?)?;
-        writer.write_all(&self.timestamp.to_bytes_le()?)?;
+        self.batch_id.write_le(&mut *writer)?;
+        self.signature.write_le(&mut *writer)?;
+        self.timestamp.write_le(&mut *writer)?;
         Ok(())
     }
 

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -43,7 +43,7 @@ impl<N: Network> EventTrait for CertificateRequest<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.certificate_id.to_bytes_le()?)?;
+        self.certificate_id.write_le(writer)?;
         Ok(())
     }
 

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -43,7 +43,7 @@ impl<N: Network> EventTrait for CertificateResponse<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.certificate.to_bytes_le()?)?;
+        self.certificate.write_le(writer)?;
         Ok(())
     }
 

--- a/node/narwhal/src/event/mod.rs
+++ b/node/narwhal/src/event/mod.rs
@@ -131,7 +131,7 @@ impl<N: Network> Event<N> {
     /// Serializes the event into the buffer.
     #[inline]
     pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.id().to_le_bytes()[..])?;
+        self.id().write_le(&mut *writer)?;
 
         match self {
             Self::BatchPropose(event) => event.serialize(writer),

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -43,7 +43,7 @@ impl<N: Network> EventTrait for TransmissionRequest<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.transmission_id.to_bytes_le()?)?;
+        self.transmission_id.write_le(writer)?;
         Ok(())
     }
 

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -44,8 +44,8 @@ impl<N: Network> EventTrait for TransmissionResponse<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&self.transmission_id.to_bytes_le()?)?;
-        writer.write_all(&self.transmission.to_bytes_le()?)?;
+        self.transmission_id.write_le(&mut *writer)?;
+        self.transmission.write_le(writer)?;
         Ok(())
     }
 

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -43,9 +43,9 @@ impl<N: Network> EventTrait for WorkerPing<N> {
     /// Serializes the event into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writer.write_all(&(self.transmission_ids.len() as u32).to_bytes_le()?)?;
+        (self.transmission_ids.len() as u32).write_le(&mut *writer)?;
         for transmission_id in &self.transmission_ids {
-            writer.write_all(&transmission_id.to_bytes_le()?)?;
+            transmission_id.write_le(&mut *writer)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR reduces the number of allocations when serializing `Event` objects.

Similar improvements are likely possible in `Message`, I'm going to look at those next.