### PR TITLE
fix: bump timestamps of all requests when a BlockResponse is handled

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -319,6 +319,11 @@ impl<N: Network> BlockSync<N> {
             }
             // Update the latest height.
             current_height = self.canon.latest_block_height();
+            // Bump the timestamps of all outstanding requests if we successfully handled a BlockResponse.
+            let mut timestamps = self.request_timestamps.write();
+            for (_height, instant) in timestamps.iter_mut() {
+                *instant = Instant::now();
+            }
         }
     }
 }

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -320,9 +320,10 @@ impl<N: Network> BlockSync<N> {
             // Update the latest height.
             current_height = self.canon.latest_block_height();
             // Bump the timestamps of all outstanding requests if we successfully handled a BlockResponse.
+            let now = Instant::now();
             let mut timestamps = self.request_timestamps.write();
-            for (_height, instant) in timestamps.iter_mut() {
-                *instant = Instant::now();
+            for instant in timestamps.values_mut() {
+                *instant = now;
             }
         }
     }


### PR DESCRIPTION
Partial fix for https://github.com/AleoHQ/snarkOS/issues/2978

Rationale:

If there's only 1 peer connected, and it's slow to send `BlockRespons`es, or we are slow processing them, the `BlockRequest`s can expire in the `self.requests` map before they can be handled. If that happens, the only peer is disconnected, and syncing comes to a halt.

This PR bumps all the timestamps for all outstanding `BlockRequest`s when we've successfully handled a `BlockResponse`.

@HarukaMa confirms this fix works.