### PR TITLE
chore(node): last typo

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1640,7 +1640,7 @@ mod tests {
         Proposal::new(committee, batch_header, transmissions).unwrap()
     }
 
-    // Creates a signature of the primary's current proposal for each committe member (excluding
+    // Creates a signature of the primary's current proposal for each committee member (excluding
     // the primary).
     fn peer_signatures_for_proposal(
         primary: &Primary<CurrentNetwork>,


### PR DESCRIPTION
The repository should now be typo free, which is quite a feat. I planned to implement a little something but I guess it won't be necessary.