### PR TITLE
Skip `Fee` type for unconfirmed transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,6 +3192,7 @@ name = "snarkos-node-consensus"
 version = "2.2.1"
 dependencies = [
  "anyhow",
+ "colored",
  "indexmap 2.0.2",
  "itertools 0.11.0",
  "lru",

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -203,6 +203,10 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         if transaction_id != transaction.id() {
             bail!("Invalid transaction - expected {transaction_id}, found {}", transaction.id());
         }
+        // Check if the transmission is a fee transaction.
+        if transaction.is_fee() {
+            bail!("Invalid transaction - 'Transaction::fee' type is not valid at this stage ({})", transaction.id());
+        }
         // Check the transaction is well-formed.
         let ledger = self.ledger.clone();
         spawn_blocking!(ledger.check_transaction_basic(&transaction, None))

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -22,6 +22,9 @@ default = [ ]
 [dependencies.anyhow]
 version = "1.0.75"
 
+[dependencies.colored]
+version = "2"
+
 [dependencies.indexmap]
 version = "2.0"
 features = [ "serde", "rayon" ]

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -193,7 +193,7 @@ impl<N: Network> Consensus<N> {
             // Add the solution to the memory pool.
             trace!("Received unconfirmed solution '{}' in the queue", fmt_id(solution_id));
             if self.solutions_queue.lock().insert(solution_id, solution).is_some() {
-                bail!("Solution '{}' exists in the memory pool {}", fmt_id(solution_id), "(skipping)".dimmed());
+                bail!("Solution '{}' exists in the memory pool", fmt_id(solution_id));
             }
         }
 

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -43,6 +43,7 @@ use snarkvm::{
 };
 
 use anyhow::Result;
+use colored::Colorize;
 use indexmap::IndexMap;
 use lru::LruCache;
 use parking_lot::Mutex;
@@ -187,12 +188,12 @@ impl<N: Network> Consensus<N> {
             }
             // Check if the solution already exists in the ledger.
             if self.ledger.contains_transmission(&TransmissionID::from(solution_id))? {
-                bail!("Solution '{}' already exists in the ledger", fmt_id(solution_id));
+                bail!("Solution '{}' exists in the ledger {}", fmt_id(solution_id), "(skipping)".dimmed());
             }
             // Add the solution to the memory pool.
             trace!("Received unconfirmed solution '{}' in the queue", fmt_id(solution_id));
             if self.solutions_queue.lock().insert(solution_id, solution).is_some() {
-                bail!("Solution '{}' already exists in the memory pool", fmt_id(solution_id));
+                bail!("Solution '{}' exists in the memory pool {}", fmt_id(solution_id), "(skipping)".dimmed());
             }
         }
 
@@ -230,6 +231,10 @@ impl<N: Network> Consensus<N> {
         {
             let transaction_id = transaction.id();
 
+            // Check that the transaction is not a fee transaction.
+            if transaction.is_fee() {
+                bail!("Transaction '{}' is a fee transaction {}", fmt_id(transaction_id), "(skipping)".dimmed());
+            }
             // Check if the transaction was recently seen.
             if self.seen_transactions.lock().put(transaction_id, ()).is_some() {
                 // If the transaction was recently seen, return early.
@@ -237,12 +242,12 @@ impl<N: Network> Consensus<N> {
             }
             // Check if the transaction already exists in the ledger.
             if self.ledger.contains_transmission(&TransmissionID::from(&transaction_id))? {
-                bail!("Transaction '{}' already exists in the ledger", fmt_id(transaction_id));
+                bail!("Transaction '{}' exists in the ledger {}", fmt_id(transaction_id), "(skipping)".dimmed());
             }
             // Add the transaction to the memory pool.
             trace!("Received unconfirmed transaction '{}' in the queue", fmt_id(transaction_id));
             if self.transactions_queue.lock().insert(transaction_id, transaction).is_some() {
-                bail!("Transaction '{}' already exists in the memory pool", fmt_id(transaction_id));
+                bail!("Transaction '{}' exists in the memory pool", fmt_id(transaction_id));
             }
         }
 

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -303,7 +303,6 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         if transaction.is_fee() {
             return true; // Maintain the connection.
         }
-
         // Check that the transaction is well-formed and unique.
         if self.ledger.check_transaction_basic(&transaction, None).is_ok() {
             // Propagate the `UnconfirmedTransaction`.

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -299,6 +299,11 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         serialized: UnconfirmedTransaction<N>,
         transaction: Transaction<N>,
     ) -> bool {
+        // Check that the transaction is not a fee transaction.
+        if transaction.is_fee() {
+            return true; // Maintain the connection.
+        }
+
         // Check that the transaction is well-formed and unique.
         if self.ledger.check_transaction_basic(&transaction, None).is_ok() {
             // Propagate the `UnconfirmedTransaction`.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -257,11 +257,6 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         serialized: UnconfirmedTransaction<N>,
         transaction: Transaction<N>,
     ) -> bool {
-        // Check that the transaction is not a fee transaction.
-        if transaction.is_fee() {
-            return true; // Maintain the connection
-        }
-
         // Add the unconfirmed transaction to the memory pool.
         if let Err(error) = self.consensus.add_unconfirmed_transaction(transaction).await {
             trace!("[UnconfirmedTransaction] {error}");

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -257,6 +257,11 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         serialized: UnconfirmedTransaction<N>,
         transaction: Transaction<N>,
     ) -> bool {
+        // Check that the transaction is not a fee transaction.
+        if transaction.is_fee() {
+            return true; // Maintain the connection
+        }
+
         // Add the unconfirmed transaction to the memory pool.
         if let Err(error) = self.consensus.add_unconfirmed_transaction(transaction).await {
             trace!("[UnconfirmedTransaction] {error}");


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR skips the processing of `Transaction::Fee` types in the router and ledger service. These transaction types should not appear until after `VM::speculate`, which is after the processing on the snarkOS side has been completed.
