### PR TITLE
Fix/compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std"
-version = "0.1.18"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa6ad1a3bb96698e7e8d8e42a6f2fda3b8611a43aab4d5effb921f18798833"
+checksum = "a3ec648bb4d936c62d63cb85983059c7fecd92175912c145470da3b03010c7c6"
 dependencies = [
  "aleo-std-cpu",
  "aleo-std-profiler",
@@ -101,9 +101,9 @@ checksum = "2bf055ddb2f54fa86394d19d87e7956df2f3cafff489fc14c0f48f2f80664c3d"
 
 [[package]]
 name = "aleo-std-storage"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503e2538d5158b869bc9c30c9754f9a23f4210987008014a9f118db99f22c217"
+checksum = "453100af40d56582265853ecb2ef660d1bc1ba6920bff020a77ceba1122c8eb5"
 dependencies = [
  "dirs",
 ]
@@ -3500,8 +3500,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3531,8 +3531,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3561,8 +3561,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3575,8 +3575,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3586,8 +3586,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3596,8 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3606,8 +3606,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "indexmap 2.1.0",
  "itertools 0.11.0",
@@ -3624,13 +3624,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3640,8 +3640,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3655,8 +3655,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3670,8 +3670,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3683,8 +3683,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3692,8 +3692,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3702,8 +3702,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3714,8 +3714,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3726,8 +3726,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3737,8 +3737,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3749,8 +3749,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3762,8 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3773,8 +3773,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3786,8 +3786,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3797,8 +3797,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -3820,8 +3820,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3838,8 +3838,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3859,8 +3859,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3874,8 +3874,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3885,16 +3885,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3903,8 +3903,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3914,8 +3914,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3925,8 +3925,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3936,8 +3936,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3947,8 +3947,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "rand",
  "rayon",
@@ -3961,8 +3961,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3978,8 +3978,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4003,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "anyhow",
  "rand",
@@ -4015,8 +4015,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4034,8 +4034,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-coinbase"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4054,8 +4054,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "anyhow",
  "indexmap 2.1.0",
@@ -4071,8 +4071,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4084,8 +4084,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4097,8 +4097,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "indexmap 2.1.0",
  "serde_json",
@@ -4109,8 +4109,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4120,8 +4120,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "indexmap 2.1.0",
  "rayon",
@@ -4134,8 +4134,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,8 +4147,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4156,8 +4156,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4169,10 +4169,10 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
- "aleo-std",
+ "aleo-std-storage",
  "anyhow",
  "bincode",
  "indexmap 2.1.0",
@@ -4194,8 +4194,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4209,8 +4209,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-metrics"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4218,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4243,8 +4243,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4268,8 +4268,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4291,8 +4291,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "indexmap 2.1.0",
  "paste",
@@ -4305,8 +4305,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4318,8 +4318,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4339,8 +4339,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "0.16.16"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=9656a7e#9656a7e0550c17cf63cd86da6029c3a0b063f731"
+version = "0.16.17"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=06bd41f#06bd41f593e8d44992fb2e9ff86bae936bbdbd0a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "9656a7e"
+rev = "06bd41f"
 # version = "=0.16.16"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 default = [ "snarkos-node/metrics" ]
 
 [dependencies.aleo-std]
-version = "0.1.18"
+version = "0.1.24"
 default-features = false
 
 [dependencies.anstyle]

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -37,7 +37,7 @@ impl Clean {
     /// Removes the specified ledger from storage.
     pub(crate) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
-        let path = aleo_std::aleo_ledger_dir(network, dev);
+        let path = aleo_std::aleo_ledger_dir(network, aleo_std::StorageMode::from(dev));
 
         // Prepare the path string.
         let path_string = format!("(in \"{}\")", path.display()).dimmed();

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -29,7 +29,7 @@ metrics = [
 ]
 
 [dependencies.aleo-std]
-version = "0.1.18"
+version = "0.1.24"
 default-features = false
 
 [dependencies.anyhow]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -70,7 +70,7 @@ pub fn phase_3_reset<N: Network, C: ConsensusStorage<N>>(
     /// Removes the specified ledger from storage.
     pub(crate) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
-        let mut path = aleo_std::aleo_ledger_dir(network, dev);
+        let mut path = aleo_std::aleo_ledger_dir(network, aleo_std::StorageMode::from(dev));
 
         // Delete the parent folder.
         path.pop();


### PR DESCRIPTION
Recent API changes in aleo-std break snarkOS compilation: https://github.com/AleoHQ/snarkOS/issues/3028, #3023 #3030 

This fixes compilation, but may not be the correct way to fix this.
- bumped snarkVM to a commit that fixes the API change: 06bd41f
- bumped aleo-std to 0.1.24
- use `StorageMode` based on `dev` parameter