### PR TITLE
Hotfix: mismatched `Body`, found `String`

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -112,7 +112,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             GovernorConfigBuilder::default()
                 .per_second(1)
                 .burst_size(rest_rps)
-                .error_handler(|error| Response::new(error.to_string()))
+                .error_handler(|error| Response::new(error.to_string().into()))
                 .finish()
                 .expect("Couldn't set up rate limiting for the REST server!"),
         );


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This is a hotfix that fixes building on `testnet3` by `./build_ubuntu.sh`.

## Test Plan

1. Tried to compile, ran into #3053 
1. Fixed the code
1. compiled successfully

## Related issues

closes https://github.com/AleoHQ/snarkOS/issues/3053
closes https://github.com/AleoHQ/snarkOS/issues/3055
