### PR TITLE
Enable `snarkos developer scan` for development networks

### DIFF
--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -16,7 +16,7 @@
 
 use super::CurrentNetwork;
 
-use snarkvm::prelude::{block::Block, Ciphertext, Field, Network, Plaintext, PrivateKey, Record, ViewKey};
+use snarkvm::prelude::{block::Block, Ciphertext, Field, FromBytes, Network, Plaintext, PrivateKey, Record, ViewKey};
 
 use anyhow::{bail, ensure, Result};
 use clap::Parser;
@@ -28,6 +28,7 @@ use std::{
 };
 
 const MAX_BLOCK_RANGE: u32 = 50;
+const CDN_ENDPOINT: &str = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase3";
 
 /// Scan the snarkOS node for records.
 #[derive(Debug, Parser)]
@@ -55,10 +56,6 @@ pub struct Scan {
     /// The endpoint to scan blocks from.
     #[clap(long)]
     endpoint: String,
-
-    /// Enables the node to prefetch initial blocks from a CDN
-    #[clap(default_value = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase3", long = "cdn")]
-    cdn: String,
 }
 
 impl Scan {
@@ -70,7 +67,7 @@ impl Scan {
         let (start_height, end_height) = self.parse_block_range()?;
 
         // Fetch the records from the network.
-        let records = Self::fetch_records(private_key, &view_key, &self.cdn, &self.endpoint, start_height, end_height)?;
+        let records = Self::fetch_records(private_key, &view_key, &self.endpoint, start_height, end_height)?;
 
         // Output the decrypted records associated with the view key.
         if records.is_empty() {
@@ -152,7 +149,6 @@ impl Scan {
     fn fetch_records(
         private_key: Option<PrivateKey<CurrentNetwork>>,
         view_key: &ViewKey<CurrentNetwork>,
-        cdn: &str,
         endpoint: &str,
         start_height: u32,
         end_height: u32,
@@ -175,20 +171,34 @@ impl Scan {
         print!("\rScanning {total_blocks} blocks for records (0% complete)...");
         stdout().flush()?;
 
-        // Scan the CDN first for records.
-        Self::scan_from_cdn(
-            start_height,
-            end_height,
-            cdn.to_string(),
-            endpoint.to_string(),
-            private_key,
-            *view_key,
-            address_x_coordinate,
-            records.clone(),
-        )?;
+        // Fetch the genesis block from the endpoint.
+        let genesis_block: Block<CurrentNetwork> =
+            ureq::get(&format!("{endpoint}/testnet3/block/0")).call()?.into_json()?;
+        // Determine if the endpoint is on a development network.
+        let is_development_network = genesis_block != Block::from_bytes_le(CurrentNetwork::genesis_bytes())?;
+
+        // Determine the request start height.
+        let mut request_start = match is_development_network {
+            true => start_height,
+            false => {
+                // Scan the CDN first for records.
+                Self::scan_from_cdn(
+                    start_height,
+                    end_height,
+                    CDN_ENDPOINT.to_string(),
+                    endpoint.to_string(),
+                    private_key,
+                    *view_key,
+                    address_x_coordinate,
+                    records.clone(),
+                )?;
+
+                // Scan the remaining blocks from the endpoint.
+                end_height.saturating_sub(start_height % MAX_BLOCK_RANGE)
+            }
+        };
 
         // Scan the endpoint for the remaining blocks.
-        let mut request_start = end_height.saturating_sub(start_height % MAX_BLOCK_RANGE);
         while request_start <= end_height {
             // Log the progress.
             let percentage_complete = request_start.saturating_sub(start_height) as f64 * 100.0 / total_blocks as f64;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `snarkos developer scan` CLI to work for development networks by disabling the CDN in those cases. We determine if we need to use the CDN by checking if the genesis block of the network we are querying via `--endpoint` is equivalent to the live network's genesis block.
