### PR TITLE
[TOB] Update ordering of cache refresh

### DIFF
--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -231,8 +231,12 @@ impl<N: Network> Cache<N> {
         map: &RwLock<LinkedHashMap<K, OffsetDateTime>>,
         key: K,
     ) -> Option<OffsetDateTime> {
+        // Insert the key, and return the previous timestamp if it existed.
+        let previous_timestamp = map.write().insert(key, OffsetDateTime::now_utc());
+        // Refresh the cache.
         Self::refresh(map);
-        map.write().insert(key, OffsetDateTime::now_utc())
+        // Return the previous timestamp.
+        previous_timestamp
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the cache `refresh` to after the fetch. This prevents the edge-case where the refresh may clear the last seen timestamp.

Finding: TOB-ALEO-12