### PR TITLE
[NCC-UJF] Prohibit sending leftover bytes over the network

### DIFF
--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -199,24 +199,29 @@ impl<N: Network> FromBytes for Event<N> {
 
         // Deserialize the data field.
         let event = match id {
-            0 => Self::BatchPropose(BatchPropose::read_le(reader)?),
-            1 => Self::BatchSignature(BatchSignature::read_le(reader)?),
-            2 => Self::BatchCertified(BatchCertified::read_le(reader)?),
-            3 => Self::BlockRequest(BlockRequest::read_le(reader)?),
-            4 => Self::BlockResponse(BlockResponse::read_le(reader)?),
-            5 => Self::CertificateRequest(CertificateRequest::read_le(reader)?),
-            6 => Self::CertificateResponse(CertificateResponse::read_le(reader)?),
-            7 => Self::ChallengeRequest(ChallengeRequest::read_le(reader)?),
-            8 => Self::ChallengeResponse(ChallengeResponse::read_le(reader)?),
-            9 => Self::Disconnect(Disconnect::read_le(reader)?),
-            10 => Self::PrimaryPing(PrimaryPing::read_le(reader)?),
-            11 => Self::TransmissionRequest(TransmissionRequest::read_le(reader)?),
-            12 => Self::TransmissionResponse(TransmissionResponse::read_le(reader)?),
-            13 => Self::ValidatorsRequest(ValidatorsRequest::read_le(reader)?),
-            14 => Self::ValidatorsResponse(ValidatorsResponse::read_le(reader)?),
-            15 => Self::WorkerPing(WorkerPing::read_le(reader)?),
+            0 => Self::BatchPropose(BatchPropose::read_le(&mut reader)?),
+            1 => Self::BatchSignature(BatchSignature::read_le(&mut reader)?),
+            2 => Self::BatchCertified(BatchCertified::read_le(&mut reader)?),
+            3 => Self::BlockRequest(BlockRequest::read_le(&mut reader)?),
+            4 => Self::BlockResponse(BlockResponse::read_le(&mut reader)?),
+            5 => Self::CertificateRequest(CertificateRequest::read_le(&mut reader)?),
+            6 => Self::CertificateResponse(CertificateResponse::read_le(&mut reader)?),
+            7 => Self::ChallengeRequest(ChallengeRequest::read_le(&mut reader)?),
+            8 => Self::ChallengeResponse(ChallengeResponse::read_le(&mut reader)?),
+            9 => Self::Disconnect(Disconnect::read_le(&mut reader)?),
+            10 => Self::PrimaryPing(PrimaryPing::read_le(&mut reader)?),
+            11 => Self::TransmissionRequest(TransmissionRequest::read_le(&mut reader)?),
+            12 => Self::TransmissionResponse(TransmissionResponse::read_le(&mut reader)?),
+            13 => Self::ValidatorsRequest(ValidatorsRequest::read_le(&mut reader)?),
+            14 => Self::ValidatorsResponse(ValidatorsResponse::read_le(&mut reader)?),
+            15 => Self::WorkerPing(WorkerPing::read_le(&mut reader)?),
             16.. => return Err(error("Unknown event ID {id}")),
         };
+
+        // Ensure that there are no "dangling" bytes.
+        if reader.bytes().next().is_some() {
+            return Err(error("Leftover bytes in an Event"));
+        }
 
         Ok(event)
     }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -185,21 +185,26 @@ impl<N: Network> FromBytes for Message<N> {
 
         // Deserialize the data field.
         let message = match id {
-            0 => Self::BlockRequest(BlockRequest::read_le(reader)?),
-            1 => Self::BlockResponse(BlockResponse::read_le(reader)?),
-            2 => Self::ChallengeRequest(ChallengeRequest::read_le(reader)?),
-            3 => Self::ChallengeResponse(ChallengeResponse::read_le(reader)?),
-            4 => Self::Disconnect(Disconnect::read_le(reader)?),
-            5 => Self::PeerRequest(PeerRequest::read_le(reader)?),
-            6 => Self::PeerResponse(PeerResponse::read_le(reader)?),
-            7 => Self::Ping(Ping::read_le(reader)?),
-            8 => Self::Pong(Pong::read_le(reader)?),
-            9 => Self::PuzzleRequest(PuzzleRequest::read_le(reader)?),
-            10 => Self::PuzzleResponse(PuzzleResponse::read_le(reader)?),
-            11 => Self::UnconfirmedSolution(UnconfirmedSolution::read_le(reader)?),
-            12 => Self::UnconfirmedTransaction(UnconfirmedTransaction::read_le(reader)?),
+            0 => Self::BlockRequest(BlockRequest::read_le(&mut reader)?),
+            1 => Self::BlockResponse(BlockResponse::read_le(&mut reader)?),
+            2 => Self::ChallengeRequest(ChallengeRequest::read_le(&mut reader)?),
+            3 => Self::ChallengeResponse(ChallengeResponse::read_le(&mut reader)?),
+            4 => Self::Disconnect(Disconnect::read_le(&mut reader)?),
+            5 => Self::PeerRequest(PeerRequest::read_le(&mut reader)?),
+            6 => Self::PeerResponse(PeerResponse::read_le(&mut reader)?),
+            7 => Self::Ping(Ping::read_le(&mut reader)?),
+            8 => Self::Pong(Pong::read_le(&mut reader)?),
+            9 => Self::PuzzleRequest(PuzzleRequest::read_le(&mut reader)?),
+            10 => Self::PuzzleResponse(PuzzleResponse::read_le(&mut reader)?),
+            11 => Self::UnconfirmedSolution(UnconfirmedSolution::read_le(&mut reader)?),
+            12 => Self::UnconfirmedTransaction(UnconfirmedTransaction::read_le(&mut reader)?),
             13.. => return Err(error("Unknown message ID {id}")),
         };
+
+        // Ensure that there are no "dangling" bytes.
+        if reader.bytes().next().is_some() {
+            return Err(error("Leftover bytes in a Message"));
+        }
 
         Ok(message)
     }


### PR DESCRIPTION
While it would be hard to exploit maliciously, "leftover" bytes in network messages could increase memory use.