### PR TITLE
Use previous committee for quorum and membership checks

### DIFF
--- a/node/narwhal/ledger-service/src/ledger.rs
+++ b/node/narwhal/ledger-service/src/ledger.rs
@@ -135,6 +135,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     }
 
     /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.
@@ -144,10 +145,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         };
 
         // Retrieve the committee for the previous round.
-        match self.ledger.get_committee_for_round(previous_round)? {
-            Some(committee) => Ok(committee),
-            None => bail!("No committee found for previous round {previous_round} in the ledger"),
-        }
+        self.get_committee_for_round(previous_round)
     }
 
     /// Returns `true` if the ledger contains the given certificate ID in block history.

--- a/node/narwhal/ledger-service/src/ledger.rs
+++ b/node/narwhal/ledger-service/src/ledger.rs
@@ -134,6 +134,20 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         }
     }
 
+    /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
+    fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
+        // Get the round number for the previous committee. Note, we subtract 2 from even rounds,
+        // because committees are updated in odd rounds.
+        let previous_round = match round % 2 == 0 {
+            true => round.saturating_sub(2),
+            false => round.saturating_sub(1),
+        };
+
+        // Retrieve the committee for the previous round.
+        self.get_committee_for_round(previous_round)
+    }
+
     /// Returns `true` if the ledger contains the given certificate ID in block history.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         self.ledger.contains_certificate(certificate_id)

--- a/node/narwhal/ledger-service/src/ledger.rs
+++ b/node/narwhal/ledger-service/src/ledger.rs
@@ -135,17 +135,19 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     }
 
     /// Returns the previous committee for the given round.
-    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
-        // Get the round number for the previous committee. Note, we subtract 2 from even rounds,
-        // because committees are updated in odd rounds.
+        // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
+        // because committees are updated in even rounds.
         let previous_round = match round % 2 == 0 {
-            true => round.saturating_sub(2),
-            false => round.saturating_sub(1),
+            true => round.saturating_sub(1),
+            false => round.saturating_sub(2),
         };
 
         // Retrieve the committee for the previous round.
-        self.get_committee_for_round(previous_round)
+        match self.ledger.get_committee_for_round(previous_round)? {
+            Some(committee) => Ok(committee),
+            None => bail!("No committee found for previous round {previous_round} in the ledger"),
+        }
     }
 
     /// Returns `true` if the ledger contains the given certificate ID in block history.

--- a/node/narwhal/ledger-service/src/mock.rs
+++ b/node/narwhal/ledger-service/src/mock.rs
@@ -126,6 +126,12 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         Ok(self.committee.clone())
     }
 
+    /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
+    fn get_previous_committee_for_round(&self, _round: u64) -> Result<Committee<N>> {
+        Ok(self.committee.clone())
+    }
+
     /// Returns `false` for all queries.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         trace!("[MockLedgerService] Contains certificate ID {} - false", fmt_id(certificate_id));

--- a/node/narwhal/ledger-service/src/mock.rs
+++ b/node/narwhal/ledger-service/src/mock.rs
@@ -127,7 +127,6 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     }
 
     /// Returns the previous committee for the given round.
-    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, _round: u64) -> Result<Committee<N>> {
         Ok(self.committee.clone())
     }

--- a/node/narwhal/ledger-service/src/prover.rs
+++ b/node/narwhal/ledger-service/src/prover.rs
@@ -109,7 +109,6 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     }
 
     /// Returns the previous committee for the given round.
-    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
         bail!("Previous committee for round {round} does not exist in prover")
     }

--- a/node/narwhal/ledger-service/src/prover.rs
+++ b/node/narwhal/ledger-service/src/prover.rs
@@ -109,6 +109,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     }
 
     /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
         bail!("Previous committee for round {round} does not exist in prover")
     }

--- a/node/narwhal/ledger-service/src/prover.rs
+++ b/node/narwhal/ledger-service/src/prover.rs
@@ -108,6 +108,12 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         bail!("Committee for round {round} does not exist in prover")
     }
 
+    /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
+    fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
+        bail!("Previous committee for round {round} does not exist in prover")
+    }
+
     /// Returns `true` if the ledger contains the given certificate ID in block history.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         bail!("Certificate '{certificate_id}' does not exist in prover")

--- a/node/narwhal/ledger-service/src/traits.rs
+++ b/node/narwhal/ledger-service/src/traits.rs
@@ -68,6 +68,10 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     /// If the given round is in the future, then the current committee is returned.
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
+    /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
+    fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
+
     /// Returns `true` if the ledger contains the given certificate ID.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool>;
 

--- a/node/narwhal/ledger-service/src/traits.rs
+++ b/node/narwhal/ledger-service/src/traits.rs
@@ -69,7 +69,6 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns the previous committee for the given round.
-    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns `true` if the ledger contains the given certificate ID.

--- a/node/narwhal/ledger-service/src/traits.rs
+++ b/node/narwhal/ledger-service/src/traits.rs
@@ -69,6 +69,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns the previous committee for the given round.
+    /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns `true` if the ledger contains the given certificate ID.

--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -243,18 +243,17 @@ impl<N: Network> BFT<N> {
             return Ok(false);
         }
 
-        // Retrieve the committee for the current round.
-        // Note: This is equivalent to calling `self.ledger().current_committee()`.
-        let Ok(committee) = self.ledger().get_committee_for_round(current_round) else {
+        // Retrieve the previous committee for the current round.
+        let Ok(previous_committee) = self.ledger().get_previous_committee_for_round(current_round) else {
             bail!("BFT failed to retrieve the committee for the even round")
         };
         // Determine the leader of the current round.
-        let leader = committee.get_leader(current_round)?;
+        let leader = previous_committee.get_leader(current_round)?;
         // Find and set the leader certificate, if the leader was present in the current even round.
         let leader_certificate = current_certificates.iter().find(|certificate| certificate.author() == leader);
         *self.leader_certificate.write() = leader_certificate.cloned();
 
-        Ok(self.is_even_round_ready_for_next_round(current_certificates, committee))
+        Ok(self.is_even_round_ready_for_next_round(current_certificates, previous_committee))
     }
 
     /// Returns 'true' under one of the following conditions:
@@ -313,18 +312,20 @@ impl<N: Network> BFT<N> {
         let leader_certificate_id = leader_certificate.certificate_id();
         // Retrieve the certificates for the current round.
         let current_certificates = self.storage().get_certificates_for_round(current_round);
-        // Retrieve the committee of the current round.
-        // Note: This is equivalent to calling `self.ledger().current_committee()`.
-        let Ok(current_committee) = self.ledger().get_committee_for_round(current_round) else {
-            bail!("BFT failed to retrieve the committee for the current round")
+        // Retrieve the previous committee of the current round.
+        let Ok(previous_committee) = self.ledger().get_previous_committee_for_round(current_round) else {
+            bail!("BFT failed to retrieve the previous committee for the current round")
         };
 
         // Compute the stake for the leader certificate.
-        let (stake_with_leader, stake_without_leader) =
-            self.compute_stake_for_leader_certificate(leader_certificate_id, current_certificates, &current_committee)?;
+        let (stake_with_leader, stake_without_leader) = self.compute_stake_for_leader_certificate(
+            leader_certificate_id,
+            current_certificates,
+            &previous_committee,
+        )?;
         // Return 'true' if any of the following conditions hold:
-        Ok(stake_with_leader >= current_committee.availability_threshold()
-            || stake_without_leader >= current_committee.quorum_threshold()
+        Ok(stake_with_leader >= previous_committee.availability_threshold()
+            || stake_without_leader >= previous_committee.quorum_threshold()
             || self.is_timer_expired())
     }
 
@@ -383,12 +384,12 @@ impl<N: Network> BFT<N> {
             return Ok(());
         }
 
-        // Retrieve the committee for the commit round.
-        let Ok(committee) = self.ledger().get_committee_for_round(commit_round) else {
+        // Retrieve the previous committee for the commit round.
+        let Ok(previous_committee) = self.ledger().get_previous_committee_for_round(commit_round) else {
             bail!("BFT failed to retrieve the committee for commit round {commit_round}");
         };
         // Compute the leader for the commit round.
-        let Ok(leader) = committee.get_leader(commit_round) else {
+        let Ok(leader) = previous_committee.get_leader(commit_round) else {
             bail!("BFT failed to compute the leader for commit round {commit_round}");
         };
         // Retrieve the leader certificate for the commit round.
@@ -411,7 +412,7 @@ impl<N: Network> BFT<N> {
             })
             .collect();
         // Check if the leader is ready to be committed.
-        if !committee.is_availability_threshold_reached(&authors) {
+        if !previous_committee.is_availability_threshold_reached(&authors) {
             // If the leader is not ready to be committed, return early.
             trace!("BFT is not ready to commit {commit_round}");
             return Ok(());

--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -230,7 +230,7 @@ impl<N: Network> BFT<N> {
             "BFT storage (at round {current_round}) is out of sync with the current even round {even_round}"
         );
         // If the current round is odd, throw an error.
-        if current_round % 2 != 0 {
+        if current_round % 2 != 0 || current_round < 2 {
             bail!("BFT cannot update the leader certificate in an odd round")
         }
 

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -296,8 +296,8 @@ impl<N: Network> Gateway<N> {
 
     /// Returns `true` if the given address is an authorized validator.
     pub fn is_authorized_validator_address(&self, validator_address: Address<N>) -> bool {
-        // Retrieve the current committee.
-        match self.ledger.current_committee() {
+        // Retrieve the previous committee for the latest round.
+        match self.ledger.get_previous_committee_for_round(self.ledger.latest_round()) {
             // Determine if the peer IP is an authorized validator.
             Ok(committee) => committee.is_committee_member(validator_address),
             Err(_) => false,

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -296,10 +296,11 @@ impl<N: Network> Gateway<N> {
 
     /// Returns `true` if the given address is an authorized validator.
     pub fn is_authorized_validator_address(&self, validator_address: Address<N>) -> bool {
-        // Determine of the validator address is a member of the previous or current committee.
-        // We allow for leniency in validation checks to accommodate two scenarios:
-        // 1. New validators should have the ability to connect immediately once they are a committee member.
-        // 2. Exiting validators should remain connected until there are no outstanding batches they are responsible for.
+        // Determine if the validator address is a member of the previous or current committee.
+        // We allow leniency in this validation check in order to accommodate these two scenarios:
+        //  1. New validators should be able to connect immediately once bonded as a committee member.
+        //  2. Existing validators must remain connected until they are no longer bonded as a committee member.
+        //     (i.e. meaning they must stay online until the next block has been produced)
         self.ledger
             .get_previous_committee_for_round(self.ledger.latest_round())
             .map_or(false, |committee| committee.is_committee_member(validator_address))

--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -296,12 +296,17 @@ impl<N: Network> Gateway<N> {
 
     /// Returns `true` if the given address is an authorized validator.
     pub fn is_authorized_validator_address(&self, validator_address: Address<N>) -> bool {
-        // Retrieve the previous committee for the latest round.
-        match self.ledger.get_previous_committee_for_round(self.ledger.latest_round()) {
-            // Determine if the peer IP is an authorized validator.
-            Ok(committee) => committee.is_committee_member(validator_address),
-            Err(_) => false,
-        }
+        // Determine of the validator address is a member of the previous or current committee.
+        // We allow for leniency in validation checks to accommodate two scenarios:
+        // 1. New validators should have the ability to connect immediately once they are a committee member.
+        // 2. Exiting validators should remain connected until there are no outstanding batches they are responsible for.
+        self.ledger
+            .get_previous_committee_for_round(self.ledger.latest_round())
+            .map_or(false, |committee| committee.is_committee_member(validator_address))
+            || self
+                .ledger
+                .current_committee()
+                .map_or(false, |committee| committee.is_committee_member(validator_address))
     }
 
     /// Returns the maximum number of connected peers.

--- a/node/narwhal/src/worker.rs
+++ b/node/narwhal/src/worker.rs
@@ -509,6 +509,7 @@ mod tests {
             fn get_batch_certificate(&self, certificate_id: &Field<N>) -> Result<BatchCertificate<N>>;
             fn current_committee(&self) -> Result<Committee<N>>;
             fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
+            fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
             fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool>;
             fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool>;
             async fn check_solution_basic(


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the quorum checks and committee membership checks for each certificate and proposal to the the previous certificate. This is required because if we use the current committee instead of the previous, new committee changes could cause invalid certificate state.

Example:
If a committee is changed in round 5, then certificates from round 5 must be checked with a committee in round 4.  In addition, round 6 must also use the committee in round 4, because round 5 can't be committed without round 6. 

Previously we were not testing committee changes, so using the use of `current_committee` was fine because the quorum requirements would be the same.