### PR TITLE
[Hotfix] Update snarkVM rev with a reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,9 +3386,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d6fb48420e229bc1249d228fcccc06ac3b0f19898b614f41d53b6f38b01b73"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3417,9 +3416,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfbd2290969a801c1bafd23f51c7a8d8acef84c07e7599124aa3004328d341"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3448,9 +3446,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8072bc6ca7ae052c7e6f4e516aef2c9039c72affac9d6e663f5aa1dfa938b7"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3463,9 +3460,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cacf35ad888287d323d34883fa9903ac92cca6a276ff7242afd4e2dc5c8a5c"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3475,9 +3471,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a431f3009222e1ae45a71f4e2774546ca5a61ecc59effb4857b3d206966ad3b2"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3486,9 +3481,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9e454cb7edce9ada862a394e95081c4b82cb4426d6d266ee8302341f87c318"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3497,9 +3491,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55fc33c5c12d0e028ab825e4a3fe9ed6974551b4b0d382eee37d365e34537e74"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3516,15 +3509,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ba2b291e079e225db125ecf95d5e8e3f1895336abcefb2b36b0cb203a5e5a7"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d547ed70ed9a1a5f2f9ad78a4a2ba4df6d64712fb656f3df8ad54b0682425c76"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3534,9 +3525,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a7940f71ad60fb7b66b4bf7fc23e7253b2df3bd49b923314ade8de66c8e4d0"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3550,9 +3540,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210d41a4c452f0b6025b4da2360a437b30a81e6f9eac203ac004a180e4fb6a04"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3566,9 +3555,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228cf239e1868534d5b682a4487c089094ba00ad27a641335aa77d38972fbe74"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3580,9 +3568,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a33a90e2594f783ee830e06c77243686ddd9755e8b5828c717311ea37bec756"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3590,9 +3577,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcae4432523640af834a3050621ced7d7515e713b23b1eb12b39c4599f2fb45"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3601,9 +3587,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a102cc9183d9fbd4e2cb35eb125dd66d078054052f7035eff49118e099cd7397"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3614,9 +3599,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb0276d8b42d3549f9057981665d1b4c9567b3e9e27438b7d2f041dadf7a7d3"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3627,9 +3611,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2278626673e5a9f60633635650bb713048b0cb773c0fe4a12dec1e6769fa1274"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3639,9 +3622,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55021ba40e4322066fbfbf5eabf312dc3dbe8c24218ef1f3849b6c86a616143"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3652,9 +3634,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92258c38e9ae49eea356e3d3757b11d20601124da34a9b0ebda4d05fc57a1f7c"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3666,9 +3647,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d76ae77cacaa39504c9dcbd9f4db7b69103760f83cbd0125c4b4a817fcbe4f"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3678,9 +3658,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e85657d9451cd262444b017e47f404e2fba890185beead5257027550077a7eb"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3692,9 +3671,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa64d2937bfb0b2c2b40cef1f716326054bb1968095bb278f6d766fe57ffea90"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3704,9 +3682,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce01c1ba23552a75721ff27f4aa0eb3c124698f32b6772d094bcdabaa28ede80"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3728,9 +3705,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8af3eb2f888221e34346336e4b39b216c125f044ff347794bdce5808aff1df"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3747,9 +3723,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9eec44d25a034f14fc0317dea02e7d3c3e3025d04a4bd3799d67f66ad4770e"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3769,9 +3744,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51894fac468fff5eff12180309435b252246640ac602b540aee87cfc5e95a42"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3785,9 +3759,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed406e9776033f0c0357778a5e29eb96c47e832935c52b3af88e656dd16d034a"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3797,18 +3770,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f1de71d361b611589b45106002307aeab85d27bfa87e0a73367d9b96c04b9d"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96887e3a16f0d806c8536abff8beb7eb8e39f5ff0e845d52d8586b3b16657ca"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3817,9 +3788,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bcfeacecfdb3fc153c114d429ac6fd73d8e4cb0e731bb8bc0ed7d1c9fe6170"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3829,9 +3799,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b447282f6cdb4afc87bb587f6774eb75a84708817b04225713025cc75a9e491b"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3841,9 +3810,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9a4ad3b4ff94bfe02f5e928d42f4cf0d62ca91dee4c700c6a5a560d5a787a5"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3853,9 +3821,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919104eed891a72c790778370ddd98dc7161a4867968ec0dfeaa8dd7e017be90"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3865,9 +3832,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f138c0addd4e0dfcf811f4cf55874adde783324aace2904afd8a924b14fc9c"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "rand",
  "rayon",
@@ -3880,9 +3846,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac467a6a1d28dd9090061138f7f97f2f63d271c63251452bfca067c6eef3fdb"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3899,9 +3864,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3877c2e9002e91892b4d5ef00474ef098d060bf9dc86dfc74adb75f10de9b2ad"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3925,9 +3889,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b1188fcd9cc90bc0778e43ea00a5afebb22d7f8c2426d51452057cfd7c7143"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "anyhow",
  "rand",
@@ -3938,9 +3901,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d582de04f43e01d01309bdb8dbd92421ac80db7ecdff42992113c4fe4ecea6a2"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -3957,9 +3919,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-coinbase"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08086e8d201a50202b9238f4bfa286cad9ecdc205b365b73af713e289b7216a"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3978,9 +3939,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7734f963717fe491c0166c90f35d83babd5e504c6e3078cf30b53558ec35e6f9"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3995,9 +3955,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ca021280bce8d17c1a9212d133566dacb6b41479e47c7c9d552902bef2c39f"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4009,9 +3968,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5288c6e8e7e269be3c9b7a60d46c46d65af4590b83221070b74b489aa36a8d"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -4022,9 +3980,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c15a409169b1a0d30e55277124044c6337240e70aca6c8bfccd91adf0034da"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -4035,9 +3992,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8aff2a9a3039a531af55908d3b45bf1057ec5c8680b065bd7c215e8270931d"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4047,9 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926e9a69c930ac514e434e8de5999f96296388595d63fbda32994b2a7e3e0243"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4062,9 +4017,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce67bcf479d6c38e81701a1c37bf3efd6c7b02684d607e36ed329c896b71e5d8"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4076,9 +4030,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd14ba1dd8d8b37d14f002f1870a0517596f37caf9cadce01af4d76e761b299"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4086,9 +4039,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b52cea9bdd1b1c482a36d450f6433de00eda2f2a94b8b0affa35b136150066"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4100,9 +4052,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0806b7f132ee20ef8c87ff050c15ee17babbcdb3f77b6bcfae9991e34ce8860e"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4126,9 +4077,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372af153300b8302392fb2bb655b7721922ad867c6472bd0ba64010891b9a1b5"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4142,9 +4092,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f140d9692a9c6ebd0f4709172bdc9cfd713257fe41a8c9a38fdb4cbb7a88fa8"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4167,9 +4116,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c79f7b3688d70499c595c415c1655853f53058f5edc689c2d7b4c9646d191"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4193,9 +4141,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ee94a4c319ac00c6dd44a89929e9c8c1bbd55a0ae7fdecf4251fca7965b302"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4217,9 +4164,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edf432edeebdb2545f2038ea60d676a0c35121558d39bae130b17fb59770fef"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4232,9 +4178,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b9276323ec77c7bf1236b5158eca94f81587e57b1bb4801cb6a694acf22db0"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4246,9 +4191,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb1dc49e03d5a4c11d10fe52c9afae70e665206962b1cba9d2b3317cae991e2"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4268,9 +4212,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.16.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3fd5c8981c25670659b8ddddc0c35db989a00a70cefaadc9af4c8ce47094aff"
+version = "0.16.12"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d5186a4#d5186a489f47f1fc6310a0f5e9e8891d283eb3a8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-version = "=0.16.11"
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "d5186a4"
+#version = "=0.16.11"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -139,6 +139,15 @@ pub fn phase_3_reset<N: Network, C: ConsensusStorage<N>>(
             std::thread::sleep(std::time::Duration::from_secs(5));
             return Ledger::<N, C>::load(genesis.clone(), dev);
         }
+    } else if let Ok(block) = ledger.get_block(726845) {
+        if *block.hash() == *ID::<N>::from_str("ab1tf3v9qef0uh3ygsc0qqem7dzeyy2m8aqz583a80z60l8t5l22u9s84y38z")? {
+            let genesis = ledger.get_block(0)?;
+            drop(ledger);
+            println!("{}.\n\n\nMIGRATION SUCCEEDED. RESTART THIS SNARKOS NODE AGAIN.\n\n", remove_ledger(N::ID, dev)?);
+            // Sleep for 5 seconds to allow the user to read the message.
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            return Ledger::<N, C>::load(genesis.clone(), dev);
+        }
     }
     Ok(ledger)
 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

[Hotfix] Update snarkVM rev with a reset

A hotfix has been made for snarkOS.

Given the short timeframe of the hotfix, we haven’t had adequate time to do thorough testing, however we have locally confirmed that the original program deployment which caused an outage no longer halts with this hotfix.

It is recommended to switch all nodes (validators and clients) to the latest commit on this branch at your earliest convenience.
