### PR TITLE
fix: cli should return non-zero exit code on error

### DIFF
--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::process::exit;
-
 use snarkos_cli::{commands::CLI, helpers::Updater};
 
 use clap::Parser;
+use std::process::exit;
 #[cfg(feature = "jemalloc")]
 use tikv_jemallocator::Jemalloc;
 

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -16,6 +16,7 @@ use snarkos_cli::{commands::CLI, helpers::Updater};
 
 use clap::Parser;
 use std::process::exit;
+
 #[cfg(feature = "jemalloc")]
 use tikv_jemallocator::Jemalloc;
 

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::process::exit;
+
 use snarkos_cli::{commands::CLI, helpers::Updater};
 
 use clap::Parser;
@@ -30,7 +32,10 @@ fn main() -> anyhow::Result<()> {
     // Run the CLI.
     match cli.command.parse() {
         Ok(output) => println!("{output}\n"),
-        Err(error) => println!("⚠️  {error}\n"),
+        Err(error) => {
+            println!("⚠️  {error}\n");
+            exit(1);
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
When a CLI command fails, it should return non-zero exit code. 

This facilitates scripting of the commands.