### PR TITLE
Increase the CDN sync backoff time

### DIFF
--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -318,7 +318,7 @@ async fn download_block_bundles<N: Network>(
                                 shutdown_clone.store(true, Ordering::Relaxed);
                                 break;
                             }
-                            tokio::time::sleep(Duration::from_secs(attempts as u64)).await;
+                            tokio::time::sleep(Duration::from_secs(attempts as u64 * 10)).await;
                             warn!("{error} - retrying ({attempts} attempt(s) so far)");
                         }
                     }


### PR DESCRIPTION
The current backoff time is a bit too low for scenarios where the most recent bundle keeps returning `Access Denied` (which seems to always go away after a while), and since we're running 16 concurrent request at all times (unless the backlog is full), we shouldn't be idling even in case a random glitch affects an earlier bundle.