### PR TITLE
Renames `Testnet3` to `MainnetV0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,6 +420,6 @@ workflows:
           filters:
             branches:
               only:
-                - testnet3
+                - mainnet
     jobs:
       - integration

--- a/.devnet/.analytics/analytics.js
+++ b/.devnet/.analytics/analytics.js
@@ -134,7 +134,7 @@ async function main() {
 
     if (match && match[1]) {
         const ipAddress = match[1];
-        const baseUrl = `http://${ipAddress}:3033/mainnet/block`;
+        const baseUrl = `http://${ipAddress}:3030/mainnet/block`;
 
         console.log(`${dimStart}IP Address: ${ipAddress}${dimEnd}`);
         console.log(`${dimStart}Base URL: ${baseUrl}${dimEnd}`);

--- a/.devnet/.analytics/analytics.js
+++ b/.devnet/.analytics/analytics.js
@@ -134,7 +134,7 @@ async function main() {
 
     if (match && match[1]) {
         const ipAddress = match[1];
-        const baseUrl = `http://${ipAddress}:3033/testnet3/block`;
+        const baseUrl = `http://${ipAddress}:3033/mainnet/block`;
 
         console.log(`${dimStart}IP Address: ${ipAddress}${dimEnd}`);
         console.log(`${dimStart}Base URL: ${baseUrl}${dimEnd}`);

--- a/.devnet/README.md
+++ b/.devnet/README.md
@@ -6,8 +6,8 @@ Start by creating EC2 instances in the AWS console.
 - Ubuntu 22.04 LTS (not Amazon Linux)
 - Security Group - Inbound Policy
   - SSH - Port 22 - 0.0.0.0/0 (or your IP)
-  - Custom TCP - Port 3033 - 0.0.0.0/0 (or your IP)
-  - Custom TCP - Port 4133 - 0.0.0.0/0
+  - Custom TCP - Port 3030 - 0.0.0.0/0 (or your IP)
+  - Custom TCP - Port 4130 - 0.0.0.0/0
   - Custom TCP - Port 5000 - 0.0.0.0/0
 
 Be sure the give the EC2 instances a name tag, i.e. `devnet`.

--- a/.devnet/README.md
+++ b/.devnet/README.md
@@ -10,7 +10,7 @@ Start by creating EC2 instances in the AWS console.
   - Custom TCP - Port 4133 - 0.0.0.0/0
   - Custom TCP - Port 5000 - 0.0.0.0/0
 
-Be sure the give the EC2 instances a name tag, i.e. `testnet3`.
+Be sure the give the EC2 instances a name tag, i.e. `devnet`.
 
 Make sure you set the correct SSH `.pem` and have the `.pem` in your `~/.ssh` directory.
 

--- a/.devnet/config.sh
+++ b/.devnet/config.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Read the EC2 instance name from the user
-read -p "Enter the EC2 instance name to filter by (e.g. Name) (default: testnet3): " INSTANCE_NAME
-INSTANCE_NAME="${INSTANCE_NAME:-testnet3}"
+read -p "Enter the EC2 instance name to filter by (e.g. Name) (default: devnet): " INSTANCE_NAME
+INSTANCE_NAME="${INSTANCE_NAME:-devnet}"
 
 # Read the PEM file path from the user or use the default in ~/.ssh
-read -p "Enter the PEM file path (default: ~/.ssh/s3-testnet3.pem): " PEM_FILE
-PEM_FILE="${PEM_FILE:-~/.ssh/s3-testnet3.pem}"
+read -p "Enter the PEM file path (default: ~/.ssh/s3-devnet.pem): " PEM_FILE
+PEM_FILE="${PEM_FILE:-~/.ssh/s3-devnet.pem}"
 
 # Use the AWS CLI to describe running EC2 instances, filter by the provided name, and store the JSON output in a variable
 instance_info=$(aws ec2 describe-instances \

--- a/.devnet/install.sh
+++ b/.devnet/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Prompt the user for the branch to install (default is "testnet3")
-read -p "Enter the branch to install (default: testnet3): " BRANCH
-BRANCH=${BRANCH:-testnet3}
+# Prompt the user for the branch to install (default is "mainnet")
+read -p "Enter the branch to install (default: mainnet): " BRANCH
+BRANCH=${BRANCH:-mainnet}
 
 # Determine the number of AWS EC2 instances by checking ~/.ssh/config
 NODE_ID=0

--- a/.devnet/reinstall.sh
+++ b/.devnet/reinstall.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Prompt the user for the branch to install (default is "testnet3")
-read -p "Enter the branch to install (default: testnet3): " BRANCH
-BRANCH=${BRANCH:-testnet3}
+# Prompt the user for the branch to install (default is "mainnet")
+read -p "Enter the branch to install (default: mainnet): " BRANCH
+BRANCH=${BRANCH:-mainnet}
 
 # Determine the number of AWS EC2 instances by checking ~/.ssh/config
 NODE_ID=0

--- a/.devnet/start.sh
+++ b/.devnet/start.sh
@@ -37,7 +37,7 @@ start_snarkos_in_tmux() {
     tmux new-session -d -s snarkos-session
 
     # Send the snarkOS start command to the tmux session with the NODE_ID
-    tmux send-keys -t "snarkos-session" "snarkos start --nodisplay --bft 0.0.0.0:5000 --rest 0.0.0.0:3033 --peers $NODE_IP:4133 --validators $NODE_IP:5000 --verbosity $VERBOSITY --dev $NODE_ID --dev-num-validators $NUM_INSTANCES --validator --metrics" C-m
+    tmux send-keys -t "snarkos-session" "snarkos start --nodisplay --bft 0.0.0.0:5000 --rest 0.0.0.0:3030 --peers $NODE_IP:4130 --validators $NODE_IP:5000 --verbosity $VERBOSITY --dev $NODE_ID --dev-num-validators $NUM_INSTANCES --validator --metrics" C-m
 
     exit  # Exit root user
 EOF

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  target-branch: "testnet3"
+  target-branch: "mainnet"
   open-pull-requests-limit: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,16 +35,16 @@ jobs:
           mkdir tempdir
           mv target/release/snarkos tempdir
           cd tempdir
-          zip -r aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-unknown-linux-gnu.zip snarkos
+          zip -r aleo-${{ steps.get_version.outputs.version }}-x86_64-unknown-linux-gnu.zip snarkos
           cd ..
-          mv tempdir/aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-unknown-linux-gnu.zip .
+          mv tempdir/aleo-${{ steps.get_version.outputs.version }}-x86_64-unknown-linux-gnu.zip .
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-unknown-linux-gnu.zip
+            aleo-${{ steps.get_version.outputs.version }}-x86_64-unknown-linux-gnu.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -75,16 +75,16 @@ jobs:
           mkdir tempdir
           mv target/release/snarkos tempdir
           cd tempdir
-          zip -r aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-apple-darwin.zip snarkos
+          zip -r aleo-${{ steps.get_version.outputs.version }}-x86_64-apple-darwin.zip snarkos
           cd ..
-          mv tempdir/aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-apple-darwin.zip .
+          mv tempdir/aleo-${{ steps.get_version.outputs.version }}-x86_64-apple-darwin.zip .
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-apple-darwin.zip
+            aleo-${{ steps.get_version.outputs.version }}-x86_64-apple-darwin.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -122,13 +122,13 @@ jobs:
 
       - name: Zip
         run: |
-          Compress-Archive target/release/snarkos.exe aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-pc-windows-msvc.zip
+          Compress-Archive target/release/snarkos.exe aleo-${{ steps.get_version.outputs.version }}-x86_64-pc-windows-msvc.zip
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            aleo-testnet1-${{ steps.get_version.outputs.version }}-x86_64-pc-windows-msvc.zip
+            aleo-${{ steps.get_version.outputs.version }}-x86_64-pc-windows-msvc.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.integration/src/lib.rs
+++ b/.integration/src/lib.rs
@@ -23,13 +23,13 @@ mod tests {
         store::helpers::memory::ConsensusMemory,
         FromBytes,
         Ledger,
+        MainnetV0,
         Network,
-        Testnet3,
     };
 
     use tracing_test::traced_test;
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     const TEST_BASE_URL: &str = "https://testnet3.blocks.aleo.org/phase3";
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "indexmap 2.2.2",
  "itertools 0.11.0",
@@ -3650,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "rand",
  "rayon",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "anyhow",
  "rand",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "indexmap 2.2.2",
  "serde_json",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "indexmap 2.2.2",
  "paste",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=97cb08d#97cb08dcc2aea125e2054440539d15cf1adad4a1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "indexmap 2.2.2",
  "itertools 0.11.0",
@@ -3650,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "rand",
  "rayon",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "anyhow",
  "rand",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "indexmap 2.2.2",
  "serde_json",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "indexmap 2.2.2",
  "paste",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ca2efa9#ca2efa99bde3fe9c85eba0110eeff33f4fad4bde"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "indexmap 2.2.2",
  "itertools 0.11.0",
@@ -3650,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "rand",
  "rayon",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "anyhow",
  "rand",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "indexmap 2.2.2",
  "serde_json",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "indexmap 2.2.2",
  "paste",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fa5f425#fa5f4250874203af80ebc461b0a3d659b3c32f04"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=62bce04#62bce0440360e2a58838795bfd1d6afa17a6acdf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "fa5f425"
+rev = "62bce04"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "ca2efa9"
+rev = "fa5f425"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "62bce04"
+rev = "b08c6fc"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Lastly, install `snarkOS`:
 cargo install --locked --path .
 ```
 
-Please ensure ports `4133/tcp` and `3033/tcp` are open on your router and OS firewall.
+Please ensure ports `4130/tcp` and `3030/tcp` are open on your router and OS firewall.
 
 ## 3. Run an Aleo Node
 
@@ -144,7 +144,7 @@ APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ### 2. My node is unable to connect to peers on the network.
 
-- Ensure ports `4133/tcp` and `3033/tcp` are open on your router and OS firewall.
+- Ensure ports `4130/tcp` and `3030/tcp` are open on your router and OS firewall.
 - Ensure `snarkOS` is started using `./run-client.sh` or `./run-prover.sh`.
 
 ### 3. I can't generate a new address ### 
@@ -191,10 +191,10 @@ OPTIONS:
         --private-key <PRIVATE_KEY>             Specify the node's account private key
         --private-key-file <PRIVATE_KEY_FILE>   Specify the path to a file containing the node's account private key
         
-        --node <IP:PORT>                        Specify the IP address and port for the node server [default: 0.0.0.0:4133]
+        --node <IP:PORT>                        Specify the IP address and port for the node server [default: 0.0.0.0:4130]
         --connect <IP:PORT>                     Specify the IP address and port of a peer to connect to
  
-        --rest <REST>                           Specify the IP address and port for the REST server [default: 0.0.0.0:3033]
+        --rest <REST>                           Specify the IP address and port for the REST server [default: 0.0.0.0:3030]
         --norest                                If the flag is set, the node will not initialize the REST server
         
         --nodisplay                             If the flag is set, the node will not render the display

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -162,9 +162,9 @@ impl<N: Network> Display for Account<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::prelude::Testnet3;
+    use snarkvm::prelude::MainnetV0;
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     #[test]
     fn test_sign() {

--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -31,12 +31,12 @@ source $HOME/.cargo/env
 cargo install --locked --path .
 
 echo "=================================================="
-echo " Attention - Please ensure ports 4133 and 3033"
+echo " Attention - Please ensure ports 4130 and 3030"
 echo "             are enabled on your local network."
 echo ""
-echo " Cloud Providers - Enable ports 4133 and 3033"
+echo " Cloud Providers - Enable ports 4130 and 3030"
 echo "                   in your network firewall"
 echo ""
 echo " Home Users - Enable port forwarding or NAT rules"
-echo "              for 4133 and 3033 on your router."
+echo "              for 4130 and 3030 on your router."
 echo "=================================================="

--- a/cli/src/commands/account.rs
+++ b/cli/src/commands/account.rs
@@ -29,7 +29,7 @@ use rayon::prelude::*;
 use std::io::{Read, Write};
 use zeroize::Zeroize;
 
-type Network = snarkvm::prelude::Testnet3;
+type Network = snarkvm::prelude::MainnetV0;
 
 /// Commands to manage Aleo accounts.
 #[derive(Debug, Parser, Zeroize)]

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -52,7 +52,7 @@ use colored::Colorize;
 use std::{path::PathBuf, str::FromStr};
 
 type CurrentAleo = snarkvm::circuit::AleoV0;
-type CurrentNetwork = snarkvm::prelude::Testnet3;
+type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
 /// Commands to deploy and execute transactions
 #[derive(Debug, Parser)]
@@ -121,7 +121,7 @@ impl Developer {
     /// Fetch the program from the given endpoint.
     fn fetch_program(program_id: &ProgramID<CurrentNetwork>, endpoint: &str) -> Result<Program<CurrentNetwork>> {
         // Send a request to the query node.
-        let response = ureq::get(&format!("{endpoint}/testnet3/program/{program_id}")).call();
+        let response = ureq::get(&format!("{endpoint}/mainnet/program/{program_id}")).call();
 
         // Deserialize the program.
         match response {
@@ -143,7 +143,7 @@ impl Developer {
 
         // Send a request to the query node.
         let response =
-            ureq::get(&format!("{endpoint}/testnet3/program/{credits}/mapping/{account_mapping}/{address}")).call();
+            ureq::get(&format!("{endpoint}/mainnet/program/{credits}/mapping/{account_mapping}/{address}")).call();
 
         // Deserialize the balance.
         let balance: Result<Option<Value<CurrentNetwork>>> = match response {

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -173,7 +173,7 @@ impl Scan {
 
         // Fetch the genesis block from the endpoint.
         let genesis_block: Block<CurrentNetwork> =
-            ureq::get(&format!("{endpoint}/testnet3/block/0")).call()?.into_json()?;
+            ureq::get(&format!("{endpoint}/mainnet/block/0")).call()?.into_json()?;
         // Determine if the endpoint is on a development network.
         let is_development_network = genesis_block != Block::from_bytes_le(CurrentNetwork::genesis_bytes())?;
 
@@ -210,7 +210,7 @@ impl Scan {
             let request_end = request_start.saturating_add(num_blocks_to_request);
 
             // Establish the endpoint.
-            let blocks_endpoint = format!("{endpoint}/testnet3/blocks?start={request_start}&end={request_end}");
+            let blocks_endpoint = format!("{endpoint}/mainnet/blocks?start={request_start}&end={request_end}");
             // Fetch blocks
             let blocks: Vec<Block<CurrentNetwork>> = ureq::get(&blocks_endpoint).call()?.into_json()?;
 
@@ -332,7 +332,7 @@ impl Scan {
                 Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::serial_number(private_key, commitment)?;
 
             // Establish the endpoint.
-            let endpoint = format!("{endpoint}/testnet3/find/transitionID/{serial_number}");
+            let endpoint = format!("{endpoint}/mainnet/find/transitionID/{serial_number}");
 
             // Check if the record is spent.
             match ureq::get(&endpoint).call() {
@@ -357,9 +357,9 @@ impl Scan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::prelude::{TestRng, Testnet3};
+    use snarkvm::prelude::{MainnetV0, TestRng};
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     #[test]
     fn test_parse_account() {

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -122,7 +122,7 @@ impl Scan {
             }
             (Some(start), None, None) => {
                 // Request the latest block height from the endpoint.
-                let endpoint = format!("{}/testnet3/latest/height", self.endpoint);
+                let endpoint = format!("{}/mainnet/latest/height", self.endpoint);
                 let latest_height = u32::from_str(&ureq::get(&endpoint).call()?.into_string()?)?;
 
                 // Print a warning message if the user is attempting to scan the whole chain.
@@ -135,7 +135,7 @@ impl Scan {
             (None, Some(end), None) => Ok((0, end)),
             (None, None, Some(last)) => {
                 // Request the latest block height from the endpoint.
-                let endpoint = format!("{}/testnet3/latest/height", self.endpoint);
+                let endpoint = format!("{}/mainnet/latest/height", self.endpoint);
                 let latest_height = u32::from_str(&ureq::get(&endpoint).call()?.into_string()?)?;
 
                 Ok((latest_height.saturating_sub(last), latest_height))

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -19,7 +19,7 @@ use snarkvm::{
     console::{
         account::{Address, PrivateKey},
         algorithms::Hash,
-        network::{Network, Testnet3},
+        network::{MainnetV0, Network},
     },
     ledger::{
         block::Block,
@@ -142,7 +142,7 @@ impl Start {
             match cli.network {
                 3 => {
                     // Parse the node from the configurations.
-                    let node = cli.parse_node::<Testnet3>().await.expect("Failed to parse the node");
+                    let node = cli.parse_node::<MainnetV0>().await.expect("Failed to parse the node");
                     // If the display is enabled, render the display.
                     if !cli.nodisplay {
                         // Initialize the display.
@@ -537,18 +537,18 @@ fn load_or_compute_genesis<N: Network>(
     preimage.extend(&to_bytes_le![public_balances.iter().collect::<Vec<(_, _)>>()]?);
 
     // Input the parameters' metadata.
-    preimage.extend(snarkvm::parameters::testnet3::BondPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::UnbondPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::UnbondDelegatorAsValidatorVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::ClaimUnbondPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::SetValidatorStateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::TransferPrivateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::TransferPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::TransferPrivateToPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::TransferPublicToPrivateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::FeePrivateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::FeePublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::testnet3::InclusionVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::BondPublicVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::UnbondPublicVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::UnbondDelegatorAsValidatorVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::SetValidatorStateVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::TransferPrivateVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::TransferPublicVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::FeePrivateVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::FeePublicVerifier::METADATA.as_bytes());
+    preimage.extend(snarkvm::parameters::mainnet::InclusionVerifier::METADATA.as_bytes());
 
     // Initialize the hasher.
     let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;
@@ -589,9 +589,9 @@ fn load_or_compute_genesis<N: Network>(
 mod tests {
     use super::*;
     use crate::commands::{Command, CLI};
-    use snarkvm::prelude::Testnet3;
+    use snarkvm::prelude::MainnetV0;
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     #[test]
     fn test_parse_trusted_peers() {

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -789,8 +789,8 @@ mod tests {
             Start::try_parse_from(["snarkos", "--dev", "3", "--client", "--private-key", ""].iter()).unwrap();
         config.parse_development(&mut trusted_peers, &mut trusted_validators).unwrap();
         let genesis = config.parse_genesis::<CurrentNetwork>().unwrap();
-        assert_eq!(config.node, SocketAddr::from_str("0.0.0.0:4130").unwrap());
-        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3030").unwrap());
+        assert_eq!(config.node, SocketAddr::from_str("0.0.0.0:4133").unwrap());
+        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3033").unwrap());
         assert_eq!(trusted_peers.len(), 3);
         assert_eq!(trusted_validators.len(), 2);
         assert!(!config.validator);

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -76,7 +76,7 @@ pub struct Start {
     pub private_key_file: Option<PathBuf>,
 
     /// Specify the IP address and port for the node server
-    #[clap(default_value = "0.0.0.0:4133", long = "node")]
+    #[clap(default_value = "0.0.0.0:4130", long = "node")]
     pub node: SocketAddr,
     /// Specify the IP address and port for the BFT
     #[clap(long = "bft")]
@@ -89,7 +89,7 @@ pub struct Start {
     pub validators: String,
 
     /// Specify the IP address and port for the REST server
-    #[clap(default_value = "0.0.0.0:3033", long = "rest")]
+    #[clap(default_value = "0.0.0.0:3030", long = "rest")]
     pub rest: SocketAddr,
     /// Specify the requests per second (RPS) rate limit per IP for the REST server
     #[clap(default_value = "10", long = "rest-rps")]
@@ -789,8 +789,8 @@ mod tests {
             Start::try_parse_from(["snarkos", "--dev", "3", "--client", "--private-key", ""].iter()).unwrap();
         config.parse_development(&mut trusted_peers, &mut trusted_validators).unwrap();
         let genesis = config.parse_genesis::<CurrentNetwork>().unwrap();
-        assert_eq!(config.node, SocketAddr::from_str("0.0.0.0:4133").unwrap());
-        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3033").unwrap());
+        assert_eq!(config.node, SocketAddr::from_str("0.0.0.0:4130").unwrap());
+        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3030").unwrap());
         assert_eq!(trusted_peers.len(), 3);
         assert_eq!(trusted_validators.len(), 2);
         assert!(!config.validator);
@@ -817,7 +817,7 @@ mod tests {
             "--validators",
             "IP1,IP2,IP3",
             "--rest",
-            "127.0.0.1:3033",
+            "127.0.0.1:3030",
         ];
         let cli = CLI::parse_from(arg_vec);
 
@@ -827,7 +827,7 @@ mod tests {
             assert!(start.validator);
             assert_eq!(start.private_key.as_deref(), Some("PRIVATE_KEY"));
             assert_eq!(start.cdn, "CDN");
-            assert_eq!(start.rest, "127.0.0.1:3033".parse().unwrap());
+            assert_eq!(start.rest, "127.0.0.1:3030".parse().unwrap());
             assert_eq!(start.network, 3);
             assert_eq!(start.peers, "IP1,IP2,IP3");
             assert_eq!(start.validators, "IP1,IP2,IP3");

--- a/node/bft/events/src/batch_certified.rs
+++ b/node/bft/events/src/batch_certified.rs
@@ -65,7 +65,7 @@ pub mod prop_tests {
     use proptest::prelude::{BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_batch_certified() -> BoxedStrategy<BatchCertified<CurrentNetwork>> {
         any_batch_certificate().prop_map(BatchCertified::from).boxed()

--- a/node/bft/events/src/batch_propose.rs
+++ b/node/bft/events/src/batch_propose.rs
@@ -72,7 +72,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_batch_propose() -> BoxedStrategy<BatchPropose<CurrentNetwork>> {
         any::<CommitteeContext>()

--- a/node/bft/events/src/batch_signature.rs
+++ b/node/bft/events/src/batch_signature.rs
@@ -65,7 +65,7 @@ pub mod prop_tests {
     use proptest::prelude::{BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_batch_signature() -> BoxedStrategy<BatchSignature<CurrentNetwork>> {
         (any_field(), any_signature())

--- a/node/bft/events/src/block_response.rs
+++ b/node/bft/events/src/block_response.rs
@@ -148,7 +148,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_block() -> BoxedStrategy<Block<CurrentNetwork>> {
         any::<u64>().prop_map(|seed| sample_genesis_block(&mut TestRng::fixed(seed))).boxed()

--- a/node/bft/events/src/certificate_request.rs
+++ b/node/bft/events/src/certificate_request.rs
@@ -68,7 +68,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_field() -> BoxedStrategy<Field<CurrentNetwork>> {
         any::<u8>().prop_map(|_| Field::rand(&mut TestRng::default())).boxed()

--- a/node/bft/events/src/certificate_response.rs
+++ b/node/bft/events/src/certificate_response.rs
@@ -80,7 +80,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_batch_header(committee: &CommitteeContext) -> BoxedStrategy<BatchHeader<CurrentNetwork>> {
         (Just(committee.clone()), any::<Selector>(), vec(any_transmission(), 0..16))

--- a/node/bft/events/src/challenge_request.rs
+++ b/node/bft/events/src/challenge_request.rs
@@ -70,7 +70,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_valid_address() -> BoxedStrategy<Address<CurrentNetwork>> {
         any::<u64>().prop_map(|seed| Address::rand(&mut TestRng::fixed(seed))).boxed()

--- a/node/bft/events/src/challenge_response.rs
+++ b/node/bft/events/src/challenge_response.rs
@@ -59,7 +59,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_signature() -> BoxedStrategy<Signature<CurrentNetwork>> {
         (0..64)

--- a/node/bft/events/src/helpers/codec.rs
+++ b/node/bft/events/src/helpers/codec.rs
@@ -335,7 +335,7 @@ mod tests {
     use snow::{params::NoiseParams, Builder};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     fn handshake_xx() -> (NoiseCodec<CurrentNetwork>, NoiseCodec<CurrentNetwork>) {
         let params: NoiseParams = NOISE_HANDSHAKE_TYPE.parse().unwrap();

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -231,7 +231,7 @@ mod tests {
     use crate::Event;
     use bytes::{Buf, BufMut, BytesMut};
     use snarkvm::console::prelude::{FromBytes, ToBytes};
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     #[test]
     fn deserializing_invalid_data_panics() {
@@ -275,7 +275,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     /// Returns the current UTC epoch timestamp.
     pub fn now() -> i64 {

--- a/node/bft/events/src/primary_ping.rs
+++ b/node/bft/events/src/primary_ping.rs
@@ -84,7 +84,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_block_locators() -> BoxedStrategy<BlockLocators<CurrentNetwork>> {
         any::<u32>().prop_map(sample_block_locators).boxed()

--- a/node/bft/events/src/transmission_request.rs
+++ b/node/bft/events/src/transmission_request.rs
@@ -74,7 +74,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
         prop_oneof![

--- a/node/bft/events/src/transmission_response.rs
+++ b/node/bft/events/src/transmission_response.rs
@@ -78,7 +78,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_transmission() -> BoxedStrategy<(TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>)> {
         prop_oneof![

--- a/node/bft/events/src/validators_response.rs
+++ b/node/bft/events/src/validators_response.rs
@@ -72,7 +72,7 @@ pub mod prop_tests {
     use std::net::{IpAddr, SocketAddr};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_valid_socket_addr() -> BoxedStrategy<SocketAddr> {
         any::<(IpAddr, u16)>().prop_map(|(ip_addr, port)| SocketAddr::new(ip_addr, port)).boxed()

--- a/node/bft/events/src/worker_ping.rs
+++ b/node/bft/events/src/worker_ping.rs
@@ -74,7 +74,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_worker_ping() -> BoxedStrategy<WorkerPing<CurrentNetwork>> {
         hash_set(any_transmission_id(), 1..16).prop_map(|ids| WorkerPing::new(ids.into_iter().collect())).boxed()

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -54,7 +54,7 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
 };
 
-type CurrentNetwork = snarkvm::prelude::Testnet3;
+type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
 /**************************************************************************************************/
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -858,7 +858,7 @@ mod tests {
     use indexmap::IndexSet;
     use std::sync::{atomic::Ordering, Arc};
 
-    type CurrentNetwork = snarkvm::console::network::Testnet3;
+    type CurrentNetwork = snarkvm::console::network::MainnetV0;
 
     /// Samples a new test instance, with an optional committee round and the given maximum GC rounds.
     fn sample_test_instance(

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1345,7 +1345,7 @@ mod prop_tests {
             prop_tests::{CommitteeContext, ValidatorSet},
             Committee,
         },
-        prelude::{PrivateKey, Testnet3},
+        prelude::{MainnetV0, PrivateKey},
     };
 
     use indexmap::IndexMap;
@@ -1360,7 +1360,7 @@ mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     impl Debug for Gateway<CurrentNetwork> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -191,11 +191,11 @@ impl<N: Network> Cache<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::prelude::Testnet3;
+    use snarkvm::prelude::MainnetV0;
 
     use std::{net::Ipv4Addr, thread, time::Duration};
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     trait Input {
         fn input() -> Self;

--- a/node/bft/src/helpers/dag.rs
+++ b/node/bft/src/helpers/dag.rs
@@ -152,13 +152,13 @@ pub(crate) mod test_helpers {
 mod tests {
     use super::*;
     use snarkvm::{
-        prelude::{narwhal::batch_certificate::test_helpers::sample_batch_certificate_for_round, Testnet3},
+        prelude::{narwhal::batch_certificate::test_helpers::sample_batch_certificate_for_round, MainnetV0},
         utilities::TestRng,
     };
 
     #[test]
     fn test_dag_empty() {
-        let dag = DAG::<Testnet3>::new();
+        let dag = DAG::<MainnetV0>::new();
 
         assert_eq!(dag.get_certificates_for_round(0), None);
         assert_eq!(dag.last_committed_round(), 0);
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_dag_insert() {
         let rng = &mut TestRng::default();
-        let mut dag = DAG::<Testnet3>::new();
+        let mut dag = DAG::<MainnetV0>::new();
 
         const ROUND: u64 = 2;
 
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn test_dag_commit() {
         let rng = &mut TestRng::default();
-        let mut dag = DAG::<Testnet3>::new();
+        let mut dag = DAG::<MainnetV0>::new();
 
         // Sample a certificate for round 2 and 3 with the same author.
         let certificate_2 = sample_batch_certificate_for_round(2, &mut TestRng::fixed(123456789));
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_is_recently_committed() {
-        let mut dag = DAG::<Testnet3>::new();
+        let mut dag = DAG::<MainnetV0>::new();
 
         // Sample a certificate for round 2, 3, and 4 with the same author.
         let certificate_2 = sample_batch_certificate_for_round(2, &mut TestRng::fixed(123456789));

--- a/node/bft/src/helpers/partition.rs
+++ b/node/bft/src/helpers/partition.rs
@@ -78,7 +78,7 @@ mod tests {
     use super::*;
     use snarkvm::prelude::coinbase::PuzzleCommitment;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     #[test]
     fn test_assign_to_worker() {

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -114,7 +114,7 @@ mod tests {
         prelude::{Rng, TestRng},
     };
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     #[test]
     fn test_pending() {

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -135,7 +135,7 @@ mod tests {
 
     use ::bytes::Bytes;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     #[test]
     fn test_ready() {

--- a/node/bft/src/helpers/resolver.rs
+++ b/node/bft/src/helpers/resolver.rs
@@ -95,7 +95,7 @@ mod tests {
     use super::*;
     use snarkvm::{prelude::Rng, utilities::TestRng};
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     #[test]
     fn test_resolver() {

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -754,7 +754,7 @@ mod tests {
     use ::bytes::Bytes;
     use indexmap::indexset;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     /// Asserts that the storage matches the expected layout.
     pub fn assert_storage<N: Network>(
@@ -968,7 +968,7 @@ pub mod prop_tests {
     use std::fmt::Debug;
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     impl Arbitrary for Storage<CurrentNetwork> {
         type Parameters = CommitteeContext;

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1402,7 +1402,7 @@ mod tests {
     use indexmap::IndexSet;
     use rand::RngCore;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     // Returns a primary and a list of accounts in the configured committee.
     async fn primary_without_handlers(

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -463,7 +463,7 @@ mod tests {
     use mockall::mock;
     use std::{io, ops::Range};
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     mock! {
         Gateway<N: Network> {}
@@ -753,7 +753,7 @@ mod prop_tests {
 
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     // Initializes a new test committee.
     fn new_test_committee(n: u16) -> Committee<CurrentNetwork> {

--- a/node/bft/tests/common/mod.rs
+++ b/node/bft/tests/common/mod.rs
@@ -15,6 +15,6 @@
 pub mod primary;
 pub mod utils;
 
-pub type CurrentNetwork = snarkvm::prelude::Testnet3;
+pub type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
 pub type TranslucentLedgerService<N, C> = snarkos_node_bft_ledger_service::TranslucentLedgerService<N, C>;

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -513,7 +513,7 @@ mod tests {
         rt.block_on(async {
             let client = reqwest::Client::new();
             let height =
-                cdn_get::<u32>(client, &format!("{TEST_BASE_URL}/testnet3/latest/height"), "height").await.unwrap();
+                cdn_get::<u32>(client, &format!("{TEST_BASE_URL}/mainnet/latest/height"), "height").await.unwrap();
             assert!(height > 0);
         });
     }

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -438,12 +438,12 @@ mod tests {
         blocks::{cdn_get, cdn_height, log_progress, BLOCKS_PER_FILE},
         load_blocks,
     };
-    use snarkvm::prelude::{block::Block, Testnet3};
+    use snarkvm::prelude::{block::Block, MainnetV0};
 
     use parking_lot::RwLock;
     use std::{sync::Arc, time::Instant};
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     const TEST_BASE_URL: &str = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase3";
 

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -121,67 +121,67 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             axum::Router::new()
 
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
-            .route("/testnet3/node/address", get(Self::get_node_address))
+            .route("/mainnet/node/address", get(Self::get_node_address))
             .route_layer(middleware::from_fn(auth_middleware))
 
             // ----------------- DEPRECATED ROUTES -----------------
             // The following `GET ../latest/..` routes will be removed before mainnet.
             // Please refer to the recommended routes for each endpoint:
 
-            // Deprecated: use `/testnet3/block/height/latest` instead.
-            .route("/testnet3/latest/height", get(Self::latest_height))
-            // Deprecated: use `/testnet3/block/hash/latest` instead.
-            .route("/testnet3/latest/hash", get(Self::latest_hash))
-            // Deprecated: use `/testnet3/latest/block/height` instead.
-            .route("/testnet3/latest/block", get(Self::latest_block))
-            // Deprecated: use `/testnet3/stateRoot/latest` instead.
-            .route("/testnet3/latest/stateRoot", get(Self::latest_state_root))
-            // Deprecated: use `/testnet3/committee/latest` instead.
-            .route("/testnet3/latest/committee", get(Self::latest_committee))
+            // Deprecated: use `/mainnet/block/height/latest` instead.
+            .route("/mainnet/latest/height", get(Self::latest_height))
+            // Deprecated: use `/mainnet/block/hash/latest` instead.
+            .route("/mainnet/latest/hash", get(Self::latest_hash))
+            // Deprecated: use `/mainnet/latest/block/height` instead.
+            .route("/mainnet/latest/block", get(Self::latest_block))
+            // Deprecated: use `/mainnet/stateRoot/latest` instead.
+            .route("/mainnet/latest/stateRoot", get(Self::latest_state_root))
+            // Deprecated: use `/mainnet/committee/latest` instead.
+            .route("/mainnet/latest/committee", get(Self::latest_committee))
             // ------------------------------------------------------
 
             // GET ../block/..
-            .route("/testnet3/block/height/latest", get(Self::get_block_height_latest))
-            .route("/testnet3/block/hash/latest", get(Self::get_block_hash_latest))
-            .route("/testnet3/block/latest", get(Self::get_block_latest))
-            .route("/testnet3/block/:height_or_hash", get(Self::get_block))
+            .route("/mainnet/block/height/latest", get(Self::get_block_height_latest))
+            .route("/mainnet/block/hash/latest", get(Self::get_block_hash_latest))
+            .route("/mainnet/block/latest", get(Self::get_block_latest))
+            .route("/mainnet/block/:height_or_hash", get(Self::get_block))
             // The path param here is actually only the height, but the name must match the route
             // above, otherwise there'll be a conflict at runtime.
-            .route("/testnet3/block/:height_or_hash/transactions", get(Self::get_block_transactions))
+            .route("/mainnet/block/:height_or_hash/transactions", get(Self::get_block_transactions))
 
             // GET and POST ../transaction/..
-            .route("/testnet3/transaction/:id", get(Self::get_transaction))
-            .route("/testnet3/transaction/confirmed/:id", get(Self::get_confirmed_transaction))
-            .route("/testnet3/transaction/broadcast", post(Self::transaction_broadcast))
+            .route("/mainnet/transaction/:id", get(Self::get_transaction))
+            .route("/mainnet/transaction/confirmed/:id", get(Self::get_confirmed_transaction))
+            .route("/mainnet/transaction/broadcast", post(Self::transaction_broadcast))
 
             // POST ../solution/broadcast
-            .route("/testnet3/solution/broadcast", post(Self::solution_broadcast))
+            .route("/mainnet/solution/broadcast", post(Self::solution_broadcast))
 
             // GET ../find/..
-            .route("/testnet3/find/blockHash/:tx_id", get(Self::find_block_hash))
-            .route("/testnet3/find/transactionID/deployment/:program_id", get(Self::find_transaction_id_from_program_id))
-            .route("/testnet3/find/transactionID/:transition_id", get(Self::find_transaction_id_from_transition_id))
-            .route("/testnet3/find/transitionID/:input_or_output_id", get(Self::find_transition_id))
+            .route("/mainnet/find/blockHash/:tx_id", get(Self::find_block_hash))
+            .route("/mainnet/find/transactionID/deployment/:program_id", get(Self::find_transaction_id_from_program_id))
+            .route("/mainnet/find/transactionID/:transition_id", get(Self::find_transaction_id_from_transition_id))
+            .route("/mainnet/find/transitionID/:input_or_output_id", get(Self::find_transition_id))
 
             // GET ../peers/..
-            .route("/testnet3/peers/count", get(Self::get_peers_count))
-            .route("/testnet3/peers/all", get(Self::get_peers_all))
-            .route("/testnet3/peers/all/metrics", get(Self::get_peers_all_metrics))
+            .route("/mainnet/peers/count", get(Self::get_peers_count))
+            .route("/mainnet/peers/all", get(Self::get_peers_all))
+            .route("/mainnet/peers/all/metrics", get(Self::get_peers_all_metrics))
 
             // GET ../program/..
-            .route("/testnet3/program/:id", get(Self::get_program))
-            .route("/testnet3/program/:id/mappings", get(Self::get_mapping_names))
-            .route("/testnet3/program/:id/mapping/:name/:key", get(Self::get_mapping_value))
+            .route("/mainnet/program/:id", get(Self::get_program))
+            .route("/mainnet/program/:id/mappings", get(Self::get_mapping_names))
+            .route("/mainnet/program/:id/mapping/:name/:key", get(Self::get_mapping_value))
 
             // GET misc endpoints.
-            .route("/testnet3/blocks", get(Self::get_blocks))
-            .route("/testnet3/height/:hash", get(Self::get_height))
-            .route("/testnet3/memoryPool/transmissions", get(Self::get_memory_pool_transmissions))
-            .route("/testnet3/memoryPool/solutions", get(Self::get_memory_pool_solutions))
-            .route("/testnet3/memoryPool/transactions", get(Self::get_memory_pool_transactions))
-            .route("/testnet3/statePath/:commitment", get(Self::get_state_path_for_commitment))
-            .route("/testnet3/stateRoot/latest", get(Self::get_state_root_latest))
-            .route("/testnet3/committee/latest", get(Self::get_committee_latest))
+            .route("/mainnet/blocks", get(Self::get_blocks))
+            .route("/mainnet/height/:hash", get(Self::get_height))
+            .route("/mainnet/memoryPool/transmissions", get(Self::get_memory_pool_transmissions))
+            .route("/mainnet/memoryPool/solutions", get(Self::get_memory_pool_solutions))
+            .route("/mainnet/memoryPool/transactions", get(Self::get_memory_pool_transactions))
+            .route("/mainnet/statePath/:commitment", get(Self::get_state_path_for_commitment))
+            .route("/mainnet/stateRoot/latest", get(Self::get_state_root_latest))
+            .route("/mainnet/committee/latest", get(Self::get_committee_latest))
 
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -45,54 +45,54 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // Please use the recommended alternatives when implementing new features or refactoring.
 
     // Deprecated: Use `get_block_height_latest` instead.
-    // GET /testnet3/latest/height
+    // GET /mainnet/latest/height
     pub(crate) async fn latest_height(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_height())
     }
 
     // Deprecated: Use `get_block_hash_latest` instead.
-    // GET /testnet3/latest/hash
+    // GET /mainnet/latest/hash
     pub(crate) async fn latest_hash(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_hash())
     }
 
     // Deprecated: Use `get_block_latest` instead.
-    // GET /testnet3/latest/block
+    // GET /mainnet/latest/block
     pub(crate) async fn latest_block(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_block())
     }
 
     // Deprecated: Use `get_state_root_latest` instead.
-    // GET /testnet3/latest/stateRoot
+    // GET /mainnet/latest/stateRoot
     pub(crate) async fn latest_state_root(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_state_root())
     }
 
     // Deprecated: Use `get_committee_latest` instead.
-    // GET /testnet3/latest/committee
+    // GET /mainnet/latest/committee
     pub(crate) async fn latest_committee(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
     }
 
     // ---------------------------------------------------------
 
-    // GET /testnet3/block/height/latest
+    // GET /mainnet/block/height/latest
     pub(crate) async fn get_block_height_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_height())
     }
 
-    // GET /testnet3/block/hash/latest
+    // GET /mainnet/block/hash/latest
     pub(crate) async fn get_block_hash_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_hash())
     }
 
-    // GET /testnet3/block/latest
+    // GET /mainnet/block/latest
     pub(crate) async fn get_block_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_block())
     }
 
-    // GET /testnet3/block/{height}
-    // GET /testnet3/block/{blockHash}
+    // GET /mainnet/block/{height}
+    // GET /mainnet/block/{blockHash}
     pub(crate) async fn get_block(
         State(rest): State<Self>,
         Path(height_or_hash): Path<String>,
@@ -112,7 +112,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(block))
     }
 
-    // GET /testnet3/blocks?start={start_height}&end={end_height}
+    // GET /mainnet/blocks?start={start_height}&end={end_height}
     pub(crate) async fn get_blocks(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
@@ -142,7 +142,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(blocks))
     }
 
-    // GET /testnet3/height/{blockHash}
+    // GET /mainnet/height/{blockHash}
     pub(crate) async fn get_height(
         State(rest): State<Self>,
         Path(hash): Path<N::BlockHash>,
@@ -150,7 +150,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_height(&hash)?))
     }
 
-    // GET /testnet3/block/{height}/transactions
+    // GET /mainnet/block/{height}/transactions
     pub(crate) async fn get_block_transactions(
         State(rest): State<Self>,
         Path(height): Path<u32>,
@@ -158,7 +158,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_transactions(height)?))
     }
 
-    // GET /testnet3/transaction/{transactionID}
+    // GET /mainnet/transaction/{transactionID}
     pub(crate) async fn get_transaction(
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
@@ -166,7 +166,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id)?))
     }
 
-    // GET /testnet3/transaction/confirmed/{transactionID}
+    // GET /mainnet/transaction/confirmed/{transactionID}
     pub(crate) async fn get_confirmed_transaction(
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
@@ -174,7 +174,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_confirmed_transaction(tx_id)?))
     }
 
-    // GET /testnet3/memoryPool/transmissions
+    // GET /mainnet/memoryPool/transmissions
     pub(crate) async fn get_memory_pool_transmissions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
             Some(consensus) => {
@@ -184,7 +184,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
     }
 
-    // GET /testnet3/memoryPool/solutions
+    // GET /mainnet/memoryPool/solutions
     pub(crate) async fn get_memory_pool_solutions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
             Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_solutions().collect::<IndexMap<_, _>>())),
@@ -192,7 +192,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
     }
 
-    // GET /testnet3/memoryPool/transactions
+    // GET /mainnet/memoryPool/transactions
     pub(crate) async fn get_memory_pool_transactions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
             Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_transactions().collect::<IndexMap<_, _>>())),
@@ -200,7 +200,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
     }
 
-    // GET /testnet3/program/{programID}
+    // GET /mainnet/program/{programID}
     pub(crate) async fn get_program(
         State(rest): State<Self>,
         Path(id): Path<ProgramID<N>>,
@@ -208,7 +208,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_program(id)?))
     }
 
-    // GET /testnet3/program/{programID}/mappings
+    // GET /mainnet/program/{programID}/mappings
     pub(crate) async fn get_mapping_names(
         State(rest): State<Self>,
         Path(id): Path<ProgramID<N>>,
@@ -216,8 +216,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.vm().finalize_store().get_mapping_names_confirmed(&id)?))
     }
 
-    // GET /testnet3/program/{programID}/mapping/{mappingName}/{mappingKey}
-    // GET /testnet3/program/{programID}/mapping/{mappingName}/{mappingKey}?metadata={true}
+    // GET /mainnet/program/{programID}/mapping/{mappingName}/{mappingKey}
+    // GET /mainnet/program/{programID}/mapping/{mappingName}/{mappingKey}?metadata={true}
     pub(crate) async fn get_mapping_value(
         State(rest): State<Self>,
         Path((id, name, key)): Path<(ProgramID<N>, Identifier<N>, Plaintext<N>)>,
@@ -238,7 +238,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(mapping_value))
     }
 
-    // GET /testnet3/statePath/{commitment}
+    // GET /mainnet/statePath/{commitment}
     pub(crate) async fn get_state_path_for_commitment(
         State(rest): State<Self>,
         Path(commitment): Path<Field<N>>,
@@ -246,37 +246,37 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_state_path_for_commitment(&commitment)?))
     }
 
-    // GET /testnet3/stateRoot/latest
+    // GET /mainnet/stateRoot/latest
     pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_state_root())
     }
 
-    // GET /testnet3/committee/latest
+    // GET /mainnet/committee/latest
     pub(crate) async fn get_committee_latest(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
     }
 
-    // GET /testnet3/peers/count
+    // GET /mainnet/peers/count
     pub(crate) async fn get_peers_count(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().number_of_connected_peers())
     }
 
-    // GET /testnet3/peers/all
+    // GET /mainnet/peers/all
     pub(crate) async fn get_peers_all(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_peers())
     }
 
-    // GET /testnet3/peers/all/metrics
+    // GET /mainnet/peers/all/metrics
     pub(crate) async fn get_peers_all_metrics(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_metrics())
     }
 
-    // GET /testnet3/node/address
+    // GET /mainnet/node/address
     pub(crate) async fn get_node_address(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().address())
     }
 
-    // GET /testnet3/find/blockHash/{transactionID}
+    // GET /mainnet/find/blockHash/{transactionID}
     pub(crate) async fn find_block_hash(
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
@@ -284,7 +284,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.find_block_hash(&tx_id)?))
     }
 
-    // GET /testnet3/find/transactionID/deployment/{programID}
+    // GET /mainnet/find/transactionID/deployment/{programID}
     pub(crate) async fn find_transaction_id_from_program_id(
         State(rest): State<Self>,
         Path(program_id): Path<ProgramID<N>>,
@@ -292,7 +292,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.find_transaction_id_from_program_id(&program_id)?))
     }
 
-    // GET /testnet3/find/transactionID/{transitionID}
+    // GET /mainnet/find/transactionID/{transitionID}
     pub(crate) async fn find_transaction_id_from_transition_id(
         State(rest): State<Self>,
         Path(transition_id): Path<N::TransitionID>,
@@ -300,7 +300,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.find_transaction_id_from_transition_id(&transition_id)?))
     }
 
-    // GET /testnet3/find/transitionID/{inputOrOutputID}
+    // GET /mainnet/find/transitionID/{inputOrOutputID}
     pub(crate) async fn find_transition_id(
         State(rest): State<Self>,
         Path(input_or_output_id): Path<Field<N>>,
@@ -308,7 +308,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.find_transition_id(&input_or_output_id)?))
     }
 
-    // POST /testnet3/transaction/broadcast
+    // POST /mainnet/transaction/broadcast
     pub(crate) async fn transaction_broadcast(
         State(rest): State<Self>,
         Json(tx): Json<Transaction<N>>,
@@ -332,7 +332,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(tx_id))
     }
 
-    // POST /testnet3/solution/broadcast
+    // POST /mainnet/solution/broadcast
     pub(crate) async fn solution_broadcast(
         State(rest): State<Self>,
         Json(prover_solution): Json<ProverSolution<N>>,

--- a/node/router/messages/src/block_response.rs
+++ b/node/router/messages/src/block_response.rs
@@ -74,7 +74,7 @@ pub mod prop_tests {
     };
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_block() -> BoxedStrategy<Block<CurrentNetwork>> {
         any::<u64>().prop_map(|seed| sample_genesis_block(&mut TestRng::fixed(seed))).boxed()

--- a/node/router/messages/src/challenge_request.rs
+++ b/node/router/messages/src/challenge_request.rs
@@ -76,7 +76,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_valid_address() -> BoxedStrategy<Address<CurrentNetwork>> {
         any::<u64>().prop_map(|seed| Address::rand(&mut TestRng::fixed(seed))).boxed()

--- a/node/router/messages/src/challenge_response.rs
+++ b/node/router/messages/src/challenge_response.rs
@@ -68,7 +68,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_signature() -> BoxedStrategy<Signature<CurrentNetwork>> {
         (0..64)

--- a/node/router/messages/src/ping.rs
+++ b/node/router/messages/src/ping.rs
@@ -111,7 +111,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_block_locators() -> BoxedStrategy<BlockLocators<CurrentNetwork>> {
         any::<u32>().prop_map(sample_block_locators).boxed()

--- a/node/router/messages/src/puzzle_response.rs
+++ b/node/router/messages/src/puzzle_response.rs
@@ -61,7 +61,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_epoch_challenge() -> BoxedStrategy<EpochChallenge<CurrentNetwork>> {
         any::<u64>()

--- a/node/router/messages/src/unconfirmed_solution.rs
+++ b/node/router/messages/src/unconfirmed_solution.rs
@@ -61,7 +61,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_solution_id() -> BoxedStrategy<PuzzleCommitment<CurrentNetwork>> {
         any::<u64>()

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -68,7 +68,7 @@ pub mod prop_tests {
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     pub fn any_transaction() -> BoxedStrategy<Transaction<CurrentNetwork>> {
         any::<u64>()

--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -260,11 +260,11 @@ impl<N: Network> Cache<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snarkvm::prelude::Testnet3;
+    use snarkvm::prelude::MainnetV0;
 
     use std::net::Ipv4Addr;
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     #[test]
     fn test_inbound_solution() {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -381,10 +381,10 @@ impl<N: Network> Router<N> {
             vec![]
         } else {
             vec![
-                SocketAddr::from_str("35.224.50.150:4133").unwrap(),
-                SocketAddr::from_str("35.227.159.141:4133").unwrap(),
-                SocketAddr::from_str("34.139.203.87:4133").unwrap(),
-                SocketAddr::from_str("34.150.221.166:4133").unwrap(),
+                SocketAddr::from_str("35.224.50.150:4130").unwrap(),
+                SocketAddr::from_str("35.227.159.141:4130").unwrap(),
+                SocketAddr::from_str("34.139.203.87:4130").unwrap(),
+                SocketAddr::from_str("34.150.221.166:4130").unwrap(),
             ]
         }
     }

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -72,7 +72,7 @@ pub trait Routing<N: Network>:
                 report.insert("node_type".to_string(), self_clone.router().node_type().to_string());
                 report.insert("is_dev".to_string(), self_clone.router().is_dev().to_string());
                 // Transmit the report.
-                let url = "https://vm.aleo.org/testnet3/report";
+                let url = "https://vm.aleo.org/mainnet/report";
                 let _ = reqwest::Client::new().post(url).json(&report).send().await;
                 // Sleep for a fixed duration in seconds.
                 tokio::time::sleep(Duration::from_secs(6 * 60 * 60)).await;

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -24,7 +24,7 @@ use std::{
 
 use snarkos_account::Account;
 use snarkos_node_router::{messages::NodeType, Router};
-use snarkvm::prelude::{block::Block, FromBytes, Network, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{block::Block, FromBytes, MainnetV0 as CurrentNetwork, Network};
 
 /// A helper macro to print the TCP listening address, along with the connected and connecting peers.
 #[macro_export]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -207,7 +207,7 @@ pub fn start_notification_message_loop() -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
             interval.tick().await;
-            // TODO (howardwu): Swap this with the official message for Testnet 3 announcements.
+            // TODO (howardwu): Swap this with the official message for announcements.
             // info!("{}", notification_message());
         }
     })
@@ -222,7 +222,7 @@ pub fn notification_message() -> String {
 
  ==================================================================================================
 
-                     🚧 Welcome to Aleo Testnet 3 Phase 3 - Calibration Period 🚧
+                     🚧 Welcome to Aleo - Calibration Period 🚧
 
  ==================================================================================================
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -249,7 +249,7 @@ pub fn notification_message() -> String {
     - IMPORTANT: EXPECT MULTIPLE NETWORK RESETS.
     - If participating, BE PREPARED TO RESET YOUR NODE AT ANY TIME.
     - When a reset occurs, RUN THE FOLLOWING TO RESET YOUR NODE:
-        - git checkout testnet3 && git pull
+        - git checkout mainnet && git pull
         - cargo install --locked --path .
         - snarkos clean
         - snarkos start --nodisplay --client

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -454,7 +454,7 @@ mod tests {
     use super::*;
     use snarkvm::prelude::{
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
-        Testnet3,
+        MainnetV0,
         VM,
     };
 
@@ -463,7 +463,7 @@ mod tests {
     use rand_chacha::ChaChaRng;
     use std::str::FromStr;
 
-    type CurrentNetwork = Testnet3;
+    type CurrentNetwork = MainnetV0;
 
     /// Use `RUST_MIN_STACK=67108864 cargo test --release profiler --features timer` to run this test.
     #[ignore]

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -470,8 +470,8 @@ mod tests {
     #[tokio::test]
     async fn test_profiler() -> Result<()> {
         // Specify the node attributes.
-        let node = SocketAddr::from_str("0.0.0.0:4133").unwrap();
-        let rest = SocketAddr::from_str("0.0.0.0:3033").unwrap();
+        let node = SocketAddr::from_str("0.0.0.0:4130").unwrap();
+        let rest = SocketAddr::from_str("0.0.0.0:3030").unwrap();
         let storage_mode = StorageMode::Development(0);
 
         // Initialize an (insecure) fixed RNG.

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -311,7 +311,7 @@ pub mod test_helpers {
     use super::*;
     use snarkvm::prelude::Field;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     /// Simulates a block locator at the given height.
     pub fn sample_block_locators(height: u32) -> BlockLocators<CurrentNetwork> {
@@ -392,7 +392,7 @@ mod tests {
 
     use core::ops::Range;
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     /// Simulates block locators for a ledger within the given `heights` range.
     fn check_is_valid(checkpoints: IndexMap<u32, <CurrentNetwork as Network>::BlockHash>, heights: Range<u32>) {

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -891,7 +891,7 @@ mod tests {
     use snarkvm::ledger::committee::Committee;
     use std::net::{IpAddr, Ipv4Addr};
 
-    type CurrentNetwork = snarkvm::prelude::Testnet3;
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     /// Returns the peer IP for the sync pool.
     fn sample_peer_ip(id: u16) -> SocketAddr {

--- a/node/tests/common/mod.rs
+++ b/node/tests/common/mod.rs
@@ -18,7 +18,7 @@ pub mod test_peer;
 use std::{env, str::FromStr};
 
 use snarkos_account::Account;
-use snarkvm::prelude::{block::Block, FromBytes, Network, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{block::Block, FromBytes, MainnetV0 as CurrentNetwork, Network};
 
 /// Returns a fixed account.
 pub fn sample_account() -> Account<CurrentNetwork> {

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -15,7 +15,7 @@
 use crate::common::test_peer::sample_genesis_block;
 use snarkos_account::Account;
 use snarkos_node::{Client, Prover, Validator};
-use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, MainnetV0 as CurrentNetwork};
 
 use aleo_std::StorageMode;
 use std::str::FromStr;

--- a/node/tests/common/test_peer.rs
+++ b/node/tests/common/test_peer.rs
@@ -19,7 +19,7 @@ use snarkos_node_router::{
 };
 use snarkvm::{
     ledger::narwhal::Data,
-    prelude::{block::Block, error, Address, FromBytes, Network, TestRng, Testnet3 as CurrentNetwork},
+    prelude::{block::Block, error, Address, FromBytes, MainnetV0 as CurrentNetwork, Network, TestRng},
 };
 
 use std::{

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -21,7 +21,7 @@ use common::{node::*, test_peer::TestPeer};
 use snarkos_node::{Client, Prover, Validator};
 use snarkos_node_router::Outbound;
 use snarkos_node_tcp::P2P;
-use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, Testnet3 as CurrentNetwork};
+use snarkvm::prelude::{store::helpers::memory::ConsensusMemory, MainnetV0 as CurrentNetwork};
 
 use pea2pea::Pea2Pea;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR renames Testnet3 to MainnetV0 in preparation for mainnet.

Note: The network ID for `mainnet` is `0` (where as it was `3` on `testnet3`). As such, please update your firewall to support these TCP ports:
- 4130 (previously 4133)
- 3030 (previously 3033)
Following this convention will ensure Aleo can better support multiple distinct testnets simultaneously after mainnet launch.

The sister PR can be found here: https://github.com/AleoHQ/snarkVM/pull/2347