### PR TITLE
[HackerOne-2279770] Prevent handshake based signature forgery

### DIFF
--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -118,7 +118,7 @@ impl<N: Network> From<DisconnectReason> for Event<N> {
 
 impl<N: Network> Event<N> {
     /// The version of the event protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 5;
+    pub const VERSION: u32 = 6;
 
     /// Returns the event name.
     #[inline]

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1176,11 +1176,13 @@ impl<N: Network> Gateway<N> {
         /* Step 3: Send the challenge response. */
 
         // Sign the counterparty nonce.
-        let Ok(our_signature) = self.account.sign_bytes(&peer_request.nonce.to_le_bytes(), rng) else {
+        let response_nonce: u64 = rng.gen();
+        let data = [peer_request.nonce.to_le_bytes(), response_nonce.to_le_bytes()].concat();
+        let Ok(our_signature) = self.account.sign_bytes(&data, rng) else {
             return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
-        let our_response = ChallengeResponse { signature: Data::Object(our_signature) };
+        let our_response = ChallengeResponse { signature: Data::Object(our_signature), nonce: response_nonce };
         send_event(&mut framed, peer_addr, Event::ChallengeResponse(our_response)).await?;
 
         // Add the peer to the gateway.
@@ -1229,11 +1231,13 @@ impl<N: Network> Gateway<N> {
         let rng = &mut rand::rngs::OsRng;
 
         // Sign the counterparty nonce.
-        let Ok(our_signature) = self.account.sign_bytes(&peer_request.nonce.to_le_bytes(), rng) else {
+        let response_nonce: u64 = rng.gen();
+        let data = [peer_request.nonce.to_le_bytes(), response_nonce.to_le_bytes()].concat();
+        let Ok(our_signature) = self.account.sign_bytes(&data, rng) else {
             return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
-        let our_response = ChallengeResponse { signature: Data::Object(our_signature) };
+        let our_response = ChallengeResponse { signature: Data::Object(our_signature), nonce: response_nonce };
         send_event(&mut framed, peer_addr, Event::ChallengeResponse(our_response)).await?;
 
         // Sample a random nonce.
@@ -1290,14 +1294,14 @@ impl<N: Network> Gateway<N> {
         expected_nonce: u64,
     ) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge response.
-        let ChallengeResponse { signature } = response;
+        let ChallengeResponse { signature, nonce } = response;
         // Perform the deferred non-blocking deserialization of the signature.
         let Ok(signature) = spawn_blocking!(signature.deserialize_blocking()) else {
             warn!("{CONTEXT} Gateway handshake with '{peer_addr}' failed (cannot deserialize the signature)");
             return Some(DisconnectReason::InvalidChallengeResponse);
         };
         // Verify the signature.
-        if !signature.verify_bytes(&peer_address, &expected_nonce.to_le_bytes()) {
+        if !signature.verify_bytes(&peer_address, &[expected_nonce.to_le_bytes(), nonce.to_le_bytes()].concat()) {
             warn!("{CONTEXT} Gateway handshake with '{peer_addr}' failed (invalid signature)");
             return Some(DisconnectReason::InvalidChallengeResponse);
         }

--- a/node/router/messages/src/challenge_response.rs
+++ b/node/router/messages/src/challenge_response.rs
@@ -25,6 +25,7 @@ use std::borrow::Cow;
 pub struct ChallengeResponse<N: Network> {
     pub genesis_header: Header<N>,
     pub signature: Data<Signature<N>>,
+    pub nonce: u64,
 }
 
 impl<N: Network> MessageTrait for ChallengeResponse<N> {
@@ -38,13 +39,18 @@ impl<N: Network> MessageTrait for ChallengeResponse<N> {
 impl<N: Network> ToBytes for ChallengeResponse<N> {
     fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
         self.genesis_header.write_le(&mut writer)?;
-        self.signature.write_le(&mut writer)
+        self.signature.write_le(&mut writer)?;
+        self.nonce.write_le(&mut writer)
     }
 }
 
 impl<N: Network> FromBytes for ChallengeResponse<N> {
     fn read_le<R: io::Read>(mut reader: R) -> io::Result<Self> {
-        Ok(Self { genesis_header: Header::read_le(&mut reader)?, signature: Data::read_le(reader)? })
+        Ok(Self {
+            genesis_header: Header::read_le(&mut reader)?,
+            signature: Data::read_le(&mut reader)?,
+            nonce: u64::read_le(reader)?,
+        })
     }
 }
 
@@ -80,8 +86,12 @@ pub mod prop_tests {
     }
 
     pub fn any_challenge_response() -> BoxedStrategy<ChallengeResponse<CurrentNetwork>> {
-        (any_signature(), any_genesis_header())
-            .prop_map(|(sig, genesis_header)| ChallengeResponse { signature: Data::Object(sig), genesis_header })
+        (any_signature(), any_genesis_header(), any::<u64>())
+            .prop_map(|(sig, genesis_header, nonce)| ChallengeResponse {
+                signature: Data::Object(sig),
+                genesis_header,
+                nonce,
+            })
             .boxed()
     }
 

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -111,7 +111,7 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 13;
+    pub const VERSION: u32 = 14;
 
     /// Returns the message name.
     #[inline]

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -164,12 +164,15 @@ impl<N: Network> Router<N> {
         }
         /* Step 3: Send the challenge response. */
 
+        let response_nonce: u64 = rng.gen();
+        let data = [peer_request.nonce.to_le_bytes(), response_nonce.to_le_bytes()].concat();
         // Sign the counterparty nonce.
-        let Ok(our_signature) = self.account.sign_bytes(&peer_request.nonce.to_le_bytes(), rng) else {
+        let Ok(our_signature) = self.account.sign_bytes(&data, rng) else {
             return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
-        let our_response = ChallengeResponse { genesis_header, signature: Data::Object(our_signature) };
+        let our_response =
+            ChallengeResponse { genesis_header, signature: Data::Object(our_signature), nonce: response_nonce };
         send(&mut framed, peer_addr, Message::ChallengeResponse(our_response)).await?;
 
         // Add the peer to the router.
@@ -213,11 +216,14 @@ impl<N: Network> Router<N> {
         let rng = &mut OsRng;
 
         // Sign the counterparty nonce.
-        let Ok(our_signature) = self.account.sign_bytes(&peer_request.nonce.to_le_bytes(), rng) else {
+        let response_nonce: u64 = rng.gen();
+        let data = [peer_request.nonce.to_le_bytes(), response_nonce.to_le_bytes()].concat();
+        let Ok(our_signature) = self.account.sign_bytes(&data, rng) else {
             return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
-        let our_response = ChallengeResponse { genesis_header, signature: Data::Object(our_signature) };
+        let our_response =
+            ChallengeResponse { genesis_header, signature: Data::Object(our_signature), nonce: response_nonce };
         send(&mut framed, peer_addr, Message::ChallengeResponse(our_response)).await?;
 
         // Sample a random nonce.
@@ -303,7 +309,7 @@ impl<N: Network> Router<N> {
         expected_nonce: u64,
     ) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge response.
-        let ChallengeResponse { genesis_header, signature } = response;
+        let ChallengeResponse { genesis_header, signature, nonce } = response;
 
         // Verify the challenge response, by checking that the block header matches.
         if genesis_header != expected_genesis_header {
@@ -316,7 +322,7 @@ impl<N: Network> Router<N> {
             return Some(DisconnectReason::InvalidChallengeResponse);
         };
         // Verify the signature.
-        if !signature.verify_bytes(&peer_address, &expected_nonce.to_le_bytes()) {
+        if !signature.verify_bytes(&peer_address, &[expected_nonce.to_le_bytes(), nonce.to_le_bytes()].concat()) {
             warn!("Handshake with '{peer_addr}' failed (invalid signature)");
             return Some(DisconnectReason::InvalidChallengeResponse);
         }


### PR DESCRIPTION
Fixes #2983.

Intuition: 
1. an attacker could locally craft a preimage that matches the `ChallengeRequest::nonce` value range. 
2. the target then signs the nonce during the handshake.
3. the attacker is able to reuse the signed nonce in any other non-handshake interactions as an authenticity proof.

In order to mitigate this issue, this PR removes the possibility of brute forcing the preimage locally by generating a `response_nonce` that is signed alongside the initial `nonce` and sent in the `ChallengeResponse` so the signature can be verified. 
