### PR TITLE
Add balance checks for CLI executions with public fees

### DIFF
--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -48,7 +48,7 @@ pub struct Deploy {
     query: String,
     /// The priority fee in microcredits.
     #[clap(short, long)]
-    fee: u64,
+    priority_fee: u64,
     /// The record to spend the fee from.
     #[clap(short, long)]
     record: String,
@@ -99,7 +99,7 @@ impl Deploy {
             let (minimum_deployment_cost, (_, _)) = deployment_cost(&deployment)?;
             // Determine the fee.
             let fee_in_microcredits = minimum_deployment_cost
-                .checked_add(self.fee)
+                .checked_add(self.priority_fee)
                 .ok_or_else(|| anyhow!("Fee overflowed for a deployment transaction"))?;
 
             // Prepare the fees.
@@ -142,7 +142,7 @@ mod tests {
             "PRIVATE_KEY",
             "--query",
             "QUERY",
-            "--fee",
+            "--priority-fee",
             "77",
             "--record",
             "RECORD",
@@ -154,7 +154,7 @@ mod tests {
             assert_eq!(deploy.program_id, "hello.aleo".try_into().unwrap());
             assert_eq!(deploy.private_key, "PRIVATE_KEY");
             assert_eq!(deploy.query, "QUERY");
-            assert_eq!(deploy.fee, 77);
+            assert_eq!(deploy.priority_fee, 77);
             assert_eq!(deploy.record, "RECORD");
         } else {
             panic!("Unexpected result of clap parsing!");

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -47,7 +47,7 @@ pub struct Deploy {
     #[clap(short, long)]
     query: String,
     /// The priority fee in microcredits.
-    #[clap(short, long)]
+    #[clap(long)]
     priority_fee: u64,
     /// The record to spend the fee from.
     #[clap(short, long)]

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -49,7 +49,7 @@ pub struct Execute {
     query: String,
     /// The priority fee in microcredits.
     #[clap(short, long)]
-    fee: Option<u64>,
+    priority_fee: Option<u64>,
     /// The record to spend the fee from.
     #[clap(short, long)]
     record: Option<String>,
@@ -99,7 +99,7 @@ impl Execute {
                 Some(record_string) => Some(Developer::parse_record(&private_key, record_string)?),
                 None => None,
             };
-            let priority_fee = self.fee.unwrap_or(0);
+            let priority_fee = self.priority_fee.unwrap_or(0);
 
             // Create a new transaction.
             vm.execute(
@@ -128,7 +128,7 @@ impl Execute {
             // Calculate the base fee.
             // This fee is the minimum fee required to pay for the transaction,
             // excluding any finalize fees that the execution may incur.
-            let base_fee = storage_cost.saturating_add(self.fee.unwrap_or(0));
+            let base_fee = storage_cost.saturating_add(self.priority_fee.unwrap_or(0));
 
             // If the public balance is insufficient, return an error.
             if public_balance < base_fee {
@@ -193,7 +193,7 @@ mod tests {
             "PRIVATE_KEY",
             "--query",
             "QUERY",
-            "--fee",
+            "--priority-fee",
             "77",
             "--record",
             "RECORD",
@@ -207,7 +207,7 @@ mod tests {
         if let Command::Developer(Developer::Execute(execute)) = cli.command {
             assert_eq!(execute.private_key, "PRIVATE_KEY");
             assert_eq!(execute.query, "QUERY");
-            assert_eq!(execute.fee, Some(77));
+            assert_eq!(execute.priority_fee, Some(77));
             assert_eq!(execute.record, Some("RECORD".into()));
             assert_eq!(execute.program_id, "hello.aleo".try_into().unwrap());
             assert_eq!(execute.function, "hello".try_into().unwrap());

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -48,7 +48,7 @@ pub struct Execute {
     #[clap(short, long)]
     query: String,
     /// The priority fee in microcredits.
-    #[clap(short, long)]
+    #[clap(long)]
     priority_fee: Option<u64>,
     /// The record to spend the fee from.
     #[clap(short, long)]

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -29,7 +29,21 @@ pub use transfer_private::*;
 
 use snarkvm::{
     package::Package,
-    prelude::{block::Transaction, Ciphertext, Plaintext, PrivateKey, Program, ProgramID, Record, ToBytes, ViewKey},
+    prelude::{
+        block::Transaction,
+        Address,
+        Ciphertext,
+        Identifier,
+        Literal,
+        Plaintext,
+        PrivateKey,
+        Program,
+        ProgramID,
+        Record,
+        ToBytes,
+        Value,
+        ViewKey,
+    },
 };
 
 use anyhow::{bail, ensure, Result};
@@ -118,6 +132,34 @@ impl Developer {
                 }
                 err => bail!(err),
             },
+        }
+    }
+
+    /// Fetch the public balance in microcredits associated with the address from the given endpoint.
+    fn get_public_balance(address: &Address<CurrentNetwork>, endpoint: &str) -> Result<u64> {
+        // Initialize the program id and account identifier.
+        let credits = ProgramID::<CurrentNetwork>::from_str("credits.aleo")?;
+        let account_mapping = Identifier::<CurrentNetwork>::from_str("account")?;
+
+        // Send a request to the query node.
+        let response =
+            ureq::get(&format!("{endpoint}/testnet3/program/{credits}/mapping/{account_mapping}/{address}")).call();
+
+        // Deserialize the balance.
+        let balance: Result<Option<Value<CurrentNetwork>>> = match response {
+            Ok(response) => response.into_json().map_err(|err| err.into()),
+            Err(err) => match err {
+                ureq::Error::Status(_status, response) => {
+                    bail!(response.into_string().unwrap_or("Response too large!".to_owned()))
+                }
+                err => bail!(err),
+            },
+        };
+
+        // Return the balance in microcredits.
+        match balance {
+            Ok(Some(Value::Plaintext(Plaintext::Literal(Literal::<CurrentNetwork>::U64(amount), _)))) => Ok(*amount),
+            _ => Ok(0),
         }
     }
 

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -159,7 +159,9 @@ impl Developer {
         // Return the balance in microcredits.
         match balance {
             Ok(Some(Value::Plaintext(Plaintext::Literal(Literal::<CurrentNetwork>::U64(amount), _)))) => Ok(*amount),
-            _ => Ok(0),
+            Ok(None) => Ok(0),
+            Ok(Some(..)) => bail!("Failed to deserialize balance for {address}"),
+            Err(err) => bail!("Failed to fetch balance for {address}: {err}"),
         }
     }
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -47,7 +47,7 @@ pub struct TransferPrivate {
     #[clap(short, long)]
     query: String,
     /// The priority fee in microcredits.
-    #[clap(short, long)]
+    #[clap(long)]
     priority_fee: u64,
     /// The record to spend the fee from.
     #[clap(long)]

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -48,7 +48,7 @@ pub struct TransferPrivate {
     query: String,
     /// The priority fee in microcredits.
     #[clap(short, long)]
-    fee: u64,
+    priority_fee: u64,
     /// The record to spend the fee from.
     #[clap(long)]
     fee_record: String,
@@ -91,7 +91,7 @@ impl TransferPrivate {
 
             // Prepare the fee.
             let fee_record = Developer::parse_record(&private_key, &self.fee_record)?;
-            let priority_fee = self.fee;
+            let priority_fee = self.priority_fee;
 
             // Prepare the inputs for a transfer.
             let input_record = Developer::parse_record(&private_key, &self.input_record)?;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds an additional check to `snarkos developer execute` to ensure that the caller has sufficient public balance to pay for at least the base fee of the execution when using `fee_public`. 