### PR TITLE
Speed up Cache::retain_and_insert

### DIFF
--- a/node/narwhal/src/gateway.rs
+++ b/node/narwhal/src/gateway.rs
@@ -218,7 +218,7 @@ impl<N: Network> Gateway<N> {
 
     /// The maximum number of duplicates for any particular request.
     fn max_cache_duplicates(&self) -> usize {
-        self.max_committee_size() * self.max_committee_size()
+        self.max_committee_size().pow(2)
     }
 }
 


### PR DESCRIPTION
I noticed `Cache::retain_and_insert` popping up in heap profiles due to the use of `BTreeMap::split_off`, and after some investigating I realized that most of those calls can be avoided, because usually all of the contents of the cache are retained due to the cutoff time being lower (i.e. "older") than all of the timestamps in the cache.

In addition, there is an improvement to `max_cache_duplicates`, which currently costs a double database lookup and double allocation; with this trivial change, only one of each is needed to calculate it.

These changes reduced the number of allocations by ~14% in my test run.