### PR TITLE
[ZKS-01] Add round check in signed proposals cache

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -525,6 +525,13 @@ impl<N: Network> Primary<N> {
         if let Some((signed_round, signed_batch_id, signature)) =
             self.signed_proposals.read().get(&batch_author).copied()
         {
+            // If the signed round is ahead of the peer's batch round, then the validator is malicious.
+            if signed_round > batch_header.round() {
+                // Proceed to disconnect the validator.
+                self.gateway.disconnect(peer_ip);
+                bail!("Malicious peer - proposed a batch for a previous round ({})", batch_header.round());
+            }
+
             // If the round matches and the batch ID differs, then the validator is malicious.
             if signed_round == batch_header.round() && signed_batch_id != batch_header.batch_id() {
                 // Proceed to disconnect the validator.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds a check for malicious validators that try to have peers double-sign proposals by circumventing the `signed_proposals` cache. The simple check is to now disconnect from peers that request signatures on proposals that are behind the `signed_round` (of other proposals they've sent).


Audit Finding: **[zksecurity 01] Lack of Dag Containment Could Lead To Safety Violation**