### PR TITLE
Ensure backwards compatibility of load_blocks

### DIFF
--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -213,9 +213,14 @@ pub async fn load_blocks<N: Network>(
                     std::process::exit(0);
                 }
 
+                // Register the next block's height, as the block gets consumed next.
+                let block_height = block.height();
+
                 // Insert the block into the ledger.
                 process_clone(block)?;
-                current_height += 1;
+
+                // Update the current height.
+                current_height = block_height;
 
                 // Log the progress.
                 log_progress::<BLOCKS_PER_FILE>(timer, current_height, cdn_start, cdn_end, "block");
@@ -465,10 +470,10 @@ mod tests {
     }
 
     #[test]
-    fn test_load_blocks_1_to_50() {
-        let start_height = 1;
+    fn test_load_blocks_0_to_50() {
+        let start_height = 0;
         let end_height = Some(50);
-        check_load_blocks(start_height, end_height, 49);
+        check_load_blocks(start_height, end_height, 50);
     }
 
     #[test]
@@ -479,10 +484,10 @@ mod tests {
     }
 
     #[test]
-    fn test_load_blocks_1_to_123() {
-        let start_height = 1;
+    fn test_load_blocks_0_to_123() {
+        let start_height = 0;
         let end_height = Some(123);
-        check_load_blocks(start_height, end_height, 122);
+        check_load_blocks(start_height, end_height, 123);
     }
 
     #[test]


### PR DESCRIPTION
This PR special-cases calls to `load_blocks` made outside of the context of a node, so that the function maintains backwards compatibility with the logic from before https://github.com/AleoHQ/snarkOS/pull/3017 for such calls.

Fixes https://github.com/AleoHQ/snarkOS/issues/3043.