### PR TITLE
bump metrics crates version + fix dashboard + add block latency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ commands:
 jobs:
   integration:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - run_serial_long:
@@ -165,7 +165,7 @@ jobs:
 
   snarkos:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - run_serial:
@@ -174,7 +174,7 @@ jobs:
 
   account:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -183,7 +183,7 @@ jobs:
 
   cli:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -192,7 +192,7 @@ jobs:
 
   display:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -201,7 +201,7 @@ jobs:
 
   node:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - run_serial:
@@ -210,7 +210,7 @@ jobs:
 
   node-bft:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - run_serial:
@@ -219,7 +219,7 @@ jobs:
 
   node-bft-events:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - run_serial:
@@ -228,7 +228,7 @@ jobs:
 
   node-bft-ledger-service:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -237,7 +237,7 @@ jobs:
 
   node-bft-storage-service:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -246,7 +246,7 @@ jobs:
 
   node-cdn:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -255,7 +255,7 @@ jobs:
 
   node-consensus:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - run_serial:
@@ -264,7 +264,7 @@ jobs:
 
   node-rest:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -273,7 +273,7 @@ jobs:
 
   node-router:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -282,7 +282,7 @@ jobs:
 
   node-router-messages:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -291,7 +291,7 @@ jobs:
 
   node-sync:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -300,7 +300,7 @@ jobs:
 
   node-sync-communication-service:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -309,7 +309,7 @@ jobs:
 
   node-sync-locators:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -318,7 +318,7 @@ jobs:
 
   node-tcp:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - run_serial:
@@ -327,7 +327,7 @@ jobs:
 
   check-fmt:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: xlarge
     steps:
       - checkout
@@ -343,7 +343,7 @@ jobs:
 
   check-clippy:
     docker:
-      - image: cimg/rust:1.71.1
+      - image: cimg/rust:1.72.1
     resource_class: 2xlarge
     steps:
       - checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,17 +900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3544,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3574,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3588,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3599,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3609,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3619,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3637,12 +3626,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3653,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3668,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3683,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3696,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3705,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3715,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3727,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3739,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3750,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3762,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3775,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3786,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3799,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3810,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3833,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3851,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3872,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3887,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3898,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3906,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3916,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3927,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3938,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3949,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3960,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "rand",
  "rayon",
@@ -3974,11 +3963,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
- "derivative",
  "itertools 0.11.0",
  "num-traits",
  "rand",
@@ -3992,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4017,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "anyhow",
  "rand",
@@ -4029,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4038,6 +4026,7 @@ dependencies = [
  "snarkvm-ledger-authority",
  "snarkvm-ledger-coinbase",
  "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission-id",
  "snarkvm-synthesizer-program",
@@ -4047,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4067,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -4084,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4097,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4110,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -4122,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4133,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4147,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4160,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4169,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4182,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4207,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4222,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4231,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4256,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4281,7 +4270,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4304,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4318,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4331,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4352,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.16"
-source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,7 +1271,7 @@ dependencies = [
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
- "quanta",
+ "quanta 0.11.1",
  "rand",
  "smallvec",
 ]
@@ -1872,56 +1872,45 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "77b9e10a211c839210fd7f99954bda26e5f8e26ec686ad68da6a32df7c80e782"
 dependencies = [
  "ahash",
- "metrics-macros",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+checksum = "83a4c4718a371ddfb7806378f23617876eea8b82e5ff1324516bcd283249d9ea"
 dependencies = [
  "base64",
  "hyper 0.14.28",
+ "hyper-tls",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
  "metrics-util",
- "quanta",
+ "quanta 0.12.2",
  "thiserror",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
-dependencies = [
- "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "metrics-util"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+checksum = "2670b8badcc285d486261e2e9f1615b506baff91427b61bd336a472b65bbf5ed"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.13.1",
  "metrics",
  "num_cpus",
- "quanta",
+ "quanta 0.12.2",
  "sketches-ddsketch",
 ]
 
@@ -2462,7 +2451,22 @@ dependencies = [
  "libc",
  "mach2",
  "once_cell",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid 11.0.1",
  "wasi",
  "web-sys",
  "winapi",
@@ -2573,6 +2577,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -3500,8 +3513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a601cab46d8f0644e4c194475cc6d84fcf1bea7ab1b17c009dadfc69555fc239"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3532,8 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4abf660be7d9bace9dbed43cfdf3aa408ba4488789a648ded455311132c3f98"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3563,8 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5b0d2ef42414104b78fc6f7167f8812a985aa6c325d1fde0cb5f651763edd8"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3578,8 +3588,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d418f2b469300bc47db257506b56de39fcab896606eb29aa7b5932b2749761"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3590,8 +3599,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8d999f58a6fd6836a6f28dd381a128a6bab4b1be54b2190c00e16c047add27"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3601,8 +3609,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df6f5b0a12f67ce319ac8a24d241e7ab0bd155e5e9eba34167f939f7f07d321"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3612,8 +3619,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1609b7be1f3f322bfc8e4684cad097a0956aba2944d740b0cbd1f53c0981b21e"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3631,14 +3637,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3e1063362406fb53dda30a6661d50383279f8e228778b4e1ff1cfe887c6a13"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37620225d344c61c7ebfff2b5e7e07fc09889a4614fbe87576ea7e97adc45c20"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3649,8 +3653,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf020f40f784b65db10379d27911bc8e359235131e3aaf59edde2e537261107e"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3665,8 +3668,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8a0f2b0918832f95629ad8f3342b49105cfad7ff7fbe4d2656d3493dc57d4"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3681,8 +3683,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a2d5e6dca71dd817c1d61a403dac2b5105f86b91fb373687185617555b1ed"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,8 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db330762009fe8b3fdd54c11f39218e79153168130398aaa9a034659d4fc5f07"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3705,8 +3705,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a33bedbce4558369d994181564dd45d2024b15b5949766fbe0b338793f651a"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3716,8 +3715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e6ccceac3b66da1fe87ab2b1c3b8d2bf515b3fda612f5049ac480ce7fd0d99"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3729,8 +3727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8401f0dbbbf8fc828ac84ba0024658d72168f1ff54499a5fe31768b96cbb6cfc"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3742,8 +3739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f4449f1448b655957c8595f34117bc9d8fa54c0e434e75b77210f506bd2c7"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3754,8 +3750,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24aa8ea898408879d6976ccbfb22cb84966d606b4ba9b7876b9a33f8c9426e7"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3767,8 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4016650cd2da73966e21a7444a435d453c6fc97ad84003faf796d695069d1a97"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3781,8 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cb6b22641ba3a9ba2806e95409712a1e202fec4b12866c378cbbb4fae1ae78"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3793,8 +3786,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196e112e8765cc64987e47cc2b01768f0a5d78fbcfe46829d790d4cec2f690fd"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3807,8 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326cd382d01296b2a8e4daffadf9627516d57e293f2c58ffa55b8a769e7f2866"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3819,8 +3810,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aeb72976ca2b1f83d181a210b0b7dd8df5dcb513bede0de00258b142f69e7a2"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3843,8 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3715203051e9e9fc1889f0ee6efebf156e2c51054995ed9cff09653a9b91e1a4"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3862,8 +3851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437d93ff8d03465602d9157e68f621d0651aec156bdb3485275cac1e09c40493"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3884,8 +3872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f6c3ad2a9266d06ce55b3a73633d7e115e879c9174f6aefe454ae2f9c6d414"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,8 +3887,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4cd745405a72fdf9335d6632dc96ad75356acd8a1f3987911983366abbcf92"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3912,8 +3898,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6b930d8e89123d5518da90d2480ab09d0bf4ce95c0d8b260a417c5975a1eb3"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3921,8 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd49889f5aa7cc4b534b51f2a0b8db89f95b22eb3aa917611c5d1349ab9268c"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3932,8 +3916,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317398866734553d78f1e6fa485b80ef9d63b3746de7e4e1576019be995a7c99"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3944,8 +3927,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f7057e5db0abff06936acbecd0482464873e38ca65a151432ef229eedc12b8"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3956,8 +3938,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcddc33850e194cb2b43a8da18f7294f489cebeea41bd8ab352ed1f9d2a5aaa"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3968,8 +3949,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871582f08f9a74906965adc962b6bd86fbd90292554ec6b5d9e3d9383b2151a9"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3980,8 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4594c70806b73e3355bc963da7c017305fd6e1c122d816e33488bea9d0d5c6"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "rand",
  "rayon",
@@ -3995,8 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225fc1a403a2078fcafb194051bbb97ba5067ae76b1014e15e18fc2c32b166fb"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4014,8 +3992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6c12d5ea4addb345dfd4a381f67ce75469fa98d91c9bd41a586cbf965d0915"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4040,8 +4017,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5335070976a6ba713c39f78b857ca77dd6c2ec0a9490046d0f3638e34a94530d"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "anyhow",
  "rand",
@@ -4053,8 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed502551869f63e685a7e2969a8e5ceb6436172dedf68e72cab79a80ce4dca8"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4072,8 +4047,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91255f48a56ebc635114bfef8b2906a256aa2166ba5f64695313ab480a45e5f8"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,8 +4067,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131d45a9aa3298480a12e6ea2648bc006647b9cb404f8f7db34b5a3b21779631"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -4111,8 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c232d4f449db34837c063d18d0900258cd7a48ab4154485cb9ee3ea0fd428695"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4125,8 +4097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea10eabee1bbeadf2a440de1fc3a36eff22ffca06685f4d45ed0c94d84e4e2"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4139,8 +4110,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2eda0839f17584b290883faab150e100aa680c5876b182cf022f6f87bad510"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -4152,8 +4122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51842e1f60bbb69d0fe380618739e9a5996b0fc798e9654d813e4d2ddfa0e69"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4164,8 +4133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fa75c482474af8b7c41c7b371d238f7e4e5eff4bae5abf48a4b71f2513466e"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4179,8 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb997c0bcd3a3f0be4ba1c2a29b8f5ace314b9f603ea827d499b563c00fcfe9"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4193,8 +4160,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdfcc4c65f3a726e23c843f44dce63d9e071cbdfdb732619d798e9f96116c3e"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4203,8 +4169,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b690751b0dae308dd0341d2e14ad60aa310143cd1c203aaf39522ca59169e99"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4217,8 +4182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b3785d72b3aa30d82a207a59f49c30b9df88940e6efcdf2dc6afcb73cd5a8b"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4243,8 +4207,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a8b4e8f3f25e02e1a3a4eaf8b10702760041188b876da9e89b9aa9669088a0"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4259,8 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326c687ebbd3610c069c309acbd9c90c529bab426b8d255d2cb6f2ce3080893b"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4269,8 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec27c5e082b869a54d7b36b0061c4308ce9ccd2a78afcd8c34b6931d9396cb9"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,8 +4256,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae48ca79cb99ec43975db55806c05bd396618ef1e5fed86bc72ad400bcc5ed1a"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4321,8 +4281,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3632d53da50c5dc94f61ab4111a9960a26f7f273f9e6babc5602633dda94b03e"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4345,8 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b25fa319bf7b3785c9f4de8fa2b2e7b91c2ecef7fe50bb1d2218c2d48cffee9"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4360,8 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bb9ff94bdc1dcdcd7191ce87234084b424c968c7e93a6993fcb183be50ae1c"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4374,8 +4331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec73c92e1963004ac6a0ea0b04976a56cda9577fe3fd49da87d1972af56326f2"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4396,8 +4352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bffc40b071d8543c5fa5e9560191c3e3adbaf44b77468ed48a816e1583ca20"
+source = "git+https://github.com/joske/snarkVM.git?branch=fix/metrics-api-changes#e2a21827effb00b583346e92da34520dbbf4369e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,6 @@ dependencies = [
 name = "snarkos-node-metrics"
 version = "2.2.7"
 dependencies = [
- "metrics",
  "metrics-exporter-prometheus",
  "snarkvm",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-version = "=0.16.16"
+git = "https://github.com/joske/snarkVM.git"
+branch = "fix/metrics-api-changes"
+# version = "=0.16.16"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 categories = [ "cryptography", "operating-systems" ]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.72.1"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/joske/snarkVM.git"
-branch = "fix/metrics-api-changes"
+git = "https://github.com/AleoHQ/snarkVM.git"
+rev = "9656a7e"
 # version = "=0.16.16"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -333,7 +333,7 @@ impl<N: Network> Consensus<N> {
         #[cfg(feature = "metrics")]
         let num_committed_certificates = subdag.values().map(|c| c.len()).sum::<usize>();
         #[cfg(feature = "metrics")]
-        let prev_block_ts = self.ledger.latest_block().header().metadata().timestamp();
+        let current_block_timestamp = self.ledger.latest_block().header().metadata().timestamp();
 
         // Create the candidate next block.
         let next_block = self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions)?;
@@ -345,16 +345,16 @@ impl<N: Network> Consensus<N> {
         #[cfg(feature = "metrics")]
         {
             let elapsed = std::time::Duration::from_secs((snarkos_node_bft::helpers::now() - start) as u64);
+            let next_block_timestamp = next_block.header().metadata().timestamp();
+            let block_latency = next_block_timestamp - current_block_timestamp;
 
             metrics::gauge(metrics::blocks::HEIGHT, next_block.height() as f64);
             metrics::counter(metrics::blocks::TRANSACTIONS, next_block.transactions().len() as u64);
             metrics::gauge(metrics::consensus::LAST_COMMITTED_ROUND, next_block.round() as f64);
             metrics::gauge(metrics::consensus::COMMITTED_CERTIFICATES, num_committed_certificates as f64);
             metrics::histogram(metrics::consensus::CERTIFICATE_COMMIT_LATENCY, elapsed.as_secs_f64());
-            let next_block_ts = next_block.header().metadata().timestamp();
-            metrics::histogram(metrics::consensus::BLOCK_LATENCY, (next_block_ts - prev_block_ts) as f64);
+            metrics::histogram(metrics::consensus::BLOCK_LATENCY, block_latency as f64);
         }
-
         Ok(())
     }
 

--- a/node/metrics/Cargo.toml
+++ b/node/metrics/Cargo.toml
@@ -19,9 +19,6 @@ edition = "2021"
 [features]
 metrics = [ "snarkvm/metrics" ]
 
-[dependencies.metrics]
-version = "0.22"
-
 [dependencies.metrics-exporter-prometheus]
 version = "0.13"
 

--- a/node/metrics/Cargo.toml
+++ b/node/metrics/Cargo.toml
@@ -20,10 +20,10 @@ edition = "2021"
 metrics = [ "snarkvm/metrics" ]
 
 [dependencies.metrics]
-version = "0.21"
+version = "0.22"
 
 [dependencies.metrics-exporter-prometheus]
-version = "0.12"
+version = "0.13"
 
 [dependencies.snarkvm]
 workspace = true

--- a/node/metrics/snarkOS-grafana.json
+++ b/node/metrics/snarkOS-grafana.json
@@ -1219,12 +1219,112 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "displayName": "Average Block Latency",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 51
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "avg(snarkos_consensus_block_latency_secs)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Block Latency",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 59
       },
       "id": 4,
       "panels": [],
@@ -1295,7 +1395,7 @@
         "h": 8,
         "w": 12,
         "x": 6,
-        "y": 52
+        "y": 60
       },
       "id": 37,
       "options": {
@@ -1396,7 +1496,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 68
       },
       "id": 32,
       "options": {
@@ -1497,7 +1597,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 68
       },
       "id": 33,
       "options": {
@@ -1601,7 +1701,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "id": 34,
       "options": {
@@ -1702,7 +1802,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 76
       },
       "id": 35,
       "options": {
@@ -1770,6 +1870,6 @@
   "timezone": "",
   "title": "snarkOS",
   "uid": "ahTJm4-4k",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/node/metrics/snarkOS-grafana.json
+++ b/node/metrics/snarkOS-grafana.json
@@ -1,4 +1,41 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.2.3"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -24,7 +61,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -42,7 +79,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -122,7 +159,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "snarkos_router_connected_total",
@@ -137,7 +174,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -217,7 +254,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "snarkos_router_candidate_total",
@@ -232,7 +269,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -312,7 +349,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "snarkos_router_restricted_total",
@@ -327,7 +364,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -369,12 +406,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "snarkos_blocks_height_total",
@@ -389,7 +426,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -465,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "sum(rate(snarkos_blocks_transactions_total[5m]))",
@@ -480,7 +517,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -560,7 +597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -580,7 +617,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -660,7 +697,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -693,7 +730,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -735,12 +772,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -759,7 +796,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -801,12 +838,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "snarkos_consensus_last_committed_round",
@@ -821,7 +858,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -863,12 +900,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "snarkos_consensus_committed_certificates_total",
@@ -883,7 +920,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -925,12 +962,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.2.2",
+      "pluginVersion": "10.2.3",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "snarkos_bft_leaders_elected_total",
@@ -958,7 +995,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1040,7 +1077,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1082,7 +1119,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1163,7 +1200,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1197,7 +1234,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1277,7 +1314,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1297,7 +1334,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1378,7 +1415,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1398,7 +1435,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1479,7 +1516,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1502,7 +1539,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1583,7 +1620,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1603,7 +1640,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1684,7 +1721,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "d7ad3b42-ab69-4a13-b542-dcee4597bb6b"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -1704,7 +1741,7 @@
   ],
   "refresh": "5s",
   "revision": 1,
-  "schemaVersion": 38,
+  "schemaVersion": 39,
   "tags": [
     "snarkos",
     "aleo"
@@ -1733,6 +1770,6 @@
   "timezone": "",
   "title": "snarkOS",
   "uid": "ahTJm4-4k",
-  "version": 14,
+  "version": 1,
   "weekStart": ""
 }

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -19,12 +19,10 @@ pub use names::*;
 // Re-export the snarkVM metrics.
 pub use snarkvm::metrics::*;
 
-/// Initialises the metrics and returns a handle to the task running the metrics exporter.
+/// Initializes the metrics and returns a handle to the task running the metrics exporter.
 pub fn initialize_metrics() {
-    use metrics_exporter_prometheus::PrometheusBuilder;
-
-    // Build the recorder and set as global.
-    PrometheusBuilder::new().install().expect("can't build the prometheus exporter");
+    // Build the Prometheus exporter.
+    metrics_exporter_prometheus::PrometheusBuilder::new().install().expect("can't build the prometheus exporter");
 
     // Register the snarkVM metrics.
     snarkvm::metrics::register_metrics();

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -29,9 +29,10 @@ pub(super) const GAUGE_NAMES: [&str; 12] = [
     tcp::TCP_TASKS,
 ];
 
-pub(super) const HISTOGRAM_NAMES: [&str; 6] = [
+pub(super) const HISTOGRAM_NAMES: [&str; 7] = [
     bft::COMMIT_ROUNDS_LATENCY,
     consensus::CERTIFICATE_COMMIT_LATENCY,
+    consensus::BLOCK_LATENCY,
     tcp::NOISE_CODEC_ENCRYPTION_TIME,
     tcp::NOISE_CODEC_DECRYPTION_TIME,
     tcp::NOISE_CODEC_ENCRYPTION_SIZE,
@@ -56,6 +57,7 @@ pub mod consensus {
     pub const CERTIFICATE_COMMIT_LATENCY: &str = "snarkos_consensus_certificate_commit_latency_secs";
     pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
     pub const LAST_COMMITTED_ROUND: &str = "snarkos_consensus_last_committed_round";
+    pub const BLOCK_LATENCY: &str = "snarkos_consensus_block_latency_secs";
 }
 
 pub mod router {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

- bump metrics + prometheus exporter versions. Adapt to new API. (the versions in snarkVM and snarkOS *must* match)
- fix the grafana dashboard (you HAVE to export with `Export for sharing externally`!)
- add block latency panel

## Test Plan

(If you changed any code, please provide clear instructions on how you verified your changes work.)

## Related PRs

** Must merge https://github.com/AleoHQ/snarkVM/pull/2307 first **
(and update the snarkVM dependency here).
