### PR TITLE
[Narwhal] detect duplicate noise state in handshake

### DIFF
--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -1158,7 +1158,6 @@ impl<N: Network> Gateway<N> {
         match self.noise_states.write().entry(peer_ip) {
             Occupied(_) => {
                 // Double-connect, abort.
-                warn!("{CONTEXT} Handshake with '{peer_ip}' failed: noise state already exists");
                 Err(io::ErrorKind::AlreadyExists.into())
             }
 
@@ -1176,7 +1175,6 @@ impl<N: Network> Gateway<N> {
             Occupied(mut entry) => {
                 // A connection with this peer listener has already occured, cancel the handshake.
                 if entry.get().is_some() {
-                    warn!("{CONTEXT} Handshake with '{peer_ip}' failed: noise state already exists");
                     return Err(io::ErrorKind::AlreadyExists.into());
                 }
 


### PR DESCRIPTION
This PR checks if an attempt is made to store a second noise state for a given listener IP and, if so, drops the handshake without mutating existing state. This prevents double-connects from corrupting internal state and causing issues with the pre-existing connections. Tested locally, though the issue is hard to reproduce to begin with. 