### PR TITLE
Clarification needed on minimum Ubuntu Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ which verifies transactions and stores the encrypted state applications in a pub
 
 The following are **minimum** requirements to run an Aleo node:
  - **OS**: 64-bit architectures only, latest up-to-date for security
-    - Clients: Ubuntu 22.04 (LTS), macOS Ventura or later, Windows 11 or later
-    - Provers: Ubuntu 22.04 (LTS), macOS Ventura or later
-    - Validators: Ubuntu 22.04 (LTS)
+    - Clients: Ubuntu 20.04 (LTS), macOS Ventura or later, Windows 11 or later
+    - Provers: Ubuntu 20.04 (LTS), macOS Ventura or later
+    - Validators: Ubuntu 20.04 (LTS)
  - **CPU**: 64-bit architectures only
     - Clients: 16-cores
     - Provers: 32-cores (64-cores preferred)


### PR DESCRIPTION
## Motivation
Snark OS wiki states minimum Ubuntu version is 22.04 (LTS)
Dev docs linked below say that Minimum Ubuntu version is 20.04 (LTS) which worked fine for me. I mistakenly closed a previous PR with the same edit because I thought the issue was fixed but error is still there in the Snark OS wiki. 

Link: https://developer.aleo.org/testnet/getting_started/installation/#21-requirements

