### PR TITLE
Tighten input validation on ping messages.

### DIFF
--- a/node/router/messages/src/ping.rs
+++ b/node/router/messages/src/ping.rs
@@ -65,29 +65,33 @@ impl<N: Network> FromBytes for Ping<N> {
         let version = u32::read_le(&mut reader)?;
         let node_type = NodeType::read_le(&mut reader)?;
 
-        if u8::read_le(&mut reader)? == 0 {
-            return Ok(Self { version, node_type, block_locators: None });
+        let selector = u8::read_le(&mut reader)?;
+
+        if selector == 0 {
+            Ok(Self { version, node_type, block_locators: None })
+        } else if selector == 1 {
+            let mut recents = IndexMap::new();
+            let num_recents = u32::read_le(&mut reader)?;
+            for _ in 0..num_recents {
+                let height = u32::read_le(&mut reader)?;
+                let hash = N::BlockHash::read_le(&mut reader)?;
+                recents.insert(height, hash);
+            }
+
+            let mut checkpoints = IndexMap::new();
+            let num_checkpoints = u32::read_le(&mut reader)?;
+            for _ in 0..num_checkpoints {
+                let height = u32::read_le(&mut reader)?;
+                let hash = N::BlockHash::read_le(&mut reader)?;
+                checkpoints.insert(height, hash);
+            }
+
+            let block_locators = Some(BlockLocators { recents, checkpoints });
+
+            Ok(Self { version, node_type, block_locators })
+        } else {
+            Err(error("Invalid selector of optional block locators in ping message"))
         }
-
-        let mut recents = IndexMap::new();
-        let num_recents = u32::read_le(&mut reader)?;
-        for _ in 0..num_recents {
-            let height = u32::read_le(&mut reader)?;
-            let hash = N::BlockHash::read_le(&mut reader)?;
-            recents.insert(height, hash);
-        }
-
-        let mut checkpoints = IndexMap::new();
-        let num_checkpoints = u32::read_le(&mut reader)?;
-        for _ in 0..num_checkpoints {
-            let height = u32::read_le(&mut reader)?;
-            let hash = N::BlockHash::read_le(&mut reader)?;
-            checkpoints.insert(height, hash);
-        }
-
-        let block_locators = Some(BlockLocators { recents, checkpoints });
-
-        Ok(Self { version, node_type, block_locators })
     }
 }
 


### PR DESCRIPTION
When a ping message is serialized, the absence or presence of the optional block locators structure is encoded as either a 0 or a 1 byte.

In deserialization, any non-zero byte is treated the same as a 1 byte for the purpose of indicating absence or presence of the optional block locators structure.

This is not necessarily a bug, if the (implicit) specification of the format of a ping message is that that byte may have any value, and that 0 indicates absence of block locators while non-0 indicates their presence. However, one might argue that messages should be represented in unique ways, so that serialization and deserialization are always each other's inverses.

If in the future the format of a ping message is extended so that that byte can have other values besides 0 or 1 (e.g. 2), then the deserialization could silently (attempt to) interpret byte 2 as if it were byte 1.

Unique message representations and tight input validation are in line with the LangSec approach.
