### PR TITLE
Reintroduce batch certificates to the `PrimaryPing`

### DIFF
--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -70,6 +70,7 @@ use snarkvm::{
     console::prelude::{error, FromBytes, Network, Read, ToBytes, Write},
     ledger::{
         block::Block,
+        committee::Committee,
         narwhal::{BatchCertificate, BatchHeader, Data, Transmission, TransmissionID},
     },
     prelude::{Address, Field, Signature},

--- a/node/bft/events/src/primary_ping.rs
+++ b/node/bft/events/src/primary_ping.rs
@@ -125,6 +125,7 @@ pub mod prop_tests {
     use snarkvm::utilities::{FromBytes, ToBytes};
 
     use bytes::{Buf, BufMut, BytesMut};
+    use indexmap::indexset;
     use proptest::prelude::{any, BoxedStrategy, Strategy};
     use test_strategy::proptest;
 

--- a/node/bft/events/src/primary_ping.rs
+++ b/node/bft/events/src/primary_ping.rs
@@ -19,6 +19,7 @@ pub struct PrimaryPing<N: Network> {
     pub version: u32,
     pub block_locators: BlockLocators<N>,
     pub primary_certificate: Data<BatchCertificate<N>>,
+    pub batch_certificates: IndexMap<Field<N>, Data<BatchCertificate<N>>>,
 }
 
 impl<N: Network> PrimaryPing<N> {
@@ -27,15 +28,28 @@ impl<N: Network> PrimaryPing<N> {
         version: u32,
         block_locators: BlockLocators<N>,
         primary_certificate: Data<BatchCertificate<N>>,
+        batch_certificates: IndexMap<Field<N>, Data<BatchCertificate<N>>>,
     ) -> Self {
-        Self { version, block_locators, primary_certificate }
+        Self { version, block_locators, primary_certificate, batch_certificates }
     }
 }
 
-impl<N: Network> From<(u32, BlockLocators<N>, BatchCertificate<N>)> for PrimaryPing<N> {
+impl<N: Network> From<(u32, BlockLocators<N>, BatchCertificate<N>, IndexSet<BatchCertificate<N>>)> for PrimaryPing<N> {
     /// Initializes a new ping event.
-    fn from((version, block_locators, primary_certificate): (u32, BlockLocators<N>, BatchCertificate<N>)) -> Self {
-        Self::new(version, block_locators, Data::Object(primary_certificate))
+    fn from(
+        (version, block_locators, primary_certificate, batch_certificates): (
+            u32,
+            BlockLocators<N>,
+            BatchCertificate<N>,
+            IndexSet<BatchCertificate<N>>,
+        ),
+    ) -> Self {
+        Self::new(
+            version,
+            block_locators,
+            Data::Object(primary_certificate),
+            batch_certificates.into_iter().map(|c| (c.id(), Data::Object(c))).collect(),
+        )
     }
 }
 
@@ -56,6 +70,17 @@ impl<N: Network> ToBytes for PrimaryPing<N> {
         // Write the primary certificate.
         self.primary_certificate.write_le(&mut writer)?;
 
+        // Determine the number of batch certificates.
+        let num_certificates =
+            u16::try_from(self.batch_certificates.len()).map_err(error)?.min(Committee::<N>::MAX_COMMITTEE_SIZE);
+
+        // Write the number of batch certificates.
+        num_certificates.write_le(&mut writer)?;
+        // Write the batch certificates.
+        for (certificate_id, certificate) in self.batch_certificates.iter().take(usize::from(num_certificates)) {
+            certificate_id.write_le(&mut writer)?;
+            certificate.write_le(&mut writer)?;
+        }
         Ok(())
     }
 }
@@ -69,8 +94,27 @@ impl<N: Network> FromBytes for PrimaryPing<N> {
         // Read the primary certificate.
         let primary_certificate = Data::read_le(&mut reader)?;
 
+        // Read the number of batch certificates.
+        let num_certificates = u16::read_le(&mut reader)?;
+        // Ensure the number of batch certificates is not greater than the maximum committee size.
+        // Note: We allow there to be 0 batch certificates. This is necessary to ensure primary pings are sent.
+        if num_certificates > Committee::<N>::MAX_COMMITTEE_SIZE {
+            return Err(error("The number of batch certificates is greater than the maximum committee size"));
+        }
+
+        // Read the batch certificates.
+        let mut batch_certificates = IndexMap::with_capacity(usize::from(num_certificates));
+        for _ in 0..num_certificates {
+            // Read the certificate ID.
+            let certificate_id = Field::read_le(&mut reader)?;
+            // Read the certificate.
+            let certificate = Data::read_le(&mut reader)?;
+            // Insert the certificate.
+            batch_certificates.insert(certificate_id, certificate);
+        }
+
         // Return the ping event.
-        Ok(Self::new(version, block_locators, primary_certificate))
+        Ok(Self::new(version, block_locators, primary_certificate, batch_certificates))
     }
 }
 
@@ -93,7 +137,7 @@ pub mod prop_tests {
     pub fn any_primary_ping() -> BoxedStrategy<PrimaryPing<CurrentNetwork>> {
         (any::<u32>(), any_block_locators(), any_batch_certificate())
             .prop_map(|(version, block_locators, batch_certificate)| {
-                PrimaryPing::from((version, block_locators, batch_certificate.clone()))
+                PrimaryPing::from((version, block_locators, batch_certificate.clone(), indexset![batch_certificate]))
             })
             .boxed()
     }
@@ -109,5 +153,13 @@ pub mod prop_tests {
             primary_ping.primary_certificate.deserialize_blocking().unwrap(),
             decoded.primary_certificate.deserialize_blocking().unwrap(),
         );
+        assert!(
+            primary_ping
+                .batch_certificates
+                .into_iter()
+                .map(|(a, bc)| (a, bc.deserialize_blocking().unwrap()))
+                .zip(decoded.batch_certificates.into_iter().map(|(a, bc)| (a, bc.deserialize_blocking().unwrap())))
+                .all(|(a, b)| a == b)
+        )
     }
 }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -637,7 +637,7 @@ impl<N: Network> Gateway<N> {
                 bail!("{CONTEXT} {:?}", disconnect.reason)
             }
             Event::PrimaryPing(ping) => {
-                let PrimaryPing { version, block_locators, primary_certificate } = ping;
+                let PrimaryPing { version, block_locators, primary_certificate, batch_certificates } = ping;
 
                 // Ensure the event version is not outdated.
                 if version < Event::<N>::VERSION {
@@ -653,7 +653,11 @@ impl<N: Network> Gateway<N> {
                 }
 
                 // Send the batch certificates to the primary.
-                let _ = self.primary_sender().tx_primary_ping.send((peer_ip, primary_certificate)).await;
+                let _ = self
+                    .primary_sender()
+                    .tx_primary_ping
+                    .send((peer_ip, primary_certificate, batch_certificates))
+                    .await;
                 Ok(())
             }
             Event::TransmissionRequest(request) => {

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -28,7 +28,7 @@ use snarkvm::{
         coinbase::{ProverSolution, PuzzleCommitment},
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::Result,
+    prelude::{Field, Result},
 };
 
 use indexmap::IndexMap;

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -125,7 +125,8 @@ pub struct PrimarySender<N: Network> {
     pub tx_batch_propose: mpsc::Sender<(SocketAddr, BatchPropose<N>)>,
     pub tx_batch_signature: mpsc::Sender<(SocketAddr, BatchSignature<N>)>,
     pub tx_batch_certified: mpsc::Sender<(SocketAddr, Data<BatchCertificate<N>>)>,
-    pub tx_primary_ping: mpsc::Sender<(SocketAddr, Data<BatchCertificate<N>>)>,
+    pub tx_primary_ping:
+        mpsc::Sender<(SocketAddr, Data<BatchCertificate<N>>, IndexMap<Field<N>, Data<BatchCertificate<N>>>)>,
     pub tx_unconfirmed_solution:
         mpsc::Sender<(PuzzleCommitment<N>, Data<ProverSolution<N>>, oneshot::Sender<Result<()>>)>,
     pub tx_unconfirmed_transaction: mpsc::Sender<(N::TransactionID, Data<Transaction<N>>, oneshot::Sender<Result<()>>)>,
@@ -166,7 +167,8 @@ pub struct PrimaryReceiver<N: Network> {
     pub rx_batch_propose: mpsc::Receiver<(SocketAddr, BatchPropose<N>)>,
     pub rx_batch_signature: mpsc::Receiver<(SocketAddr, BatchSignature<N>)>,
     pub rx_batch_certified: mpsc::Receiver<(SocketAddr, Data<BatchCertificate<N>>)>,
-    pub rx_primary_ping: mpsc::Receiver<(SocketAddr, Data<BatchCertificate<N>>)>,
+    pub rx_primary_ping:
+        mpsc::Receiver<(SocketAddr, Data<BatchCertificate<N>>, IndexMap<Field<N>, Data<BatchCertificate<N>>>)>,
     pub rx_unconfirmed_solution:
         mpsc::Receiver<(PuzzleCommitment<N>, Data<ProverSolution<N>>, oneshot::Sender<Result<()>>)>,
     pub rx_unconfirmed_transaction:

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -852,22 +852,21 @@ impl<N: Network> Primary<N> {
                     };
 
                     // Retrieve the batch certificates.
-                    // let batch_certificates = {
-                    //     // Retrieve the current round.
-                    //     let current_round = self_.current_round();
-                    //     // Retrieve the batch certificates for the current round.
-                    //     let mut current_certificates = self_.storage.get_certificates_for_round(current_round);
-                    //     // If there are no batch certificates for the current round,
-                    //     // then retrieve the batch certificates for the previous round.
-                    //     if current_certificates.is_empty() {
-                    //         // Retrieve the previous round.
-                    //         let previous_round = current_round.saturating_sub(1);
-                    //         // Retrieve the batch certificates for the previous round.
-                    //         current_certificates = self_.storage.get_certificates_for_round(previous_round);
-                    //     }
-                    //     current_certificates
-                    // };
-                    let batch_certificates = IndexSet::default();
+                    let batch_certificates = {
+                        // Retrieve the current round.
+                        let current_round = self_.current_round();
+                        // Retrieve the batch certificates for the current round.
+                        let mut current_certificates = self_.storage.get_certificates_for_round(current_round);
+                        // If there are no batch certificates for the current round,
+                        // then retrieve the batch certificates for the previous round.
+                        if current_certificates.is_empty() {
+                            // Retrieve the previous round.
+                            let previous_round = current_round.saturating_sub(1);
+                            // Retrieve the batch certificates for the previous round.
+                            current_certificates = self_.storage.get_certificates_for_round(previous_round);
+                        }
+                        current_certificates
+                    };
 
                     // Construct the primary ping.
                     let primary_ping = PrimaryPing::from((

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -760,6 +760,34 @@ impl<N: Network> Primary<N> {
         }
         Ok(())
     }
+
+    /// Processes a batch certificate from a primary ping.
+    ///
+    /// This method performs the following steps:
+    /// 1. Stores the given batch certificate, after ensuring it is valid.
+    /// 2. If there are enough certificates to reach quorum threshold for the current round,
+    ///  then proceed to advance to the next round.
+    async fn process_batch_certificate_from_ping(
+        &self,
+        peer_ip: SocketAddr,
+        certificate: BatchCertificate<N>,
+    ) -> Result<()> {
+        // Ensure storage does not already contain the certificate.
+        if self.storage.contains_certificate(certificate.id()) {
+            return Ok(());
+        }
+
+        // Ensure the batch certificate is from an authorized validator.
+        if !self.gateway.is_authorized_validator_ip(peer_ip) {
+            // Proceed to disconnect the validator.
+            self.gateway.disconnect(peer_ip);
+            bail!("Malicious peer - Received a batch certificate from an unauthorized validator IP ({peer_ip})");
+        }
+
+        // Store the certificate, after ensuring it is valid.
+        self.sync_with_certificate_from_peer(peer_ip, certificate).await?;
+        Ok(())
+    }
 }
 
 impl<N: Network> Primary<N> {
@@ -823,8 +851,31 @@ impl<N: Network> Primary<N> {
                         }
                     };
 
+                    // Retrieve the batch certificates.
+                    // let batch_certificates = {
+                    //     // Retrieve the current round.
+                    //     let current_round = self_.current_round();
+                    //     // Retrieve the batch certificates for the current round.
+                    //     let mut current_certificates = self_.storage.get_certificates_for_round(current_round);
+                    //     // If there are no batch certificates for the current round,
+                    //     // then retrieve the batch certificates for the previous round.
+                    //     if current_certificates.is_empty() {
+                    //         // Retrieve the previous round.
+                    //         let previous_round = current_round.saturating_sub(1);
+                    //         // Retrieve the batch certificates for the previous round.
+                    //         current_certificates = self_.storage.get_certificates_for_round(previous_round);
+                    //     }
+                    //     current_certificates
+                    // };
+                    let batch_certificates = IndexSet::default();
+
                     // Construct the primary ping.
-                    let primary_ping = PrimaryPing::from((<Event<N>>::VERSION, block_locators, primary_certificate));
+                    let primary_ping = PrimaryPing::from((
+                        <Event<N>>::VERSION,
+                        block_locators,
+                        primary_certificate,
+                        batch_certificates,
+                    ));
                     // Broadcast the event.
                     self_.gateway.broadcast(Event::PrimaryPing(primary_ping));
                 }
@@ -834,7 +885,7 @@ impl<N: Network> Primary<N> {
         // Start the primary ping handler.
         let self_ = self.clone();
         self.spawn(async move {
-            while let Some((peer_ip, primary_certificate)) = rx_primary_ping.recv().await {
+            while let Some((peer_ip, primary_certificate, batch_certificates)) = rx_primary_ping.recv().await {
                 // If the primary is not synced, then do not process the primary ping.
                 if !self_.sync.is_synced() {
                     trace!("Skipping a primary ping from '{peer_ip}' {}", "(node is syncing)".dimmed());
@@ -854,6 +905,34 @@ impl<N: Network> Primary<N> {
                         // Process the primary certificate.
                         if let Err(e) = self_.process_batch_certificate_from_peer(peer_ip, primary_certificate).await {
                             warn!("Cannot process a primary certificate in a 'PrimaryPing' from '{peer_ip}' - {e}");
+                        }
+                    });
+                }
+
+                // Iterate through the batch certificates.
+                for (certificate_id, certificate) in batch_certificates {
+                    // Ensure storage does not already contain the certificate.
+                    if self_.storage.contains_certificate(certificate_id) {
+                        continue;
+                    }
+                    // Spawn a task to process the batch certificate.
+                    let self_ = self_.clone();
+                    tokio::spawn(async move {
+                        // Deserialize the batch certificate in the primary ping.
+                        let Ok(batch_certificate) = spawn_blocking!(certificate.deserialize_blocking()) else {
+                            warn!("Failed to deserialize batch certificate in a 'PrimaryPing' from '{peer_ip}'");
+                            return;
+                        };
+                        // Ensure the batch certificate ID matches.
+                        if batch_certificate.id() != certificate_id {
+                            warn!("Batch certificate ID mismatch in a 'PrimaryPing' from '{peer_ip}'");
+                            // Proceed to disconnect the validator.
+                            self_.gateway.disconnect(peer_ip);
+                            return;
+                        }
+                        // Process the batch certificate.
+                        if let Err(e) = self_.process_batch_certificate_from_ping(peer_ip, batch_certificate).await {
+                            warn!("Cannot process a batch certificate in a 'PrimaryPing' from '{peer_ip}' - {e}");
                         }
                     });
                 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR reverts some of the changes in https://github.com/AleoHQ/snarkOS/pull/3082, and reintroduces the batch certificates in the primary ping.

We may want to consider reducing the `BlockLocators` range to reduce network load. It is currently 100 block_hashes + block_height / 10_000 additional block hashes being sent. Which could be quite large as the chain grows.