### PR TITLE
[Feature] Prints fees when using `snarkos developer`.

### DIFF
--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -98,6 +98,8 @@ impl Deploy {
             // Compute the minimum deployment cost.
             let (minimum_deployment_cost, (_, _)) = deployment_cost(&deployment)?;
 
+            println!("📦 The minimum deployment cost for this transaction is {minimum_deployment_cost} microcredits");
+
             // Prepare the fees.
             let fee = match &self.record {
                 Some(record) => {


### PR DESCRIPTION
This PR prints out the minimum deployment and execution cost when using `snarkos developer deploy` and `snarkos developer execute` respectively.