### PR TITLE
fix: Ubuntu Release Build 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: snarkOS Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
 
 env:
   RUST_BACKTRACE: 1
@@ -10,7 +10,7 @@ env:
 jobs:
   ubuntu:
     name: Ubuntu
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: snarkOS Release
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Motivation

Fixes the Ubuntu snarkOS release build which has [been broken for some time](https://github.com/AleoHQ/snarkOS/actions/workflows/release.yml)

## Test Plan

[I have a branch that I published a new release in my fork here showing that this fix works](https://github.com/craigjson/snarkOS/actions/runs/6193232254).

 You can test it yourself by forking snarkOS, updating the `ubuntu18.04` in the `.github/workflows/release.yaml` file to `ubuntu-latest` and publishing a new release.

## Related PRs

Referenced in issue #2662 
