### PR TITLE
Remove redundant transmission verification from `Primary::propose_batch`

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -392,29 +392,15 @@ impl<N: Network> Primary<N> {
                     trace!("Proposing - Skipping transmission '{}' - Already in ledger", fmt_id(id));
                     continue;
                 }
-                // Check the transmission is still valid.
-                match (id, transmission.clone()) {
-                    (TransmissionID::Solution(solution_id), Transmission::Solution(solution)) => {
-                        // Check if the solution is still valid.
-                        if let Err(e) = self.ledger.check_solution_basic(solution_id, solution).await {
-                            trace!("Proposing - Skipping solution '{}' - {e}", fmt_id(solution_id));
-                            continue;
-                        }
-                    }
-                    (TransmissionID::Transaction(transaction_id), Transmission::Transaction(transaction)) => {
-                        // Check if the transaction is still valid.
-                        if let Err(e) = self.ledger.check_transaction_basic(transaction_id, transaction).await {
-                            trace!("Proposing - Skipping transaction '{}' - {e}", fmt_id(transaction_id));
-                            continue;
-                        }
-                        // Increment the number of transactions.
-                        num_transactions += 1;
-                    }
+
+                if let TransmissionID::Ratification = id {
                     // Note: We explicitly forbid including ratifications,
                     // as the protocol currently does not support ratifications.
-                    (TransmissionID::Ratification, Transmission::Ratification) => continue,
-                    // All other combinations are clearly invalid.
-                    _ => continue,
+                    continue;
+                }
+                if let TransmissionID::Transaction(_) = id {
+                    // Increment the number of transactions.
+                    num_transactions += 1;
                 }
                 // Insert the transmission into the map.
                 transmissions.insert(id, transmission);


### PR DESCRIPTION
This PR removes the redundant transmission verification when constructing the batch proposal. Currently, there are three separate steps in which the incoming transmissions are verified before they end up in a block:
1. `Worker::process_unconfirmed_transaction` and `Worker::process_unconfirmed_solution` run the basic verifications before adding them to the ready-queue.
2. `Primary::propose_batch` drains the ready-queue and runs the basic verifications on the transmissions
3. finally, `Consensus::try_advance_to_next_block` checks all transmissions in the block's sub-DAG after the leader certificate is committed.

Step 3 cannot be removed for safety reasons, and having workers verify the transmissions in step 1 makes sense as workers can verify transmissions concurrently. However, issue with having transmissions re-verified in the `Primary::propose_batch` is that it is happening in a critical path when function is holding the `self.propose_lock` mutex, so the lock wait times grow with the number of transmissions and their verification times. This might be a DoS vector too. 

Since workers and primary are running in the same runtime, there is no reason not to trust that worker threads insert only valid transmissions into ready-queue, so the verification in `Primary::propose_batch` is redundant and it's safe to remove. 