### PR TITLE
Expand timestamp liveness check

### DIFF
--- a/node/narwhal/src/helpers/proposal.rs
+++ b/node/narwhal/src/helpers/proposal.rs
@@ -145,6 +145,7 @@ impl<N: Network> Proposal<N> {
         signer: Address<N>,
         signature: Signature<N>,
         timestamp: i64,
+        previous_timestamp: i64,
         committee: &Committee<N>,
     ) -> Result<()> {
         // Ensure the signer is in the committee.
@@ -161,7 +162,7 @@ impl<N: Network> Proposal<N> {
             bail!("Signature verification failed")
         }
         // Check the timestamp for liveness.
-        check_timestamp_for_liveness(timestamp)?;
+        check_timestamp_for_liveness(timestamp, previous_timestamp)?;
         // Insert the signature.
         self.signatures.insert(signature, timestamp);
         Ok(())

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -359,10 +359,7 @@ impl<N: Network> Storage<N> {
         }
 
         // Check the timestamp for liveness.
-        check_timestamp_for_liveness(
-            batch_header.timestamp(),
-            self.median_timestamp_for_round(self.current_round() - 1),
-        )?;
+        check_timestamp_for_liveness(batch_header.timestamp(), self.median_timestamp_for_round(round - 1))?;
 
         // Initialize a list for the missing transmissions from storage.
         let mut missing_transmissions = HashMap::new();
@@ -470,7 +467,7 @@ impl<N: Network> Storage<N> {
         // Iterate over the timestamps.
         for timestamp in certificate.timestamps() {
             // Check the timestamp for liveness.
-            check_timestamp_for_liveness(timestamp, self.median_timestamp_for_round(self.current_round() - 1))?;
+            check_timestamp_for_liveness(timestamp, self.median_timestamp_for_round(round - 1))?;
         }
 
         // Retrieve the previous committee for the batch round.

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -308,6 +308,10 @@ impl<N: Network> Storage<N> {
     /// Returns the median timestamp for the given `round`.
     pub fn median_timestamp_for_round(&self, round: u64) -> i64 {
         let previous_certificates = self.get_certificates_for_round(round);
+        if previous_certificates.is_empty() {
+            return 0;
+        }
+
         let mut timestamps = previous_certificates
             .into_iter()
             .map(|batch_certificate| batch_certificate.median_timestamp())

--- a/node/narwhal/src/helpers/timestamp.rs
+++ b/node/narwhal/src/helpers/timestamp.rs
@@ -30,7 +30,7 @@ pub fn check_timestamp_for_liveness(timestamp: i64, previous_timestamp: i64) -> 
     }
 
     // Ensure the timestamp is after the previous timestamp.
-    if timestamp <= previous_timestamp {
+    if timestamp < previous_timestamp {
         bail!(
             "Timestamp {timestamp} for the proposed batch must be after the previous round timestamp {previous_timestamp}"
         )

--- a/node/narwhal/src/helpers/timestamp.rs
+++ b/node/narwhal/src/helpers/timestamp.rs
@@ -23,16 +23,17 @@ pub fn now() -> i64 {
 }
 
 /// Sanity checks the timestamp for liveness.
-pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
+pub fn check_timestamp_for_liveness(timestamp: i64, previous_timestamp: i64) -> Result<()> {
     // Ensure the timestamp is within range.
     if timestamp > (now() + MAX_TIMESTAMP_DELTA_IN_SECS) {
         bail!("Timestamp {timestamp} is too far in the future")
     }
-    // TODO (howardwu): Ensure the timestamp is after the previous timestamp. (Needs Bullshark committee)
-    // // Ensure the timestamp is after the previous timestamp.
-    // if timestamp <= committee.previous_timestamp() {
-    //     bail!("Timestamp {timestamp} for the proposed batch must be after the previous round timestamp")
-    // }
+
+    // Ensure the timestamp is after the previous timestamp.
+    if timestamp <= previous_timestamp {
+        bail!("Timestamp {timestamp} for the proposed batch must be after the previous round timestamp")
+    }
+
     Ok(())
 }
 

--- a/node/narwhal/src/helpers/timestamp.rs
+++ b/node/narwhal/src/helpers/timestamp.rs
@@ -31,7 +31,9 @@ pub fn check_timestamp_for_liveness(timestamp: i64, previous_timestamp: i64) -> 
 
     // Ensure the timestamp is after the previous timestamp.
     if timestamp <= previous_timestamp {
-        bail!("Timestamp {timestamp} for the proposed batch must be after the previous round timestamp")
+        bail!(
+            "Timestamp {timestamp} for the proposed batch must be after the previous round timestamp {previous_timestamp}"
+        )
     }
 
     Ok(())

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -541,7 +541,13 @@ impl<N: Network> Primary<N> {
                     // Retrieve the address of the peer.
                     match self.gateway.resolver().get_address(peer_ip) {
                         // Add the signature to the batch.
-                        Some(signer) => proposal.add_signature(signer, signature, timestamp, &previous_committee)?,
+                        Some(signer) => proposal.add_signature(
+                            signer,
+                            signature,
+                            timestamp,
+                            self.storage.median_timestamp_for_round(self.current_round() - 1),
+                            &previous_committee,
+                        )?,
                         None => bail!("Signature is from a disconnected peer"),
                     };
                     info!("Received a batch signature for round {} from '{peer_ip}'", proposal.round());


### PR DESCRIPTION
The liveness check verifies the timestamp equals or is larger than the timestamp for the previous round which is the median timestamp of all its batches. This is implemented through calls to storage. 