### PR TITLE
[ZKS-02] Update the set of authorized validators 

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -89,6 +89,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         self.ledger.get_hash(height)
     }
 
+    /// Returns the block round for the given block height, if it exists.
+    fn get_block_round(&self, height: u32) -> Result<u64> {
+        self.ledger.get_block(height).map(|block| block.round())
+    }
+
     /// Returns the block for the given block height.
     fn get_block(&self, height: u32) -> Result<Block<N>> {
         self.ledger.get_block(height)

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -71,6 +71,11 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         bail!("Block {height} does not exist in prover")
     }
 
+    /// Returns the block round for the given block height, if it exists.
+    fn get_block_round(&self, height: u32) -> Result<u64> {
+        bail!("Block {height} does not exist in prover")
+    }
+
     /// Returns the block for the given block height.
     fn get_block(&self, height: u32) -> Result<Block<N>> {
         bail!("Block {height} does not exist in prover")

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -45,6 +45,9 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     /// Returns the block hash for the given block height, if it exists.
     fn get_block_hash(&self, height: u32) -> Result<N::BlockHash>;
 
+    /// Returns the block round for the given block height, if it exists.
+    fn get_block_round(&self, height: u32) -> Result<u64>;
+
     /// Returns the block for the given block height.
     fn get_block(&self, height: u32) -> Result<Block<N>>;
 

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -82,6 +82,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         self.inner.get_block_hash(height)
     }
 
+    /// Returns the block round for the given block height, if it exists.
+    fn get_block_round(&self, height: u32) -> Result<u64> {
+        self.inner.get_block_round(height)
+    }
+
     /// Returns the block for the given block height.
     fn get_block(&self, height: u32) -> Result<Block<N>> {
         self.inner.get_block(height)

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1365,16 +1365,22 @@ mod prop_tests {
     };
     use snarkos_account::Account;
     use snarkos_node_bft_ledger_service::MockLedgerService;
+    use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkos_node_tcp::P2P;
     use snarkvm::{
-        ledger::committee::{
-            prop_tests::{CommitteeContext, ValidatorSet},
-            Committee,
+        ledger::{
+            committee::{
+                prop_tests::{CommitteeContext, ValidatorSet},
+                test_helpers::sample_committee_for_round_and_members,
+                Committee,
+            },
+            narwhal::{batch_certificate::test_helpers::sample_batch_certificate_for_round, BatchHeader},
         },
         prelude::{MainnetV0, PrivateKey},
+        utilities::TestRng,
     };
 
-    use indexmap::IndexMap;
+    use indexmap::{IndexMap, IndexSet};
     use proptest::{
         prelude::{any, any_with, Arbitrary, BoxedStrategy, Just, Strategy},
         sample::Selector,
@@ -1555,64 +1561,48 @@ mod prop_tests {
         );
         assert_eq!(gateway.num_workers(), workers.len() as u8);
     }
+
     #[proptest]
     fn test_is_authorized_validator(#[strategy(any_valid_dev_gateway())] input: GatewayInput) {
-        use indexmap::IndexSet;
-        use crate::helpers::Storage;
-        use snarkos_account::Account;
-        use snarkos_node_bft_ledger_service::MockLedgerService;
-        use snarkos_node_bft_storage_service::BFTMemoryService;
-        use snarkvm::{
-            ledger::{
-                narwhal::batch_certificate::test_helpers::sample_batch_certificate_for_round,
-                committee::test_helpers::sample_committee_for_round_and_members,
-            },
-            utilities::TestRng,
-        };
         let rng = &mut TestRng::default();
 
-        // Initialize the round parameters. 
-        let current_round = 2; 
-        let committee_size = 4; 
-        let max_gc_rounds = snarkvm::ledger::narwhal::BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64;
+        // Initialize the round parameters.
+        let current_round = 2;
+        let committee_size = 4;
+        let max_gc_rounds = BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64;
         let (_, _, private_key, dev) = input;
         let account = Account::try_from(private_key).unwrap();
 
-        // Sample the certificates. 
-        let mut certificates = IndexSet::new(); 
-        for _ in 0..committee_size{ 
-            certificates.insert(sample_batch_certificate_for_round(current_round, rng)); 
+        // Sample the certificates.
+        let mut certificates = IndexSet::new();
+        for _ in 0..committee_size {
+            certificates.insert(sample_batch_certificate_for_round(current_round, rng));
         }
-        let addresses: Vec<_> = certificates.iter()
-            .map(|certificate| certificate.author())
-            .collect();
+        let addresses: Vec<_> = certificates.iter().map(|certificate| certificate.author()).collect();
         // Initialize the committee.
-        let committee = sample_committee_for_round_and_members(
-            current_round,
-            addresses, 
-            rng,
-        );
-        // Sample extra certificates from non-committee members. 
-        for _ in 0..committee_size{ 
-            certificates.insert(sample_batch_certificate_for_round(current_round, rng)); 
-        }    
+        let committee = sample_committee_for_round_and_members(current_round, addresses, rng);
+        // Sample extra certificates from non-committee members.
+        for _ in 0..committee_size {
+            certificates.insert(sample_batch_certificate_for_round(current_round, rng));
+        }
         // Initialize the ledger.
         let ledger = Arc::new(MockLedgerService::new(committee.clone()));
         // Initialize the storage.
         let storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
-        // Initialize the gateway. 
-        let gateway = Gateway::new(account.clone(), storage.clone(), ledger.clone(), dev.ip(), &[], dev.port()).unwrap();
+        // Initialize the gateway.
+        let gateway =
+            Gateway::new(account.clone(), storage.clone(), ledger.clone(), dev.ip(), &[], dev.port()).unwrap();
         // Insert certificate to the storage.
         for certificate in certificates.iter() {
             storage.testing_only_insert_certificate_testing_only(certificate.clone());
         }
         // Check that the current committee members are authorized validators.
-        for i in 0..certificates.clone().len(){ 
-            let is_authorized = gateway.is_authorized_validator_address(certificates[i].author()); 
-            if i < committee_size { 
-                assert!(is_authorized); 
-            } else { 
-                assert!(!is_authorized); 
+        for i in 0..certificates.clone().len() {
+            let is_authorized = gateway.is_authorized_validator_address(certificates[i].author());
+            if i < committee_size {
+                assert!(is_authorized);
+            } else {
+                assert!(!is_authorized);
             }
         }
     }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -337,8 +337,8 @@ impl<N: Network> Gateway<N> {
         // Retrieve the previous block height to consider from the sync tolerance.
         let previous_block_height = self.ledger.latest_block_height().saturating_sub(MAX_BLOCKS_BEHIND);
         // Determine if the validator is in any of the previous committee lookbacks.
-        let exists_in_previous_committee_lookback = match self.ledger.get_block(previous_block_height) {
-            Ok(block) => (block.round()..self.storage.current_round()).step_by(2).any(|round| {
+        let exists_in_previous_committee_lookback = match self.ledger.get_block_round(previous_block_height) {
+            Ok(block_round) => (block_round..self.storage.current_round()).step_by(2).any(|round| {
                 self.ledger
                     .get_committee_lookback_for_round(round)
                     .map_or(false, |committee| committee.is_committee_member(validator_address))

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -108,7 +108,7 @@ impl<N: Network> Primary<N> {
         dev: Option<u16>,
     ) -> Result<Self> {
         // Initialize the gateway.
-        let gateway = Gateway::new(account, ledger.clone(), ip, trusted_validators, dev)?;
+        let gateway = Gateway::new(account, storage.clone(), ledger.clone(), ip, trusted_validators, dev)?;
         // Initialize the sync module.
         let sync = Sync::new(gateway.clone(), storage.clone(), ledger.clone());
         // Initialize the primary instance.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -492,6 +492,7 @@ mod tests {
             fn contains_block_height(&self, height: u32) -> bool;
             fn get_block_height(&self, hash: &N::BlockHash) -> Result<u32>;
             fn get_block_hash(&self, height: u32) -> Result<N::BlockHash>;
+            fn get_block_round(&self, height: u32) -> Result<u64>;
             fn get_block(&self, height: u32) -> Result<Block<N>>;
             fn get_blocks(&self, heights: Range<u32>) -> Result<Vec<Block<N>>>;
             fn get_solution(&self, solution_id: &PuzzleCommitment<N>) -> Result<ProverSolution<N>>;

--- a/node/bft/tests/components/mod.rs
+++ b/node/bft/tests/components/mod.rs
@@ -59,12 +59,15 @@ pub fn sample_storage<N: Network>(ledger: Arc<TranslucentLedgerService<N, Consen
 }
 
 /// Samples a new gateway with the given ledger.
-pub fn sample_gateway<N: Network>(ledger: Arc<TranslucentLedgerService<N, ConsensusMemory<N>>>) -> Gateway<N> {
+pub fn sample_gateway<N: Network>(
+    storage: Storage<N>,
+    ledger: Arc<TranslucentLedgerService<N, ConsensusMemory<N>>>,
+) -> Gateway<N> {
     let num_nodes: u16 = ledger.current_committee().unwrap().num_members().try_into().unwrap();
     let (accounts, _committee) = primary::new_test_committee(num_nodes);
     let account = Account::from_str(&accounts[0].private_key().to_string()).unwrap();
     // Initialize the gateway.
-    Gateway::new(account, ledger, None, &[], None).unwrap()
+    Gateway::new(account, storage, ledger, None, &[], None).unwrap()
 }
 
 /// Samples a new worker with the given ledger.
@@ -72,7 +75,7 @@ pub fn sample_worker<N: Network>(id: u8, ledger: Arc<TranslucentLedgerService<N,
     // Sample a storage.
     let storage = sample_storage(ledger.clone());
     // Sample a gateway.
-    let gateway = sample_gateway(ledger.clone());
+    let gateway = sample_gateway(storage.clone(), ledger.clone());
     // Sample a dummy proposed batch.
     let proposed_batch = Arc::new(RwLock::new(None));
     // Construct the worker instance.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the set of authorized validators to include current committee members along with committee members from rounds up until the sync range tolerance, which is currently set at one block before nodes are considered out-of-sync. 

Previously, the code would fetch the committee lookback at the latest ledger round, but this is not always the same as the committee lookback from the storage’s current round. For example, if the latest ledger round is ‘n’ but the current round is ‘n+2’, the committees may disagree. In some cases, this may lead to validators being disconnected who should still be considered as authorized to participate in consensus. 

One of the implications of the previous logic is that if these committees differ substantially and affect (2f+1), then a validator will be unable to connect to a quorum of nodes in the current committee and halt. 

Audit Finding: **[zksecurity 02] Dynamic Committee Feature is Not Safe**