### PR TITLE
Prevent the gaps between `propose_batch` and `process_batch_signature_from_peer`

### DIFF
--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -41,6 +41,7 @@ features = [ "serde", "rayon" ]
 
 [dependencies.parking_lot]
 version = "0.12"
+features = ["send_guard"]
 
 [dependencies.rand]
 version = "0.8"

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -630,10 +630,9 @@ impl<N: Network> Primary<N> {
         if self.gateway.account().address() == signer {
             bail!("Invalid peer - received a batch signature from myself ({signer})");
         }
-
+        let mut proposed_batch = self.proposed_batch.write();
         let proposal = {
             // Acquire the write lock.
-            let mut proposed_batch = self.proposed_batch.write();
             // Add the signature to the batch, and determine if the batch is ready to be certified.
             match proposed_batch.as_mut() {
                 Some(proposal) => {

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1115,8 +1115,6 @@ impl<N: Network> Primary<N> {
             while fast_forward_round < next_round.saturating_sub(1) {
                 // Update to the next round in storage.
                 fast_forward_round = self.storage.increment_to_next_round(fast_forward_round)?;
-                // Clear the proposed batch.
-                *self.proposed_batch.write() = None;
             }
         }
 
@@ -1150,7 +1148,8 @@ impl<N: Network> Primary<N> {
 
             // If the node is ready, propose a batch for the next round.
             if is_ready {
-                self.propose_batch().await?;
+                // TODO: This will cause deadlock
+                // self.propose_batch().await?;
             }
         }
         Ok(())


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

After the `proposed_batch.take()`, before `self.store_and_broadcast_certificate` increment next round.  There is gaps that, when `fn propose_batch()`  is checking  `proposed_batch` is None. 
ATTENTION: 
Current solution may cause deadlock in the `self.store_and_broadcast_certificate` logic.
We need another solution to solve it.


## Test Plan

(If you changed any code, please provide clear instructions on how you verified your changes work.)

## Related PRs

(Link any related PRs here)
