### PR TITLE
Use CDN for bulk of `snarkos developer scan`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,6 +2975,7 @@ dependencies = [
  "aleo-std",
  "anstyle",
  "anyhow",
+ "bincode",
  "clap",
  "colored",
  "crossterm 0.27.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "snarkos-account",
  "snarkos-display",
  "snarkos-node",
+ "snarkos-node-cdn",
  "snarkos-node-rest",
  "snarkvm",
  "sys-info",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -82,6 +82,10 @@ version = "=2.1.7"
 path = "../node"
 version = "=2.1.7"
 
+[dependencies.snarkos-node-cdn]
+path = "../node/cdn"
+version = "=2.1.7"
+
 [dependencies.snarkos-node-rest]
 path = "../node/rest"
 version = "=2.1.7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,6 +26,9 @@ version = "1"
 [dependencies.anyhow]
 version = "1.0.75"
 
+[dependencies.bincode]
+version = "1.0"
+
 [dependencies.clap]
 version = "4.4"
 features = [ "derive", "color", "unstable-styles" ]

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -18,10 +18,14 @@ use snarkvm::prelude::{block::Block, Ciphertext, Field, Network, Plaintext, Priv
 
 use anyhow::{bail, ensure, Result};
 use clap::Parser;
+use parking_lot::RwLock;
 use std::{
     io::{stdout, Write},
     str::FromStr,
+    sync::Arc,
 };
+
+const MAX_BLOCK_RANGE: u32 = 50;
 
 /// Scan the snarkOS node for records.
 #[derive(Debug, Parser)]
@@ -159,15 +163,30 @@ impl Scan {
         // Derive the x-coordinate of the address corresponding to the given view key.
         let address_x_coordinate = view_key.to_address().to_x_coordinate();
 
-        const MAX_BLOCK_RANGE: u32 = 50;
-
-        let mut records = Vec::new();
+        // Initialize a vector to store the records.
+        let records = Arc::new(RwLock::new(Vec::new()));
 
         // Calculate the number of blocks to scan.
         let total_blocks = end_height.saturating_sub(start_height);
 
-        // Scan the endpoint starting from the start height
-        let mut request_start = start_height.saturating_sub(start_height % MAX_BLOCK_RANGE);
+        // Log the initial progress.
+        print!("\rScanning {total_blocks} blocks for records (0% complete)...");
+        stdout().flush()?;
+
+        // Scan the CDN first for records.
+        Self::scan_from_cdn(
+            start_height,
+            end_height,
+            cdn.to_string(),
+            endpoint.to_string(),
+            private_key.clone(),
+            view_key.clone(),
+            address_x_coordinate,
+            records.clone(),
+        )?;
+
+        // Scan the endpoint for the remaining blocks.
+        let mut request_start = end_height.saturating_sub(start_height % MAX_BLOCK_RANGE);
         while request_start <= end_height {
             // Log the progress.
             let percentage_complete = request_start.saturating_sub(start_height) as f64 * 100.0 / total_blocks as f64;
@@ -178,40 +197,14 @@ impl Scan {
                 std::cmp::min(MAX_BLOCK_RANGE, end_height.saturating_sub(request_start).saturating_add(1));
             let request_end = request_start.saturating_add(num_blocks_to_request);
 
-            // Attempt to fetch the blocks from the CDN first.
-            let cdn_request_end = request_start.saturating_add(MAX_BLOCK_RANGE);
-            let cdn_blocks_url = format!("{cdn}/{request_start}.{cdn_request_end}.blocks");
-            let mut blocks: Vec<Block<CurrentNetwork>> = match ureq::get(&cdn_blocks_url).call() {
-                Ok(response) => {
-                    // Read the bytes from the response.
-                    let mut bytes = Vec::new();
-                    response.into_reader().read_to_end(&mut bytes)?;
-                    // Deserialize the blocks.
-                    bincode::deserialize(&bytes)?
-                }
-                Err(_) => {
-                    // Establish the endpoint.
-                    let blocks_endpoint = format!("{endpoint}/testnet3/blocks?start={request_start}&end={request_end}");
-                    // Fetch blocks
-                    ureq::get(&blocks_endpoint).call()?.into_json()?
-                }
-            };
-            // Only keep the blocks that are in the requested range.
-            blocks.retain(|block| block.height() >= start_height && block.height() <= end_height);
+            // Establish the endpoint.
+            let blocks_endpoint = format!("{endpoint}/testnet3/blocks?start={request_start}&end={request_end}");
+            // Fetch blocks
+            let blocks: Vec<Block<CurrentNetwork>> = ureq::get(&blocks_endpoint).call()?.into_json()?;
 
             // Scan the blocks for owned records.
             for block in &blocks {
-                for (commitment, ciphertext_record) in block.records() {
-                    // Check if the record is owned by the given view key.
-                    if ciphertext_record.is_owner_with_address_x_coordinate(view_key, &address_x_coordinate) {
-                        // Decrypt and optionally filter the records.
-                        if let Some(record) =
-                            Self::decrypt_record(private_key, view_key, endpoint, *commitment, ciphertext_record)?
-                        {
-                            records.push(record);
-                        }
-                    }
-                }
+                Self::scan_block(&block, &endpoint, private_key, &view_key, &address_x_coordinate, records.clone())?;
             }
 
             request_start = request_start.saturating_add(num_blocks_to_request);
@@ -221,7 +214,78 @@ impl Scan {
         println!("\rScanning {total_blocks} blocks for records (100% complete)...   \n");
         stdout().flush()?;
 
-        Ok(records)
+        let result = records.read().clone();
+        Ok(result)
+    }
+
+    /// Scan the blocks from the CDN.
+    fn scan_from_cdn(
+        start_height: u32,
+        end_height: u32,
+        cdn: String,
+        endpoint: String,
+        private_key: Option<PrivateKey<CurrentNetwork>>,
+        view_key: ViewKey<CurrentNetwork>,
+        address_x_coordinate: Field<CurrentNetwork>,
+        records: Arc<RwLock<Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>>>,
+    ) -> Result<()> {
+        // Calculate the number of blocks to scan.
+        let total_blocks = end_height.saturating_sub(start_height);
+
+        // Get the start_height with
+        let cdn_request_start = start_height.saturating_sub(start_height % MAX_BLOCK_RANGE);
+        let cdn_request_end = end_height.saturating_sub(start_height % MAX_BLOCK_RANGE);
+
+        // Construct the runtime.
+        let rt = tokio::runtime::Runtime::new()?;
+
+        // Scan the blocks via the CDN.
+        rt.block_on(async move {
+            let _ = snarkos_node_cdn::load_blocks(&cdn, cdn_request_start, Some(cdn_request_end), move |block| {
+                // Check if the block is within the requested range.
+                if block.height() < start_height || block.height() > end_height {
+                    return Ok(());
+                }
+
+                // Log the progress.
+                let percentage_complete =
+                    block.height().saturating_sub(start_height) as f64 * 100.0 / total_blocks as f64;
+                print!("\rScanning {total_blocks} blocks for records ({percentage_complete:.2}% complete)...");
+                stdout().flush()?;
+
+                // Scan the block for records.
+                Self::scan_block(&block, &endpoint, private_key, &view_key, &address_x_coordinate, records.clone())?;
+
+                Ok(())
+            })
+            .await;
+        });
+
+        Ok(())
+    }
+
+    /// Scan a block for owned records.
+    fn scan_block(
+        block: &Block<CurrentNetwork>,
+        endpoint: &str,
+        private_key: Option<PrivateKey<CurrentNetwork>>,
+        view_key: &ViewKey<CurrentNetwork>,
+        address_x_coordinate: &Field<CurrentNetwork>,
+        records: Arc<RwLock<Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>>>,
+    ) -> Result<()> {
+        for (commitment, ciphertext_record) in block.records() {
+            // Check if the record is owned by the given view key.
+            if ciphertext_record.is_owner_with_address_x_coordinate(view_key, address_x_coordinate) {
+                // Decrypt and optionally filter the records.
+                if let Some(record) =
+                    Self::decrypt_record(private_key, view_key, endpoint, *commitment, ciphertext_record)?
+                {
+                    records.write().push(record);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Decrypts the ciphertext record and filters spend record if a private key was provided.

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::type_complexity)]
+
 use super::CurrentNetwork;
 
 use snarkvm::prelude::{block::Block, Ciphertext, Field, Network, Plaintext, PrivateKey, Record, ViewKey};
@@ -179,8 +181,8 @@ impl Scan {
             end_height,
             cdn.to_string(),
             endpoint.to_string(),
-            private_key.clone(),
-            view_key.clone(),
+            private_key,
+            *view_key,
             address_x_coordinate,
             records.clone(),
         )?;
@@ -204,7 +206,7 @@ impl Scan {
 
             // Scan the blocks for owned records.
             for block in &blocks {
-                Self::scan_block(&block, &endpoint, private_key, &view_key, &address_x_coordinate, records.clone())?;
+                Self::scan_block(block, endpoint, private_key, view_key, &address_x_coordinate, records.clone())?;
             }
 
             request_start = request_start.saturating_add(num_blocks_to_request);
@@ -219,6 +221,7 @@ impl Scan {
     }
 
     /// Scan the blocks from the CDN.
+    #[allow(clippy::too_many_arguments)]
     fn scan_from_cdn(
         start_height: u32,
         end_height: u32,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates `snarkOS developer scan` to utilize the CDN for record scanning, and default to the standard endpoint if the CDN does not have the latest blocks.
