### PR TITLE
fix: build should not run as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cd snarkOS
 
 Lastly, install `snarkOS`:
 ```
-cargo install --path .
+cargo install --locked --path .
 ```
 
 Please ensure ports `4133/tcp` and `3033/tcp` are open on your router and OS firewall.

--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -33,7 +33,7 @@ source $HOME/.cargo/env
 
 # Install snarkOS
 # cargo clean
-cargo install --path .
+cargo install --locked --path .
 
 echo "=================================================="
 echo " Attention - Please ensure ports 4133 and 3033"

--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -20,11 +20,6 @@ sudo apt-get install -y \
 	xz-utils \
 	ufw
 
-# Open ports on system
-
-sudo ufw allow 5000/tcp
-sudo ufw allow 4133/tcp
-sudo ufw allow 3033/tcp
 
 # Install Rust
 

--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
-if [[ $(/usr/bin/id -u) -ne 0 ]]; then
-    echo "Aborting: run as root user!"
-    exit 1
-fi
-
 echo "================================================"
 echo " Attention - Building snarkOS from source code."
+echo " This will request root permissions with sudo."
 echo "================================================"
 
 # Install Ubuntu dependencies
 
-apt-get update
-apt-get install -y \
-    build-essential \
-    curl \
-    clang \
-    gcc \
-    libssl-dev \
-    llvm \
-    make \
-    pkg-config \
-    tmux \
-    xz-utils \
-    ufw
+sudo apt-get update
+sudo apt-get install -y \
+	build-essential \
+	curl \
+	clang \
+	gcc \
+	libssl-dev \
+	llvm \
+	make \
+	pkg-config \
+	tmux \
+	xz-utils \
+	ufw
+
+# Open ports on system
+
+sudo ufw allow 5000/tcp
+sudo ufw allow 4133/tcp
+sudo ufw allow 3033/tcp
 
 # Install Rust
 
@@ -43,8 +45,3 @@ echo ""
 echo " Home Users - Enable port forwarding or NAT rules"
 echo "              for 4133 and 3033 on your router."
 echo "=================================================="
-
-# Open ports on system
-ufw allow 5000/tcp
-ufw allow 4133/tcp
-ufw allow 3033/tcp

--- a/devnet.sh
+++ b/devnet.sh
@@ -8,8 +8,8 @@ total_validators=${total_validators:-4}
 read -p "Enter the total number of clients (default: 2): " total_clients
 total_clients=${total_clients:-2}
 
-# Ask the user if they want to run 'cargo install --path .' or use a pre-installed binary
-read -p "Do you want to run 'cargo install --path .' to build the binary? (y/n, default: y): " build_binary
+# Ask the user if they want to run 'cargo install --locked --path .' or use a pre-installed binary
+read -p "Do you want to run 'cargo install --locked --path .' to build the binary? (y/n, default: y): " build_binary
 build_binary=${build_binary:-y}
 
 # Ask the user whether to clear the existing ledger history
@@ -18,7 +18,7 @@ clear_ledger=${clear_ledger:-n}
 
 if [[ $build_binary == "y" ]]; then
   # Build the binary using 'cargo install --path .'
-  cargo install --path . || exit 1
+  cargo install --locked --path . || exit 1
 fi
 
 # Clear the ledger logs for each validator if the user chooses to clear ledger

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -219,7 +219,7 @@ pub fn notification_message() -> String {
     - If participating, BE PREPARED TO RESET YOUR NODE AT ANY TIME.
     - When a reset occurs, RUN THE FOLLOWING TO RESET YOUR NODE:
         - git checkout testnet3 && git pull
-        - cargo install --path .
+        - cargo install --locked --path .
         - snarkos clean
         - snarkos start --nodisplay --client
 


### PR DESCRIPTION
## Motivation

Running the entire `build-ubuntu.sh` as root will also create root-owned folder/files which will create problems later. It's better to put `sudo` in front of the commands that need it only (apt, ufw).
