### PR TITLE
Make run_prover.sh respect the lockfile

### DIFF
--- a/run-prover.sh
+++ b/run-prover.sh
@@ -39,7 +39,6 @@ while :
 do
   echo "Checking for updates..."
   git stash
-  rm Cargo.lock
   STATUS=$(git pull)
 
   if [ "$STATUS" != "Already up to date." ]; then


### PR DESCRIPTION
I'm not sure what the rationale was for removing it in the update loop, but it has been causing trouble due to it being recreated with updates afterwards.

This should fix https://github.com/AleoHQ/snarkOS/issues/3071, filing as a draft first just to double-check.