### PR TITLE
Fetch certificate from ledger as backup and increase timeouts

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -341,7 +341,7 @@ impl<N: Network> Sync<N> {
             }
         }
         // Wait for the certificate to be fetched.
-        match tokio::time::timeout(core::time::Duration::from_millis(MAX_BATCH_DELAY_IN_MS * 3), callback_receiver)
+        match tokio::time::timeout(core::time::Duration::from_millis(MAX_BATCH_DELAY_IN_MS * 2), callback_receiver)
             .await
         {
             // If the certificate was fetched, return it.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -341,7 +341,9 @@ impl<N: Network> Sync<N> {
             }
         }
         // Wait for the certificate to be fetched.
-        match tokio::time::timeout(core::time::Duration::from_millis(MAX_BATCH_DELAY_IN_MS), callback_receiver).await {
+        match tokio::time::timeout(core::time::Duration::from_millis(MAX_BATCH_DELAY_IN_MS * 3), callback_receiver)
+            .await
+        {
             // If the certificate was fetched, return it.
             Ok(result) => Ok(result?),
             // If the certificate was not fetched, return an error.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -383,7 +383,7 @@ impl<N: Network> Worker<N> {
             bail!("Unable to fetch transmission - failed to send request")
         }
         // Wait for the transmission to be fetched.
-        match timeout(Duration::from_millis(MAX_BATCH_DELAY_IN_MS), callback_receiver).await {
+        match timeout(Duration::from_millis(MAX_BATCH_DELAY_IN_MS * 2), callback_receiver).await {
             // If the transmission was fetched, return it.
             Ok(result) => Ok((transmission_id, result?)),
             // If the transmission was not fetched, return an error.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -40,7 +40,7 @@ pub const REDUNDANCY_FACTOR: usize = 3;
 const EXTRA_REDUNDANCY_FACTOR: usize = REDUNDANCY_FACTOR * 2;
 const NUM_SYNC_CANDIDATE_PEERS: usize = REDUNDANCY_FACTOR * 5;
 
-const BLOCK_REQUEST_TIMEOUT_IN_SECS: u64 = 15; // 15 seconds
+const BLOCK_REQUEST_TIMEOUT_IN_SECS: u64 = 25; // 25 seconds
 const MAX_BLOCK_REQUESTS: usize = 50; // 50 requests
 const MAX_BLOCK_REQUEST_TIMEOUTS: usize = 5; // 5 timeouts
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR attempts to fetch a certificate from the ledger if the certificate ID (from a CertificateRequest) does not exist in the Certificate Storage. In addition the request timeouts are increased for the following:

Block requests: 15s -> 25s
Batch Certificate: 2.5s -> 5s
Transmission: 2.5s -> 5s


Note: These values are experimental and should be tuned.
