### PR TITLE
[Fix] Limit the number of duplicate certificate and transmission requests

### DIFF
--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -21,6 +21,11 @@ use std::{
 use time::OffsetDateTime;
 use tokio::sync::oneshot;
 
+#[cfg(not(test))]
+pub const NUM_REDUNDANT_REQUESTS: usize = 2;
+#[cfg(test)]
+pub const NUM_REDUNDANT_REQUESTS: usize = 10;
+
 #[derive(Debug)]
 pub struct Pending<T: PartialEq + Eq + Hash, V: Clone> {
     /// The map of pending `items` to `peer IPs` that have the item.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -356,10 +356,10 @@ impl<N: Network> Sync<N> {
         let (callback_sender, callback_receiver) = oneshot::channel();
         // Insert the certificate ID into the pending queue.
         if self.pending.insert(certificate_id, peer_ip, Some(callback_sender)) {
-            // Determine how many requests have been sent for the certificate.
-            let num_requests = self.pending.get(certificate_id).map(|pending| pending.len()).unwrap_or(0);
-            // If the number of requests is less than the redundancy factor, send the certificate request to the peer.
-            if num_requests <= REDUNDANCY_FACTOR {
+            // Determine how many requests are pending for the certificate.
+            let num_pending_requests = self.pending.num_callbacks(certificate_id);
+            // If the number of requests is less than or equal to the redundancy factor, send the certificate request to the peer.
+            if num_pending_requests <= REDUNDANCY_FACTOR {
                 // Send the certificate request to the peer.
                 if self.gateway.send(peer_ip, Event::CertificateRequest(certificate_id.into())).await.is_none() {
                     bail!("Unable to fetch batch certificate {certificate_id} - failed to send request")

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -421,10 +421,7 @@ impl<N: Network> Sync<N> {
                     bail!("Unable to fetch batch certificate {certificate_id} - failed to send request")
                 }
             } else {
-                debug!(
-                    "Skipped sending certificate request to {peer_ip} for {} - already pending {NUM_REDUNDANT_REQUESTS} requests",
-                    fmt_id(certificate_id)
-                );
+                trace!("Skipped sending redundant request for certificate {} to '{peer_ip}'", fmt_id(certificate_id));
             }
         }
         // Wait for the certificate to be fetched.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -387,10 +387,10 @@ impl<N: Network> Worker<N> {
         let (callback_sender, callback_receiver) = oneshot::channel();
         // Insert the transmission ID into the pending queue.
         self.pending.insert(transmission_id, peer_ip, Some(callback_sender));
-        // Determine how many requests have been sent for the transmission.
-        let num_requests = self.pending.get(transmission_id).map(|pending| pending.len()).unwrap_or(0);
-        // If the number of requests is less than the redundancy factor, send the transmission request to the peer.
-        if num_requests <= REDUNDANCY_FACTOR {
+        // Determine how many requests are pending for the transmission.
+        let num_pending_requests = self.pending.num_callbacks(transmission_id);
+        // If the number of requests is less than or equal to the the redundancy factor, send the transmission request to the peer.
+        if num_pending_requests <= REDUNDANCY_FACTOR {
             // Send the transmission request to the peer.
             if self.gateway.send(peer_ip, Event::TransmissionRequest(transmission_id.into())).await.is_none() {
                 bail!("Unable to fetch transmission - failed to send request")

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -395,10 +395,7 @@ impl<N: Network> Worker<N> {
                 bail!("Unable to fetch transmission - failed to send request")
             }
         } else {
-            debug!(
-                "Skipped sending transmission request to {peer_ip} for {} - already pending {NUM_REDUNDANT_REQUESTS} requests",
-                fmt_id(transmission_id)
-            );
+            trace!("Skipped sending redundant request for transmission {} to '{peer_ip}'", fmt_id(transmission_id));
         }
         // Wait for the transmission to be fetched.
         match timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver).await {

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -80,7 +80,7 @@ impl<N: Network> Decoder for MessageCodec<N> {
         match Message::read_le(reader) {
             Ok(message) => Ok(Some(message)),
             Err(error) => {
-                error!("Failed to deserialize a message: {}", error);
+                warn!("Failed to deserialize a message - {}", error);
                 Err(std::io::ErrorKind::InvalidData.into())
             }
         }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR reduces network overhead by reducing the number of duplicate certificate and transmission requests sent to peers. Previously these duplicate requests were unbounded, but now it is limited to the `REDUNDANCY_FACTOR`.

In addition, the pending request callbacks can now be expired and removed.