### PR TITLE
Handle `sync_certificate_with_block` for rejected transactions

### DIFF
--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -607,6 +607,14 @@ impl<N: Network> Storage<N> {
         }
         // Retrieve the transmissions for the certificate.
         let mut missing_transmissions = HashMap::new();
+
+        // Reconstruct the unconfirmed transactions.
+        let mut unconfirmed_transactions = block
+            .transactions()
+            .iter()
+            .filter_map(|tx| tx.unconfirmed_transaction().map(|unconfirmed| (unconfirmed.id(), unconfirmed)).ok())
+            .collect::<IndexMap<_, _>>();
+
         // Iterate over the transmission IDs.
         for transmission_id in certificate.transmission_ids() {
             // If the transmission ID already exists in the map, skip it.
@@ -638,9 +646,9 @@ impl<N: Network> Storage<N> {
                 }
                 TransmissionID::Transaction(transaction_id) => {
                     // Retrieve the transaction.
-                    match block.get_transaction(transaction_id) {
+                    match unconfirmed_transactions.remove(transaction_id) {
                         // Insert the transaction.
-                        Some(transaction) => missing_transmissions.insert(*transmission_id, transaction.clone().into()),
+                        Some(transaction) => missing_transmissions.insert(*transmission_id, transaction.into()),
                         // Otherwise, try to load the transaction from the ledger.
                         None => match self.ledger.get_transaction(*transaction_id) {
                             // Insert the transaction.

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -19,11 +19,12 @@ use snarkvm::{
         block::Block,
         narwhal::{BatchCertificate, BatchHeader, Transmission, TransmissionID},
     },
-    prelude::{bail, ensure, Address, Field, Network, Result},
+    prelude::{bail, cfg_iter, ensure, Address, Field, Network, Result},
 };
 
 use indexmap::{map::Entry, IndexMap, IndexSet};
 use parking_lot::RwLock;
+use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -609,9 +610,7 @@ impl<N: Network> Storage<N> {
         let mut missing_transmissions = HashMap::new();
 
         // Reconstruct the unconfirmed transactions.
-        let mut unconfirmed_transactions = block
-            .transactions()
-            .iter()
+        let mut unconfirmed_transactions = cfg_iter!(block.transactions())
             .filter_map(|tx| tx.unconfirmed_transaction().map(|unconfirmed| (unconfirmed.id(), unconfirmed)).ok())
             .collect::<IndexMap<_, _>>();
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR uses the `unconfirmed_transactions` when processing transmissions in `sync_certificate_with_block`. This allows us to boot and process rejected transactions. 

This is required because the if a transaction is rejected, the ID will be different from its original transmission ID. Thus, requiring the use of `ConfirmedTransaction::unconfirmed_transaction` to derive the original transmission.


NOTE: This does not cover the case of `aborted` transmission transactions.
