### PR TITLE
fix: block sync issue

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -218,6 +218,13 @@ impl<N: Network> BlockSync<N> {
         let block_requests = self.prepare_block_requests();
         trace!("Prepared {} block requests", block_requests.len());
 
+        // If there are no block requests, then try if we can advance with responses we already
+        // have in the sync pool.
+        if block_requests.is_empty() && !self.responses.read().is_empty() {
+            trace!("No block requests to send - try handling responses we already have");
+            self.handle_responses(self.canon.latest_block_height());
+        }
+
         // Process the block requests.
         'outer: for (height, (hash, previous_hash, sync_ips)) in block_requests {
             // Insert the block request into the sync pool.
@@ -281,8 +288,14 @@ impl<N: Network> BlockSync<N> {
         };
 
         // Retrieve the latest block height.
-        let mut current_height = self.canon.latest_block_height();
+        let current_height = self.canon.latest_block_height();
         // Try to advance the ledger with the sync pool.
+        self.handle_responses(current_height);
+        Ok(())
+    }
+
+    /// Handles the block responses from the sync pool.
+    fn handle_responses(&self, mut current_height: u32) {
         while let Some(block) = self.remove_block_response(current_height + 1) {
             // Ensure the block height matches.
             if block.height() != current_height + 1 {
@@ -302,7 +315,6 @@ impl<N: Network> BlockSync<N> {
             // Update the latest height.
             current_height = self.canon.latest_block_height();
         }
-        Ok(())
     }
 }
 
@@ -548,6 +560,8 @@ impl<N: Network> BlockSync<N> {
         }
         // Remove the request entry for the given height.
         requests.remove(&height);
+        // Remove the request timestamp entry for the given height.
+        self.request_timestamps.write().remove(&height);
         // Remove the response entry for the given height.
         self.responses.write().remove(&height)
     }
@@ -572,6 +586,7 @@ impl<N: Network> BlockSync<N> {
 
     /// Removes all block requests for the given peer IP.
     fn remove_block_requests_to_peer(&self, peer_ip: &SocketAddr) {
+        trace!("Removing all block requests to peer {peer_ip}");
         // Acquire the write lock on the requests map.
         let mut requests = self.requests.write();
         // Acquire the read lock on the responses map.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -223,6 +223,7 @@ impl<N: Network> BlockSync<N> {
         if block_requests.is_empty() && !self.responses.read().is_empty() {
             trace!("No block requests to send - try handling responses we already have");
             self.handle_responses(self.canon.latest_block_height());
+            return;
         }
 
         // Process the block requests.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -587,7 +587,7 @@ impl<N: Network> BlockSync<N> {
 
     /// Removes all block requests for the given peer IP.
     fn remove_block_requests_to_peer(&self, peer_ip: &SocketAddr) {
-        trace!("Removing all block requests to peer {peer_ip}");
+        trace!("Block sync is removing all block requests to peer {peer_ip}");
         // Acquire the write lock on the requests map.
         let mut requests = self.requests.write();
         // Acquire the read lock on the responses map.


### PR DESCRIPTION
If your node is syncing many blocks, it can stop syncing. The cause is the following:
* node sends out block request to 3 nodes
* only 2 respond, now sync can't continue as the response is not 'complete'
* sync proceeds to send all block requests it can so no more are sent out (50 outstanding)
* concurrently another thread removes the peer that was not responding using `remove_block_requests_to_peer`
* now this request IS considered complete, so it's not eligible for timeout handling
* incoming responses are **only** considered if there are BlockResponses coming in, but none will ever come in anymore (as we've already sent out and received them all) - completely stuck

The fix is to check if we have any responses that can proceed in `try_block_sync` (this is called every 5 seconds) if we don't have any requests to send out. This seems to solve the problem.

Included is also a smaller bugfix that will reduce memory somewhat (we were not cleaning up the `request_timestamps` when handling `remove_block_response`, keeping these longer in the map than necessary - these would be cleaned up 15s later anyway, but better to correct this).

@howardwu Matthew Davids confirms this fix works.