### PR TITLE
[TOB] Clean up the list of connecting peers in case of handshake timeout

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -79,6 +79,29 @@ async fn send<N: Network>(
     framed.send(message).await
 }
 
+/// This object is a self-destruct wrapper that removes a peer from the list of
+/// connecting entities in case the handshake is broken due to a timeout; this is
+/// only needed when the node responds to a peer's connection request.
+struct ConnectingPeer<'a, N: Network> {
+    ip: SocketAddr,
+    router: &'a Router<N>,
+    connected: bool,
+}
+
+impl<'a, N: Network> ConnectingPeer<'a, N> {
+    fn new(ip: SocketAddr, router: &'a Router<N>) -> Self {
+        Self { ip, router, connected: false }
+    }
+}
+
+impl<'a, N: Network> Drop for ConnectingPeer<'a, N> {
+    fn drop(&mut self) {
+        if !self.connected {
+            self.router.remove_connecting_peer(self.ip);
+        }
+    }
+}
+
 impl<N: Network> Router<N> {
     /// Executes the handshake protocol.
     pub async fn handshake<'a>(
@@ -199,9 +222,10 @@ impl<N: Network> Router<N> {
         let peer_ip = peer_ip.unwrap();
 
         // Knowing the peer's listening address, ensure it is allowed to connect.
-        if let Err(forbidden_message) = self.ensure_peer_is_allowed(peer_ip) {
-            return Err(error(format!("{forbidden_message}")));
-        }
+        let mut connecting_peer = match self.ensure_peer_is_allowed(peer_ip) {
+            Ok(peer) => peer,
+            Err(forbidden_message) => return Err(error(format!("{forbidden_message}"))),
+        };
         // Verify the challenge request. If a disconnect reason was returned, send the disconnect message and abort.
         if let Some(reason) = self.verify_challenge_request(peer_addr, &peer_request) {
             send(&mut framed, peer_addr, reason.into()).await?;
@@ -241,19 +265,23 @@ impl<N: Network> Router<N> {
         // Add the peer to the router.
         self.insert_connected_peer(Peer::new(peer_ip, &peer_request), peer_addr);
 
+        connecting_peer.connected = true;
+
         Ok((peer_ip, framed))
     }
 
     /// Ensure the peer is allowed to connect.
-    fn ensure_peer_is_allowed(&self, peer_ip: SocketAddr) -> Result<()> {
+    fn ensure_peer_is_allowed(&self, peer_ip: SocketAddr) -> Result<ConnectingPeer<'_, N>> {
         // Ensure the peer IP is not this node.
         if self.is_local_ip(&peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (attempted to self-connect)")
         }
         // Ensure the node is not already connecting to this peer.
-        if !self.connecting_peers.lock().insert(peer_ip) {
+        let connecting_peer = if !self.connecting_peers.lock().insert(peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (already shaking hands as the initiator)")
-        }
+        } else {
+            ConnectingPeer::new(peer_ip, self)
+        };
         // Ensure the node is not already connected to this peer.
         if self.is_connected(&peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (already connected)")
@@ -273,7 +301,7 @@ impl<N: Network> Router<N> {
                 bail!("Dropping connection request from '{peer_ip}' (tried {num_attempts} times)")
             }
         }
-        Ok(())
+        Ok(connecting_peer)
     }
 
     /// Verifies the given challenge request. Returns a disconnect reason if the request is invalid.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -294,6 +294,11 @@ impl<N: Network> Router<N> {
         self.connected_peers.read().len()
     }
 
+    /// Returns the number of connecting peers.
+    pub fn number_of_connecting_peers(&self) -> usize {
+        self.connecting_peers.lock().len()
+    }
+
     /// Returns the number of connected validators.
     pub fn number_of_connected_validators(&self) -> usize {
         self.connected_peers.read().values().filter(|peer| peer.is_validator()).count()
@@ -451,6 +456,11 @@ impl<N: Network> Router<N> {
         self.connected_peers.write().remove(&peer_ip);
         // Add the peer to the candidate peers.
         self.candidate_peers.write().insert(peer_ip);
+    }
+
+    /// Removes the connecting peer.
+    pub fn remove_connecting_peer(&self, peer_ip: SocketAddr) {
+        self.connecting_peers.lock().remove(&peer_ip);
     }
 
     #[cfg(feature = "test")]


### PR DESCRIPTION
Supersedes https://github.com/AleoHQ/snarkOS/pull/2690 as a much simpler and tighter solution.

I verified that this works by manually reducing the handshake timeout to 1ms and checking the number of connecting peers in 2 nodes after a timed out handshake between them (which is non-zero in `testnet3` and zero with this PR). While adding a regular test case for this would be possible, it would be quite verbose (as one of the nodes would need to use a custom handshake impl), so I didn't include one.

This change should obviate the current extra `Disconnect` check, but I'm leaving it in for now just to be sure we're no longer hitting it.

Finding: TOB-ALEO-22