### PR TITLE
fix: validator doesn't participate in consensus

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -251,6 +251,7 @@ impl<N: Network> BFT<N> {
             // Update to the next round in storage.
             if let Err(e) = self.storage().increment_to_next_round(current_round) {
                 warn!("BFT failed to increment to the next round from round {current_round} - {e}");
+                return false;
             }
             // Update the timer for the leader certificate.
             self.leader_certificate_timer.store(now(), Ordering::SeqCst);


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

the problem is  that when the current round is sent to the bft using `bft_sender.send_primary_round_to_bft(current_round).await`, if this returns true, the primary starts to propose batches. The problem is that it also returns true when the storage fails to increment to next round. If this returns false, it fixes the issue (well the one I was seeing, where the 4th node syncs but can't participate in consensus)

## Test Plan

steps to reproduce (without the fix):
* clear the local ledger
* start 3 nodes and wait for about 30 rounds
* start 4th node
* notice that it syncs up, but not quite, and doesn't participate in consensus and keeps on resending an old batch

with the fix:
* 4th node syncs and starts to participate in consensus

## Related PRs

https://github.com/AleoHQ/snarkOS/pull/3074
