### PR TITLE
Add `latest/committee` REST endpoint

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -108,6 +108,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/testnet3/latest/hash", get(Self::latest_hash))
             .route("/testnet3/latest/block", get(Self::latest_block))
             .route("/testnet3/latest/stateRoot", get(Self::latest_state_root))
+            .route("/testnet3/latest/committee", get(Self::latest_committee))
 
             // GET ../block/..
             .route("/testnet3/block/:height_or_hash", get(Self::get_block))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -49,6 +49,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         ErasedJson::pretty(rest.ledger.latest_state_root())
     }
 
+    // GET /testnet3/latest/committee
+    pub(crate) async fn latest_committee(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
+    }
+
     // GET /testnet3/block/{height}
     // GET /testnet3/block/{blockHash}
     pub(crate) async fn get_block(


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR introduces a `testnet3/latest/committee` REST endpoint, to access the node's current view of the committee set. 
