### PR TITLE
Prevent committing the subdag certificates on block failures

### DIFF
--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -489,8 +489,8 @@ impl<N: Network> BFT<N> {
                             self.dag.write().commit(certificate, self.storage().max_gc_rounds());
                         }
                     }
-                    Ok(Err(e)) => bail!("BFT failed to advance the subdag for round {anchor_round} - {e}"),
-                    Err(e) => bail!("BFT failed to receive the callback for round {anchor_round} - {e}"),
+                    Ok(Err(e)) => error!("BFT failed to advance the subdag for round {anchor_round} - {e}"),
+                    Err(e) => error!("BFT failed to receive the callback for round {anchor_round} - {e}"),
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR ensures that we don't prematurely commit subdag certificates to the DAG if the subdag failed to be committed in a block. 

This is important because, if the block production fails for any reason, but we already assume that certain certificates are canonicalized in the DAG, then subsequent block production will create corrupted state.
