### PR TITLE
Store a bitset of transmissions in compact subdag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-version = "=0.16.15"
+git = "https://github.com/aleoHQ/snarkVM.git"
+branch = "block_transmission_id_dedup"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -48,6 +48,7 @@ version = "=2.2.7"
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "ledger" ]
 
 [dependencies.snow]
 version = "0.9"

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -71,7 +71,7 @@ use snarkvm::{
     ledger::{
         block::Block,
         committee::Committee,
-        narwhal::{BatchCertificate, BatchHeader, Data, Transmission, TransmissionID},
+        narwhal::{BatchCertificate, BatchHeader, Data, NarwhalCertificate, Transmission, TransmissionID},
     },
     prelude::{Address, Field, Signature},
 };

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -203,7 +203,7 @@ fn consensus_handler(receiver: ConsensusReceiver<CurrentNetwork>) {
     let ConsensusReceiver { mut rx_consensus_subdag } = receiver;
 
     tokio::task::spawn(async move {
-        while let Some((subdag, transmissions, callback)) = rx_consensus_subdag.recv().await {
+        while let Some((subdag, transmissions, _, callback)) = rx_consensus_subdag.recv().await {
             // Determine the amount of time to sleep for the subdag.
             let subdag_ms = subdag.num_certificates();
             // Determine the amount of time to sleep for the transmissions.

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -203,7 +203,7 @@ fn consensus_handler(receiver: ConsensusReceiver<CurrentNetwork>) {
     let ConsensusReceiver { mut rx_consensus_subdag } = receiver;
 
     tokio::task::spawn(async move {
-        while let Some((subdag, transmissions, _, callback)) = rx_consensus_subdag.recv().await {
+        while let Some((subdag, transmissions, _, _, callback)) = rx_consensus_subdag.recv().await {
             // Determine the amount of time to sleep for the subdag.
             let subdag_ms = subdag.num_certificates();
             // Determine the amount of time to sleep for the transmissions.

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -203,11 +203,11 @@ fn consensus_handler(receiver: ConsensusReceiver<CurrentNetwork>) {
     let ConsensusReceiver { mut rx_consensus_subdag } = receiver;
 
     tokio::task::spawn(async move {
-        while let Some((subdag, transmissions, _, _, callback)) = rx_consensus_subdag.recv().await {
+        while let Some((subdag, subdag_transmissions, callback)) = rx_consensus_subdag.recv().await {
             // Determine the amount of time to sleep for the subdag.
             let subdag_ms = subdag.num_certificates();
             // Determine the amount of time to sleep for the transmissions.
-            let transmissions_ms = transmissions.len() * 25;
+            let transmissions_ms = subdag_transmissions.len() * 25;
             // Add a constant delay.
             let constant_ms = 100;
             // Compute the total amount of time to sleep.

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -205,7 +205,7 @@ fn consensus_handler(receiver: ConsensusReceiver<CurrentNetwork>) {
     tokio::task::spawn(async move {
         while let Some((subdag, transmissions, callback)) = rx_consensus_subdag.recv().await {
             // Determine the amount of time to sleep for the subdag.
-            let subdag_ms = subdag.values().flatten().count();
+            let subdag_ms = subdag.num_certificates();
             // Determine the amount of time to sleep for the transmissions.
             let transmissions_ms = transmissions.len() * 25;
             // Add a constant delay.

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -285,8 +285,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         prior_transmissions: IndexSet<TransmissionID<N>>,
+        aborted_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
-        self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, prior_transmissions)
+        self.ledger.prepare_advance_to_next_quorum_block(
+            subdag,
+            transmissions,
+            prior_transmissions,
+            aborted_transmissions,
+        )
     }
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -21,11 +21,11 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         store::ConsensusStorage,
         Ledger,
+        SubdagTransmissions,
     },
     prelude::{bail, Field, Network, Result},
 };
 
-use indexmap::{IndexMap, IndexSet};
 use std::{
     fmt,
     ops::Range,
@@ -283,16 +283,9 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     fn prepare_advance_to_next_quorum_block(
         &self,
         subdag: Subdag<N>,
-        transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
-        prior_transmissions: IndexSet<TransmissionID<N>>,
-        aborted_transmissions: IndexSet<TransmissionID<N>>,
+        subdag_transmissions: SubdagTransmissions<N>,
     ) -> Result<Block<N>> {
-        self.ledger.prepare_advance_to_next_quorum_block(
-            subdag,
-            transmissions,
-            prior_transmissions,
-            aborted_transmissions,
-        )
+        self.ledger.prepare_advance_to_next_quorum_block(subdag, subdag_transmissions)
     }
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -25,7 +25,7 @@ use snarkvm::{
     prelude::{bail, Field, Network, Result},
 };
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use std::{
     fmt,
     ops::Range,
@@ -284,8 +284,9 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         &self,
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+        prior_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
-        self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions)
+        self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, prior_transmissions)
     }
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -23,7 +23,7 @@ use snarkvm::{
     prelude::{bail, ensure, Field, Network, Result},
 };
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use parking_lot::Mutex;
 use std::{collections::BTreeMap, ops::Range};
 use tracing::*;
@@ -184,6 +184,7 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         &self,
         _subdag: Subdag<N>,
         _transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+        _prior_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
         unreachable!("MockLedgerService does not support prepare_advance_to_next_quorum_block")
     }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -185,6 +185,7 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         _subdag: Subdag<N>,
         _transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         _prior_transmissions: IndexSet<TransmissionID<N>>,
+        _aborted_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
         unreachable!("MockLedgerService does not support prepare_advance_to_next_quorum_block")
     }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -20,10 +20,9 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::{bail, ensure, Field, Network, Result},
+    prelude::{bail, ensure, Field, Network, Result, SubdagTransmissions},
 };
 
-use indexmap::{IndexMap, IndexSet};
 use parking_lot::Mutex;
 use std::{collections::BTreeMap, ops::Range};
 use tracing::*;
@@ -183,9 +182,7 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     fn prepare_advance_to_next_quorum_block(
         &self,
         _subdag: Subdag<N>,
-        _transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
-        _prior_transmissions: IndexSet<TransmissionID<N>>,
-        _aborted_transmissions: IndexSet<TransmissionID<N>>,
+        _subdag_transmissions: SubdagTransmissions<N>,
     ) -> Result<Block<N>> {
         unreachable!("MockLedgerService does not support prepare_advance_to_next_quorum_block")
     }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -20,10 +20,9 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::{bail, Field, Network, Result},
+    prelude::{bail, Field, Network, Result, SubdagTransmissions},
 };
 
-use indexmap::{IndexMap, IndexSet};
 use std::ops::Range;
 
 /// A ledger service for a prover.
@@ -161,9 +160,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     fn prepare_advance_to_next_quorum_block(
         &self,
         _subdag: Subdag<N>,
-        _transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
-        _prior_transmissions: IndexSet<TransmissionID<N>>,
-        _aborted_transmissions: IndexSet<TransmissionID<N>>,
+        _subdag_transmissions: SubdagTransmissions<N>,
     ) -> Result<Block<N>> {
         bail!("Cannot prepare advance to next quorum block in prover")
     }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -23,7 +23,7 @@ use snarkvm::{
     prelude::{bail, Field, Network, Result},
 };
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use std::ops::Range;
 
 /// A ledger service for a prover.
@@ -162,6 +162,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         &self,
         _subdag: Subdag<N>,
         _transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+        _prior_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
         bail!("Cannot prepare advance to next quorum block in prover")
     }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -163,6 +163,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         _subdag: Subdag<N>,
         _transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         _prior_transmissions: IndexSet<TransmissionID<N>>,
+        _aborted_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
         bail!("Cannot prepare advance to next quorum block in prover")
     }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -109,6 +109,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         prior_transmissions: IndexSet<TransmissionID<N>>,
+        aborted_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>>;
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -22,7 +22,7 @@ use snarkvm::{
     prelude::{Field, Network, Result},
 };
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use std::{fmt::Debug, ops::Range};
 
 #[async_trait]
@@ -108,6 +108,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
         &self,
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+        prior_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>>;
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -19,10 +19,9 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::{Field, Network, Result},
+    prelude::{Field, Network, Result, SubdagTransmissions},
 };
 
-use indexmap::{IndexMap, IndexSet};
 use std::{fmt::Debug, ops::Range};
 
 #[async_trait]
@@ -107,9 +106,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn prepare_advance_to_next_quorum_block(
         &self,
         subdag: Subdag<N>,
-        transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
-        prior_transmissions: IndexSet<TransmissionID<N>>,
-        aborted_transmissions: IndexSet<TransmissionID<N>>,
+        subdag_transmissions: SubdagTransmissions<N>,
     ) -> Result<Block<N>>;
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -171,8 +171,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         prior_transmissions: IndexSet<TransmissionID<N>>,
+        aborted_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
-        self.inner.prepare_advance_to_next_quorum_block(subdag, transmissions, prior_transmissions)
+        self.inner.prepare_advance_to_next_quorum_block(
+            subdag,
+            transmissions,
+            prior_transmissions,
+            aborted_transmissions,
+        )
     }
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -14,7 +14,7 @@
 
 use crate::{CoreLedgerService, LedgerService};
 use async_trait::async_trait;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use snarkvm::{
     ledger::{
         block::{Block, Transaction},
@@ -170,8 +170,9 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         &self,
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+        prior_transmissions: IndexSet<TransmissionID<N>>,
     ) -> Result<Block<N>> {
-        self.inner.prepare_advance_to_next_quorum_block(subdag, transmissions)
+        self.inner.prepare_advance_to_next_quorum_block(subdag, transmissions, prior_transmissions)
     }
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -14,17 +14,16 @@
 
 use crate::{CoreLedgerService, LedgerService};
 use async_trait::async_trait;
-use indexmap::{IndexMap, IndexSet};
 use snarkvm::{
     ledger::{
         block::{Block, Transaction},
         coinbase::{ProverSolution, PuzzleCommitment},
         committee::Committee,
-        narwhal::{Data, Subdag, Transmission, TransmissionID},
+        narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         store::ConsensusStorage,
         Ledger,
     },
-    prelude::{narwhal::BatchCertificate, Field, Network, Result},
+    prelude::{Field, Network, Result, SubdagTransmissions},
 };
 use std::{
     fmt,
@@ -169,16 +168,9 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     fn prepare_advance_to_next_quorum_block(
         &self,
         subdag: Subdag<N>,
-        transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
-        prior_transmissions: IndexSet<TransmissionID<N>>,
-        aborted_transmissions: IndexSet<TransmissionID<N>>,
+        subdag_transmissions: SubdagTransmissions<N>,
     ) -> Result<Block<N>> {
-        self.inner.prepare_advance_to_next_quorum_block(
-            subdag,
-            transmissions,
-            prior_transmissions,
-            aborted_transmissions,
-        )
+        self.inner.prepare_advance_to_next_quorum_block(subdag, subdag_transmissions)
     }
 
     /// Adds the given block as the next block in the ledger.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -35,7 +35,7 @@ use snarkvm::{
         block::Transaction,
         coinbase::{ProverSolution, PuzzleCommitment},
         committee::Committee,
-        narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
+        narwhal::{BatchCertificate, Data, NarwhalCertificate, Subdag, Transmission, TransmissionID},
     },
     prelude::{bail, ensure, Field, Network, Result},
 };
@@ -538,13 +538,13 @@ impl<N: Network> BFT<N> {
         // If the node is not syncing, trigger consensus, as this will build a new block for the ledger.
         if !IS_SYNCING {
             // Construct the subdag.
-            let subdag = Subdag::from(commit_subdag.clone(), election_certificate_ids.clone())?;
+            let subdag = Subdag::from_full(commit_subdag.clone(), election_certificate_ids.clone())?;
             // Retrieve the anchor round.
             let anchor_round = subdag.anchor_round();
             // Retrieve the number of transmissions.
             let num_transmissions = transmissions.len();
             // Retrieve metadata about the subdag.
-            let subdag_metadata = subdag.iter().map(|(round, c)| (*round, c.len())).collect::<Vec<_>>();
+            let subdag_metadata = subdag.num_certificates_rounds();
 
             // Ensure the subdag anchor round matches the leader round.
             ensure!(
@@ -819,7 +819,10 @@ mod tests {
     use snarkvm::{
         ledger::{
             committee::Committee,
-            narwhal::batch_certificate::test_helpers::{sample_batch_certificate, sample_batch_certificate_for_round},
+            narwhal::{
+                batch_certificate::test_helpers::{sample_batch_certificate, sample_batch_certificate_for_round},
+                NarwhalCertificate,
+            },
         },
         utilities::TestRng,
     };

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -526,7 +526,7 @@ impl<N: Network> BFT<N> {
                 match self.ledger().contains_transmission(transmission_id) {
                     // On failure to read from the ledger, we skip including this transmission, out of safety.
                     Err(err) => {
-                        warn!("{}", err.to_string());
+                        warn!("{}", err);
                         aborted_transmissions.insert(*transmission_id);
                         continue;
                     }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -528,12 +528,10 @@ impl<N: Network> BFT<N> {
                     Err(err) => {
                         warn!("{}", err);
                         aborted_transmissions.insert(*transmission_id);
-                        continue;
                     }
                     // If the transmission already exists in the ledger, save just the transmission ID.
                     Ok(true) => {
                         prior_included_transmissions.insert(*transmission_id);
-                        continue;
                     }
                     // If the transmission does not exist in the ledger, retrieve it from the storage.
                     Ok(false) => {

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -55,7 +55,7 @@ use snarkos_node_tcp::{
 use snarkvm::{
     console::prelude::*,
     ledger::{committee::Committee, narwhal::Data},
-    prelude::Address,
+    prelude::{Address, NarwhalCertificate},
 };
 
 use colored::Colorize;

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -26,9 +26,9 @@ use snarkvm::{
     ledger::{
         block::{Block, Transaction},
         coinbase::{ProverSolution, PuzzleCommitment},
-        narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
+        narwhal::{BatchCertificate, Data, Subdag, TransmissionID},
     },
-    prelude::Result,
+    prelude::{Result, SubdagTransmissions},
 };
 
 use indexmap::{IndexMap, IndexSet};
@@ -37,28 +37,14 @@ use tokio::sync::{mpsc, oneshot};
 
 const MAX_CHANNEL_SIZE: usize = 8192;
 
-type TransmissionMap<N> = IndexMap<TransmissionID<N>, Transmission<N>>;
-
 #[derive(Debug)]
 pub struct ConsensusSender<N: Network> {
-    pub tx_consensus_subdag: mpsc::Sender<(
-        Subdag<N>,
-        TransmissionMap<N>,
-        IndexSet<TransmissionID<N>>,
-        IndexSet<TransmissionID<N>>,
-        oneshot::Sender<Result<()>>,
-    )>,
+    pub tx_consensus_subdag: mpsc::Sender<(Subdag<N>, SubdagTransmissions<N>, oneshot::Sender<Result<()>>)>,
 }
 
 #[derive(Debug)]
 pub struct ConsensusReceiver<N: Network> {
-    pub rx_consensus_subdag: mpsc::Receiver<(
-        Subdag<N>,
-        TransmissionMap<N>,
-        IndexSet<TransmissionID<N>>,
-        IndexSet<TransmissionID<N>>,
-        oneshot::Sender<Result<()>>,
-    )>,
+    pub rx_consensus_subdag: mpsc::Receiver<(Subdag<N>, SubdagTransmissions<N>, oneshot::Sender<Result<()>>)>,
 }
 
 /// Initializes the consensus channels.

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -37,16 +37,18 @@ use tokio::sync::{mpsc, oneshot};
 
 const MAX_CHANNEL_SIZE: usize = 8192;
 
+type TransmissionMap<N> = IndexMap<TransmissionID<N>, Transmission<N>>;
+
 #[derive(Debug)]
 pub struct ConsensusSender<N: Network> {
     pub tx_consensus_subdag:
-        mpsc::Sender<(Subdag<N>, IndexMap<TransmissionID<N>, Transmission<N>>, oneshot::Sender<Result<()>>)>,
+        mpsc::Sender<(Subdag<N>, TransmissionMap<N>, IndexSet<TransmissionID<N>>, oneshot::Sender<Result<()>>)>,
 }
 
 #[derive(Debug)]
 pub struct ConsensusReceiver<N: Network> {
     pub rx_consensus_subdag:
-        mpsc::Receiver<(Subdag<N>, IndexMap<TransmissionID<N>, Transmission<N>>, oneshot::Sender<Result<()>>)>,
+        mpsc::Receiver<(Subdag<N>, TransmissionMap<N>, IndexSet<TransmissionID<N>>, oneshot::Sender<Result<()>>)>,
 }
 
 /// Initializes the consensus channels.

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -41,14 +41,24 @@ type TransmissionMap<N> = IndexMap<TransmissionID<N>, Transmission<N>>;
 
 #[derive(Debug)]
 pub struct ConsensusSender<N: Network> {
-    pub tx_consensus_subdag:
-        mpsc::Sender<(Subdag<N>, TransmissionMap<N>, IndexSet<TransmissionID<N>>, oneshot::Sender<Result<()>>)>,
+    pub tx_consensus_subdag: mpsc::Sender<(
+        Subdag<N>,
+        TransmissionMap<N>,
+        IndexSet<TransmissionID<N>>,
+        IndexSet<TransmissionID<N>>,
+        oneshot::Sender<Result<()>>,
+    )>,
 }
 
 #[derive(Debug)]
 pub struct ConsensusReceiver<N: Network> {
-    pub rx_consensus_subdag:
-        mpsc::Receiver<(Subdag<N>, TransmissionMap<N>, IndexSet<TransmissionID<N>>, oneshot::Sender<Result<()>>)>,
+    pub rx_consensus_subdag: mpsc::Receiver<(
+        Subdag<N>,
+        TransmissionMap<N>,
+        IndexSet<TransmissionID<N>>,
+        IndexSet<TransmissionID<N>>,
+        oneshot::Sender<Result<()>>,
+    )>,
 }
 
 /// Initializes the consensus channels.

--- a/node/bft/src/helpers/dag.rs
+++ b/node/bft/src/helpers/dag.rs
@@ -14,7 +14,7 @@
 
 use snarkvm::{
     console::types::{Address, Field},
-    ledger::narwhal::BatchCertificate,
+    ledger::narwhal::{BatchCertificate, NarwhalCertificate},
     prelude::Network,
 };
 
@@ -152,7 +152,10 @@ pub(crate) mod test_helpers {
 mod tests {
     use super::*;
     use snarkvm::{
-        prelude::{narwhal::batch_certificate::test_helpers::sample_batch_certificate_for_round, Testnet3},
+        prelude::{
+            narwhal::{batch_certificate::test_helpers::sample_batch_certificate_for_round, NarwhalCertificate},
+            Testnet3,
+        },
         utilities::TestRng,
     };
 

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -55,7 +55,7 @@ impl<N: Network> Proposal<N> {
             batch_header.transmission_ids().len() == transmissions.len(),
             "The transmission IDs do not match in the batch header and transmissions"
         );
-        for (a, b) in batch_header.transmission_ids().iter().zip_eq(transmissions.keys()) {
+        for (a, b) in batch_header.transmission_ids().iter().zip_eq(transmissions.keys().sorted()) {
             ensure!(a == b, "The transmission IDs do not match in the batch header and transmissions");
         }
         // Return the proposal.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -50,7 +50,7 @@ use snarkvm::{
     ledger::{
         block::Transaction,
         coinbase::{ProverSolution, PuzzleCommitment},
-        narwhal::{BatchCertificate, BatchHeader, Data, Transmission, TransmissionID},
+        narwhal::{BatchCertificate, BatchHeader, Data, NarwhalCertificate, Transmission, TransmissionID},
     },
     prelude::committee::Committee,
 };

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -507,6 +507,7 @@ mod tests {
                 &self,
                 subdag: Subdag<N>,
                 transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+                prior_transmissions: IndexSet<TransmissionID<N>>,
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
         }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -508,6 +508,7 @@ mod tests {
                 subdag: Subdag<N>,
                 transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
                 prior_transmissions: IndexSet<TransmissionID<N>>,
+                aborted_transmissions: IndexSet<TransmissionID<N>>,
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
         }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -447,11 +447,11 @@ mod tests {
             block::Block,
             committee::Committee,
             narwhal::{BatchCertificate, Subdag, Transmission, TransmissionID},
+            SubdagTransmissions,
         },
     };
 
     use bytes::Bytes;
-    use indexmap::IndexMap;
     use mockall::mock;
     use std::{io, ops::Range};
 
@@ -506,9 +506,7 @@ mod tests {
             fn prepare_advance_to_next_quorum_block(
                 &self,
                 subdag: Subdag<N>,
-                transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
-                prior_transmissions: IndexSet<TransmissionID<N>>,
-                aborted_transmissions: IndexSet<TransmissionID<N>>,
+                subdag_transmissions: SubdagTransmissions<N>,
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
         }

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -20,7 +20,7 @@ use snarkvm::{
 
 use indexmap::{indexset, map::Entry, IndexMap, IndexSet};
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use tracing::error;
 
 /// A BFT in-memory storage service.
@@ -87,7 +87,7 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
     fn insert_transmissions(
         &self,
         certificate_id: Field<N>,
-        transmission_ids: IndexSet<TransmissionID<N>>,
+        transmission_ids: BTreeSet<TransmissionID<N>>,
         mut missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     ) {
         // Acquire the transmissions write lock.
@@ -121,7 +121,7 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
     /// Removes the certificate ID for the transmissions from storage.
     ///
     /// If the transmission no longer references any certificate IDs, the entry is removed from storage.
-    fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &IndexSet<TransmissionID<N>>) {
+    fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &BTreeSet<TransmissionID<N>>) {
         // Acquire the transmissions write lock.
         let mut transmissions = self.transmissions.write();
         // If this is the last certificate ID for the transmission ID, remove the transmission.

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -30,7 +30,10 @@ use snarkvm::{
 
 use indexmap::{indexset, IndexSet};
 use snarkvm::ledger::store::cow_to_cloned;
-use std::{borrow::Cow, collections::HashMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeSet, HashMap},
+};
 use tracing::error;
 
 /// A BFT persistent storage service.
@@ -110,7 +113,7 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
     fn insert_transmissions(
         &self,
         certificate_id: Field<N>,
-        transmission_ids: IndexSet<TransmissionID<N>>,
+        transmission_ids: BTreeSet<TransmissionID<N>>,
         mut missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     ) {
         // Inserts the following:
@@ -154,7 +157,7 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
     /// Removes the certificate ID for the transmissions from storage.
     ///
     /// If the transmission no longer references any certificate IDs, the entry is removed from storage.
-    fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &IndexSet<TransmissionID<N>>) {
+    fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &BTreeSet<TransmissionID<N>>) {
         // If this is the last certificate ID for the transmission ID, remove the transmission.
         'outer: for transmission_id in transmission_ids {
             // Retrieve the transmission entry.

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -18,7 +18,10 @@ use snarkvm::{
 };
 
 use indexmap::IndexSet;
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Debug,
+};
 
 pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// Returns `true` if the storage contains the specified `transmission ID`.
@@ -39,14 +42,14 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     fn insert_transmissions(
         &self,
         certificate_id: Field<N>,
-        transmission_ids: IndexSet<TransmissionID<N>>,
+        transmission_ids: BTreeSet<TransmissionID<N>>,
         missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     );
 
     /// Removes the certificate ID for the transmissions from storage.
     ///
     /// If the transmission no longer references any certificate IDs, the entry is removed from storage.
-    fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &IndexSet<TransmissionID<N>>);
+    fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &BTreeSet<TransmissionID<N>>);
 
     /// Returns a HashMap over the `(transmission ID, (transmission, certificate IDs))` entries.
     #[cfg(any(test, feature = "test"))]

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -329,9 +329,9 @@ impl<N: Network> Consensus<N> {
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
     ) -> Result<()> {
         #[cfg(feature = "metrics")]
-        let start = subdag.leader_certificate().batch_header().timestamp();
+        let start = subdag.leader_timestamp()?;
         #[cfg(feature = "metrics")]
-        let num_committed_certificates = subdag.values().map(|c| c.len()).sum::<usize>();
+        let num_committed_certificates = subdag.num_certificates();
 
         // Create the candidate next block.
         let next_block = self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions)?;


### PR DESCRIPTION
## Motivation

Subdags can include duplicate transmission_ids which scales very badly at the moment (30MB w/ 50 validators). In this PRs, Subdags can track transmission_ids using a succinct bitset.

New types:
- CompactCertificate
- CompactHeader
- Subdag enum can hold either
- NarwhalCertificate trait provides an interface
- We use BitSet, which used to be part of standard library

## Test Plan

- [x] Unit tests pass.
- [x] Local network passes.
- [ ] Integration with snarkOS on existing testnet passes. Or we just go for mainnet integration.

## Related PRs

https://github.com/AleoHQ/snarkVM/pull/2304