### PR TITLE
Add a histogram for tcp events based on Event type

### DIFF
--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -36,6 +36,10 @@ path = "../../metrics"
 version = "=2.2.7"
 optional = true
 
+[dependencies.metrics_external]
+version = "0.22"
+package = "metrics" 
+
 [dependencies.rayon]
 version = "1"
 

--- a/node/bft/events/src/helpers/codec.rs
+++ b/node/bft/events/src/helpers/codec.rs
@@ -89,6 +89,7 @@ impl<N: Network> Decoder for EventCodec<N> {
         let reader = bytes.reader();
         match Event::read_le(reader) {
             Ok(event) => {
+                #[cfg(feature = "metrics")]
                 histogram!(metrics::tcp::TCP_GATEWAY, "event" => event.name()).record(bytes_len);
                 Ok(Some(event))
             },

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -72,5 +72,5 @@ pub mod tcp {
     pub const NOISE_CODEC_ENCRYPTION_SIZE: &str = "snarkos_tcp_noise_codec_encryption_size";
     pub const NOISE_CODEC_DECRYPTION_SIZE: &str = "snarkos_tcp_noise_codec_decryption_size";
     pub const TCP_TASKS: &str = "snarkos_tcp_tasks_total";
-    pub const TCP_GATEWAY: &str = "snarkos_tcp_gateway_messages";
+    pub const TCP_GATEWAY: &str = "snarkos_tcp_gateway_messages_received";
 }

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -72,4 +72,5 @@ pub mod tcp {
     pub const NOISE_CODEC_ENCRYPTION_SIZE: &str = "snarkos_tcp_noise_codec_encryption_size";
     pub const NOISE_CODEC_DECRYPTION_SIZE: &str = "snarkos_tcp_noise_codec_decryption_size";
     pub const TCP_TASKS: &str = "snarkos_tcp_tasks_total";
+    pub const TCP_GATEWAY: &str = "snarkos_tcp_gateway_messages";
 }


### PR DESCRIPTION
## Motivation
To better understand what is going on in SnarkOS TCP land, it may be beneficial to create a histogram (1 metric in Prometheus) that shows count and sum in bytes of each Event Message [type](https://github.com/AleoHQ/snarkOS/blob/testnet3/node/bft/events/src/lib.rs#L94-L110), so this PR adds one called `snarkos_tcp_gateway_messages_received`, with dynamic labeling based on the event name, in the `Decoder` impl of the `EventCodec`. I am using the basic `metrics` rust crate to call the [histogram macro](https://docs.rs/metrics/latest/metrics/macro.histogram.html), however it appears that in SnarkVM this functionality is overridden by the implementation of the snarkVM metrics crate, so I figured the easiest thing to do was to just add an alias for the default crate.

Note, the `histogram!` macro used currently only needs to be called once, so we don't need to register the metrics in `/node/metrics/src/names.rs`, which might be worth revisiting at a later date.

## Test Plan
Run on local devnets

<img width="760" alt="Screenshot 2024-02-07 at 10 44 48 PM" src="https://github.com/AleoHQ/snarkOS/assets/93600681/fdfbafb9-97ab-4a32-9b54-7c1061484d82">

