### PR TITLE
[Fix] Synced up validator fails to participate in consensus

### DIFF
--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -164,14 +164,20 @@ impl<N: Network> Storage<N> {
 
         // Retrieve the current committee.
         let current_committee = self.ledger.current_committee()?;
-        // If the primary is behind the current committee's starting round, sync with the latest block. 
-        if next_round < current_committee.starting_round() {
-            info!("Primary is behind the current committee's starting round ({}). Syncing with the latest block...", 
-            current_committee.starting_round()
-            ); 
-            let latest_block = self.ledger.latest_block();
-            self.sync_round_with_block(latest_block.round());
-            return Ok(latest_block.round()); 
+        // Retrieve the current committee's starting round.
+        let starting_round = current_committee.starting_round();
+        // If the primary is behind the current committee's starting round, sync with the latest block.
+        if next_round < starting_round {
+            // Retrieve the latest block round.
+            let latest_block_round = self.ledger.latest_round();
+            // Log the round sync.
+            info!(
+                "Syncing primary round ({next_round}) with the current committee's starting round ({starting_round}). Syncing with the latest block round {latest_block_round}..."
+            );
+            // Sync the round with the latest block.
+            self.sync_round_with_block(latest_block_round);
+            // Return the latest block round.
+            return Ok(latest_block_round);
         }
 
         // Update the storage to the next round.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -164,12 +164,14 @@ impl<N: Network> Storage<N> {
 
         // Retrieve the current committee.
         let current_committee = self.ledger.current_committee()?;
-        // Ensure the next round is at or after the current committee's starting round.
+        // If the primary is behind the current committee's starting round, sync with the latest block. 
         if next_round < current_committee.starting_round() {
-            bail!(
-                "Next round ({next_round}) is behind the current committee's starting round ({})",
-                current_committee.starting_round()
-            );
+            info!("Primary is behind the current committee's starting round ({}). Syncing with the latest block...", 
+            current_committee.starting_round()
+            ); 
+            let latest_block = self.ledger.latest_block();
+            self.sync_round_with_block(latest_block.round());
+            return Ok(latest_block.round()); 
         }
 
         // Update the storage to the next round.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR is an attempt at addressing the issue where a validator syncing up will have difficulty participating in consensus properly. 

A validator that is behind attempts to sync up blocks. Despite the ledger state being updated and continuously advancing blocks, the `Storage` is stuck on an old round and keeps sending a proposed batch on an old round. This validator will continue to sync up blocks, but will be unable to participate in the consensus voting. Once the proposal is too far behind (past GC range), then the validator should remedy itself, but that would mean the validator was unable to participate for 100 rounds, which is too long.

The fix for this issue is to discard stale proposals, and advance to the latest round that the other validators are on. The current approach should address the problem, however it is potentially dropping the proposal too early by disregarding the `is_proposing` check.
