### PR TITLE
Introduce `GET transaction/confirmed/{tx_id}` endpoint

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -135,6 +135,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
             // GET and POST ../transaction/..
             .route("/testnet3/transaction/:id", get(Self::get_transaction))
+            .route("/testnet3/transaction/confirmed/:id", get(Self::get_confirmed_transaction))
             .route("/testnet3/transaction/broadcast", post(Self::transaction_broadcast))
 
             // GET ../find/..

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -155,6 +155,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id)?))
     }
 
+    // GET /testnet3/transaction/confirmed/{transactionID}
+    pub(crate) async fn get_confirmed_transaction(
+        State(rest): State<Self>,
+        Path(tx_id): Path<N::TransactionID>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.get_confirmed_transaction(tx_id)?))
+    }
+
     // GET /testnet3/memoryPool/transmissions
     pub(crate) async fn get_memory_pool_transmissions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds a new `GET testnet3/transaction/confirmed/{transaction_id}` endpoint that will return the full `ConfirmedTransaction` object for the given transaction id.

Note: If you provide the unconfirmed transaction id, it will return the `ConfirmedTransaction` object for any accepted/rejected transaction, but not for aborted transactions.