### PR TITLE
Update `UnconfirmedSolution` propagation

### DIFF
--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -278,8 +278,8 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
                 // If the solution is valid, propagate the `UnconfirmedSolution`.
                 Ok(Ok(true)) => {
                     let message = Message::UnconfirmedSolution(serialized);
-                    // Propagate the "UnconfirmedSolution" to the connected validators.
-                    self.propagate_to_validators(message, &[peer_ip]);
+                    // Propagate the "UnconfirmedSolution".
+                    self.propagate(message, &[peer_ip]);
                 }
                 Ok(Ok(false)) | Ok(Err(_)) => {
                     trace!("Invalid prover solution '{}' for the proof target.", solution.commitment())

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -238,8 +238,8 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
                 // If the solution is valid, propagate the `UnconfirmedSolution`.
                 Ok(Ok(true)) => {
                     let message = Message::UnconfirmedSolution(serialized);
-                    // Propagate the "UnconfirmedSolution" to the connected validators.
-                    self.propagate_to_validators(message, &[peer_ip]);
+                    // Propagate the "UnconfirmedSolution".
+                    self.propagate(message, &[peer_ip]);
                 }
                 Ok(Ok(false)) | Ok(Err(_)) => {
                     trace!("Invalid prover solution '{}' for the proof target.", solution.commitment())


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the propagation rules of UnconfirmedSolutions.

- Provers propagate to all connected peers.

- Clients propagate to all connected peers.

- Validators only propagate solutions to other validators.
