### PR TITLE
[Fix] Optimize validator block sync while outside GC range

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -290,18 +290,14 @@ impl<N: Network> Sync<N> {
         // Determine the maximum height that the peer would have garbage collected.
         let max_gc_height = tip.saturating_sub(max_gc_blocks);
 
-        // Determine if we can sync the ledger without updating the BFT.
+        // Determine if we can sync the ledger without updating the BFT first.
         if current_height <= max_gc_height {
-            // Try to advance the ledger without updating the BFT.
+            // Try to advance the ledger *to tip* without updating the BFT.
             while let Some(block) = self.block_sync.process_next_block(current_height) {
                 info!("Syncing the ledger to block {}...", block.height());
                 self.sync_ledger_with_block_without_bft(block).await?;
                 // Update the current height.
                 current_height += 1;
-                // Break if the current height exceeds the maximum GC height.
-                if current_height > max_gc_height {
-                    break;
-                }
             }
             // Sync the storage with the ledger if we should transition to the BFT sync.
             if current_height > max_gc_height {

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -306,7 +306,7 @@ impl<N: Network> Sync<N> {
     }
 
     /// Syncs the ledger with the given block without using the BFT.
-    pub async fn sync_ledger_with_block_without_bft(&self, block: Block<N>) -> Result<()> {
+    async fn sync_ledger_with_block_without_bft(&self, block: Block<N>) -> Result<()> {
         // Acquire the sync lock.
         let _lock = self.lock.lock().await;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR optimizes validator block sync by allowing validators to sync the standard way (without having to commit certificates) while they are outside the sync peer's GC range. Once we get close to tip and within GC range, then we transition into syncing with the current BFT approach by committing certificates.