### PR TITLE
[Bug Bounty] Limit number of provers we connect to

### DIFF
--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -38,10 +38,10 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     const MINIMUM_NUMBER_OF_PEERS: usize = 3;
     /// The median number of peers to maintain connections with.
     const MEDIAN_NUMBER_OF_PEERS: usize = max(Self::MAXIMUM_NUMBER_OF_PEERS / 2, Self::MINIMUM_NUMBER_OF_PEERS);
-    /// The maximum number of provers to maintain connections with.
-    const MAXIMUM_NUMBER_OF_PROVERS: usize = Self::MAXIMUM_NUMBER_OF_PEERS / 4;
     /// The maximum number of peers permitted to maintain connections with.
     const MAXIMUM_NUMBER_OF_PEERS: usize = 21;
+    /// The maximum number of provers to maintain connections with.
+    const MAXIMUM_NUMBER_OF_PROVERS: usize = Self::MAXIMUM_NUMBER_OF_PEERS / 4;
 
     /// Handles the heartbeat request.
     fn heartbeat(&self) {

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -176,7 +176,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
                 .into_iter()
                 .filter_map(|peer| {
                     let peer_ip = peer.ip();
-                    if !trusted.contains(&peer_ip) && !bootstrap.contains(&peer_ip) && !peer.is_prover() {
+                    if !peer.is_prover() && !trusted.contains(&peer_ip) && !bootstrap.contains(&peer_ip) {
                         Some(peer_ip)
                     } else {
                         None

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -133,16 +133,17 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     /// TODO (howardwu): If the node is a validator, keep the validator.
     /// This function keeps the number of connected peers within the allowed range.
     fn handle_connected_peers(&self) {
+        // Obtain the number of connected peers.
+        let num_connected = self.router().number_of_connected_peers();
+        // Compute the total number of surplus peers.
+        let num_surplus_peers = num_connected.saturating_sub(Self::MAXIMUM_NUMBER_OF_PEERS);
+
         // Obtain the number of connected provers.
         let num_connected_provers = self.router().number_of_connected_provers();
         // Compute the number of surplus provers.
         let num_surplus_provers = num_connected_provers.saturating_sub(Self::MAXIMUM_NUMBER_OF_PROVERS);
         // Compute the number of provers remaining connected.
         let num_remaining_provers = num_connected_provers.saturating_sub(num_surplus_provers);
-        // Obtain the number of connected peers.
-        let num_connected = self.router().number_of_connected_peers();
-        // Compute the total number of surplus peers.
-        let num_surplus_peers = num_connected.saturating_sub(Self::MAXIMUM_NUMBER_OF_PEERS);
         // Compute the number of surplus clients and validators.
         let num_surplus_clients_validators = num_surplus_peers.saturating_sub(num_remaining_provers);
 


### PR DESCRIPTION
## Motivation

Partially mitigates: https://github.com/AleoHQ/snarkOS/issues/3011 - clients are not syncing on testnet because they're only connected to provers.
Explicitly limits the number of prover connections we maintain - assuming honest peer responses.

## Test Plan

Should be stress tested on a network with clients and provers.