### PR TITLE
Cast Option<u16> to StorageMode

### DIFF
--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -16,6 +16,8 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
 
+use aleo_std::StorageMode;
+
 /// Cleans the snarkOS node storage.
 #[derive(Debug, Parser)]
 pub struct Clean {
@@ -37,7 +39,7 @@ impl Clean {
     /// Removes the specified ledger from storage.
     pub(crate) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
-        let path = aleo_std::aleo_ledger_dir(network, dev);
+        let path = aleo_std::aleo_ledger_dir(network, StorageMode::from(dev));
 
         // Prepare the path string.
         let path_string = format!("(in \"{}\")", path.display()).dimmed();

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -45,6 +45,8 @@ pub use node::*;
 mod traits;
 pub use traits::*;
 
+use aleo_std::StorageMode;
+
 /// A helper to log instructions to recover.
 pub fn log_clean_error(dev: Option<u16>) {
     match dev {
@@ -70,7 +72,7 @@ pub fn phase_3_reset<N: Network, C: ConsensusStorage<N>>(
     /// Removes the specified ledger from storage.
     pub(crate) fn remove_ledger(network: u16, dev: Option<u16>) -> Result<String> {
         // Construct the path to the ledger in storage.
-        let mut path = aleo_std::aleo_ledger_dir(network, dev);
+        let mut path = aleo_std::aleo_ledger_dir(network, StorageMode::from(dev));
 
         // Delete the parent folder.
         path.pop();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Avoid casting bugs while compiling. When I compile it I got the following bugs

error[E0308]: mismatched types
  --> cli/src/commands/clean.rs:40:55
   |
40 |         let path = aleo_std::aleo_ledger_dir(network, dev);
   |                    -------------------------          ^^^ expected `StorageMode`, found `Option<u16>`
   |                    |
   |                    arguments to this function are incorrect
   |
   = note: expected enum `StorageMode`
              found enum `std::option::Option<u16>`
note: function defined here
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aleo-std-storage-0.1.7/src/lib.rs:89:8
   |
89 | pub fn aleo_ledger_dir(network: u16, mode: StorageMode) -> PathBuf {
   |        ^^^^^^^^^^^^^^^
help: call `Into::into` on this expression to convert `std::option::Option<u16>` into `StorageMode`
   |
40 |         let path = aleo_std::aleo_ledger_dir(network, dev.into());
   |                                                          +++++++

For more information about this error, try `rustc --explain E0308`.
error: could not compile `snarkos-cli` (lib) due to previous error

## Test Plan

2024-01-23T12:50:16.477367Z  INFO Synced up to block 9749 of 1234200 - 0% complete (est. 805 minutes remaining)
2024-01-23T12:50:16.477573Z DEBUG Requesting blocks 16100 to 16150 (of 1234200)
2024-01-23T12:50:16.895164Z  INFO Synced up to block 9799 of 1234200 - 0% complete (est. 802 minutes remaining)
2024-01-23T12:50:16.895372Z DEBUG Requesting blocks 16150 to 16200 (of 1234200)
2024-01-23T12:50:17.310665Z  INFO Synced up to block 9849 of 1234200 - 0% complete (est. 799 minutes remaining)
2024-01-23T12:50:17.310748Z DEBUG Requesting blocks 16200 to 16250 (of 1234200)
2024-01-23T12:50:17.717368Z  INFO Synced up to block 9899 of 1234200 - 0% complete (est. 796 minutes remaining)
2024-01-23T12:50:17.717495Z DEBUG Requesting blocks 16250 to 16300 (of 1234200)
2024-01-23T12:50:18.114375Z  INFO Synced up to block 9949 of 1234200 - 0% complete (est. 793 minutes remaining)
2024-01-23T12:50:18.114555Z DEBUG Requesting blocks 16300 to 16350 (of 1234200)
2024-01-23T12:50:18.520897Z  INFO Synced up to block 9999 of 1234200 - 0% complete (est. 790 minutes remaining)
2024-01-23T12:50:18.521185Z DEBUG Requesting blocks 16350 to 16400 (of 1234200)
2024-01-23T12:50:18.904299Z  INFO Synced up to block 10049 of 1234200 - 0% complete (est. 787 minutes remaining)
2024-01-23T12:50:18.904499Z DEBUG Requesting blocks 16400 to 16450 (of 1234200)
2024-01-23T12:50:19.284175Z  INFO Synced up to block 10099 of 1234200 - 0% complete (est. 784 minutes remaining)
2024-01-23T12:50:19.284358Z DEBUG Requesting blocks 16450 to 16500 (of 1234200)
2024-01-23T12:50:19.636709Z  INFO Synced up to block 10149 of 1234200 - 0% complete (est. 781 minutes remaining)
2024-01-23T12:50:19.636775Z DEBUG Requesting blocks 16500 to 16550 (of 1234200)
2024-01-23T12:50:19.985985Z  INFO Synced up to block 10199 of 1234200 - 0% complete (est. 778 minutes remaining)
2024-01-23T12:50:19.986164Z DEBUG Requesting blocks 16550 to 16600 (of 1234200)
2024-01-23T12:50:20.322651Z  INFO Synced up to block 10249 of 1234200 - 0% complete (est. 775 minutes remaining)
2024-01-23T12:50:20.322804Z DEBUG Requesting blocks 16600 to 16650 (of 1234200)
2024-01-23T12:50:20.698261Z  INFO Synced up to block 10299 of 1234200 - 0% complete (est. 772 minutes remaining)

