### PR TITLE
[ZKS-00] Revert election certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "indexmap 2.2.2",
  "itertools 0.11.0",
@@ -3650,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "rand",
  "rayon",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "anyhow",
  "rand",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "indexmap 2.2.2",
  "serde_json",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "indexmap 2.2.2",
  "paste",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2d062ce#2d062ceba8c570fcfd784106c89320a8cdd229a1"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "indexmap 2.2.2",
  "itertools 0.11.0",
@@ -3650,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "rand",
  "rayon",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "anyhow",
  "rand",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "indexmap 2.2.2",
  "serde_json",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "indexmap 2.2.2",
  "paste",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.18"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7faebdd#7faebdd323d847abc89a81f142ee1081837f075b"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d1255de#d1255de834af6bcf1827515b6670480c63c7f74d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "2d062ce"
+rev = "d1255de"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/events/src/certificate_response.rs
+++ b/node/bft/events/src/certificate_response.rs
@@ -90,16 +90,7 @@ pub mod prop_tests {
                 let signer = selector.select(validators);
                 let transmission_ids = transmissions.into_iter().map(|(id, _)| id).collect();
 
-                BatchHeader::new(
-                    &signer.private_key,
-                    0,
-                    now(),
-                    transmission_ids,
-                    Default::default(),
-                    Default::default(),
-                    &mut rng,
-                )
-                .unwrap()
+                BatchHeader::new(&signer.private_key, 0, now(), transmission_ids, Default::default(), &mut rng).unwrap()
             })
             .boxed()
     }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -67,8 +67,6 @@ pub struct BFT<N: Network> {
     leader_certificate: Arc<RwLock<Option<BatchCertificate<N>>>>,
     /// The timer for the leader certificate to be received.
     leader_certificate_timer: Arc<AtomicI64>,
-    /// The last election certificate IDs.
-    last_election_certificate_ids: Arc<RwLock<IndexSet<Field<N>>>>,
     /// The consensus sender.
     consensus_sender: Arc<OnceCell<ConsensusSender<N>>>,
     /// The spawned handles.
@@ -92,7 +90,6 @@ impl<N: Network> BFT<N> {
             dag: Default::default(),
             leader_certificate: Default::default(),
             leader_certificate_timer: Default::default(),
-            last_election_certificate_ids: Default::default(),
             consensus_sender: Default::default(),
             handles: Default::default(),
             lock: Default::default(),
@@ -144,11 +141,6 @@ impl<N: Network> BFT<N> {
     /// Returns the certificate of the leader from the current even round, if one was present.
     pub const fn leader_certificate(&self) -> &Arc<RwLock<Option<BatchCertificate<N>>>> {
         &self.leader_certificate
-    }
-
-    /// Returns the last election certificate IDs.
-    pub fn last_election_certificate_ids(&self) -> IndexSet<Field<N>> {
-        self.last_election_certificate_ids.read().clone()
     }
 }
 
@@ -485,17 +477,14 @@ impl<N: Network> BFT<N> {
         /* Proceeding to commit the leader. */
         info!("Proceeding to commit round {commit_round} with leader {leader}...");
 
-        // Prepare the election certificate IDs.
-        let election_certificate_ids = certificates.values().map(|c| c.id()).collect::<IndexSet<_>>();
         // Commit the leader certificate, and all previous leader certificates since the last committed round.
-        self.commit_leader_certificate::<ALLOW_LEDGER_ACCESS, false>(leader_certificate, election_certificate_ids).await
+        self.commit_leader_certificate::<ALLOW_LEDGER_ACCESS, false>(leader_certificate).await
     }
 
     /// Commits the leader certificate, and all previous leader certificates since the last committed round.
     async fn commit_leader_certificate<const ALLOW_LEDGER_ACCESS: bool, const IS_SYNCING: bool>(
         &self,
         leader_certificate: BatchCertificate<N>,
-        election_certificate_ids: IndexSet<Field<N>>,
     ) -> Result<()> {
         // Determine the list of all previous leader certificates since the last committed round.
         // The order of the leader certificates is from **newest** to **oldest**.
@@ -579,7 +568,7 @@ impl<N: Network> BFT<N> {
             // If the node is not syncing, trigger consensus, as this will build a new block for the ledger.
             if !IS_SYNCING {
                 // Construct the subdag.
-                let subdag = Subdag::from(commit_subdag.clone(), election_certificate_ids.clone())?;
+                let subdag = Subdag::from(commit_subdag.clone())?;
                 // Retrieve the anchor round.
                 let anchor_round = subdag.anchor_round();
                 // Retrieve the number of transmissions.
@@ -621,15 +610,6 @@ impl<N: Network> BFT<N> {
                 for certificate in commit_subdag.values().flatten() {
                     dag_write.commit(certificate, self.storage().max_gc_rounds());
                 }
-            }
-            // Update the last election certificate IDs.
-            // TODO (howardwu): This is currently writing the *latest* election certificate IDs,
-            //  however this needs to be dynamically retrieving the election certificate IDs for the
-            //  leader round (technically the `leader_round+1` round to get the election round)
-            //  that it is currently committing.
-            {
-                let mut last_election_certificate_ids = self.last_election_certificate_ids.write();
-                *last_election_certificate_ids = election_certificate_ids.clone();
             }
         }
         Ok(())
@@ -745,21 +725,11 @@ impl<N: Network> BFT<N> {
     /// Starts the BFT handlers.
     fn start_handlers(&self, bft_receiver: BFTReceiver<N>) {
         let BFTReceiver {
-            mut rx_last_election_certificate_ids,
             mut rx_primary_round,
             mut rx_primary_certificate,
             mut rx_sync_bft_dag_at_bootup,
             mut rx_sync_bft,
         } = bft_receiver;
-
-        // Process the request for the last election certificate IDs.
-        let self_ = self.clone();
-        self.spawn(async move {
-            while let Some(callback) = rx_last_election_certificate_ids.recv().await {
-                // Retrieve the last election certificate IDs, and send them to the callback.
-                callback.send(self_.last_election_certificate_ids()).ok();
-            }
-        });
 
         // Process the current round from the primary.
         let self_ = self.clone();
@@ -809,11 +779,11 @@ impl<N: Network> BFT<N> {
     /// Finally, it updates the DAG with the latest leader certificate.
     async fn sync_bft_dag_at_bootup(
         &self,
-        leader_certificates: Vec<(BatchCertificate<N>, IndexSet<Field<N>>)>,
+        leader_certificates: Vec<BatchCertificate<N>>,
         certificates: Vec<BatchCertificate<N>>,
     ) {
-        // Split the leader certificates into past leader certificates, the latest leader certificate, and the election certificate IDs.
-        let (past_leader_certificates, leader_certificate, election_certificate_ids) = {
+        // Split the leader certificates into past leader certificates and the latest leader certificate.
+        let (past_leader_certificates, leader_certificate) = {
             // Compute the penultimate index.
             let index = leader_certificates.len().saturating_sub(1);
             // Split the leader certificates.
@@ -821,9 +791,7 @@ impl<N: Network> BFT<N> {
             debug_assert!(latest.len() == 1, "There should only be one latest leader certificate");
             // Retrieve the latest leader certificate.
             match latest.first() {
-                Some((leader_certificate, election_certificate_ids)) => {
-                    (past, leader_certificate.clone(), election_certificate_ids.clone())
-                }
+                Some(leader_certificate) => (past, leader_certificate.clone()),
                 // If there is no latest leader certificate, return early.
                 None => return,
             }
@@ -840,23 +808,14 @@ impl<N: Network> BFT<N> {
                 }
             }
 
-            // Acquire the last election certificate IDs.
-            let mut last_election_certificate_ids = self.last_election_certificate_ids.write();
             // Iterate over the leader certificates.
-            for (leader_certificate, election_certificate_ids) in past_leader_certificates {
+            for leader_certificate in past_leader_certificates {
                 // Commit the leader certificate.
                 dag.commit(leader_certificate, self.storage().max_gc_rounds());
-                // Update the last election certificate IDs.
-                //
-                // Note: Because we will be committing the latest leader certificate after this,
-                // technically we do not need to be updating the last election certificate IDs
-                // for intermediate leader certificates. However, this is a safety mechanic to ensure completeness.
-                *last_election_certificate_ids = election_certificate_ids.clone();
             }
         }
         // Commit the latest leader certificate.
-        if let Err(e) = self.commit_leader_certificate::<true, true>(leader_certificate, election_certificate_ids).await
-        {
+        if let Err(e) = self.commit_leader_certificate::<true, true>(leader_certificate).await {
             error!("BFT failed to update the DAG with the latest leader certificate - {e}");
         }
     }

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -61,25 +61,13 @@ pub fn init_consensus_channels<N: Network>() -> (ConsensusSender<N>, ConsensusRe
 
 #[derive(Clone, Debug)]
 pub struct BFTSender<N: Network> {
-    pub tx_last_election_certificate_ids: mpsc::Sender<oneshot::Sender<IndexSet<Field<N>>>>,
     pub tx_primary_round: mpsc::Sender<(u64, oneshot::Sender<bool>)>,
     pub tx_primary_certificate: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
-    pub tx_sync_bft_dag_at_bootup:
-        mpsc::Sender<(Vec<(BatchCertificate<N>, IndexSet<Field<N>>)>, Vec<BatchCertificate<N>>)>,
+    pub tx_sync_bft_dag_at_bootup: mpsc::Sender<(Vec<BatchCertificate<N>>, Vec<BatchCertificate<N>>)>,
     pub tx_sync_bft: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
 }
 
 impl<N: Network> BFTSender<N> {
-    /// Retrieves the last election certificate IDs.
-    pub async fn get_last_election_certificate_ids(&self) -> Result<IndexSet<Field<N>>> {
-        // Initialize a callback sender and receiver.
-        let (callback_sender, callback_receiver) = oneshot::channel();
-        // Send the request to get the last election certificate IDs.
-        self.tx_last_election_certificate_ids.send(callback_sender).await?;
-        // Await the callback to continue.
-        Ok(callback_receiver.await?)
-    }
-
     /// Sends the current round to the BFT.
     pub async fn send_primary_round_to_bft(&self, current_round: u64) -> Result<bool> {
         // Initialize a callback sender and receiver.
@@ -113,36 +101,21 @@ impl<N: Network> BFTSender<N> {
 
 #[derive(Debug)]
 pub struct BFTReceiver<N: Network> {
-    pub rx_last_election_certificate_ids: mpsc::Receiver<oneshot::Sender<IndexSet<Field<N>>>>,
     pub rx_primary_round: mpsc::Receiver<(u64, oneshot::Sender<bool>)>,
     pub rx_primary_certificate: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
-    pub rx_sync_bft_dag_at_bootup:
-        mpsc::Receiver<(Vec<(BatchCertificate<N>, IndexSet<Field<N>>)>, Vec<BatchCertificate<N>>)>,
+    pub rx_sync_bft_dag_at_bootup: mpsc::Receiver<(Vec<BatchCertificate<N>>, Vec<BatchCertificate<N>>)>,
     pub rx_sync_bft: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
 }
 
 /// Initializes the BFT channels.
 pub fn init_bft_channels<N: Network>() -> (BFTSender<N>, BFTReceiver<N>) {
-    let (tx_last_election_certificate_ids, rx_last_election_certificate_ids) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_primary_round, rx_primary_round) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_primary_certificate, rx_primary_certificate) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_sync_bft_dag_at_bootup, rx_sync_bft_dag_at_bootup) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_sync_bft, rx_sync_bft) = mpsc::channel(MAX_CHANNEL_SIZE);
 
-    let sender = BFTSender {
-        tx_last_election_certificate_ids,
-        tx_primary_round,
-        tx_primary_certificate,
-        tx_sync_bft_dag_at_bootup,
-        tx_sync_bft,
-    };
-    let receiver = BFTReceiver {
-        rx_last_election_certificate_ids,
-        rx_primary_round,
-        rx_primary_certificate,
-        rx_sync_bft_dag_at_bootup,
-        rx_sync_bft,
-    };
+    let sender = BFTSender { tx_primary_round, tx_primary_certificate, tx_sync_bft_dag_at_bootup, tx_sync_bft };
+    let receiver = BFTReceiver { rx_primary_round, rx_primary_certificate, rx_sync_bft_dag_at_bootup, rx_sync_bft };
 
     (sender, receiver)
 }

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -207,7 +207,6 @@ mod prop_tests {
             now(),
             transmission_map.keys().cloned().collect(),
             Default::default(),
-            Default::default(),
             &mut rng,
         )
         .unwrap();

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -1118,7 +1118,6 @@ pub mod prop_tests {
             now(),
             transmission_map.keys().cloned().collect(),
             Default::default(),
-            Default::default(),
             &mut rng,
         )
         .unwrap();

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -222,9 +222,7 @@ impl<N: Network> Sync<N> {
                     // If the block authority is a beacon, then skip the block.
                     Authority::Beacon(_) => None,
                     // If the block authority is a subdag, then retrieve the certificates.
-                    Authority::Quorum(subdag) => {
-                        Some((subdag.leader_certificate().clone(), subdag.election_certificate_ids().clone()))
-                    }
+                    Authority::Quorum(subdag) => Some(subdag.leader_certificate().clone()),
                 }
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This change was made as part of a potential fix for the BFT, however it became clear we actually do not need it. So we are removing it to bring this back to vanilla Bullshark.

The sister PR can be found here: https://github.com/AleoHQ/snarkVM/pull/2343

This was originally a fix intended for Audit Finding: **[zksecurity 00] Commit Flow Can Lead to Safety Violation**, however it is now unnecessary with the new fixes.