### PR TITLE
fix: avoid falling back to random port if desired port not free

### DIFF
--- a/node/narwhal/tests/common/primary.rs
+++ b/node/narwhal/tests/common/primary.rs
@@ -28,7 +28,7 @@ use snarkos_node_narwhal::{
 use snarkos_node_narwhal_committee::{Committee, MIN_STAKE};
 use snarkvm::prelude::TestRng;
 
-use std::{collections::HashMap, ops::RangeBounds, sync::Arc, time::Duration};
+use std::{collections::HashMap, net::SocketAddr, ops::RangeBounds, sync::Arc, time::Duration};
 
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -117,11 +117,12 @@ impl TestNetwork {
             let storage = Storage::new(committee.clone(), MAX_GC_ROUNDS);
             let ledger = Arc::new(MockLedgerService::new());
 
+            let bft_ip: SocketAddr = "127.0.0.1:0".parse().unwrap();
             let (primary, bft) = if config.bft {
-                let bft = BFT::<CurrentNetwork>::new(account, storage, ledger, None, Some(id as u16)).unwrap();
+                let bft = BFT::<CurrentNetwork>::new(account, storage, ledger, Some(bft_ip), None).unwrap();
                 (bft.primary().clone(), Some(bft))
             } else {
-                let primary = Primary::<CurrentNetwork>::new(account, storage, ledger, None, Some(id as u16)).unwrap();
+                let primary = Primary::<CurrentNetwork>::new(account, storage, ledger, Some(bft_ip), None).unwrap();
                 (primary, None)
             };
 

--- a/node/src/beacon/mod.rs
+++ b/node/src/beacon/mod.rs
@@ -70,9 +70,11 @@ pub struct Beacon<N: Network, C: ConsensusStorage<N>> {
 
 impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
     /// Initializes a new beacon node.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         node_ip: SocketAddr,
         rest_ip: Option<SocketAddr>,
+        bft_ip: Option<SocketAddr>,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
         genesis: Block<N>,
@@ -96,7 +98,7 @@ impl<N: Network, C: ConsensusStorage<N>> Beacon<N, C> {
         }
 
         // Initialize the consensus.
-        let mut consensus = Consensus::new(account.clone(), ledger.clone(), None, dev)?;
+        let mut consensus = Consensus::new(account.clone(), ledger.clone(), bft_ip, dev)?;
         // Initialize the primary channels.
         let (primary_sender, primary_receiver) = init_primary_channels::<N>();
         // Start the consensus.
@@ -465,6 +467,7 @@ mod tests {
         let beacon = Beacon::<CurrentNetwork, ConsensusMemory<CurrentNetwork>>::new(
             node,
             Some(rest),
+            None,
             beacon_account,
             &[],
             genesis,

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -49,7 +49,9 @@ impl<N: Network> Node<N> {
         cdn: Option<String>,
         dev: Option<u16>,
     ) -> Result<Self> {
-        Ok(Self::Beacon(Arc::new(Beacon::new(node_ip, rest_ip, account, trusted_peers, genesis, cdn, dev).await?)))
+        Ok(Self::Beacon(Arc::new(
+            Beacon::new(node_ip, rest_ip, None, account, trusted_peers, genesis, cdn, dev).await?,
+        )))
     }
 
     /// Initializes a new validator node.
@@ -63,7 +65,7 @@ impl<N: Network> Node<N> {
         dev: Option<u16>,
     ) -> Result<Self> {
         Ok(Self::Validator(Arc::new(
-            Validator::new(node_ip, rest_ip, account, trusted_peers, genesis, cdn, dev).await?,
+            Validator::new(node_ip, rest_ip, None, account, trusted_peers, genesis, cdn, dev).await?,
         )))
     }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -64,9 +64,11 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
 
 impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
     /// Initializes a new validator node.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         node_ip: SocketAddr,
         rest_ip: Option<SocketAddr>,
+        bft_ip: Option<SocketAddr>,
         account: Account<N>,
         trusted_peers: &[SocketAddr],
         genesis: Block<N>,
@@ -84,7 +86,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             }
         }
         // Initialize the consensus.
-        let mut consensus = Consensus::new(account.clone(), ledger.clone(), None, dev)?;
+        let mut consensus = Consensus::new(account.clone(), ledger.clone(), bft_ip, dev)?;
         // Initialize the primary channels.
         let (primary_sender, primary_receiver) = init_primary_channels::<N>();
         // Start the consensus.

--- a/node/tcp/src/helpers/config.rs
+++ b/node/tcp/src/helpers/config.rs
@@ -84,7 +84,7 @@ impl Default for Config {
             name: None,
             listener_ip: default_ip(),
             desired_listening_port: None,
-            allow_random_port: true,
+            allow_random_port: false,
             fatal_io_errors: vec![ConnectionReset, ConnectionAborted, BrokenPipe, InvalidData, UnexpectedEof],
             max_connections: 100,
             connection_timeout_ms: 1_000,

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -509,6 +509,7 @@ mod tests {
     async fn test_new() {
         let tcp = Tcp::new(Config {
             listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            desired_listening_port: Some(0),
             max_connections: 200,
             ..Default::default()
         });
@@ -523,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect() {
-        let tcp = Tcp::new(Config::default());
+        let tcp = Tcp::new(Config { desired_listening_port: Some(0), ..Default::default() });
         let node_ip = tcp.enable_listener().await.unwrap();
 
         // Ensure self-connecting is not possible.
@@ -552,7 +553,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_disconnect() {
-        let tcp = Tcp::new(Config::default());
+        let tcp = Tcp::new(Config { desired_listening_port: Some(0), ..Default::default() });
         let _node_ip = tcp.enable_listener().await.unwrap();
 
         // Initialize the peer.

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -17,12 +17,14 @@ use snarkos_account::Account;
 use snarkos_node::{Beacon, Client, Prover, Validator};
 use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, Testnet3 as CurrentNetwork};
 
-use std::str::FromStr;
+use std::{net::SocketAddr, str::FromStr};
 
 pub async fn beacon() -> Beacon<CurrentNetwork, ConsensusMemory<CurrentNetwork>> {
+    let bft_ip: SocketAddr = "127.0.0.1:0".parse().unwrap();
     Beacon::new(
         "127.0.0.1:0".parse().unwrap(),
         None,
+        Some(bft_ip),
         Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
         &[],
         sample_genesis_block(), // Should load the current network's genesis block.
@@ -58,9 +60,11 @@ pub async fn prover() -> Prover<CurrentNetwork, ConsensusMemory<CurrentNetwork>>
 }
 
 pub async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNetwork>> {
+    let bft_ip: SocketAddr = "127.0.0.1:0".parse().unwrap();
     Validator::new(
         "127.0.0.1:0".parse().unwrap(),
         None,
+        Some(bft_ip),
         Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
         &[],
         sample_genesis_block(), // Should load the current network's genesis block.


### PR DESCRIPTION
If you ask for a desired port and it's not available, the TCP stack should not silently choose a random port, but return an error.

Some tests needed to be fixed for this, as they were all trying to bind to the same port, making parallel test execution impossible.