### PR TITLE
[Optimize] Cache the recently queried committees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,6 +3309,7 @@ version = "2.2.7"
 dependencies = [
  "async-trait",
  "indexmap 2.2.3",
+ "lru",
  "parking_lot",
  "rand",
  "snarkvm",

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 default = [ ]
 ledger = [ "rand", "tokio", "tracing" ]
 ledger-write = [ ]
-mock = [ "parking_lot", "tracing" ]
+mock = [ "tracing" ]
 prover = [ ]
 test = [ "mock", "translucent" ]
 translucent = [ "ledger" ]
@@ -32,9 +32,11 @@ version = "0.1"
 version = "2.1"
 features = [ "serde", "rayon" ]
 
+[dependencies.lru]
+version = "0.12"
+
 [dependencies.parking_lot]
 version = "0.12"
-optional = true
 
 [dependencies.rand]
 version = "0.8"

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2021"
 
 [features]
 default = [ ]
-ledger = [ "rand", "tokio", "tracing" ]
+ledger = [ "parking_lot", "rand", "tokio", "tracing" ]
 ledger-write = [ ]
-mock = [ "tracing" ]
+mock = [ "parking_lot", "tracing" ]
 prover = [ ]
 test = [ "mock", "translucent" ]
 translucent = [ "ledger" ]
@@ -37,6 +37,7 @@ version = "0.12"
 
 [dependencies.parking_lot]
 version = "0.12"
+optional = true
 
 [dependencies.rand]
 version = "0.8"

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -44,8 +44,8 @@ const COMMITTEE_CACHE_SIZE: usize = 16;
 pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     ledger: Ledger<N, C>,
     coinbase_verifying_key: Arc<CoinbaseVerifyingKey<N>>,
-    shutdown: Arc<AtomicBool>,
     committee_cache: Arc<Mutex<LruCache<u64, Committee<N>>>>,
+    shutdown: Arc<AtomicBool>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
@@ -53,7 +53,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     pub fn new(ledger: Ledger<N, C>, shutdown: Arc<AtomicBool>) -> Self {
         let coinbase_verifying_key = Arc::new(ledger.coinbase_puzzle().coinbase_verifying_key().clone());
         let committee_cache = Arc::new(Mutex::new(LruCache::new(COMMITTEE_CACHE_SIZE.try_into().unwrap())));
-        Self { ledger, coinbase_verifying_key, shutdown, committee_cache }
+        Self { ledger, coinbase_verifying_key, committee_cache, shutdown }
     }
 }
 
@@ -144,6 +144,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             Some(committee) => {
                 // Insert the committee into the cache.
                 self.committee_cache.lock().push(round, committee.clone());
+                // Return the committee.
                 Ok(committee)
             }
             // Return the current committee if the round is in the future.


### PR DESCRIPTION
Committee queries are very prominent in CPU profiles, even with small committee sizes - they are performed quite often, and the deserialization involved is relatively expensive.

This PR adds a simple, small LRU cache that speeds them up; I've double-checked its results by obtaining a new CPU profile (which - as expected - is very different), and ensuring that the cache gets hit (which happens quite a lot).