### PR TITLE
Serialize invocations of propose_batch

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -431,7 +431,7 @@ impl<N: Network> Primary<N> {
             return Ok(());
         }
         // Ditto if the batch had already been proposed.
-        assert!(round > 0);
+        ensure!(round > 0, "Round 0 cannot have transaction batches");
         if *lock_guard == round {
             warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
             return Ok(());

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -66,7 +66,10 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{sync::OnceCell, task::JoinHandle};
+use tokio::{
+    sync::{Mutex as TMutex, OnceCell},
+    task::JoinHandle,
+};
 
 /// A helper type for an optional proposed batch.
 pub type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
@@ -91,6 +94,8 @@ pub struct Primary<N: Network> {
     signed_proposals: Arc<RwLock<HashMap<Address<N>, (u64, Field<N>, Signature<N>)>>>,
     /// The spawned handles.
     handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    /// The lock for propose_batch.
+    propose_lock: Arc<TMutex<u64>>,
 }
 
 impl<N: Network> Primary<N> {
@@ -118,6 +123,7 @@ impl<N: Network> Primary<N> {
             proposed_batch: Default::default(),
             signed_proposals: Default::default(),
             handles: Default::default(),
+            propose_lock: Default::default(),
         })
     }
 
@@ -264,6 +270,9 @@ impl<N: Network> Primary<N> {
     /// 3. Set the batch proposal in the primary.
     /// 4. Broadcast the batch header to all validators for signing.
     pub async fn propose_batch(&self) -> Result<()> {
+        // This function isn't re-entrant.
+        let mut lock_guard = self.propose_lock.lock().await;
+
         // Check if the proposed batch has expired, and clear it if it has expired.
         if let Err(e) = self.check_proposed_batch_for_expiration().await {
             warn!("Failed to check the proposed batch for expiration - {e}");
@@ -421,6 +430,14 @@ impl<N: Network> Primary<N> {
             debug!("Primary is safely skipping a batch proposal {}", "(no unconfirmed transactions)".dimmed());
             return Ok(());
         }
+        // Ditto if the batch had already been proposed.
+        assert!(round > 0);
+        if *lock_guard == round {
+            warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
+            return Ok(());
+        }
+
+        *lock_guard = round;
 
         /* Proceeding to sign & propose the batch. */
         info!("Proposing a batch with {} transmissions for round {round}...", transmissions.len());


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

The propose_batch function is called 1) from a dedicated task started in start_handlers, and 2) from try_increment_to_the_next_round - so potentially from different threads. If those threads start it in parallel,
it might send different batches for the same round, breaking the protocol. This patch adds a lock enforcing
that doesn't happen.

## Test Plan

Without this patch, the recipient produces a warning on the duplicate batches:

2023-10-30T11:33:02.170998Z  WARN snarkos_node_bft::primary: Cannot sign a batch from '10.0.0.36:5002' - Malicious peer - proposed another batch for the same round (5)

With the fix, the warning should never appear.

## Related PRs

Unlike #2813 , this patch waits on a lock, rather than using try_lock - the difference shouldn't matter to the dedicated task, but other threads call try_increment_to_the_next_round while handling an incoming network event, and propose_batch erroring out leads to that event being dropped, which is probably less efficient that waiting...
