### PR TITLE
[Narwhal] use ToBytes and FromBytes in Events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,7 +3165,6 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "bincode 1.3.3",
  "bytes",
  "clap",
  "deadline",

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -25,9 +25,6 @@ version = "1.0"
 [dependencies.async-trait]
 version = "0.1"
 
-[dependencies.bincode]
-version = "1.0"
-
 [dependencies.bytes]
 version = "1"
 

--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -40,12 +40,6 @@ impl<N: Network> EventTrait for BatchCertified<N> {
         "BatchCertified"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.certificate.serialize_blocking_into(writer)
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -54,6 +48,13 @@ impl<N: Network> EventTrait for BatchCertified<N> {
         let certificate = Data::Buffer(reader.into_inner().freeze());
 
         Ok(Self { certificate })
+    }
+}
+
+impl<N: Network> ToBytes for BatchCertified<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.certificate.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -39,22 +39,20 @@ impl<N: Network> EventTrait for BatchCertified<N> {
     fn name(&self) -> &'static str {
         "BatchCertified"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let reader = bytes.reader();
-
-        let certificate = Data::Buffer(reader.into_inner().freeze());
-
-        Ok(Self { certificate })
-    }
 }
 
 impl<N: Network> ToBytes for BatchCertified<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         self.certificate.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for BatchCertified<N> {
+    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
+        let certificate = Data::read_le(reader)?;
+
+        Ok(Self { certificate })
     }
 }
 

--- a/node/narwhal/src/event/batch_certified.rs
+++ b/node/narwhal/src/event/batch_certified.rs
@@ -58,12 +58,10 @@ impl<N: Network> FromBytes for BatchCertified<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{
-        event::{certificate_response::prop_tests::any_batch_certificate, EventTrait},
-        BatchCertified,
-    };
-    use bytes::{BufMut, BytesMut};
+    use crate::{event::certificate_response::prop_tests::any_batch_certificate, BatchCertified};
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::prelude::{BoxedStrategy, Strategy};
+    use snarkvm::console::prelude::{FromBytes, ToBytes};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
@@ -75,9 +73,9 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_batch_certified())] original: BatchCertified<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        BatchCertified::serialize(&original, &mut buf).unwrap();
+        BatchCertified::write_le(&original, &mut buf).unwrap();
 
-        let deserialized: BatchCertified<CurrentNetwork> = BatchCertified::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized: BatchCertified<CurrentNetwork> = BatchCertified::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(
             original.certificate.deserialize_blocking().unwrap(),
             deserialized.certificate.deserialize_blocking().unwrap()

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -41,13 +41,6 @@ impl<N: Network> EventTrait for BatchPropose<N> {
         "BatchPropose"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.round.write_le(&mut *writer)?;
-        self.batch_header.serialize_blocking_into(writer)
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -57,6 +50,14 @@ impl<N: Network> EventTrait for BatchPropose<N> {
         let batch_header = Data::Buffer(reader.into_inner().freeze());
 
         Ok(Self { round, batch_header })
+    }
+}
+
+impl<N: Network> ToBytes for BatchPropose<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.round.write_le(&mut writer)?;
+        self.batch_header.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/batch_propose.rs
+++ b/node/narwhal/src/event/batch_propose.rs
@@ -40,17 +40,6 @@ impl<N: Network> EventTrait for BatchPropose<N> {
     fn name(&self) -> &'static str {
         "BatchPropose"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-
-        let round = u64::read_le(&mut reader)?;
-        let batch_header = Data::Buffer(reader.into_inner().freeze());
-
-        Ok(Self { round, batch_header })
-    }
 }
 
 impl<N: Network> ToBytes for BatchPropose<N> {
@@ -58,6 +47,15 @@ impl<N: Network> ToBytes for BatchPropose<N> {
         self.round.write_le(&mut writer)?;
         self.batch_header.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for BatchPropose<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let round = u64::read_le(&mut reader)?;
+        let batch_header = Data::read_le(&mut reader)?;
+
+        Ok(Self { round, batch_header })
     }
 }
 

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -34,17 +34,6 @@ impl<N: Network> EventTrait for BatchSignature<N> {
     fn name(&self) -> &'static str {
         "BatchSignature"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-        Ok(Self {
-            batch_id: Field::read_le(&mut reader)?,
-            signature: Signature::read_le(&mut reader)?,
-            timestamp: i64::read_le(&mut reader)?,
-        })
-    }
 }
 
 impl<N: Network> ToBytes for BatchSignature<N> {
@@ -53,6 +42,16 @@ impl<N: Network> ToBytes for BatchSignature<N> {
         self.signature.write_le(&mut writer)?;
         self.timestamp.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for BatchSignature<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let batch_id = Field::read_le(&mut reader)?;
+        let signature = Signature::read_le(&mut reader)?;
+        let timestamp = i64::read_le(&mut reader)?;
+
+        Ok(Self { batch_id, signature, timestamp })
     }
 }
 

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -35,15 +35,6 @@ impl<N: Network> EventTrait for BatchSignature<N> {
         "BatchSignature"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.batch_id.write_le(&mut *writer)?;
-        self.signature.write_le(&mut *writer)?;
-        self.timestamp.write_le(&mut *writer)?;
-        Ok(())
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -53,6 +44,15 @@ impl<N: Network> EventTrait for BatchSignature<N> {
             signature: Signature::read_le(&mut reader)?,
             timestamp: i64::read_le(&mut reader)?,
         })
+    }
+}
+
+impl<N: Network> ToBytes for BatchSignature<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.batch_id.write_le(&mut writer)?;
+        self.signature.write_le(&mut writer)?;
+        self.timestamp.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/batch_signature.rs
+++ b/node/narwhal/src/event/batch_signature.rs
@@ -58,16 +58,13 @@ impl<N: Network> FromBytes for BatchSignature<N> {
 #[cfg(test)]
 pub mod prop_tests {
     use crate::{
-        event::{
-            certificate_request::prop_tests::any_field,
-            challenge_response::prop_tests::any_signature,
-            EventTrait,
-        },
+        event::{certificate_request::prop_tests::any_field, challenge_response::prop_tests::any_signature},
         helpers::now,
         BatchSignature,
     };
-    use bytes::{BufMut, BytesMut};
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::prelude::{BoxedStrategy, Just, Strategy};
+    use snarkvm::console::prelude::{FromBytes, ToBytes};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
@@ -83,9 +80,9 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_batch_signature())] original: BatchSignature<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        BatchSignature::serialize(&original, &mut buf).unwrap();
+        BatchSignature::write_le(&original, &mut buf).unwrap();
 
-        let deserialized: BatchSignature<CurrentNetwork> = BatchSignature::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized: BatchSignature<CurrentNetwork> = BatchSignature::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -39,22 +39,20 @@ impl<N: Network> EventTrait for CertificateRequest<N> {
     fn name(&self) -> &'static str {
         "CertificateRequest"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-
-        let certificate_id = Field::read_le(&mut reader)?;
-
-        Ok(Self { certificate_id })
-    }
 }
 
 impl<N: Network> ToBytes for CertificateRequest<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         self.certificate_id.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for CertificateRequest<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let certificate_id = Field::read_le(&mut reader)?;
+
+        Ok(Self { certificate_id })
     }
 }
 

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -58,10 +58,13 @@ impl<N: Network> FromBytes for CertificateRequest<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{event::EventTrait, helpers::storage::prop_tests::CryptoTestRng, CertificateRequest};
-    use bytes::{BufMut, BytesMut};
+    use crate::{helpers::storage::prop_tests::CryptoTestRng, CertificateRequest};
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::prelude::{any, BoxedStrategy, Strategy};
-    use snarkvm::prelude::{Field, Uniform};
+    use snarkvm::{
+        console::prelude::{FromBytes, ToBytes},
+        prelude::{Field, Uniform},
+    };
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
@@ -77,10 +80,10 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_certificate_request())] original: CertificateRequest<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        CertificateRequest::serialize(&original, &mut buf).unwrap();
+        CertificateRequest::write_le(&original, &mut buf).unwrap();
 
         let deserialized: CertificateRequest<CurrentNetwork> =
-            CertificateRequest::deserialize(buf.get_ref().clone()).unwrap();
+            CertificateRequest::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/certificate_request.rs
+++ b/node/narwhal/src/event/certificate_request.rs
@@ -40,13 +40,6 @@ impl<N: Network> EventTrait for CertificateRequest<N> {
         "CertificateRequest"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.certificate_id.write_le(writer)?;
-        Ok(())
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -55,6 +48,13 @@ impl<N: Network> EventTrait for CertificateRequest<N> {
         let certificate_id = Field::read_le(&mut reader)?;
 
         Ok(Self { certificate_id })
+    }
+}
+
+impl<N: Network> ToBytes for CertificateRequest<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.certificate_id.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -39,22 +39,20 @@ impl<N: Network> EventTrait for CertificateResponse<N> {
     fn name(&self) -> &'static str {
         "CertificateResponse"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-
-        let certificate = BatchCertificate::read_le(&mut reader)?;
-
-        Ok(Self { certificate })
-    }
 }
 
 impl<N: Network> ToBytes for CertificateResponse<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         self.certificate.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for CertificateResponse<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let certificate = BatchCertificate::read_le(&mut reader)?;
+
+        Ok(Self { certificate })
     }
 }
 

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -59,21 +59,24 @@ impl<N: Network> FromBytes for CertificateResponse<N> {
 #[cfg(test)]
 pub mod prop_tests {
     use crate::{
-        event::{transmission_response::prop_tests::any_transmission, EventTrait},
+        event::transmission_response::prop_tests::any_transmission,
         helpers::{
             now,
             storage::prop_tests::{sign_batch_header, CryptoTestRng},
         },
         CertificateResponse,
     };
-    use bytes::{BufMut, BytesMut};
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::{
         collection::vec,
         prelude::{any, BoxedStrategy, Just, Strategy},
         sample::Selector,
     };
     use snarkos_node_narwhal_committee::prop_tests::{CommitteeContext, ValidatorSet};
-    use snarkvm::ledger::narwhal::{BatchCertificate, BatchHeader};
+    use snarkvm::{
+        console::prelude::{FromBytes, ToBytes},
+        ledger::narwhal::{BatchCertificate, BatchHeader},
+    };
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
@@ -109,10 +112,10 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_certificate_response())] original: CertificateResponse<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        CertificateResponse::serialize(&original, &mut buf).unwrap();
+        CertificateResponse::write_le(&original, &mut buf).unwrap();
 
         let deserialized: CertificateResponse<CurrentNetwork> =
-            CertificateResponse::deserialize(buf.get_ref().clone()).unwrap();
+            CertificateResponse::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/certificate_response.rs
+++ b/node/narwhal/src/event/certificate_response.rs
@@ -40,13 +40,6 @@ impl<N: Network> EventTrait for CertificateResponse<N> {
         "CertificateResponse"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.certificate.write_le(writer)?;
-        Ok(())
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -55,6 +48,13 @@ impl<N: Network> EventTrait for CertificateResponse<N> {
         let certificate = BatchCertificate::read_le(&mut reader)?;
 
         Ok(Self { certificate })
+    }
+}
+
+impl<N: Network> ToBytes for CertificateResponse<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.certificate.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -35,13 +35,6 @@ impl<N: Network> EventTrait for ChallengeRequest<N> {
     fn name(&self) -> &'static str {
         "ChallengeRequest"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let (version, listener_port, address, nonce) = bincode::deserialize_from(&mut bytes.reader())?;
-        Ok(Self { version, listener_port, address, nonce })
-    }
 }
 
 impl<N: Network> ToBytes for ChallengeRequest<N> {
@@ -51,6 +44,17 @@ impl<N: Network> ToBytes for ChallengeRequest<N> {
         self.address.write_le(&mut writer)?;
         self.nonce.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for ChallengeRequest<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let version = u32::read_le(&mut reader)?;
+        let listener_port = u16::read_le(&mut reader)?;
+        let address = Address::<N>::read_le(&mut reader)?;
+        let nonce = u64::read_le(&mut reader)?;
+
+        Ok(Self { version, listener_port, address, nonce })
     }
 }
 

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -60,10 +60,11 @@ impl<N: Network> FromBytes for ChallengeRequest<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{event::EventTrait, ChallengeRequest};
-    use bytes::{BufMut, BytesMut};
+    use crate::ChallengeRequest;
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use snarkos_node_narwhal_committee::prop_tests::any_valid_account;
+    use snarkvm::console::prelude::{FromBytes, ToBytes};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::Testnet3;
@@ -82,10 +83,10 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_challenge_request())] original: ChallengeRequest<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        ChallengeRequest::serialize(&original, &mut buf).unwrap();
+        ChallengeRequest::write_le(&original, &mut buf).unwrap();
 
         let deserialized: ChallengeRequest<CurrentNetwork> =
-            ChallengeRequest::deserialize(buf.get_ref().clone()).unwrap();
+            ChallengeRequest::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/challenge_request.rs
+++ b/node/narwhal/src/event/challenge_request.rs
@@ -36,17 +36,21 @@ impl<N: Network> EventTrait for ChallengeRequest<N> {
         "ChallengeRequest"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        Ok(bincode::serialize_into(writer, &(self.version, self.listener_port, self.address, self.nonce))?)
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
         let (version, listener_port, address, nonce) = bincode::deserialize_from(&mut bytes.reader())?;
         Ok(Self { version, listener_port, address, nonce })
+    }
+}
+
+impl<N: Network> ToBytes for ChallengeRequest<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.version.write_le(&mut writer)?;
+        self.listener_port.write_le(&mut writer)?;
+        self.address.write_le(&mut writer)?;
+        self.nonce.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/challenge_response.rs
+++ b/node/narwhal/src/event/challenge_response.rs
@@ -25,19 +25,20 @@ impl<N: Network> EventTrait for ChallengeResponse<N> {
     fn name(&self) -> &'static str {
         "ChallengeResponse"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let reader = bytes.reader();
-        Ok(Self { signature: Data::Buffer(reader.into_inner().freeze()) })
-    }
 }
 
 impl<N: Network> ToBytes for ChallengeResponse<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         self.signature.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for ChallengeResponse<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let signature = Data::read_le(&mut reader)?;
+
+        Ok(Self { signature })
     }
 }
 

--- a/node/narwhal/src/event/challenge_response.rs
+++ b/node/narwhal/src/event/challenge_response.rs
@@ -26,17 +26,18 @@ impl<N: Network> EventTrait for ChallengeResponse<N> {
         "ChallengeResponse"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.signature.serialize_blocking_into(writer)
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
         let reader = bytes.reader();
         Ok(Self { signature: Data::Buffer(reader.into_inner().freeze()) })
+    }
+}
+
+impl<N: Network> ToBytes for ChallengeResponse<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.signature.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/disconnect.rs
+++ b/node/narwhal/src/event/disconnect.rs
@@ -108,7 +108,7 @@ mod tests {
     #[should_panic(expected = "Invalid 'Disconnect' event")]
     fn deserializing_invalid_data_panics() {
         let mut buf = BytesMut::default().writer();
-        bincode::serialize_into(&mut buf, "not a DisconnectReason-value").unwrap();
+        "not a DisconnectReason-value".as_bytes().write_le(&mut buf).unwrap();
         let _disconnect = Disconnect::read_le(buf.into_inner().reader()).unwrap();
     }
 }

--- a/node/narwhal/src/event/disconnect.rs
+++ b/node/narwhal/src/event/disconnect.rs
@@ -16,6 +16,7 @@ use super::*;
 
 /// The reason behind the node disconnecting from a peer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[repr(u8)]
 pub enum DisconnectReason {
     /// The peer's challenge response is invalid.
     InvalidChallengeResponse,
@@ -45,12 +46,6 @@ impl EventTrait for Disconnect {
         "Disconnect"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        Ok(bincode::serialize_into(writer, &self.reason)?)
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -61,6 +56,13 @@ impl EventTrait for Disconnect {
         } else {
             bail!("Invalid 'Disconnect' event");
         }
+    }
+}
+
+impl ToBytes for Disconnect {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (self.reason as u16).write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/mod.rs
+++ b/node/narwhal/src/event/mod.rs
@@ -55,12 +55,11 @@ use ::bytes::{Buf, BytesMut};
 use anyhow::{bail, Result};
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
+pub use std::io::Result as IoResult;
 
-pub trait EventTrait {
+pub trait EventTrait: ToBytes {
     /// Returns the event name.
     fn name(&self) -> &'static str;
-    /// Serializes the event into the buffer.
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()>;
     /// Deserializes the given buffer into a event.
     fn deserialize(bytes: BytesMut) -> Result<Self>
     where
@@ -130,21 +129,21 @@ impl<N: Network> Event<N> {
 
     /// Serializes the event into the buffer.
     #[inline]
-    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+    pub fn serialize<W: Write>(&self, writer: &mut W) -> IoResult<()> {
         self.id().write_le(&mut *writer)?;
 
         match self {
-            Self::BatchPropose(event) => event.serialize(writer),
-            Self::BatchSignature(event) => event.serialize(writer),
-            Self::BatchCertified(event) => event.serialize(writer),
-            Self::CertificateRequest(event) => event.serialize(writer),
-            Self::CertificateResponse(event) => event.serialize(writer),
-            Self::ChallengeRequest(event) => event.serialize(writer),
-            Self::ChallengeResponse(event) => event.serialize(writer),
-            Self::Disconnect(event) => event.serialize(writer),
-            Self::TransmissionRequest(event) => event.serialize(writer),
-            Self::TransmissionResponse(event) => event.serialize(writer),
-            Self::WorkerPing(event) => event.serialize(writer),
+            Self::BatchPropose(event) => event.write_le(writer),
+            Self::BatchSignature(event) => event.write_le(writer),
+            Self::BatchCertified(event) => event.write_le(writer),
+            Self::CertificateRequest(event) => event.write_le(writer),
+            Self::CertificateResponse(event) => event.write_le(writer),
+            Self::ChallengeRequest(event) => event.write_le(writer),
+            Self::ChallengeResponse(event) => event.write_le(writer),
+            Self::Disconnect(event) => event.write_le(writer),
+            Self::TransmissionRequest(event) => event.write_le(writer),
+            Self::TransmissionResponse(event) => event.write_le(writer),
+            Self::WorkerPing(event) => event.write_le(writer),
         }
     }
 

--- a/node/narwhal/src/event/mod.rs
+++ b/node/narwhal/src/event/mod.rs
@@ -247,6 +247,7 @@ mod prop_tests {
 mod tests {
     use crate::Event;
     use bytes::{BufMut, BytesMut};
+    use snarkvm::console::prelude::ToBytes;
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
     #[test]
@@ -260,7 +261,7 @@ mod tests {
     fn deserializing_invalid_data_panics() {
         let mut buf = BytesMut::default().writer();
         let invalid_id = u16::MAX;
-        bincode::serialize_into(&mut buf, &invalid_id).unwrap();
+        invalid_id.write_le(&mut buf).unwrap();
         assert_eq!(
             Event::<CurrentNetwork>::deserialize(buf.get_ref().clone()).unwrap_err().to_string(),
             format!("Unknown event ID {invalid_id}")

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -59,16 +59,18 @@ impl<N: Network> FromBytes for TransmissionRequest<N> {
 #[cfg(test)]
 pub mod prop_tests {
     use crate::{
-        event::EventTrait,
         helpers::storage::prop_tests::{any_puzzle_commitment, any_transaction_id},
         TransmissionRequest,
     };
-    use bytes::{BufMut, BytesMut};
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::{
         prelude::{BoxedStrategy, Strategy},
         prop_oneof,
     };
-    use snarkvm::ledger::narwhal::TransmissionID;
+    use snarkvm::{
+        console::prelude::{FromBytes, ToBytes},
+        ledger::narwhal::TransmissionID,
+    };
     use test_strategy::proptest;
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
@@ -87,9 +89,9 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_transmission_request())] original: TransmissionRequest<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        TransmissionRequest::serialize(&original, &mut buf).unwrap();
+        TransmissionRequest::write_le(&original, &mut buf).unwrap();
 
-        let deserialized = TransmissionRequest::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized = TransmissionRequest::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -39,22 +39,20 @@ impl<N: Network> EventTrait for TransmissionRequest<N> {
     fn name(&self) -> &'static str {
         "TransmissionRequest"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-
-        let transmission_id = TransmissionID::read_le(&mut reader)?;
-
-        Ok(Self { transmission_id })
-    }
 }
 
 impl<N: Network> ToBytes for TransmissionRequest<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         self.transmission_id.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for TransmissionRequest<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let transmission_id = TransmissionID::read_le(&mut reader)?;
+
+        Ok(Self { transmission_id })
     }
 }
 

--- a/node/narwhal/src/event/transmission_request.rs
+++ b/node/narwhal/src/event/transmission_request.rs
@@ -40,13 +40,6 @@ impl<N: Network> EventTrait for TransmissionRequest<N> {
         "TransmissionRequest"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.transmission_id.write_le(writer)?;
-        Ok(())
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -55,6 +48,13 @@ impl<N: Network> EventTrait for TransmissionRequest<N> {
         let transmission_id = TransmissionID::read_le(&mut reader)?;
 
         Ok(Self { transmission_id })
+    }
+}
+
+impl<N: Network> ToBytes for TransmissionRequest<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.transmission_id.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -40,17 +40,6 @@ impl<N: Network> EventTrait for TransmissionResponse<N> {
     fn name(&self) -> &'static str {
         "TransmissionResponse"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-
-        let transmission_id = TransmissionID::read_le(&mut reader)?;
-        let transmission = Transmission::read_le(&mut reader)?;
-
-        Ok(Self { transmission_id, transmission })
-    }
 }
 
 impl<N: Network> ToBytes for TransmissionResponse<N> {
@@ -58,6 +47,15 @@ impl<N: Network> ToBytes for TransmissionResponse<N> {
         self.transmission_id.write_le(&mut writer)?;
         self.transmission.write_le(&mut writer)?;
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for TransmissionResponse<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let transmission_id = TransmissionID::read_le(&mut reader)?;
+        let transmission = Transmission::read_le(&mut reader)?;
+
+        Ok(Self { transmission_id, transmission })
     }
 }
 

--- a/node/narwhal/src/event/transmission_response.rs
+++ b/node/narwhal/src/event/transmission_response.rs
@@ -41,14 +41,6 @@ impl<N: Network> EventTrait for TransmissionResponse<N> {
         "TransmissionResponse"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        self.transmission_id.write_le(&mut *writer)?;
-        self.transmission.write_le(writer)?;
-        Ok(())
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -58,6 +50,14 @@ impl<N: Network> EventTrait for TransmissionResponse<N> {
         let transmission = Transmission::read_le(&mut reader)?;
 
         Ok(Self { transmission_id, transmission })
+    }
+}
+
+impl<N: Network> ToBytes for TransmissionResponse<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.transmission_id.write_le(&mut writer)?;
+        self.transmission.write_le(&mut writer)?;
+        Ok(())
     }
 }
 

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -65,12 +65,13 @@ impl<N: Network> FromBytes for WorkerPing<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{event::EventTrait, helpers::storage::prop_tests::any_transmission_id, WorkerPing};
-    use bytes::{BufMut, BytesMut};
+    use crate::{helpers::storage::prop_tests::any_transmission_id, WorkerPing};
+    use bytes::{Buf, BufMut, BytesMut};
     use proptest::{
         collection::hash_set,
         prelude::{BoxedStrategy, Strategy},
     };
+    use snarkvm::console::prelude::{FromBytes, ToBytes};
     use test_strategy::proptest;
     type CurrentNetwork = snarkvm::prelude::Testnet3;
 
@@ -81,9 +82,9 @@ pub mod prop_tests {
     #[proptest]
     fn serialize_deserialize(#[strategy(any_worker_ping())] original: WorkerPing<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();
-        WorkerPing::serialize(&original, &mut buf).unwrap();
+        WorkerPing::write_le(&original, &mut buf).unwrap();
 
-        let deserialized = WorkerPing::deserialize(buf.get_ref().clone()).unwrap();
+        let deserialized = WorkerPing::read_le(buf.into_inner().reader()).unwrap();
         assert_eq!(original, deserialized);
     }
 }

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -39,20 +39,6 @@ impl<N: Network> EventTrait for WorkerPing<N> {
     fn name(&self) -> &'static str {
         "WorkerPing"
     }
-
-    /// Deserializes the given buffer into an event.
-    #[inline]
-    fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-
-        let num_transmissions = u32::read_le(&mut reader)?;
-        let mut transmission_ids = IndexSet::with_capacity(num_transmissions as usize);
-        for _ in 0..num_transmissions {
-            transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
-        }
-
-        Ok(Self { transmission_ids })
-    }
 }
 
 impl<N: Network> ToBytes for WorkerPing<N> {
@@ -62,6 +48,18 @@ impl<N: Network> ToBytes for WorkerPing<N> {
             transmission_id.write_le(&mut writer)?;
         }
         Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for WorkerPing<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let num_transmissions = u32::read_le(&mut reader)?;
+        let mut transmission_ids = IndexSet::with_capacity(num_transmissions as usize);
+        for _ in 0..num_transmissions {
+            transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
+        }
+
+        Ok(Self { transmission_ids })
     }
 }
 

--- a/node/narwhal/src/event/worker_ping.rs
+++ b/node/narwhal/src/event/worker_ping.rs
@@ -40,16 +40,6 @@ impl<N: Network> EventTrait for WorkerPing<N> {
         "WorkerPing"
     }
 
-    /// Serializes the event into the buffer.
-    #[inline]
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        (self.transmission_ids.len() as u32).write_le(&mut *writer)?;
-        for transmission_id in &self.transmission_ids {
-            transmission_id.write_le(&mut *writer)?;
-        }
-        Ok(())
-    }
-
     /// Deserializes the given buffer into an event.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
@@ -62,6 +52,16 @@ impl<N: Network> EventTrait for WorkerPing<N> {
         }
 
         Ok(Self { transmission_ids })
+    }
+}
+
+impl<N: Network> ToBytes for WorkerPing<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        (self.transmission_ids.len() as u32).write_le(&mut writer)?;
+        for transmission_id in &self.transmission_ids {
+            transmission_id.write_le(&mut writer)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This simplifies the (de)serialization of `Event`s and removes a dependency on `bincode`.

In addition, this change appears to reduce the number of allocations.