### PR TITLE
Fix syncing edge-case

### DIFF
--- a/node/narwhal/src/sync/mod.rs
+++ b/node/narwhal/src/sync/mod.rs
@@ -297,6 +297,9 @@ impl<N: Network> Sync<N> {
 impl<N: Network> Sync<N> {
     /// Returns `true` if the node is synced.
     pub fn is_synced(&self) -> bool {
+        if self.gateway.number_of_connected_peers() == 0 {
+            return false;
+        }
         self.block_sync.is_block_synced()
     }
 

--- a/node/narwhal/src/sync/mod.rs
+++ b/node/narwhal/src/sync/mod.rs
@@ -295,7 +295,7 @@ impl<N: Network> Sync<N> {
 
 // Methods to assist with the block sync module.
 impl<N: Network> Sync<N> {
-    /// Returns `true` if the node is synced.
+    /// Returns `true` if the node is synced and has connected peers.
     pub fn is_synced(&self) -> bool {
         if self.gateway.number_of_connected_peers() == 0 {
             return false;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR changes updates `Sync::is_synced` to return false if the gateway is not connected to any peers. This also addresses an edge-case where the node initially fails to sync properly.