### PR TITLE
[Narwhal] Serialize Disconnect event reasons as u8

### DIFF
--- a/node/narwhal/src/event/disconnect.rs
+++ b/node/narwhal/src/event/disconnect.rs
@@ -51,7 +51,7 @@ impl EventTrait for Disconnect {
 
 impl ToBytes for Disconnect {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (self.reason as u16).write_le(&mut writer)?;
+        (self.reason as u8).write_le(&mut writer)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This is some mishap that got into https://github.com/AleoHQ/snarkOS/pull/2606: the `DisconnectReason` is represented and deserialized with `u8`, so it needs to be serialized as one as well.