### PR TITLE
More connection tests, a workaround for "unclean" disconnects

### DIFF
--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -192,7 +192,12 @@ impl<N: Network> Router<N> {
             if let Some(peer_addr) = router.resolve_to_ambiguous(&peer_ip) {
                 // Disconnect from this peer.
                 let disconnected = router.tcp.disconnect(peer_addr).await;
-                debug_assert!(disconnected);
+                // FIXME: this shouldn't be necessary; it's a double-check
+                // that the higher-level collection is cleaned up after the
+                // lower-level disconnect.
+                if router.is_connected(&peer_ip) && !router.tcp.is_connected(peer_addr) {
+                    router.remove_connected_peer(peer_ip);
+                }
                 disconnected
             } else {
                 false

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -186,13 +186,16 @@ impl<N: Network> Router<N> {
     }
 
     /// Disconnects from the given peer IP, if the peer is connected.
-    pub fn disconnect(&self, peer_ip: SocketAddr) -> JoinHandle<()> {
+    pub fn disconnect(&self, peer_ip: SocketAddr) -> JoinHandle<bool> {
         let router = self.clone();
         tokio::spawn(async move {
             if let Some(peer_addr) = router.resolve_to_ambiguous(&peer_ip) {
                 // Disconnect from this peer.
-                let _disconnected = router.tcp.disconnect(peer_addr).await;
-                debug_assert!(_disconnected);
+                let disconnected = router.tcp.disconnect(peer_addr).await;
+                debug_assert!(disconnected);
+                disconnected
+            } else {
+                false
             }
         })
     }

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -290,6 +290,8 @@ async fn duplicate_connection_attempts() {
 
     // Attempt to connect the 1st node to the other one several times at once.
     let (result1, result2, result3) = tokio::join!(conn1, conn2, conn3);
+    // A small anti-flakiness buffer.
+    sleep(Duration::from_millis(200)).await;
 
     // Count the successes.
     let mut successes = 0;

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -19,12 +19,14 @@ mod common;
 use common::{node::*, test_peer::TestPeer};
 
 use snarkos_node::{Beacon, Client, Prover, Validator};
+use snarkos_node_router::Outbound;
 use snarkos_node_tcp::P2P;
 use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, Testnet3 as CurrentNetwork};
 
 use pea2pea::Pea2Pea;
 
-use std::{io, net::SocketAddr};
+use std::{io, net::SocketAddr, time::Duration};
+use tokio::time::sleep;
 
 // Trait to unify Pea2Pea and P2P traits.
 #[async_trait::async_trait]
@@ -201,5 +203,64 @@ mod validator {
         validator <- client,
         validator <- validator,
         validator <- prover
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn simultaneous_connection_attempt() {
+    // common::initialise_logger(3);
+
+    // Spin up 2 full nodes.
+    let node1 = validator().await;
+    let addr1 = node1.listening_addr();
+    let node2 = validator().await;
+    let addr2 = node2.listening_addr();
+
+    // Prepare connection attempts.
+    let node1_clone = node1.clone();
+    let conn1 = tokio::spawn(async move {
+        if let Some(conn_task) = node1_clone.router().connect(addr2) { conn_task.await.unwrap() } else { false }
+    });
+    let node2_clone = node2.clone();
+    let conn2 = tokio::spawn(async move {
+        if let Some(conn_task) = node2_clone.router().connect(addr1) { conn_task.await.unwrap() } else { false }
+    });
+
+    // Attempt to connect both nodes to one another at the same time.
+    let (result1, result2) = tokio::join!(conn1, conn2);
+    // A small anti-flakiness buffer.
+    sleep(Duration::from_millis(200)).await;
+
+    // Count connection successes.
+    let mut successes = 0;
+    if result1.unwrap() {
+        successes += 1;
+    }
+    if result2.unwrap() {
+        successes += 1;
+    }
+
+    // Record the number of connected peers for both nodes.
+    let tcp_connected1 = node1.tcp().num_connected();
+    let tcp_connected2 = node2.tcp().num_connected();
+    let router_connected1 = node1.router().number_of_connected_peers();
+    let router_connected2 = node2.router().number_of_connected_peers();
+
+    // It's possible for both attempts to fail and that's ok; the important
+    // thing is that at most a single connection is established in the end.
+    assert!(successes <= 1);
+
+    // If both attempts failed, all the counters should be 0; otherwise,
+    // all should be 1.
+    if successes == 0 {
+        assert_eq!(tcp_connected1, 0);
+        assert_eq!(tcp_connected2, 0);
+        assert_eq!(router_connected1, 0);
+        assert_eq!(router_connected2, 0);
+    } else {
+        assert_eq!(tcp_connected1, 1);
+        assert_eq!(tcp_connected2, 1);
+        assert_eq!(router_connected1, 1);
+        assert_eq!(router_connected2, 1);
     }
 }


### PR DESCRIPTION
note: this PR targets the `staging` branch.

While the newly introduced connection tests haven't revealed the cause of disconnects not performing a full cleanup in some edge cases, this PR also introduces a workaround that has been confirmed to fix that issue; it is marked as FIXME so that we can handle it more graciously in the future.