### PR TITLE
Use From/ToBytes to (de)serialize Message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,7 +3275,6 @@ name = "snarkos-node-router-messages"
 version = "2.1.7"
 dependencies = [
  "anyhow",
- "bincode",
  "bytes",
  "indexmap 2.0.2",
  "rayon",

--- a/node/router/messages/Cargo.toml
+++ b/node/router/messages/Cargo.toml
@@ -23,9 +23,6 @@ test = [ ]
 [dependencies.anyhow]
 version = "1.0"
 
-[dependencies.bincode]
-version = "1.0"
-
 [dependencies.bytes]
 version = "1"
 

--- a/node/router/messages/src/block_request.rs
+++ b/node/router/messages/src/block_request.rs
@@ -40,17 +40,18 @@ impl MessageTrait for BlockRequest {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        Ok(bincode::serialize_into(writer, &(self.start_height, self.end_height))?)
+        self.start_height.write_le(&mut *writer)?;
+        self.end_height.write_le(writer)?;
+        Ok(())
     }
 
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
         let mut reader = bytes.reader();
-        Ok(Self {
-            start_height: bincode::deserialize_from(&mut reader)?,
-            end_height: bincode::deserialize_from(&mut reader)?,
-        })
+        let start_height = u32::read_le(&mut reader)?;
+        let end_height = u32::read_le(&mut reader)?;
+        Ok(Self { start_height, end_height })
     }
 }
 

--- a/node/router/messages/src/block_response.rs
+++ b/node/router/messages/src/block_response.rs
@@ -47,12 +47,8 @@ impl<N: Network> MessageTrait for BlockResponse<N> {
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
-        let mut reader = bytes.reader();
-        let request = BlockRequest {
-            start_height: bincode::deserialize_from(&mut reader)?,
-            end_height: bincode::deserialize_from(&mut reader)?,
-        };
-        let blocks = Data::Buffer(reader.into_inner().freeze());
+        let request = BlockRequest::deserialize(bytes.clone())?;
+        let blocks = Data::Buffer(bytes.freeze());
         Ok(Self { request, blocks })
     }
 }

--- a/node/router/messages/src/disconnect.rs
+++ b/node/router/messages/src/disconnect.rs
@@ -37,18 +37,13 @@ impl MessageTrait for Disconnect {
     /// Serializes the message into the buffer.
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
-        Ok(bincode::serialize_into(writer, &self.reason)?)
+        Ok(self.reason.write_le(writer)?)
     }
 
     /// Deserializes the given buffer into a message.
     #[inline]
     fn deserialize(bytes: BytesMut) -> Result<Self> {
-        if bytes.remaining() == 0 {
-            Ok(Self { reason: DisconnectReason::NoReasonGiven })
-        } else if let Ok(reason) = bincode::deserialize_from(&mut bytes.reader()) {
-            Ok(Self { reason })
-        } else {
-            bail!("Invalid 'Disconnect' message");
-        }
+        let mut reader = bytes.reader();
+        Ok(Disconnect { reason: DisconnectReason::read_le(&mut reader)? })
     }
 }

--- a/node/router/messages/src/helpers/mod.rs
+++ b/node/router/messages/src/helpers/mod.rs
@@ -14,7 +14,6 @@
 
 mod codec;
 pub use codec::MessageCodec;
-pub(crate) use codec::MAXIMUM_MESSAGE_SIZE;
 
 mod data;
 pub use data::Data;

--- a/node/router/messages/src/helpers/node_type.rs
+++ b/node/router/messages/src/helpers/node_type.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snarkvm::prelude::{error, FromBytes, ToBytes};
+
 use serde::{Deserialize, Serialize};
+use std::io;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[repr(u8)]
@@ -58,5 +61,25 @@ impl core::fmt::Display for NodeType {
             Self::Prover => "Prover",
             Self::Validator => "Validator",
         })
+    }
+}
+
+impl ToBytes for NodeType {
+    fn write_le<W: io::Write>(&self, writer: W) -> io::Result<()> {
+        (*self as u8).write_le(writer)
+    }
+}
+
+impl FromBytes for NodeType {
+    fn read_le<R: io::Read>(reader: R) -> io::Result<Self>
+    where
+        Self: Sized,
+    {
+        match u8::read_le(reader)? {
+            0 => Ok(Self::Client),
+            1 => Ok(Self::Prover),
+            2 => Ok(Self::Validator),
+            _ => Err(error("Invalid node type")),
+        }
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/AleoHQ/snarkOS/pull/2469.

This PR replaces the uses of `bincode` in the (de)serialization of `Message` with `From/ToBytes`.

It is a breaking change.