### PR TITLE
[NCC-7VR] `Zeroize` CLI input keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3234,6 +3234,7 @@ dependencies = [
  "tokio",
  "tracing-subscriber 0.3.18",
  "ureq",
+ "zeroize",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -118,5 +118,9 @@ features = [ "env-filter" ]
 [dependencies.ureq]
 version = "2.9"
 
+[dependencies.zeroize]
+version = "1"
+features = [ "derive" ]
+
 [target."cfg(target_family = \"unix\")".dependencies.nix]
 version = "0.26"

--- a/cli/src/commands/account.rs
+++ b/cli/src/commands/account.rs
@@ -27,11 +27,12 @@ use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use rayon::prelude::*;
 use std::io::{Read, Write};
+use zeroize::Zeroize;
 
 type Network = snarkvm::prelude::Testnet3;
 
 /// Commands to manage Aleo accounts.
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Zeroize)]
 pub enum Account {
     /// Generates a new Aleo account
     New {

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -22,9 +22,10 @@ use snarkvm::{
 use anyhow::{bail, Result};
 use clap::Parser;
 use std::str::FromStr;
+use zeroize::Zeroize;
 
 /// Decrypts a record ciphertext.
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Zeroize)]
 pub struct Decrypt {
     /// The record ciphertext to decrypt.
     #[clap(short, long)]

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -31,6 +31,7 @@ use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use colored::Colorize;
 use std::str::FromStr;
+use zeroize::Zeroize;
 
 /// Executes an Aleo program function.
 #[derive(Debug, Parser)]
@@ -62,6 +63,13 @@ pub struct Execute {
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
+}
+
+impl Drop for Execute {
+    /// Zeroize the private key when the `Execute` struct goes out of scope.
+    fn drop(&mut self) {
+        self.private_key.zeroize();
+    }
 }
 
 impl Execute {
@@ -143,7 +151,7 @@ impl Execute {
         println!("✅ Created execution transaction for '{}'", locator.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(self.broadcast, self.dry_run, self.store, transaction, locator.to_string())
+        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, transaction, locator.to_string())
     }
 }
 

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -84,7 +84,7 @@ impl Developer {
     fn parse_package(program_id: ProgramID<CurrentNetwork>, path: &Option<String>) -> Result<Package<CurrentNetwork>> {
         // Instantiate a path to the directory containing the manifest file.
         let directory = match path {
-            Some(path) => PathBuf::from_str(&path)?,
+            Some(path) => PathBuf::from_str(path)?,
             None => std::env::current_dir()?,
         };
 
@@ -181,7 +181,7 @@ impl Developer {
 
         // Determine if the transaction should be stored.
         if let Some(path) = store {
-            match PathBuf::from_str(&path) {
+            match PathBuf::from_str(path) {
                 Ok(file_path) => {
                     let transaction_bytes = transaction.to_bytes_le()?;
                     std::fs::write(&file_path, transaction_bytes)?;
@@ -196,7 +196,7 @@ impl Developer {
         // Determine if the transaction should be broadcast to the network.
         if let Some(endpoint) = broadcast {
             // Send the deployment request to the local development node.
-            match ureq::post(&endpoint).send_json(&transaction) {
+            match ureq::post(endpoint).send_json(&transaction) {
                 Ok(id) => {
                     // Remove the quotes from the response.
                     let response_string = id.into_string()?.trim_matches('\"').to_string();

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -81,7 +81,7 @@ impl Developer {
     }
 
     /// Parse the package from the directory.
-    fn parse_package(program_id: ProgramID<CurrentNetwork>, path: Option<String>) -> Result<Package<CurrentNetwork>> {
+    fn parse_package(program_id: ProgramID<CurrentNetwork>, path: &Option<String>) -> Result<Package<CurrentNetwork>> {
         // Instantiate a path to the directory containing the manifest file.
         let directory = match path {
             Some(path) => PathBuf::from_str(&path)?,
@@ -167,9 +167,9 @@ impl Developer {
 
     /// Determine if the transaction should be broadcast or displayed to user.
     fn handle_transaction(
-        broadcast: Option<String>,
+        broadcast: &Option<String>,
         dry_run: bool,
-        store: Option<String>,
+        store: &Option<String>,
         transaction: Transaction<CurrentNetwork>,
         operation: String,
     ) -> Result<String> {

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -208,14 +208,14 @@ impl Developer {
                     match transaction {
                         Transaction::Deploy(..) => {
                             println!(
-                                "✅ Successfully broadcast deployment {transaction_id} ('{}') to {}.",
+                                "⌛ Deployment {transaction_id} ('{}') has been broadcast to {}.",
                                 operation.bold(),
                                 endpoint
                             )
                         }
                         Transaction::Execute(..) => {
                             println!(
-                                "✅ Successfully broadcast execution {transaction_id} ('{}') to {}.",
+                                "⌛ Execution {transaction_id} ('{}') has been broadcast to {}.",
                                 operation.bold(),
                                 endpoint
                             )

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -26,12 +26,13 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
+use zeroize::Zeroize;
 
 const MAX_BLOCK_RANGE: u32 = 50;
 const CDN_ENDPOINT: &str = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase3";
 
 /// Scan the snarkOS node for records.
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Zeroize)]
 pub struct Scan {
     /// An optional private key scan for unspent records.
     #[clap(short, long)]

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -27,6 +27,7 @@ use snarkvm::prelude::{
 use anyhow::{bail, Result};
 use clap::Parser;
 use std::str::FromStr;
+use zeroize::Zeroize;
 
 /// Executes the `transfer_private` function in the `credits.aleo` program.
 #[derive(Debug, Parser)]
@@ -61,6 +62,13 @@ pub struct TransferPrivate {
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
+}
+
+impl Drop for TransferPrivate {
+    /// Zeroize the private key when the `TransferPrivate` struct goes out of scope.
+    fn drop(&mut self) {
+        self.private_key.zeroize();
+    }
 }
 
 impl TransferPrivate {
@@ -116,6 +124,6 @@ impl TransferPrivate {
         println!("✅ Created private transfer of {} microcredits to {}\n", &self.amount, self.recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(self.broadcast, self.dry_run, self.store, transaction, locator.to_string())
+        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, transaction, locator.to_string())
     }
 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR uses the `zeroize` crate to zeroize the CLI keys after they have been dropped. This prevents some memory related attacks.

Some structs directly derive `Zeroize`, however others that include variables that do not derive `Zeroize`, we selectively zeroize the sensitive keys when the struct is dropped.