### PR TITLE
Introduce `Metadata` query to `GET ../mapping/:name/:key` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,6 +3257,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
+ "serde_json",
  "snarkos-node-consensus",
  "snarkos-node-router",
  "snarkvm",

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -52,6 +52,10 @@ version = "1"
 default-features = false
 features = [ "derive" ]
 
+[dependencies.serde_json]
+version = "1"
+features = [ "preserve_order" ]
+
 [dependencies.snarkos-node-consensus]
 path = "../consensus"
 version = "=2.2.4"


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds an optional `Metadata` query object to the ` GET /testnet3/program/:id/mapping/:name/:key` endpoint.

If the metadata query exists, this endpoint will also include the block height as a json object.
```
{
    "data": data,
    "height": height,
}
```

Otherwise, it will just return the data object.

Example queries:
```
    // GET /testnet3/program/{programID}/mapping/{mappingName}/{mappingKey}
    // GET /testnet3/program/{programID}/mapping/{mappingName}/{mappingKey}?metadata={true}
```
