### PR TITLE
feat: explicitly reject seralize if too many peers in PeerResponse

### DIFF
--- a/node/router/messages/src/peer_response.rs
+++ b/node/router/messages/src/peer_response.rs
@@ -33,9 +33,13 @@ impl MessageTrait for PeerResponse {
 
 impl ToBytes for PeerResponse {
     fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
-        // Restrict the maximum number of peers to share.
-        (self.peers.len().min(u8::MAX as usize) as u8).write_le(&mut writer)?;
-        for peer in self.peers.iter().take(u8::MAX as usize) {
+        // Return error if the number of peers exceeds the maximum.
+        if self.peers.len() > u8::MAX as usize {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("Too many peers: {}", self.peers.len())));
+        }
+
+        (self.peers.len() as u8).write_le(&mut writer)?;
+        for peer in self.peers.iter() {
             peer.write_le(&mut writer)?;
         }
         Ok(())

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -256,7 +256,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
         // Retrieve the connected peers.
         let peers = self.router().connected_peers();
         // Filter out invalid addresses.
-        let peers = peers.into_iter().filter(|ip| self.router().is_valid_peer_ip(ip)).collect();
+        let peers = peers.into_iter().filter(|ip| self.router().is_valid_peer_ip(ip)).take(u8::MAX as usize).collect();
         // Send a `PeerResponse` message to the peer.
         self.send(peer_ip, Message::PeerResponse(PeerResponse { peers }));
         true


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Explicitly reject `PeerResponse` in serialization instead of implicitly truncating.
