### PR TITLE
[Optimize] Cache the latest leader

### DIFF
--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 default = [ ]
 ledger = [ "rand", "tokio", "tracing" ]
 ledger-write = [ ]
-mock = [ "parking_lot", "tracing" ]
+mock = [ "tracing" ]
 prover = [ ]
 test = [ "mock", "translucent" ]
 translucent = [ "ledger" ]
@@ -34,7 +34,6 @@ features = [ "serde", "rayon" ]
 
 [dependencies.parking_lot]
 version = "0.12"
-optional = true
 
 [dependencies.rand]
 version = "0.8"

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -41,6 +41,7 @@ use std::{
 const COMMITTEE_CACHE_SIZE: usize = 16;
 
 /// A core ledger service.
+#[allow(clippy::type_complexity)]
 pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     ledger: Ledger<N, C>,
     coinbase_verifying_key: Arc<CoinbaseVerifyingKey<N>>,

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -20,7 +20,7 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::{bail, ensure, Field, Network, Result},
+    prelude::{bail, ensure, Address, Field, Network, Result},
 };
 
 use indexmap::IndexMap;
@@ -67,6 +67,14 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     fn latest_block(&self) -> Block<N> {
         unreachable!("MockLedgerService does not support latest_block")
     }
+
+    /// Returns the latest cached leader and its associated round.
+    fn latest_leader(&self) -> Option<(u64, Address<N>)> {
+        None
+    }
+
+    /// Updates the latest cached leader and its associated round.
+    fn update_latest_leader(&self, _round: u64, _leader: Address<N>) {}
 
     /// Returns `true` if the given block height exists in the canonical ledger.
     fn contains_block_height(&self, height: u32) -> bool {

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -20,7 +20,7 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::{bail, Field, Network, Result},
+    prelude::{bail, Address, Field, Network, Result},
 };
 
 use indexmap::IndexMap;
@@ -54,6 +54,16 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     /// Returns the latest block in the ledger.
     fn latest_block(&self) -> Block<N> {
         unreachable!("Latest block does not exist in prover")
+    }
+
+    /// Returns the latest cached leader and its associated round.
+    fn latest_leader(&self) -> Option<(u64, Address<N>)> {
+        unreachable!("Latest leader does not exist in prover");
+    }
+
+    /// Updates the latest cached leader and its associated round.
+    fn update_latest_leader(&self, _round: u64, _leader: Address<N>) {
+        unreachable!("Latest leader does not exist in prover");
     }
 
     /// Returns `true` if the given block height exists in the ledger.

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -19,7 +19,7 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
     },
-    prelude::{Field, Network, Result},
+    prelude::{Address, Field, Network, Result},
 };
 
 use indexmap::IndexMap;
@@ -35,6 +35,12 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
 
     /// Returns the latest block in the ledger.
     fn latest_block(&self) -> Block<N>;
+
+    /// Returns the latest cached leader and its associated round.
+    fn latest_leader(&self) -> Option<(u64, Address<N>)>;
+
+    /// Updates the latest cached leader and its associated round.
+    fn update_latest_leader(&self, round: u64, leader: Address<N>);
 
     /// Returns `true` if the given block height exists in the ledger.
     fn contains_block_height(&self, height: u32) -> bool;

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -24,7 +24,7 @@ use snarkvm::{
         store::ConsensusStorage,
         Ledger,
     },
-    prelude::{narwhal::BatchCertificate, Field, Network, Result},
+    prelude::{narwhal::BatchCertificate, Address, Field, Network, Result},
 };
 use std::{
     fmt,
@@ -65,6 +65,16 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     /// Returns the latest block in the ledger.
     fn latest_block(&self) -> Block<N> {
         self.inner.latest_block()
+    }
+
+    /// Returns the latest cached leader and its associated round.
+    fn latest_leader(&self) -> Option<(u64, Address<N>)> {
+        self.inner.latest_leader()
+    }
+
+    /// Updates the latest cached leader and its associated round.
+    fn update_latest_leader(&self, round: u64, leader: Address<N>) {
+        self.inner.update_latest_leader(round, leader);
     }
 
     /// Returns `true` if the given block height exists in the ledger.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -463,6 +463,7 @@ mod tests {
             committee::Committee,
             narwhal::{BatchCertificate, Subdag, Transmission, TransmissionID},
         },
+        prelude::Address,
     };
 
     use bytes::Bytes;
@@ -489,6 +490,8 @@ mod tests {
             fn latest_round(&self) -> u64;
             fn latest_block_height(&self) -> u32;
             fn latest_block(&self) -> Block<N>;
+            fn latest_leader(&self) -> Option<(u64, Address<N>)>;
+            fn update_latest_leader(&self, round: u64, leader: Address<N>);
             fn contains_block_height(&self, height: u32) -> bool;
             fn get_block_height(&self, hash: &N::BlockHash) -> Result<u32>;
             fn get_block_hash(&self, height: u32) -> Result<N::BlockHash>;


### PR DESCRIPTION
Leader computation is a relatively costly operation (it can take more than 1ms with a 4-member committee), and it is currently called several times for the same round. With a little bit of extra code and with negligible overhead we can cache the latest computed leader and in case of a hit, the leader can be procured 3 orders of magnitude (under 1 µs) faster.

note: this PR has a little bit of overlap (mostly related to dependencies) with https://github.com/AleoHQ/snarkOS/pull/3106