### PR TITLE
chore: respect tmux's base-index config in devnet.sh

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -51,13 +51,12 @@ for validator_index in "${validator_indices[@]}"; do
   # Generate a unique and incrementing log file name based on the validator index
   log_file="$log_dir/validator-$validator_index.log"
 
-  # Create a new window with a unique name
-  tmux new-window -t "devnet:$validator_index" -n "window$validator_index"
-
   # Send the command to start the validator to the new window and capture output to the log file
   if [ "$validator_index" -eq 0 ]; then
     tmux send-keys -t "devnet:window$validator_index" "snarkos start --nodisplay --dev $validator_index --dev-num-validators $total_validators --validator --logfile $log_file --metrics" C-m
   else
+    # Create a new window with a unique name
+    tmux new-window -t "devnet:$validator_index" -n "window$validator_index"
     tmux send-keys -t "devnet:window$validator_index" "snarkos start --nodisplay --dev $validator_index --dev-num-validators $total_validators --validator --logfile $log_file" C-m
   fi
 done

--- a/devnet.sh
+++ b/devnet.sh
@@ -81,7 +81,7 @@ for client_index in "${client_indices[@]}"; do
   # Generate a unique and incrementing log file name based on the client index
   log_file="$log_dir/client-$client_index.log"
 
-  window_index=$(($client_index + $total_validators))
+  window_index=$((client_index + total_validators + index_offset))
 
   # Create a new window with a unique name
   tmux new-window -t "devnet:$window_index" -n "window-$window_index"

--- a/devnet.sh
+++ b/devnet.sh
@@ -43,6 +43,13 @@ mkdir -p "$log_dir"
 # Create a new tmux session named "devnet"
 tmux new-session -d -s "devnet" -n "window0"
 
+# Get the tmux's base-index for windows
+# we have to create all windows with index offseted by this much
+index_offset="$(tmux show-option -gv base-index)"
+if [ -z "$index_offset" ]; then
+  index_offset=0
+fi
+
 # Generate validator indices from 0 to (total_validators - 1)
 validator_indices=($(seq 0 $((total_validators - 1))))
 
@@ -56,7 +63,8 @@ for validator_index in "${validator_indices[@]}"; do
     tmux send-keys -t "devnet:window$validator_index" "snarkos start --nodisplay --dev $validator_index --dev-num-validators $total_validators --validator --logfile $log_file --metrics" C-m
   else
     # Create a new window with a unique name
-    tmux new-window -t "devnet:$validator_index" -n "window$validator_index"
+    window_index=$((validator_index + index_offset))
+    tmux new-window -t "devnet:$window_index" -n "window$validator_index"
     tmux send-keys -t "devnet:window$validator_index" "snarkos start --nodisplay --dev $validator_index --dev-num-validators $total_validators --validator --logfile $log_file" C-m
   fi
 done


### PR DESCRIPTION
## Motivation

I have a following line in my `.tmux.conf`
```
set -g base-index 1
```

which configures tmux to create windows with indexes starting from 1 instead of the default 0. I use it so that when I want to switch the windows using their indexes, the order of windows matches the order of num keys on keyboard.

This however doesn't play nice with the `devnet.sh` script, which assumes the indexing of windows from 0, thus failing on creating the second window `window1` as the index 1 got taken by the `window0`.

It would be cool if this tmux setting was taken into account.

I've opened this PR on top of the #2975 as it is kinda required, however I didn't want to include this directly in the previous PR as I  am not sure if you'd like to support this config option.

## Test Plan

manual check
