### PR TITLE
Add `InputID` filtering to transmission selection

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -149,6 +149,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         self.get_committee_for_round(previous_round)
     }
 
+    /// Returns `true` if the ledger contains the given input ID.
+    fn contains_input_id(&self, input_id: &Field<N>) -> Result<bool> {
+        self.ledger.contains_input_id(input_id)
+    }
+
     /// Returns `true` if the ledger contains the given certificate ID in block history.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         self.ledger.contains_certificate(certificate_id)

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -132,6 +132,12 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     }
 
     /// Returns `false` for all queries.
+    fn contains_input_id(&self, input_id: &Field<N>) -> Result<bool> {
+        trace!("[MockLedgerService] Contains input ID {} - false", fmt_id(input_id));
+        Ok(false)
+    }
+
+    /// Returns `false` for all queries.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         trace!("[MockLedgerService] Contains certificate ID {} - false", fmt_id(certificate_id));
         Ok(false)

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -114,6 +114,11 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         bail!("Previous committee for round {round} does not exist in prover")
     }
 
+    /// Returns `true` if the ledger contains the given input ID.
+    fn contains_input_id(&self, input_id: &Field<N>) -> Result<bool> {
+        bail!("Input '{input_id}' does not exist in prover")
+    }
+
     /// Returns `true` if the ledger contains the given certificate ID in block history.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         bail!("Certificate '{certificate_id}' does not exist in prover")

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -72,6 +72,9 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     /// If the previous round is in the future, then the current committee is returned.
     fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
+    /// Returns `true` if the ledger contains the given input ID.
+    fn contains_input_id(&self, input_id: &Field<N>) -> Result<bool>;
+
     /// Returns `true` if the ledger contains the given certificate ID.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool>;
 

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -119,6 +119,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         self.inner.get_previous_committee_for_round(round)
     }
 
+    /// Returns `true` if the ledger contains the given input ID.
+    fn contains_input_id(&self, input_id: &Field<N>) -> Result<bool> {
+        self.inner.contains_input_id(input_id)
+    }
+
     /// Returns `true` if the ledger contains the given certificate ID in block history.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool> {
         self.inner.contains_certificate(certificate_id)

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -482,6 +482,7 @@ mod tests {
             fn current_committee(&self) -> Result<Committee<N>>;
             fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
             fn get_previous_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
+            fn contains_input_id(&self, input_id: &Field<N>) -> Result<bool>;
             fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool>;
             fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool>;
             async fn check_solution_basic(


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds additional filtering to the transmissions we decide to commit via `BFT::commit_leader_certificate`. We now check against the transaction `InputID`s to prevent block production failure when multiple transactions attempt to spend the same record.

We've also added snarkVM level safety checks - https://github.com/AleoHQ/snarkVM/pull/2229