### PR TITLE
Stop processing block sync when ctrlc

### DIFF
--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -198,7 +198,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
         self.shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
 
         // Abort the tasks.
-        trace!("Shutting down the validator...");
+        trace!("Shutting down the client...");
         self.handles.lock().iter().for_each(|handle| handle.abort());
 
         // Shut down the router.

--- a/node/src/traits.rs
+++ b/node/src/traits.rs
@@ -71,7 +71,7 @@ pub trait NodeInterface<N: Network>: Routing<N> {
                     }
 
                     // A best-effort attempt to let any ongoing activity conclude.
-                    tokio::time::sleep(Duration::from_secs(3)).await;
+                    tokio::time::sleep(Duration::from_secs(5)).await;
 
                     // Terminate the process.
                     std::process::exit(0);


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR improves the synchronization logic of CDN: when the program receives the sigint signal (ctrl-c), the CDN synchronization process of the block is stopped in time to avoid data inconsistency and damage.

## Related PRs

https://github.com/AleoHQ/snarkOS/issues/2951
