### PR TITLE
Bump snarkOS version, update snarkVM rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3468,12 +3468,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3536,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3558,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3570,7 +3570,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3593,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3617,7 +3617,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3769,7 +3769,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "rand",
  "rayon",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3848,7 +3848,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "anyhow",
  "rand",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4063,6 +4063,7 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
  "lazy_static",
+ "parking_lot",
  "paste",
  "rand",
  "serde_json",
@@ -4075,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4100,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4123,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4137,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4150,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4171,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.12"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=b7c5f49#b7c5f49ba0a6b573f5a1f6850338507152827f8c"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=40c4fcc#40c4fcc9e2bf102119ad751818432b3382054f66"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "40c4fcc"
-#version = "=0.16.11"
+#git = "https://github.com/AleoHQ/snarkVM.git"
+#rev = "40c4fcc"
+version = "=0.16.13"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "b7c5f49"
+rev = "40c4fcc"
 #version = "=0.16.11"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -118,7 +118,7 @@ impl<N: Network> From<DisconnectReason> for Event<N> {
 
 impl<N: Network> Event<N> {
     /// The version of the event protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 4;
+    pub const VERSION: u32 = 5;
 
     /// Returns the event name.
     #[inline]

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -111,7 +111,7 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 12;
+    pub const VERSION: u32 = 13;
 
     /// Returns the message name.
     #[inline]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -157,6 +157,15 @@ pub fn phase_3_reset<N: Network, C: ConsensusStorage<N>>(
             std::thread::sleep(std::time::Duration::from_secs(5));
             return Ledger::<N, C>::load(genesis.clone(), dev);
         }
+    } else if let Ok(block) = ledger.get_block(997810) {
+        if *block.hash() == *ID::<N>::from_str("ab1fx4mpz0fdqx75djf3n9grsjkc229xfs8fzmjqsxkajtj8j8sdurqufgvyz")? {
+            let genesis = ledger.get_block(0)?;
+            drop(ledger);
+            println!("{}.\n\n\nMIGRATION SUCCEEDED. RESTART THIS SNARKOS NODE AGAIN.\n\n", remove_ledger(N::ID, dev)?);
+            // Sleep for 5 seconds to allow the user to read the message.
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            return Ledger::<N, C>::load(genesis.clone(), dev);
+        }
     }
     Ok(ledger)
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -148,6 +148,15 @@ pub fn phase_3_reset<N: Network, C: ConsensusStorage<N>>(
             std::thread::sleep(std::time::Duration::from_secs(5));
             return Ledger::<N, C>::load(genesis.clone(), dev);
         }
+    } else if let Ok(block) = ledger.get_block(997810) {
+        if *block.hash() == *ID::<N>::from_str("ab1pap9sxh5fcskw7l3msax4fq2mrqd80kxp0epx9dguxua2e8dacys78key5")? {
+            let genesis = ledger.get_block(0)?;
+            drop(ledger);
+            println!("{}.\n\n\nMIGRATION SUCCEEDED. RESTART THIS SNARKOS NODE AGAIN.\n\n", remove_ledger(N::ID, dev)?);
+            // Sleep for 5 seconds to allow the user to read the message.
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            return Ledger::<N, C>::load(genesis.clone(), dev);
+        }
     }
     Ok(ledger)
 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps snarkVM rev to [40c4fcc](https://github.com/AleoHQ/snarkVM/commit/40c4fcc9e2bf102119ad751818432b3382054f66). This update includes various additional checks and optimizations, including proper solutions bounds, reduced allocations, reduced ledger loading time, etc.

In addition, the `Message` and `Event` versions were bumped.
