### PR TITLE
Reduce redundant debug-logging on larger networks

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -919,10 +919,7 @@ impl<N: Network> Gateway<N> {
         }
 
         // Then go through remaining peers in `cached_view` to resolve the peers not in new view (= removed ones).
-        for (peer_ip, address) in cached_view.iter() {
-            if new_view.contains_key(peer_ip) {
-                continue;
-            }
+        for (peer_ip, address) in cached_view.iter().filter(|(peer_ip, _)| !new_view.contains_key(peer_ip)) {
             let removed_validator = format!("{peer_ip} - {address}").dimmed();
             debug!("  - {}", removed_validator);
         }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -126,7 +126,7 @@ pub struct Gateway<N: Network> {
     /// prevent simultaneous "two-way" connections between two peers (i.e. both nodes simultaneously
     /// attempt to connect to each other). This set is used to prevent this from happening.
     connecting_peers: Arc<Mutex<IndexSet<SocketAddr>>>,
-    /// The cached view of connected validators validators.
+    /// The cached view of connected validator.
     cached_validator_view: Arc<Mutex<HashMap<SocketAddr, Address<N>>>>,
     /// The primary sender.
     primary_sender: Arc<OnceCell<PrimarySender<N>>>,

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -890,7 +890,7 @@ impl<N: Network> Gateway<N> {
         let mut new_view = IndexMap::with_capacity(resolved_peer_ips.len());
 
         // `resolver.get_address()` should always return address for SocketAddrs in `resolved_peer_ips`,
-        // so we do `filter_map` to reduce a noise inside loop
+        // so we do `filter_map` to reduce noise inside a loop.
         for (peer_ip, new_address) in resolved_peer_ips
             .iter()
             .filter_map(|peer_ip| self.resolver.get_address(*peer_ip).map(|address| (peer_ip, address)))


### PR DESCRIPTION
In larger BFT networks, some of the recurring debug-logging events are currently unnecessarily noisy which makes observing node/network operation harder. This PR improves this in two fronts.

**Logging only validator set changes**. Currently, each `Gateway` logs all connected validators (their SocketAddrs and Aleo addresses) in every heartbeat. During a stable operation in network of $n$ nodes, this means $n(n-1)$ redundant debug log lines, every 15 seconds. This PR instead only logs the validator set differences between each heartbeat, indicating connected and disconnected validators with `+` and `-` symbols . For example:
```
 INFO Connected to 41 validators (of 49 bonded validators)                                 
DEBUG   + 10.166.0.3:5011 - aleo1sufp275hshd7srrkxwdf7yczmc89em6e5ly933ftnaz64jlq8qysnuz88d
DEBUG   + 10.166.0.3:5003 - aleo12ux3gdauck0v60westgcpqj7v8rrcr3v346e4jtq04q7kkt22czsh808v2
DEBUG   + 10.166.0.3:5010 - aleo1s2tyzgqr9p95sxtj9t0s38cmz9pa26edxp4nv0s8mk3tmdzmqgzsctqhxg
DEBUG   - 10.166.0.3:5005 - aleo1l4z0j5cn5s6u6tpuqcj6anh30uaxkdfzatt9seap0atjcqk6nq9qnm9eqf
DEBUG   - 10.166.0.3:5008 - aleo1xh2lnryvtzxcvlz8zzgranu6yldaq5257cac44de4v0aasgu45yq3yk3yv
```
As this change involves using a `RWLock` and doing some extra allocations, it is only enabled when `tracing::Level::DEBUG` is enabled.

**Folding batch proposal resends into a single line**. Currently, when resending proposals, `Primary::propose_batch()` logs a single line per each non-signer `SocketAddr`s. This is repeated every 2.5 seconds and during network events, can result in a lot of redundant log spam. This PR folds the information content into a single debug-log line before resending the proposals.

I estimate that in larger networks these changes can reduce the total aggregated log size significantly due to combinatorial explosion - using my recent debug log of a 16-hour test run in a 50-node devnet as an example the reduction was ~50% (of a total of 7.1M lines, 3.5M lines were removed).