### PR TITLE
[Fix] Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  windows: circleci/windows@2.4.0
+  windows: circleci/windows@5.0
 
 commands:
   check_windows:
@@ -17,13 +17,17 @@ commands:
           name: "Install Rust and run cargo check"
           command: |
             $ProgressPreference = "SilentlyContinue"
+            # Remove the circleci installed rustc.
+            choco uninstall rust
+            # Install llvm (libclang for rocksdb).
+            choco install llvm -y 
+            refreshenv
+            # Install rust with rustup.
             Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "C:\rustup-init.exe"
             & C:\rustup-init.exe -y --default-toolchain "stable-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
-            choco install llvm -y
-            refreshenv
-            $env:Path += ";C:\Users\circleci\.cargo\bin"
-            rustc -Vv
-            cargo --version
+            $Env:Path += ";$Env:USERPROFILE\.cargo\bin"
+            # Verify the installation.
+            cargo --version --verbose
             rustc --version | Out-File -FilePath "rust-version"
             if (!(Test-Path "Cargo.lock" -PathType Leaf)) {
                 cargo generate-lockfile


### PR DESCRIPTION
This PR:
- updates circleci to use the latest windows orb
- uninstalls the pre-existing version of rust (installed with choco, gnu version) before installing rustup (msvc version)
- fixes the PATH for the rust installation. 

Fixes #3080. 