### PR TITLE
Prevent deadlock in block_sync

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -451,6 +451,8 @@ impl<N: Network> BlockSync<N> {
             if block != existing_block {
                 // Remove the candidate block.
                 responses.remove(&height);
+                // Drop the write lock on the responses map.
+                drop(responses);
                 // Remove all block requests to the peer.
                 self.remove_block_requests_to_peer(&peer_ip);
                 bail!("Candidate block {height} from '{peer_ip}' is malformed");


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR drops the `responses` lock in `insert_block_response` before the `remove_block_requests_to_peer` call to prevent  a deadlock condition where the `response.write()` is called before the previous lock was released.
