### PR TITLE
Delay peer status promotion

### DIFF
--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -22,6 +22,8 @@ use std::{net::SocketAddr, time::Instant};
 pub struct Peer<N: Network> {
     /// The IP address of the peer, with the port set to the listener port.
     peer_ip: SocketAddr,
+    /// The connected address of the peer.
+    peer_addr: SocketAddr,
     /// The Aleo address of the peer.
     address: Address<N>,
     /// The node type of the peer.
@@ -36,9 +38,10 @@ pub struct Peer<N: Network> {
 
 impl<N: Network> Peer<N> {
     /// Initializes a new instance of `Peer`.
-    pub fn new(listening_ip: SocketAddr, challenge_request: &ChallengeRequest<N>) -> Self {
+    pub fn new(listening_ip: SocketAddr, connected_ip: SocketAddr, challenge_request: &ChallengeRequest<N>) -> Self {
         Self {
             peer_ip: listening_ip,
+            peer_addr: connected_ip,
             address: challenge_request.address,
             node_type: challenge_request.node_type,
             version: challenge_request.version,
@@ -50,6 +53,11 @@ impl<N: Network> Peer<N> {
     /// Returns the IP address of the peer, with the port set to the listener port.
     pub const fn ip(&self) -> SocketAddr {
         self.peer_ip
+    }
+
+    /// Returns the connected address of the peer.
+    pub const fn addr(&self) -> SocketAddr {
+        self.peer_addr
     }
 
     /// Returns the Aleo address of the peer.

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -17,11 +17,8 @@ use common::*;
 
 use deadline::deadline;
 use peak_alloc::PeakAlloc;
-use snarkos_node_router::Routing;
-use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake},
-    P2P,
-};
+use snarkos_node_router::{Outbound, Routing};
+use snarkos_node_tcp::protocols::{Disconnect, Handshake, OnConnect};
 use snarkvm::{prelude::Rng, utilities::TestRng};
 
 use core::time::Duration;
@@ -58,6 +55,9 @@ async fn test_connection_cleanups() {
     nodes[0].enable_disconnect().await;
     nodes[1].enable_disconnect().await;
 
+    nodes[0].enable_on_connect().await;
+    nodes[1].enable_on_connect().await;
+
     nodes[0].enable_listener().await;
     nodes[1].enable_listener().await;
 
@@ -70,9 +70,10 @@ async fn test_connection_cleanups() {
         nodes[1].connect(nodes[0].local_ip());
 
         // Wait until the connection is complete.
-        let tcp0 = nodes[0].tcp().clone();
-        let tcp1 = nodes[1].tcp().clone();
-        deadline!(Duration::from_secs(3), move || tcp0.num_connected() == 1 && tcp1.num_connected() == 1);
+        let node0 = nodes[0].clone();
+        let node1 = nodes[1].clone();
+        deadline!(Duration::from_secs(3), move || node0.router().number_of_connected_peers() == 1
+            && node1.router().number_of_connected_peers() == 1);
 
         // Since the connectee doesn't read from the connector, it can't tell that the connector disconnected
         // from it, so it needs to disconnect from it manually.
@@ -80,9 +81,10 @@ async fn test_connection_cleanups() {
         nodes[1].disconnect(nodes[0].local_ip());
 
         // Wait until the disconnect is complete.
-        let tcp0 = nodes[0].tcp().clone();
-        let tcp1 = nodes[1].tcp().clone();
-        deadline!(Duration::from_secs(3), move || tcp0.num_connected() == 0 && tcp1.num_connected() == 0);
+        let node0 = nodes[0].clone();
+        let node1 = nodes[1].clone();
+        deadline!(Duration::from_secs(3), move || node0.router().number_of_connected_peers() == 0
+            && node1.router().number_of_connected_peers() == 0);
 
         // Register heap use after a single connection.
         if i == 0 {

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -81,8 +81,15 @@ impl<N: Network> Handshake for TestRouter<N> {
 
 #[async_trait]
 impl<N: Network> OnConnect for TestRouter<N> {
-    async fn on_connect(&self, _peer_addr: SocketAddr) {
-        // This behavior is currently not tested.
+    async fn on_connect(&self, peer_addr: SocketAddr) {
+        let peer_ip = if let Some(ip) = self.router().resolve_to_listener(&peer_addr) {
+            ip
+        } else {
+            panic!("The peer IP should be known by the time OnConnect is triggered!");
+        };
+
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
     }
 }
 

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -15,7 +15,10 @@
 mod common;
 use common::*;
 
-use snarkos_node_tcp::{protocols::Handshake, P2P};
+use snarkos_node_tcp::{
+    protocols::{Handshake, OnConnect},
+    P2P,
+};
 
 use core::time::Duration;
 
@@ -86,6 +89,10 @@ async fn test_connect_with_handshake() {
     // Enable handshake protocol.
     node0.enable_handshake().await;
     node1.enable_handshake().await;
+
+    // Enable on_connect protocol.
+    node0.enable_on_connect().await;
+    node1.enable_on_connect().await;
 
     // Start listening.
     node0.tcp().enable_listener().await.unwrap();

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -15,7 +15,10 @@
 mod common;
 use common::*;
 
-use snarkos_node_tcp::{protocols::Handshake, P2P};
+use snarkos_node_tcp::{
+    protocols::{Handshake, OnConnect},
+    P2P,
+};
 
 use core::time::Duration;
 
@@ -72,6 +75,10 @@ async fn test_disconnect_with_handshake() {
     // Enable handshake protocol.
     node0.enable_handshake().await;
     node1.enable_handshake().await;
+
+    // Enable on_connect protocol.
+    node0.enable_on_connect().await;
+    node1.enable_on_connect().await;
 
     // Start listening.
     node0.tcp().enable_listener().await.unwrap();

--- a/node/src/beacon/router.rs
+++ b/node/src/beacon/router.rs
@@ -56,6 +56,9 @@ where
             return;
         };
 
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
+
         // Retrieve the block locators.
         let block_locators = match crate::helpers::get_block_locators(&self.ledger) {
             Ok(block_locators) => Some(block_locators),

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -55,6 +55,9 @@ where
             return;
         };
 
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
+
         // Send the first `Ping` message to the peer.
         self.send_ping(peer_ip, None);
     }

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -54,6 +54,9 @@ where
             return;
         };
 
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
+
         // Send the first `Ping` message to the peer.
         self.send_ping(peer_ip, None);
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -65,6 +65,9 @@ where
             return;
         };
 
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
+
         // Retrieve the block locators.
         let block_locators = match crate::helpers::get_block_locators(&self.ledger) {
             Ok(block_locators) => Some(block_locators),


### PR DESCRIPTION
This PR aims to resolve a rare issue where the high-level peer collection indicates that a peer is connected while the TCP stack is not aware of it, requiring a workaround in `Router::disconnect`. Based on the logs I've analyzed, it seems that we need to make sure that the high-level collection of peers is updated only once all the lower-level TCP work is complete; the way to do it is via the `OnConnect` protocol.

The workaround remains in place for now so that we can make sure that we don't see it being used anymore.

Filing as a draft to do some more testing and consider additional improvements to the logic.