### PR TITLE
Deprecate `GET ../latest/..` routes

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -155,9 +155,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/testnet3/memoryPool/solutions", get(Self::get_memory_pool_solutions))
             .route("/testnet3/memoryPool/transactions", get(Self::get_memory_pool_transactions))
             .route("/testnet3/statePath/:commitment", get(Self::get_state_path_for_commitment))
-            .route("/testnet3/committee/latest", get(Self::get_committee_latest))
             .route("/testnet3/stateRoot/latest", get(Self::get_state_root_latest))
-            .route("/testnet3/node/address", get(Self::get_node_address))
+                .route("/testnet3/committee/latest", get(Self::get_committee_latest))
+                .route("/testnet3/node/address", get(Self::get_node_address))
 
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -103,14 +103,26 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let router = {
             axum::Router::new()
 
-            // GET ../latest/..
+            // ----------------- DEPRECATED ROUTES -----------------
+            // The following `GET ../latest/..` routes will be removed before mainnet.
+            // Please refer to the recommended routes for each endpoint:
+
+            // Deprecated: use `/testnet3/block/height/latest` instead.
             .route("/testnet3/latest/height", get(Self::latest_height))
+            // Deprecated: use `/testnet3/block/hash/latest` instead.
             .route("/testnet3/latest/hash", get(Self::latest_hash))
+            // Deprecated: use `/testnet3/latest/block/height` instead.
             .route("/testnet3/latest/block", get(Self::latest_block))
+            // Deprecated: use `/testnet3/stateRoot/latest` instead.
             .route("/testnet3/latest/stateRoot", get(Self::latest_state_root))
+            // Deprecated: use `/testnet3/committee/latest` instead.
             .route("/testnet3/latest/committee", get(Self::latest_committee))
+            // ------------------------------------------------------
 
             // GET ../block/..
+            .route("/testnet3/block/height/latest", get(Self::get_block_height_latest))
+            .route("/testnet3/block/hash/latest", get(Self::get_block_hash_latest))
+            .route("/testnet3/block/latest", get(Self::get_block_latest))
             .route("/testnet3/block/:height_or_hash", get(Self::get_block))
             // The path param here is actually only the height, but the name must match the route
             // above, otherwise there'll be a conflict at runtime.
@@ -144,6 +156,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/testnet3/memoryPool/transactions", get(Self::get_memory_pool_transactions))
             .route("/testnet3/statePath/:commitment", get(Self::get_state_path_for_commitment))
             .route("/testnet3/committee/latest", get(Self::get_committee_latest))
+            .route("/testnet3/stateRoot/latest", get(Self::get_state_root_latest))
             .route("/testnet3/node/address", get(Self::get_node_address))
 
             // Pass in `Rest` to make things convenient.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -156,8 +156,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/testnet3/memoryPool/transactions", get(Self::get_memory_pool_transactions))
             .route("/testnet3/statePath/:commitment", get(Self::get_state_path_for_commitment))
             .route("/testnet3/stateRoot/latest", get(Self::get_state_root_latest))
-                .route("/testnet3/committee/latest", get(Self::get_committee_latest))
-                .route("/testnet3/node/address", get(Self::get_node_address))
+            .route("/testnet3/committee/latest", get(Self::get_committee_latest))
+            .route("/testnet3/node/address", get(Self::get_node_address))
 
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -213,14 +213,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_state_path_for_commitment(&commitment)?))
     }
 
-    // GET /testnet3/committee/latest
-    pub(crate) async fn get_committee_latest(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
-    }
-
     // GET /testnet3/stateRoot/latest
     pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_state_root())
+    }
+
+    // GET /testnet3/committee/latest
+    pub(crate) async fn get_committee_latest(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
     }
 
     // GET /testnet3/peers/count

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -29,29 +29,55 @@ pub(crate) struct BlockRange {
 }
 
 impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
+    // ----------------- DEPRECATED FUNCTIONS -----------------
+    // The functions below are associated with deprecated routes.
+    // Please use the recommended alternatives when implementing new features or refactoring.
+
+    // Deprecated: Use `get_block_height_latest` instead.
     // GET /testnet3/latest/height
     pub(crate) async fn latest_height(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_height())
     }
 
+    // Deprecated: Use `get_block_hash_latest` instead.
     // GET /testnet3/latest/hash
     pub(crate) async fn latest_hash(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_hash())
     }
 
+    // Deprecated: Use `get_block_latest` instead.
     // GET /testnet3/latest/block
     pub(crate) async fn latest_block(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_block())
     }
 
+    // Deprecated: Use `get_state_root_latest` instead.
     // GET /testnet3/latest/stateRoot
     pub(crate) async fn latest_state_root(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_state_root())
     }
 
+    // Deprecated: Use `get_committee_latest` instead.
     // GET /testnet3/latest/committee
     pub(crate) async fn latest_committee(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
+    }
+
+    // ---------------------------------------------------------
+
+    // GET /testnet3/block/height/latest
+    pub(crate) async fn get_block_height_latest(State(rest): State<Self>) -> ErasedJson {
+        ErasedJson::pretty(rest.ledger.latest_height())
+    }
+
+    // GET /testnet3/block/hash/latest
+    pub(crate) async fn get_block_hash_latest(State(rest): State<Self>) -> ErasedJson {
+        ErasedJson::pretty(rest.ledger.latest_hash())
+    }
+
+    // GET /testnet3/block/latest
+    pub(crate) async fn get_block_latest(State(rest): State<Self>) -> ErasedJson {
+        ErasedJson::pretty(rest.ledger.latest_block())
     }
 
     // GET /testnet3/block/{height}
@@ -190,6 +216,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /testnet3/committee/latest
     pub(crate) async fn get_committee_latest(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
+    }
+
+    // GET /testnet3/stateRoot/latest
+    pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
+        ErasedJson::pretty(rest.ledger.latest_state_root())
     }
 
     // GET /testnet3/peers/count


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

In our ongoing efforts to standardize the REST API as described in https://github.com/AleoHQ/snarkOS/issues/2002, this PR deprecates the `GET ../latest/..` routes in favor of the new convention. The changes are as follows:

- `/testnet3/latest/height` -> `/testnet3/block/height/latest`
- `/testnet3/latest/hash` -> `/testnet3/block/hash/latest`
- `/testnet3/latest/block` -> `/testnet3/block/latest`
- `/testnet3/latest/stateRoot` -> `/testnet3/stateRoot/latest`
- `/testnet3/latest/committee` -> `/testnet3/committee/latest`
