### PR TITLE
chore: Corrected a spelling error

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -48,7 +48,7 @@ mkdir -p "$log_dir"
 tmux new-session -d -s "devnet" -n "window0"
 
 # Get the tmux's base-index for windows
-# we have to create all windows with index offseted by this much
+# we have to create all windows with index offset by this much
 index_offset="$(tmux show-option -gv base-index)"
 if [ -z "$index_offset" ]; then
   index_offset=0


### PR DESCRIPTION
The reason for the spelling error "offseted" is that in English, the past participle form of the verb "offset" is "offset," not "offseted." The past participle form is typically used to indicate an action or state that has already occurred. In this context, we want to convey that the index has already been offset, so using "offset" is more in line with standard English grammar. "Offseted" is not a common or correct spelling, hence the correction to "offset."