### PR TITLE
Handshake error

### DIFF
--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -904,7 +904,10 @@ impl<N: Network> Gateway<N> {
         framed.try_next().await?;
 
         // Set the codec to post-handshake mode.
-        let mut framed = framed.map_codec(|c| NoiseCodec::<N>::new(c.noise_state.into_post_handshake_state()));
+        let mut framed = framed.map_codec(|c| NoiseCodec::<N>::new(c.noise_state.into_post_handshake_state_fallible()));
+        if let NoiseState::Failed = framed.codec().noise_state {
+            return Err(error(format!("Noise handshake with '{peer_addr}' failed")));
+        }
 
         /* Post noise handshake */
         /* Step 1: Receive the challenge request. */

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -823,6 +823,9 @@ impl<N: Network> Gateway<N> {
 
         // Set the codec to post-handshake mode.
         let mut framed = framed.map_codec(|c| NoiseCodec::<N>::new(c.noise_state.into_post_handshake_state()));
+        if let NoiseState::Failed = framed.codec().noise_state {
+            return Err(error(format!("Noise initiator with '{peer_addr}' failed")));
+        }
 
         /* Post noise handshake */
 
@@ -904,9 +907,9 @@ impl<N: Network> Gateway<N> {
         framed.try_next().await?;
 
         // Set the codec to post-handshake mode.
-        let mut framed = framed.map_codec(|c| NoiseCodec::<N>::new(c.noise_state.into_post_handshake_state_fallible()));
+        let mut framed = framed.map_codec(|c| NoiseCodec::<N>::new(c.noise_state.into_post_handshake_state()));
         if let NoiseState::Failed = framed.codec().noise_state {
-            return Err(error(format!("Noise handshake with '{peer_addr}' failed")));
+            return Err(error(format!("Noise responder with '{peer_addr}' failed")));
         }
 
         /* Post noise handshake */

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -288,7 +288,7 @@ impl<N: Network> Decoder for NoiseCodec<N> {
                 self.event_codec.decode(&mut plaintext)?.map(|msg| EventOrBytes::Event(msg))
             }
 
-            NoiseState::Failed => unreachable!()
+            NoiseState::Failed => unreachable!("Noise handshake failed to decode")
         };
 
         Ok(msg)

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -231,7 +231,7 @@ impl<N: Network> Encoder<EventOrBytes<N>> for NoiseCodec<N> {
                 buffer
             }
 
-            NoiseState::Failed => unreachable!()
+            NoiseState::Failed => unreachable!("Noise handshake failed to encode")
         };
 
         // Encode the resulting ciphertext using the length-delimited codec.

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -133,7 +133,11 @@ impl NoiseState {
         if let Self::Handshake(noise_state) = self {
             match noise_state.into_stateless_transport_mode() {
                 Ok(new_state) => {
-                    return Self::PostHandshake(PostHandshakeState { state: Arc::new(new_state), tx_nonce: 0, rx_nonce: 0 });
+                    return Self::PostHandshake(PostHandshakeState {
+                        state: Arc::new(new_state),
+                        tx_nonce: 0,
+                        rx_nonce: 0,
+                    });
                 }
                 Err(error) => {
                     warn!("Handshake not finished - {error}");
@@ -221,7 +225,7 @@ impl<N: Network> Encoder<EventOrBytes<N>> for NoiseCodec<N> {
                 buffer
             }
 
-            NoiseState::Failed => unreachable!("Noise handshake failed to encode")
+            NoiseState::Failed => unreachable!("Noise handshake failed to encode"),
         };
 
         // Encode the resulting ciphertext using the length-delimited codec.
@@ -278,7 +282,7 @@ impl<N: Network> Decoder for NoiseCodec<N> {
                 self.event_codec.decode(&mut plaintext)?.map(|msg| EventOrBytes::Event(msg))
             }
 
-            NoiseState::Failed => unreachable!("Noise handshake failed to decode")
+            NoiseState::Failed => unreachable!("Noise handshake failed to decode"),
         };
 
         Ok(msg)

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -138,7 +138,7 @@ impl NoiseState {
         }
     }
 
-    // The function above actually might fail (for some handshakes on the responder side) - not clear why
+    // Initiator might fail (time out) the handshake at any stage, so responder shouldn't use the function above
     pub fn into_post_handshake_state_fallible(self) -> Self {
         if let Self::Handshake(noise_state) = self {
             match noise_state.into_stateless_transport_mode() {

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -123,7 +123,7 @@ impl Clone for NoiseState {
         match self {
             Self::Handshake(..) => unreachable!(),
             Self::PostHandshake(ph_state) => Self::PostHandshake(ph_state.clone()),
-            Self::Failed => unreachable!(),
+            Self::Failed => unreachable!("Forbidden: cloning noise handshake"),
         }
     }
 }

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -131,16 +131,6 @@ impl Clone for NoiseState {
 impl NoiseState {
     pub fn into_post_handshake_state(self) -> Self {
         if let Self::Handshake(noise_state) = self {
-            let noise_state = noise_state.into_stateless_transport_mode().expect("handshake isn't finished");
-            Self::PostHandshake(PostHandshakeState { state: Arc::new(noise_state), tx_nonce: 0, rx_nonce: 0 })
-        } else {
-            NoiseState::Failed
-        }
-    }
-
-    // Initiator might fail (time out) the handshake at any stage, so responder shouldn't use the function above
-    pub fn into_post_handshake_state_fallible(self) -> Self {
-        if let Self::Handshake(noise_state) = self {
             match noise_state.into_stateless_transport_mode() {
                 Ok(new_state) => {
                     return Self::PostHandshake(PostHandshakeState { state: Arc::new(new_state), tx_nonce: 0, rx_nonce: 0 });

--- a/node/narwhal/src/helpers/codec.rs
+++ b/node/narwhal/src/helpers/codec.rs
@@ -134,7 +134,7 @@ impl NoiseState {
             let noise_state = noise_state.into_stateless_transport_mode().expect("handshake isn't finished");
             Self::PostHandshake(PostHandshakeState { state: Arc::new(noise_state), tx_nonce: 0, rx_nonce: 0 })
         } else {
-            unreachable!()
+            NoiseState::Failed
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This should fix the "handshake isn't finished" panic, by replacing it with a regular handshake error.

## Test Plan

Test whatever use cases were used to trigger the "handshake isn't finished" panic.

## Related PRs
