### PR TITLE
Verify incoming `TransmissionResponse`s

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -171,9 +171,8 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         }
     }
 
-    // TODO (raychu86): Rename to `check_transmission_basic`.
-    /// Ensures the given transmission ID matches the given transmission.
-    async fn ensure_transmission_id_matches(
+    /// Checks the given transmission is well-formed and unique.
+    async fn check_transmission_basic(
         &self,
         transmission_id: TransmissionID<N>,
         transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{fmt_id, spawn_blocking, LedgerService};
+use crate::{spawn_blocking, LedgerService};
 use snarkvm::{
     ledger::{
         block::{Block, Transaction},
@@ -183,18 +183,13 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             (TransmissionID::Transaction(expected_transaction_id), Transmission::Transaction(transaction_data)) => {
                 match transaction_data.clone().deserialize_blocking() {
                     Ok(transaction) => {
-                        let deserialized_transaction_data = Data::Object(transaction);
+                        let deserialized_transaction = Data::Object(transaction);
 
                         // Check that the transaction is valid.
-                        if let Err(err) = self
-                            .check_transaction_basic(expected_transaction_id, deserialized_transaction_data.clone())
-                            .await
-                        {
-                            bail!("Failed to check transmission - {err}")
-                        }
+                        self.check_transaction_basic(expected_transaction_id, deserialized_transaction.clone()).await?;
 
                         // Update the transmission with the deserialized transaction.
-                        *transaction_data = deserialized_transaction_data;
+                        *transaction_data = deserialized_transaction;
                     }
                     Err(err) => {
                         bail!("Failed to deserialize transaction: {err}");
@@ -204,17 +199,13 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             (TransmissionID::Solution(expected_commitment), Transmission::Solution(solution_data)) => {
                 match solution_data.clone().deserialize_blocking() {
                     Ok(solution) => {
-                        let deserialized_solution_data = Data::Object(solution);
+                        let deserialized_solution = Data::Object(solution);
 
                         // Check that the solution is valid.
-                        if let Err(err) =
-                            self.check_solution_basic(expected_commitment, deserialized_solution_data.clone()).await
-                        {
-                            bail!("Failed to check transmission - {err}")
-                        }
+                        self.check_solution_basic(expected_commitment, deserialized_solution.clone()).await?;
 
                         // Update the transmission with the deserialized solution.
-                        *solution_data = deserialized_solution_data;
+                        *solution_data = deserialized_solution;
                     }
                     Err(err) => {
                         bail!("Failed to deserialize solution: {err}");

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -144,7 +144,7 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     }
 
     /// Ensures the given transmission ID matches the given transmission.
-    fn ensure_transmission_id_matches(
+    async fn ensure_transmission_id_matches(
         &self,
         transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -143,13 +143,13 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         Ok(false)
     }
 
-    /// Ensures the given transmission ID matches the given transmission.
-    async fn ensure_transmission_id_matches(
+    /// Checks the given transmission is well-formed and unique.
+    async fn check_transmission_basic(
         &self,
         transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,
     ) -> Result<()> {
-        trace!("[MockLedgerService] Ensure transmission ID matches {:?} - Ok", fmt_id(transmission_id));
+        trace!("[MockLedgerService] Check transmission basic {:?} - Ok", fmt_id(transmission_id));
         Ok(())
     }
 

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -125,7 +125,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     }
 
     /// Ensures the given transmission ID matches the given transmission.
-    fn ensure_transmission_id_matches(
+    async fn ensure_transmission_id_matches(
         &self,
         _transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -124,8 +124,8 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         bail!("Transmission '{transmission_id}' does not exist in prover")
     }
 
-    /// Ensures the given transmission ID matches the given transmission.
-    async fn ensure_transmission_id_matches(
+    /// Checks the given transmission is well-formed and unique.
+    async fn check_transmission_basic(
         &self,
         _transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -78,8 +78,8 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     /// Returns `true` if the ledger contains the given transmission ID.
     fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool>;
 
-    /// Ensures the given transmission ID matches the given transmission.
-    async fn ensure_transmission_id_matches(
+    /// Checks the given transmission is well-formed and unique.
+    async fn check_transmission_basic(
         &self,
         transmission_id: TransmissionID<N>,
         transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -79,7 +79,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool>;
 
     /// Ensures the given transmission ID matches the given transmission.
-    fn ensure_transmission_id_matches(
+    async fn ensure_transmission_id_matches(
         &self,
         transmission_id: TransmissionID<N>,
         transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -134,7 +134,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     }
 
     /// Always succeeds.
-    fn ensure_transmission_id_matches(
+    async fn ensure_transmission_id_matches(
         &self,
         _transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -134,7 +134,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     }
 
     /// Always succeeds.
-    async fn ensure_transmission_id_matches(
+    async fn check_transmission_basic(
         &self,
         _transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -405,7 +405,7 @@ impl<N: Network> Worker<N> {
                     // Remove the transmission ID from the pending queue.
                     self.pending.remove(transmission_id, Some(transmission));
                 }
-                Err(err) => warn!("Malicious peer ('{peer_ip}') send an invalid transmission: {err}"),
+                Err(err) => warn!("Malicious peer ('{peer_ip}') sent an invalid transmission: {err}"),
             };
         }
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR performs transmission verification when processing transmissions from `TransmissionResponse`s. Previously we were blindly accepting them into the batch, which could lead to possible halting cases, where malicious nodes inject faulty transactions.

This should fix:
https://github.com/AleoHQ/snarkOS/issues/2990
https://github.com/AleoHQ/snarkOS/issues/2991
