### PR TITLE
Trim the logs in the temporary logfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,6 +3026,7 @@ dependencies = [
  "sys-info",
  "thiserror",
  "tokio",
+ "tracing-appender",
  "tracing-subscriber 0.3.17",
  "ureq",
 ]
@@ -4665,6 +4676,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -103,6 +103,9 @@ version = "1.0"
 version = "1.28"
 features = [ "rt" ]
 
+[dependencies.tracing-appender]
+version = "0.2"
+
 [dependencies.tracing-subscriber]
 version = "0.3"
 features = [ "env-filter" ]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -121,8 +121,9 @@ pub struct Start {
 impl Start {
     /// Starts the snarkOS node.
     pub fn parse(self) -> Result<String> {
-        // Initialize the logger.
-        let log_receiver = crate::helpers::initialize_logger(self.verbosity, self.nodisplay, self.logfile.clone());
+        // Initialize the logger; the log guard is moved into the async block.
+        let (log_receiver, _log_guard) =
+            crate::helpers::initialize_logger(self.verbosity, self.nodisplay, self.logfile.clone());
         // Initialize the runtime.
         Self::runtime().block_on(async move {
             // Clone the configurations.


### PR DESCRIPTION
This was a lot more tricky than I anticipated, but now this PR not only performs log trimming, but should also make logging to the filesystem faster.

We might also want to consider using [RollingFileAppender](https://docs.rs/tracing-appender/0.2.2/tracing_appender/rolling/struct.RollingFileAppender.html), which can work in tandem with `NonBlocking` used in this PR.