### PR TITLE
Update `get_committee_for_round` to get committees from previous rounds

### DIFF
--- a/node/narwhal/ledger-service/src/ledger.rs
+++ b/node/narwhal/ledger-service/src/ledger.rs
@@ -22,7 +22,7 @@ use snarkvm::{
         store::ConsensusStorage,
         Ledger,
     },
-    prelude::{bail, Field, Network, Result},
+    prelude::{bail, ensure, Field, Network, Result},
 };
 
 use indexmap::IndexMap;
@@ -114,7 +114,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
                     }
                 }
                 // Otherwise, return the committee of the previous round.
-                false => self.get_committee_for_round(round.saturating_sub(1)),
+                false => {
+                    let committee = self.get_committee_for_round(round.saturating_sub(1))?;
+                    ensure!(round >= committee.starting_round(), "Batch round must be >= the committee round");
+                    committee
+                }
             },
         }
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates `get_committee_for_round` to recursively search for the previous round's committee.

The previous logic was defaulting to the ledger's current committee, which may be far ahead and not relevant to your current round.