### PR TITLE
Update snarkVM rev; Removes `Result` from `update_to_next_round`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,8 +3313,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4463a0d14ec067854fefd2e8f5af1b97d6047cfddb3f5965d95b631d15a479a1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3342,8 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0050550e70d891e2a3be9ed25e1b89ab84050fa5c22934639a53326aa99428a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3372,8 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f11611e9252cd7c1066437f31fba0e17eeec1406441a3adfd277d32e788dfea"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3386,8 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535744dd2ae37d041cd93190cd8548aeffc7bb22bbbda780a40d78a57ca07ef3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3397,8 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797debdc9c666125b7713be46c9a2986312363da4188a902cfb3cac1f596ab4"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3407,8 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15e31d02d38cd3386705731669b24e7a35ec0f8497fe2de3f2fe81e4db2b793"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3417,8 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31636b4de9d439ef2e1ccbbbdcc93d62508d742c329d4d21435acba74ba3505"
 dependencies = [
  "indexmap 2.0.2",
  "itertools 0.11.0",
@@ -3435,13 +3442,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f336969b6a82cd0c342ef5fd237d576d323f71d42977836fc0b0ae059221fbec"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3eaa5b5aa3a52851e3c233836ab2e63571e6be258fc8a26a27289f09f7c5f2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3451,8 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedca89ddc7efb6261b18ddfb6e98df5b683d9e51745bdf969eba9a271918cef"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3466,8 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ac2f802c10be39d08d6a264417848324160a9b0ad7f47bbfa851d51a682cf7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3481,8 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b73f7e8e8869ad99a8d1f144b11bf74d1ea28bdc1eb5b6429a4786188ae7dc"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3494,8 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5857740058175efbd4337a64fe57160bbb6e616d9aeb62555010507689acbd15"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3503,8 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed93b155384602119256a858d8a75dfa28199408a4f92ecb2768008692e8eae"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3513,8 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f81f2530bf73dd7c24b67350f5750471f17adfc79286ff6a8e64f754dd2ee43"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3525,8 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970b3a1a6ca6de376b24bc30624dc256b28969b93f0f1534d9dc1a286900414e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,8 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ebff84ec736c234bafe88aff44d3052dc6be2cebc74ec279d998bc550bdeaa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3548,8 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "554a349c917de7725fb38a1e0d3fe28cc4c2c7739254f7031fa9c229e198afca"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3560,8 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acd970a8091656d2fa227b5fc5394b5ce25703b3ce3d5b67e80fa4af69e5c6c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3573,18 +3592,21 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4226a7eeb804daa95cfa64c88d2d4d0b6463f8bc8d5e51056aab2c88700cbe1"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
  "snarkvm-console-types",
+ "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d72a6a58ec8d923ee54c6067bf31f1aee5f5a96b23c64fd9d3610e1a6f3e88d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3596,8 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0c230e5333e0e7ea242e4530a638f53caa453e0aa4b6bf3d96128f6103c248"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3607,8 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67afd16a1a2d104b91663d6f9afe21c6303b4953ce4a8461c10511ceb56a4bf9"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -3630,8 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d990553154f07377420524ebbf7997901a67216ea7131db495a27082f05acf"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3643,12 +3668,14 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-utilities",
+ "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda66bc63c31f4151c002ea6044ae5dfe0858e5c98faa29caed9165f5574187b"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3668,8 +3695,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7cf53908e11dd20f4b2811677e14a1823fd0d18c8bf48211b67c3bd7e73dee"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3683,8 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f297ce3c20b93f4f4d9671dc345de289fc2c441ad289a79a6c6ca6862da890"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3694,25 +3723,29 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44f1bc3bb525eb398fb0bf2c13dcea8110758d2198559b9b7ea584258b6e60"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e42ec5c5a4da6fdfbeb146fda520b8533a187506e8d129e674ccfd3581cbd95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
+ "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d240f9913f3766ff041ff1bb23423499859274361953728ca4ee89c6a85afc2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3722,8 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ce50a812ef5aaf0ffbe56850906147a12eeb1e52f6c360066e6a882afac82a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3733,18 +3767,21 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c810e73cfd13fd882c59aa529cd110c086440f9663aae2c5d8cfe898853cb3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
  "snarkvm-console-types-field",
+ "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099e02b9227a7fa64df67202f3e16977e3ec6aaffc9099e1f313f566afa15251"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3754,8 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bbd8ac401c401aa420dca3014885f0a4685a8c4f0f71ddad2e999e5c8b58ea7"
 dependencies = [
  "rand",
  "rayon",
@@ -3768,8 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd6bc4c9354f0d781f8b911ff8440333ca67e71c4a8dabb48dfeb126015a015"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3781,12 +3820,14 @@ dependencies = [
  "serde",
  "snarkvm-utilities",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6253cc317e7ed32fe1038ea4bed859574ccff508c3049a30d1fa4635131d904"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3809,8 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84440f065eb4c5355e5e2ab0259ebd19af4991938c0a321ea38a11a1a00d168a"
 dependencies = [
  "anyhow",
  "rand",
@@ -3821,8 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea858b84ce304804390659b8ab8da85fc30b3380889224ce517cc9ba085785d8"
 dependencies = [
  "indexmap 2.0.2",
  "rayon",
@@ -3839,8 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-coinbase"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2eb406164fdf5edffe00f694e486b1e0426e259bb734ee85f80ad5aa8d762"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3859,8 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d69fa022fdea3166c43c393b1d39db9845d70afc8ca520c0ae4548609a5c43"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -3875,8 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66eac72010cc24c788aa626e94b2ebe37853764e706d871695c7d33dfa1a7a7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3888,8 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0161c77c5af4fffe0635d84312c3a3de14ef752809acfdf0400e8d17a0550231"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -3901,8 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff38cb3bd5b871a8e3defd2361eecd28bb9c252d15d9e91c2a4e99b9138779e0"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -3913,8 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97869eb796a78d3e484a9220635fcc73e79bdcd2345d29b18f63dd55d11d22c2"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3924,8 +3973,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8cfdf2e44685cf7db8a0a43903b5adcef41abe3243513ea1499f34a34b4c98"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -3936,8 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3ec1ee1ad68445f3792afb36dc62d854b97db52ab72fc32d1e00e35c96d313"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3949,8 +4000,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aab8836c6e4771779d3c1f7a9e8c91c4516c27832fc46ef75650a18cf5712d8"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -3958,8 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f8102d82acb223db0bb5e73be3cd7cf01d61194ce49b5d75132cf9974a8a04"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3971,8 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c1792e28df2ab85cbeb6ae43b40eed2580235b8070d7f74b199a0e50cd16e2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3996,8 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169f7733dfb6b38b47e8ceadd0df4eb16faabdcd9455596b81a6c275cee0edc7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4020,8 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c8aeb86bbdf52a10d608d4a4a908b753dd2a109a015aae8bffdc39893b1012"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4044,8 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82f680a9b03e6f62e007c3c486a3b81c02951fd8ce6278885049c980bdfb642"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4066,8 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604d1a75398700fd6177d894096d3d3d314d7e83d2360f51d3e4e6b4a5264ad8"
 dependencies = [
  "indexmap 2.0.2",
  "paste",
@@ -4080,8 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a685bbba09aeb531c67308582002a3b7fb756e17e55fb78795336c659acc01b"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4093,8 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18983a4b5897b2dc5464c0c252266d3699820dd61c31869c738f9b67832155bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4109,12 +4169,14 @@ dependencies = [
  "smol_str",
  "snarkvm-utilities-derives",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.15.3"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f887760a4ea59fba3b15030591c242c86e290fb7bd95568cb2c3b9f503df5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",
@@ -5148,3 +5210,17 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 2.0.37",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,9 +3313,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9abe3f82716c94854189f54d9ca4aaa5cdc45e27c49cadd285ebc638047990"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3343,9 +3342,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df1d509edf48abedfe292f6e2af526b78807fd01ef80ca16bb03bfcff8b1083"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3374,9 +3372,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4088a546d85b0c3494760c585160e9d2b2c204f690ec53ea339959c44c62bdd"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3389,9 +3386,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefe4d21d4f4cca45ec3baaf81ca8ed9442407c409802b84b4af4b1a0e8ed5d8"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3401,9 +3397,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815a1270493eaacfda64513023185f96972d1bb60427f6c9796e7a6f95cf33f8"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3412,9 +3407,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d262d8ac5f770fda64bb7563ffa9879856dbf58d9159af93dc2ef23352247965"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3423,9 +3417,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdd8ed85171d99cad3886f916e06ff7e676b9e12ec540387746cbcdecafa167"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "indexmap 2.0.2",
  "itertools 0.11.0",
@@ -3442,15 +3435,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f7d693647d753d3fff696d04e11282153fa539b7cc983ccf0625bc5c657511"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c52ff76b4fceaf0737ce9be2f52331873a9ef0c5beba5ab2458e34656b79285"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3460,9 +3451,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff67571826123ede74c82687e4690be9ab07cb86f57bc20fb1f81b7360a68d4"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3476,9 +3466,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91562eb799fb08e9fafa527c6059241da0f9a90f46ecc4c6fd6a89c37470e94"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3492,9 +3481,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3740c4f0c5495e893679341dda7c1814ad1bd9f66aa0b7fe5a66102f3db6a085"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3506,9 +3494,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d128a9a1f244b383f7c32e3cc7a4ef67bb2205254a7eaaf12e6f0ea4e11f38d3"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3516,9 +3503,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d4aee3ab3f9ca85e3a19e7126b47236041b4a7cd57176819dc84d50f56756d"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3527,9 +3513,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06725897312966c9965a4f3f95f19972f8ef0e3b96c91ae17238e715b92c17f"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3540,9 +3525,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ea25c1095173299d4b5447cc9bd47869ae63576e8fc2c998740f0a7c8bf1e6"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3553,9 +3537,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c35472a484b3a98c5c0036ccf6691cf3bca738c24e983e22083eee6110472f"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3565,9 +3548,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c2bed010fff59ffacf6368809e3db3a84a9912337ce8fce2acabbd05c52f08"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3578,9 +3560,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb56e78e3b41db6eb15af32104937422f5239a44b187a6c1945f215f3f9f22b"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3592,9 +3573,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b864fbd0d81e46f041dfe978a1dd71e9e36d72a13c591118b9076d217df1f73"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3603,9 +3583,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdfd52cb11e2d95f346a3e5657dcd2b05fa9ac599b0265e66199b71f11a5213"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3617,9 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ec0b45a98ef399bce242d804d542db75e5b462a1ba902b5c59a35bb5fe806e"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3629,9 +3607,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6017b73e2b80aa2a8e969262079fbb863802a32054da61f0c81adfd06bade"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -3653,9 +3630,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a2a411167f191750ae04305114af3931568f85d94e96e911c67bb71f161c85"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3671,9 +3647,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f07318585873a3dfbfff302de458724bde0a5f6b89599fca325f251c8a4c0"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3693,9 +3668,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbfc409d1a92f768e663a401b03f354a0bf951a3886cc5ba580f94bc3cdd44e"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3709,9 +3683,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf205cacd166f41ed24e68eec7ca04e05b14fd24748a738e5d11298c6346fc5d"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3721,18 +3694,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0eea9cdd565875ab5fb18298be01e8facd72cacfccd08b294ea6b03cdd8081"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a0bfe2c017496393b2017ab750a0ccd9afbfdf8414ed0dabfaf92aa29758bf"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3740,9 +3711,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d22b536d8418c1f110ff243d136462caa13413e52bcd4b5ecd6a2a778e4a97e"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3752,9 +3722,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ec4b73deb05a531120fe10235b0bd17a966dbded6ec188ce2276d273f74f4b"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3764,9 +3733,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7db61d513b502aa9c0465393b03941a263d90cf881bfd9b6d83952cba8e5ef"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3775,9 +3743,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c98f603c0cdb39a4e0628d190b1cc8c1b55dc6e088dcf202d362dc5632570c"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3787,9 +3754,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f768630da1ff927da9d2ed135ca20044233ed283d30926bf665032e4f55ced"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "rand",
  "rayon",
@@ -3802,9 +3768,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4d96aa3ffc1fd840b475514c546506e2ad06ef0b29f9218a720c7b95cf0098"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3820,9 +3785,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d81b079f73d6272a9d5c79937c1279b26d446e9d6b8abb53ec61249cd5d14e8"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3845,9 +3809,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f96443017d29f07740333e6ef3a92837862d036d74ac332fca32d9e26545cd"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "anyhow",
  "rand",
@@ -3858,9 +3821,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc9e271a7d9d3ed2337df027c09cd2b6788f2cf22dca712f208fca605be322e"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "indexmap 2.0.2",
  "rayon",
@@ -3877,9 +3839,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-coinbase"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171a2e2fef2d41e14087463e1a69eeed6ac0375e995ba3fe053c7d2343d3cfcd"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3898,9 +3859,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e8fafb9c567c36325cb638a296562b905f03582784b0ce25e40f99520065b1"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -3915,9 +3875,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8eeb28ded8c168b170978cf88583569e36956e2f1214153ad7ecd6f1bfce9b"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3929,9 +3888,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66a97bc3cc66dd1763c8398067949b323c7bc2d3ec1316bf2a4186a5272ae81"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -3943,9 +3901,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fafec7263c61859dc53a1963ba2ec0cce7f45c3f1177ebeebb1ee77d85e7f6"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -3956,9 +3913,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a734795d33f94f7f63963160a1eda2c7860a8cd196b36e59583ed83f741732"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3968,9 +3924,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8e187bbf7aac65a3d81266fcc27e8da9739b5763d990c5360bac6b7d034de"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "indexmap 2.0.2",
  "serde_json",
@@ -3981,9 +3936,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb476b5b6a8a213117b25ca9085a6bd41eea48fcbd3af4aa9bca8a99d1778b2e"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3995,9 +3949,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd4cd23c77a9a63465103e09c5f527db2cd87490621b8dd6a5c4b9a859c4ffb"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4005,9 +3958,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4586cdebdc2c5fc74d66853f5b90d8fc7459ec4604e06005bf8dab44114c69"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4019,9 +3971,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e18df6e866f52dd5e9e4bd411c34a1cd41ffa73fa55b2f4fbd382d281c8aab3"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4045,9 +3996,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c89a7abaa42772fa811a11371a86c2b3f1312e9095edeaad7009ad35696f7b"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4070,9 +4020,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024355346ad5f81c6acd9df3b10274bc056370907cc97df6b98a922dd0a9140e"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4095,9 +4044,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b5547d4420fb0760a3055af015f71b13cd7e33f217fdc1290c7a893e94958d"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4118,9 +4066,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da221632881549d109c68446977e829add60d31226fa8bffcf80d8f2d839990d"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "indexmap 2.0.2",
  "paste",
@@ -4133,9 +4080,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cf79a2a8c7a4a066e5921c967f46e3dd220fb458e67bba6924e9591d6ce8c4"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4147,9 +4093,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dddef43c0e2907aa330c3f3e243a0f1cb7b6c4b8ef3f4445db48fbbe481d65d2"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4168,9 +4113,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a2b8b0d67ffa2d6fc0b512ac7bb08fa2e4a57f986d626f7787b7ef811270d5"
+version = "0.15.3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f827660#f82766018bb5e72955060761bf36c81b653032b7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,6 +3148,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber 0.3.17",
+ "tracing-test 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "f827660"
-#version = "=0.15.2"
+#git = "https://github.com/AleoHQ/snarkVM.git"
+#rev = "f827660"
+version = "=0.15.4"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-#git = "https://github.com/AleoHQ/snarkVM.git"
-#rev = "18509ab"
-version = "=0.15.2"
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "f827660"
+#version = "=0.15.2"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/narwhal/Cargo.toml
+++ b/node/narwhal/Cargo.toml
@@ -154,5 +154,8 @@ features = [ "fs", "trace" ]
 version = "0.3"
 features = [ "env-filter" ]
 
+[dev-dependencies.tracing-test]
+version = "0.1"
+
 [dev-dependencies.mockall]
 version = "0.11.4"

--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -206,10 +206,25 @@ impl<N: Network> BFT<N> {
             false => self.is_leader_quorum_or_nonleaders_available(current_round),
         };
 
-        // Log the leader election.
+        // Log whether the round is going to update.
         if current_round % 2 == 0 {
+            // Determine if there is a leader certificate.
             if let Some(leader_certificate) = self.leader_certificate.read().as_ref() {
-                info!("\n\nRound {current_round} elected a leader - {}\n", leader_certificate.author());
+                // Ensure the state of the leader certificate is consistent with the BFT being ready.
+                if !is_ready {
+                    error!(is_ready, "BFT - A leader certificate was found, but 'is_ready' is false");
+                }
+                // Log the leader election.
+                let leader_round = leader_certificate.round();
+                match leader_round == current_round {
+                    true => info!("\n\nRound {current_round} elected a leader - {}\n", leader_certificate.author()),
+                    false => warn!("BFT failed to elect a leader for round {current_round} (!= {leader_round})"),
+                }
+            } else {
+                match is_ready {
+                    true => info!("\n\nRound {current_round} reached quorum without a leader\n"),
+                    false => info!("\n\nRound {current_round} did not elect a leader\n"),
+                }
             }
         }
 
@@ -273,7 +288,7 @@ impl<N: Network> BFT<N> {
         let leader_certificate = current_certificates.iter().find(|certificate| certificate.author() == leader);
         *self.leader_certificate.write() = leader_certificate.cloned();
 
-        self.is_even_round_ready_for_next_round(current_certificates, previous_committee)
+        self.is_even_round_ready_for_next_round(current_certificates, previous_committee, current_round)
     }
 
     /// Returns 'true' under one of the following conditions:
@@ -284,13 +299,17 @@ impl<N: Network> BFT<N> {
         &self,
         certificates: IndexSet<BatchCertificate<N>>,
         committee: Committee<N>,
+        current_round: u64,
     ) -> bool {
         // If the leader certificate is set for the current even round, return 'true'.
-        if self.leader_certificate.read().is_some() {
-            return true;
+        if let Some(leader_certificate) = self.leader_certificate.read().as_ref() {
+            if leader_certificate.round() == current_round {
+                return true;
+            }
         }
         // If the timer has expired, and we can achieve quorum threshold (2f + 1) without the leader, return 'true'.
         if self.is_timer_expired() {
+            debug!("BFT - timer expired for the leader, checking for quorum threshold (without the leader)");
             // Retrieve the certificate authors.
             let authors = certificates.into_iter().map(|c| c.author()).collect();
             // Determine if the quorum threshold is reached.
@@ -728,6 +747,7 @@ mod tests {
     use std::sync::{atomic::Ordering, Arc};
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_is_leader_quorum_odd() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -764,6 +784,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_is_leader_quorum_even_out_of_sync() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -785,6 +806,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_is_leader_quorum_even() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -805,6 +827,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_is_even_round_ready() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -816,20 +839,21 @@ mod tests {
         // Initialize the BFT.
         let bft = BFT::new(account, storage, ledger, None, &[], None)?;
 
-        let result = bft.is_even_round_ready_for_next_round(IndexSet::new(), committee.clone());
+        let result = bft.is_even_round_ready_for_next_round(IndexSet::new(), committee.clone(), 2);
         assert!(!result);
 
         // Set the leader certificate.
-        let leader_certificate = sample_batch_certificate(rng);
+        let leader_certificate = sample_batch_certificate_for_round(2, rng);
         *bft.leader_certificate.write() = Some(leader_certificate);
 
-        let result = bft.is_even_round_ready_for_next_round(IndexSet::new(), committee);
+        let result = bft.is_even_round_ready_for_next_round(IndexSet::new(), committee, 2);
         // If leader certificate is set, we should be ready for next round.
         assert!(result);
         Ok(())
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_update_leader_certificate_odd() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -848,6 +872,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_update_leader_certificate_bad_round() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -866,6 +891,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_update_leader_certificate_even() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -879,7 +905,7 @@ mod tests {
         let bft = BFT::new(account, storage, ledger, None, &[], None)?;
 
         // Set the leader certificate.
-        let leader_certificate = sample_batch_certificate(rng);
+        let leader_certificate = sample_batch_certificate_for_round(2, rng);
         *bft.leader_certificate.write() = Some(leader_certificate);
 
         // Update the leader certificate.
@@ -891,6 +917,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[tracing_test::traced_test]
     async fn test_order_dag_with_dfs() -> Result<()> {
         use snarkvm::ledger::narwhal::batch_certificate::test_helpers::{
             sample_batch_certificate_for_round,
@@ -991,6 +1018,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_order_dag_with_dfs_fails_on_missing_previous_certificate() -> Result<()> {
         let rng = &mut TestRng::default();
 

--- a/node/narwhal/src/bft.rs
+++ b/node/narwhal/src/bft.rs
@@ -343,17 +343,8 @@ impl<N: Network> BFT<N> {
         };
 
         // Compute the stake for the leader certificate.
-        let (stake_with_leader, stake_without_leader) = match self.compute_stake_for_leader_certificate(
-            leader_certificate_id,
-            current_certificates,
-            &previous_committee,
-        ) {
-            Ok(stakes) => stakes,
-            Err(e) => {
-                error!("BFT failed to compute the stake for the leader certificate - {e}");
-                return false;
-            }
-        };
+        let (stake_with_leader, stake_without_leader) =
+            self.compute_stake_for_leader_certificate(leader_certificate_id, current_certificates, &previous_committee);
         // Return 'true' if any of the following conditions hold:
         stake_with_leader >= previous_committee.availability_threshold()
             || stake_without_leader >= previous_committee.quorum_threshold()
@@ -366,10 +357,10 @@ impl<N: Network> BFT<N> {
         leader_certificate_id: Field<N>,
         current_certificates: IndexSet<BatchCertificate<N>>,
         current_committee: &Committee<N>,
-    ) -> Result<(u64, u64)> {
+    ) -> (u64, u64) {
         // If there are no current certificates, return early.
         if current_certificates.is_empty() {
-            return Ok((0, 0));
+            return (0, 0);
         }
 
         // Initialize a tracker for the stake with the leader.
@@ -389,7 +380,7 @@ impl<N: Network> BFT<N> {
             }
         }
         // Return the stake with the leader, and the stake without the leader.
-        Ok((stake_with_leader, stake_without_leader))
+        (stake_with_leader, stake_without_leader)
     }
 }
 

--- a/node/narwhal/src/helpers/channels.rs
+++ b/node/narwhal/src/helpers/channels.rs
@@ -64,7 +64,7 @@ pub fn init_consensus_channels<N: Network>() -> (ConsensusSender<N>, ConsensusRe
 
 #[derive(Clone, Debug)]
 pub struct BFTSender<N: Network> {
-    pub tx_primary_round: mpsc::Sender<(u64, oneshot::Sender<Result<()>>)>,
+    pub tx_primary_round: mpsc::Sender<(u64, oneshot::Sender<()>)>,
     pub tx_primary_certificate: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
     pub tx_sync_bft_dag_at_bootup: mpsc::Sender<(Vec<BatchCertificate<N>>, Vec<BatchCertificate<N>>)>,
     pub tx_sync_bft: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
@@ -78,7 +78,7 @@ impl<N: Network> BFTSender<N> {
         // Send the current round to the BFT.
         self.tx_primary_round.send((current_round, callback_sender)).await?;
         // Await the callback to continue.
-        callback_receiver.await?
+        Ok(callback_receiver.await?)
     }
 
     /// Sends the batch certificate to the BFT.
@@ -104,7 +104,7 @@ impl<N: Network> BFTSender<N> {
 
 #[derive(Debug)]
 pub struct BFTReceiver<N: Network> {
-    pub rx_primary_round: mpsc::Receiver<(u64, oneshot::Sender<Result<()>>)>,
+    pub rx_primary_round: mpsc::Receiver<(u64, oneshot::Sender<()>)>,
     pub rx_primary_certificate: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
     pub rx_sync_bft_dag_at_bootup: mpsc::Receiver<(Vec<BatchCertificate<N>>, Vec<BatchCertificate<N>>)>,
     pub rx_sync_bft: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,

--- a/node/narwhal/src/helpers/storage.rs
+++ b/node/narwhal/src/helpers/storage.rs
@@ -257,6 +257,21 @@ impl<N: Network> Storage<N> {
         self.certificates.read().get(&certificate_id).cloned()
     }
 
+    /// Returns the certificate for the given `round` and `author`.
+    /// If the round does not exist in storage, `None` is returned.
+    /// If the author for the round does not exist in storage, `None` is returned.
+    pub fn get_certificate_for_round_with_author(&self, round: u64, author: Address<N>) -> Option<BatchCertificate<N>> {
+        // Retrieve the certificates.
+        if let Some(entries) = self.rounds.read().get(&round) {
+            let certificates = self.certificates.read();
+            entries.iter().find_map(
+                |(certificate_id, _, a)| if a == &author { certificates.get(certificate_id).cloned() } else { None },
+            )
+        } else {
+            Default::default()
+        }
+    }
+
     /// Returns the certificates for the given `round`.
     /// If the round does not exist in storage, `None` is returned.
     pub fn get_certificates_for_round(&self, round: u64) -> IndexSet<BatchCertificate<N>> {
@@ -709,6 +724,47 @@ impl<N: Network> Storage<N> {
     ) -> impl Iterator<Item = (TransmissionID<N>, (Transmission<N>, IndexSet<Field<N>>))> {
         self.transmissions.read().clone().into_iter()
     }
+
+    /// Inserts the given `certificate` into storage.
+    ///
+    /// Note: Do NOT use this in production. This is for **testing only**.
+    #[doc(hidden)]
+    pub(crate) fn testing_only_insert_certificate_testing_only(&self, certificate: BatchCertificate<N>) {
+        // Retrieve the round.
+        let round = certificate.round();
+        // Retrieve the certificate ID.
+        let certificate_id = certificate.certificate_id();
+        // Retrieve the batch ID.
+        let batch_id = certificate.batch_id();
+        // Retrieve the author of the batch.
+        let author = certificate.author();
+
+        // Insert the round to certificate ID entry.
+        self.rounds.write().entry(round).or_default().insert((certificate_id, batch_id, author));
+        // Obtain the certificate's transmission ids.
+        let transmission_ids = certificate.transmission_ids().clone();
+        // Insert the certificate.
+        self.certificates.write().insert(certificate_id, certificate);
+        // Insert the batch ID.
+        self.batch_ids.write().insert(batch_id, round);
+        // Acquire the transmissions write lock.
+        let mut transmissions = self.transmissions.write();
+        // Inserts the following:
+        //   - Inserts **only the missing** transmissions from storage.
+        //   - Inserts the certificate ID into the corresponding set for **all** transmissions.
+        for transmission_id in transmission_ids {
+            // Retrieve the transmission entry.
+            transmissions.entry(transmission_id)
+                // Insert **only the missing** transmissions from storage.
+                .or_insert_with( || {
+                    // Return the transmission and an empty set of certificate IDs.
+                    let dummy = snarkvm::ledger::narwhal::Data::Buffer(bytes::Bytes::new());
+                    (Transmission::Transaction(dummy), Default::default())
+                })
+                // Insert the certificate ID into the corresponding set for **all** transmissions.
+                .1.insert(certificate_id);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -820,6 +876,8 @@ mod tests {
         assert!(storage.contains_certificate(certificate_id));
         // Ensure the certificate is stored in the correct round.
         assert_eq!(storage.get_certificates_for_round(round), indexset! { certificate.clone() });
+        // Ensure the certificate is stored for the correct round and author.
+        assert_eq!(storage.get_certificate_for_round_with_author(round, author), Some(certificate.clone()));
 
         // Check that the underlying storage representation is correct.
         {
@@ -844,6 +902,8 @@ mod tests {
         assert!(!storage.contains_certificate(certificate_id));
         // Ensure the certificate is no longer stored in the round.
         assert!(storage.get_certificates_for_round(round).is_empty());
+        // Ensure the certificate is no longer stored for the round and author.
+        assert_eq!(storage.get_certificate_for_round_with_author(round, author), None);
         // Ensure the storage is empty.
         assert_storage(&storage, &[], &[], &[], &Default::default());
     }

--- a/node/narwhal/src/primary.rs
+++ b/node/narwhal/src/primary.rs
@@ -299,7 +299,7 @@ impl<N: Network> Primary<N> {
             // If a BFT sender was provided, attempt to advance the current round.
             if let Some(bft_sender) = self.bft_sender.get() {
                 if let Err(e) = bft_sender.send_primary_round_to_bft(self.current_round()).await {
-                    warn!("Failed to update the BFT to the next round: {e}");
+                    warn!("Failed to update the BFT to the next round - {e}");
                     return Err(e);
                 }
             }
@@ -813,7 +813,7 @@ impl<N: Network> Primary<N> {
             // If a BFT sender was provided, send the current round to the BFT.
             if let Some(bft_sender) = self.bft_sender.get() {
                 if let Err(e) = bft_sender.send_primary_round_to_bft(self.current_round()).await {
-                    warn!("Failed to update the BFT to the next round: {e}");
+                    warn!("Failed to update the BFT to the next round - {e}");
                     return Err(e);
                 }
             }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Removes `Result` from `update_to_next_round`.

The goal here is to improve ergonomics and to catch any case where failure is unpredictable.

Note: I have tested this code change on my machine and it performs unchanged.

In addition, to support the test cases, snarkVM is updated to `0.15.4`.