### PR TITLE
[Coinbase Go/No-Go] Add bonded balances to development genesis block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3623,7 +3623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "indexmap 2.2.3",
  "itertools 0.11.0",
@@ -3641,12 +3641,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3790,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3953,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "rand",
  "rayon",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "anyhow",
  "rand",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4115,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "indexmap 2.2.3",
  "serde_json",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4229,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "indexmap 2.2.3",
  "paste",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=88347f3#88347f37d6912d295f3de50dc8a575bd79e0d522"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=6e182c6#6e182c6d6c9ec92a0140dbf543e9149699b68c60"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "indexmap 2.2.2",
  "itertools 0.11.0",
@@ -3650,12 +3650,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3763,7 +3763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "rand",
  "rayon",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "anyhow",
  "rand",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "anyhow",
  "indexmap 2.2.2",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "indexmap 2.2.2",
  "serde_json",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "indexmap 2.2.2",
  "rayon",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4208,6 +4208,7 @@ dependencies = [
  "rayon",
  "rocksdb",
  "serde",
+ "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-authority",
  "snarkvm-ledger-block",
@@ -4222,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4237,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4246,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4271,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4295,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4318,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "indexmap 2.2.2",
  "paste",
@@ -4332,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4345,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4366,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=525764a#525764a56e5cb0d8cff5efa0c2bb1d959bbf4d1f"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=425db4d#425db4da1dfd1e33b45adf7027787ee8cf91a1b4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "88347f3"
+rev = "6e182c6"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "525764a"
+rev = "425db4d"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR is based on the changes made in https://github.com/AleoHQ/snarkVM/pull/2308.

We now pass through an optional `bonded_balances` variable to the `START` CLI  to specify custom genesis bond state. Note that we still enforce that the validators must be from the set of development addresses and the number of validators must match the number specified in `dev_num_validators`

Example Command:

```
snarkos start --dev 0 --dev-num-validators 4 --dev-bonded-balances '{"validator_address_0":["validator_address_0",validator_amount_0], "validator_address_1":["validator_address_1",validator_amount_1], "validator_address_2":["validator_address_2",validator_amount_2], "validator_address_3":["validator_address_3",validator_amount_3], "delegator_address_0":["validator_address_0",delegator_amount_0]}'
```

Note: We may want to make this a `.toml` or JSON file instead.