### PR TITLE
Add LRU cache to mitigate flood traffic

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -63,7 +63,7 @@ pub struct Consensus<N: Network> {
     /// The primary sender.
     primary_sender: Arc<OnceCell<PrimarySender<N>>>,
     /// The unconfirmed solutions queue.
-    solutions_queue: Arc<Mutex<IndexMap<PuzzleCommitment<N>, ProverSolution<N>>>>,
+    solutions_queue: Arc<Mutex<LruCache<PuzzleCommitment<N>, ProverSolution<N>>>>,
     /// The unconfirmed transactions queue.
     transactions_queue: Arc<Mutex<LruCache<N::TransactionID, Transaction<N>>>>,
     /// The recently-seen unconfirmed solutions.
@@ -94,10 +94,12 @@ impl<N: Network> Consensus<N> {
             ledger,
             bft,
             primary_sender: Default::default(),
-            solutions_queue: Default::default(),
-            transactions_queue: Arc::new(
-                Mutex::new(LruCache::new(NonZeroUsize::new(MAX_TRANSMISSIONS_PER_BATCH).unwrap()))
-            ),
+            solutions_queue: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(MAX_TRANSMISSIONS_PER_BATCH).unwrap(),
+            ))),
+            transactions_queue: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(MAX_TRANSMISSIONS_PER_BATCH).unwrap(),
+            ))),
             seen_solutions: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1 << 16).unwrap()))),
             seen_transactions: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1 << 16).unwrap()))),
             handles: Default::default(),
@@ -197,7 +199,7 @@ impl<N: Network> Consensus<N> {
             }
             // Add the solution to the memory pool.
             trace!("Received unconfirmed solution '{}' in the queue", fmt_id(solution_id));
-            if self.solutions_queue.lock().insert(solution_id, solution).is_some() {
+            if self.solutions_queue.lock().put(solution_id, solution).is_some() {
                 bail!("Solution '{}' exists in the memory pool", fmt_id(solution_id));
             }
         }
@@ -216,10 +218,10 @@ impl<N: Network> Consensus<N> {
             // Determine the number of solutions to send.
             let num_solutions = queue.len().min(capacity);
             // Drain the solutions from the queue.
-            queue.drain(..num_solutions).collect::<Vec<_>>()
+            (0..num_solutions).filter_map(|_| queue.pop_lru().map(|(_, solution)| solution)).collect::<Vec<_>>()
         };
         // Iterate over the solutions.
-        for (_, solution) in solutions.into_iter() {
+        for solution in solutions.into_iter() {
             let solution_id = solution.commitment();
             trace!("Adding unconfirmed solution '{}' to the memory pool...", fmt_id(solution_id));
             // Send the unconfirmed solution to the primary.


### PR DESCRIPTION
## Motivation

Large volumes of unconfirmed_transactions introduce a state where the network significantly slows due to states on individual nodes becoming very far out of sync with each other. 

The exact reason why isn't %100 known, but evidence from logs indicate it might be because too many async tasks prevent the `Tokio` executor from allowing tasks to proceed such as batch signing that are key to advancing Consensus rounds - and once this happens, the network takes some time to Establish a normal cadence of block production.

An LRU cache is introduced to limit the number of transactions that can be in the `transaction_queue` object.

## Test Plan & Performance

* This fix is currently being tested on a 40-node network where transaction volume will reach roughly 2000tx/minute to validate that the nodes simply processing a lower volume of transaction via usage of the LRU cache works. 

* Should this experiment prove to work, a cache in the primary for transactions might considered wherein `unconfirmed_transactions` are pulled at a cadence which doesn't slow other critical Consensus processes.