### PR TITLE
Add snarkVM level duplicate `InputID` checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3464,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3513,12 +3513,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "rand",
  "rayon",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "anyhow",
  "rand",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3972,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -3996,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4043,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f58905e#f58905ea5b04522bf4928a331454579d569692f2"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3464,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3513,12 +3513,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3727,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "rand",
  "rayon",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "anyhow",
  "rand",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3972,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -3996,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4043,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4216,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=18f5dd2#18f5dd2fea1389ee8c3c59f808430ba9167fd2e7"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "f58905e"
+rev = "18f5dd2"
 #version = "=0.16.11"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "18f5dd2"
+rev = "b7c5f49"
 #version = "=0.16.11"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the snarkVM rev to [b7c5f49](https://github.com/AleoHQ/snarkVM/commit/b7c5f49ba0a6b573f5a1f6850338507152827f8c). This adds `InputID` logic that aborts transactions that attempt to spend `InputID`s multiple times in a block or that have already been spent.
