### PR TITLE
[Optimize] Skip the scheduled batch proposal if already proposing

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -900,6 +900,11 @@ impl<N: Network> Primary<N> {
                     debug!("Skipping batch proposal {}", "(node is syncing)".dimmed());
                     continue;
                 }
+                // A best-effort attempt to skip the scheduled batch proposal if
+                // round progression already triggered one.
+                if self_.propose_lock.try_lock().is_err() {
+                    continue;
+                };
                 // If there is no proposed batch, attempt to propose a batch.
                 // Note: Do NOT spawn a task around this function call. Proposing a batch is a critical path,
                 // and only one batch needs be proposed at a time.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -903,6 +903,7 @@ impl<N: Network> Primary<N> {
                 // A best-effort attempt to skip the scheduled batch proposal if
                 // round progression already triggered one.
                 if self_.propose_lock.try_lock().is_err() {
+                    trace!("Skipping batch proposal {}", "(node is already proposing)".dimmed());
                     continue;
                 };
                 // If there is no proposed batch, attempt to propose a batch.


### PR DESCRIPTION
If I'm not missing anything, a batch proposal can be triggered by a timed loop or round progression, and if we're already proposing a batch for a new round, it seems reasonable to me that we may skip the timed one. This would save some network traffic and CPU use for the validators.

I tested it locally and can see the skip happening from time to time, which means those attempts can currently overlap.