### PR TITLE
[ZKS-04] Perform garbage collection on subdag commit

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -495,6 +495,8 @@ impl<N: Network> BFT<N> {
         &self,
         leader_certificate: BatchCertificate<N>,
     ) -> Result<()> {
+        // Fetch the leader round.
+        let latest_leader_round = leader_certificate.round();
         // Determine the list of all previous leader certificates since the last committed round.
         // The order of the leader certificates is from **newest** to **oldest**.
         let mut leader_certificates = vec![leader_certificate.clone()];
@@ -621,6 +623,10 @@ impl<N: Network> BFT<N> {
                 }
             }
         }
+
+        // Perform garbage collection based on the latest committed leader round.
+        self.storage().garbage_collect_certificates(latest_leader_round);
+
         Ok(())
     }
 

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -204,6 +204,12 @@ impl<N: Network> Storage<N> {
         // Update the current round.
         self.current_round.store(next_round, Ordering::SeqCst);
 
+        // Perform garbage collection.
+        self.garbage_collect_certificates(next_round);
+    }
+
+    /// Update the storage by performing garbage collection based on the next round.
+    fn garbage_collect_certificates(&self, next_round: u64) {
         // Fetch the current GC round.
         let current_gc_round = self.gc_round();
         // Compute the next GC round.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -203,13 +203,10 @@ impl<N: Network> Storage<N> {
     fn update_current_round(&self, next_round: u64) {
         // Update the current round.
         self.current_round.store(next_round, Ordering::SeqCst);
-
-        // Perform garbage collection.
-        self.garbage_collect_certificates(next_round);
     }
 
     /// Update the storage by performing garbage collection based on the next round.
-    fn garbage_collect_certificates(&self, next_round: u64) {
+    pub(crate) fn garbage_collect_certificates(&self, next_round: u64) {
         // Fetch the current GC round.
         let current_gc_round = self.gc_round();
         // Compute the next GC round.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR performs garbage collection on subdag commits only. Previously we were performing GC on every round advancement, which was relying on the improbability of going 100 rounds without committing a subdag. Now we guarantee that we don't throw away older certificates in the case we do go more than MAX_GC_ROUNDS without a commit.

Note: We may also consider adding a manual skip of older certificates in the commit phase.

Audit Finding: **[zksecurity 04] Garbage Collection Can Block Commits From Happening**