### PR TITLE
[TOB] Improve peer address filtering

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -260,10 +260,6 @@ impl<N: Network> Router<N> {
 
     /// Ensure the peer is allowed to connect.
     fn ensure_peer_is_allowed(&self, peer_ip: SocketAddr) -> Result<()> {
-        // Ensure the peer IP is not this node.
-        if self.is_local_ip(&peer_ip) {
-            bail!("Dropping connection request from '{peer_ip}' (attempted to self-connect)")
-        }
         // Ensure the node is not already connecting to this peer.
         if !self.connecting_peers.lock().insert(peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (already shaking hands as the initiator)")

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -24,7 +24,7 @@ use snarkos_node_messages::{
     UnconfirmedSolution,
     UnconfirmedTransaction,
 };
-use snarkos_node_tcp::{is_bogon_address, protocols::Reading};
+use snarkos_node_tcp::{is_bogon_address, is_unspecified_address, protocols::Reading};
 use snarkvm::prelude::{
     block::{Block, Header, Transaction},
     coinbase::{EpochChallenge, ProverSolution},
@@ -307,8 +307,12 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
 
     /// Handles a `PeerResponse` message.
     fn peer_response(&self, _peer_ip: SocketAddr, peers: &[SocketAddr]) -> bool {
-        // Filter out bogon addresses.
-        let peers = peers.iter().copied().filter(|addr| !is_bogon_address(addr.ip())).collect::<Vec<_>>();
+        // Filter out bogon and unspecified addresses.
+        let peers = peers
+            .iter()
+            .copied()
+            .filter(|addr| !is_bogon_address(addr.ip()) && !is_unspecified_address(addr.ip()))
+            .collect::<Vec<_>>();
         // Adds the given peer IPs to the list of candidate peers.
         self.router().insert_candidate_peers(&peers);
         true

--- a/node/tcp/src/lib.rs
+++ b/node/tcp/src/lib.rs
@@ -43,3 +43,11 @@ pub fn is_bogon_address(ip: IpAddr) -> bool {
         IpAddr::V6(ipv6) => ipv6.is_loopback(),
     }
 }
+
+/// Checks if the given IP address is unspecified or broadcast.
+pub fn is_unspecified_address(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ipv4) => ipv4.is_unspecified() || ipv4.is_broadcast(),
+        ipv6 => ipv6.is_unspecified(),
+    }
+}


### PR DESCRIPTION
This approach allows us to be stricter and more clear about the filtering of addresses received from other peers while not restricting addresses the node may want to connect to itself.

Finding: TOB-ALEO-11