### PR TITLE
allowing repeated BatchPropose for the same batch

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -504,11 +504,6 @@ impl<N: Network> Primary<N> {
                 self.gateway.disconnect(peer_ip);
                 bail!("Malicious peer - proposed another batch for the same round ({signed_round})");
             }
-            // If the round and batch ID matches, then skip signing the batch a second time.
-            if signed_round == batch_header.round() && signed_batch_id == batch_header.batch_id() {
-                debug!("Skipping a proposal for round {signed_round} from '{peer_ip}' {}", "(already signed)".dimmed());
-                return Ok(());
-            }
         }
 
         // If the peer is ahead, use the batch header to sync up to the peer.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

The network shouldn't stall on malformed or missing `BatchSignature` event. Currently its recipient handles it correctly, by asking for the signature again, but the sender has an extra check dropping such repeated requests, in `process_batch_propose_from_peer`:

``` 
// If the round and batch ID matches, then skip signing the batch a second time.
            if signed_round == batch_header.round() && signed_batch_id == batch_header.batch_id() {
                debug!("Skipping a proposal for round {signed_round} from '{peer_ip}' {}", "(already signed)".dimmed());
                return Ok(());
            }
```

This is wrong and should be removed, so that `process_batch_propose_from_peer` can proceed to send the `BatchSignature` again.

## Test Plan

This was causing problems in a test setup on 2 machines, running 11 of 16 validators (i.e. just the quorum) which occasionally produces malformed `BatchSignature` events (still not clear why). The check above reliably stops progress after the first "Signature verification failed" warning. Without the check,
the same setup runs for much longer, logging repeated  "Signature verification failed" warnings but not stopping
on them.

## Related PRs

This reverts a part of  #2792.
