### PR TITLE
Add leniency to received certificates

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -778,7 +778,7 @@ impl<N: Network> Primary<N> {
         if !self.gateway.is_authorized_validator_ip(peer_ip) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
-            bail!("Malicious peer - Received a batch certificate from a non-authorized validator ip ({peer_ip})");
+            bail!("Malicious peer - Received a batch certificate from an unauthorized validator IP ({peer_ip})");
         }
 
         // Store the certificate, after ensuring it is valid.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -717,23 +717,11 @@ impl<N: Network> Primary<N> {
         // Retrieve the batch certificate author.
         let author = certificate.author();
 
-        // Ensure the batch certificate is from the validator.
-        match self.gateway.resolver().get_address(peer_ip) {
-            // If the peer is a validator, then ensure the batch certificate is from the validator.
-            Some(address) => {
-                if address != author {
-                    // Proceed to disconnect the validator.
-                    self.gateway.disconnect(peer_ip);
-                    bail!("Malicious peer - batch certificate from a different validator ({author})");
-                }
-            }
-            None => bail!("Batch certificate from a disconnected validator"),
-        }
-        // Ensure the batch certificate is authored by a current committee member.
-        if !self.gateway.is_authorized_validator_address(author) {
+        // Ensure the batch certificate is from an authorized validator.
+        if !self.gateway.is_authorized_validator_ip(peer_ip) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
-            bail!("Malicious peer - Received a batch certificate from a non-committee member ({author})");
+            bail!("Malicious peer - Received a batch certificate from a non-authorized validator ip ({peer_ip})");
         }
         // Ensure the batch certificate is not from the current primary.
         if self.gateway.account().address() == author {
@@ -786,14 +774,11 @@ impl<N: Network> Primary<N> {
             return Ok(());
         }
 
-        // Retrieve the batch certificate author.
-        let author = certificate.author();
-
-        // Ensure the batch certificate is authored by a current committee member.
-        if !self.gateway.is_authorized_validator_address(author) {
+        // Ensure the batch certificate is from an authorized validator.
+        if !self.gateway.is_authorized_validator_ip(peer_ip) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
-            bail!("Malicious peer - Received a batch certificate from a non-committee member ({author})");
+            bail!("Malicious peer - Received a batch certificate from a non-authorized validator ip ({peer_ip})");
         }
 
         // Store the certificate, after ensuring it is valid.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -721,7 +721,7 @@ impl<N: Network> Primary<N> {
         if !self.gateway.is_authorized_validator_ip(peer_ip) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
-            bail!("Malicious peer - Received a batch certificate from a non-authorized validator ip ({peer_ip})");
+            bail!("Malicious peer - Received a batch certificate from an unauthorized validator IP ({peer_ip})");
         }
         // Ensure the batch certificate is not from the current primary.
         if self.gateway.account().address() == author {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds leniency for processing received certificates. Previously we were requiring the certificates come from the author, however if the author happens to unbond from the validator set, then other validators would be unable to fetch that particular certificate, which would block syncing and possibly halt block production.

The new rule is that validators can now process a certificate as long as it comes from a validator in the current committee set.