### PR TITLE
[Fix] Updates conditions to advance from odd and even rounds 

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -323,10 +323,9 @@ impl<N: Network> BFT<N> {
         self.is_even_round_ready_for_next_round(current_certificates, committee_lookback, current_round)
     }
 
-    /// Returns 'true' under one of the following conditions:
-    ///  - If the leader certificate is set for the current even round,
-    ///  - The timer for the leader certificate has expired, and we can
-    ///    achieve quorum threshold (2f + 1) without the leader.
+    /// Returns 'true' if the quorum threshold is reached for this round under one of the following conditions:
+    ///  - If the leader certificate is set for the current even round.
+    ///  - The timer for the leader certificate has expired.
     fn is_even_round_ready_for_next_round(
         &self,
         certificates: IndexSet<BatchCertificate<N>>,
@@ -360,9 +359,8 @@ impl<N: Network> BFT<N> {
         self.leader_certificate_timer.load(Ordering::SeqCst) + MAX_LEADER_CERTIFICATE_DELAY_IN_SECS <= now()
     }
 
-    /// Returns 'true' if any of the following conditions hold:
-    ///  - The leader certificate is 'None'.
-    ///  - The leader certificate reached quorum threshold `(2f + 1)` (in the previous certificates in the current round).
+    /// Returns 'true' if the quorum threshold is reached for this round under one of the following conditions:
+    ///  - The leader certificate is `None`.
     ///  - The leader certificate is not included up to availability threshold `(f + 1)` (in the previous certificates of the current round).
     ///  - The leader certificate timer has expired.
     fn is_leader_quorum_or_nonleaders_available(&self, odd_round: u64) -> bool {
@@ -853,6 +851,7 @@ mod tests {
     use snarkos_node_bft_ledger_service::MockLedgerService;
     use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkvm::{
+        console::account::{Address, PrivateKey},
         ledger::{
             committee::Committee,
             narwhal::batch_certificate::test_helpers::{sample_batch_certificate, sample_batch_certificate_for_round},
@@ -861,7 +860,7 @@ mod tests {
     };
 
     use anyhow::Result;
-    use indexmap::IndexSet;
+    use indexmap::{IndexMap, IndexSet};
     use std::sync::Arc;
 
     type CurrentNetwork = snarkvm::console::network::MainnetV0;

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -398,11 +398,9 @@ impl<N: Network> BFT<N> {
             // If there is no leader certificate for the previous round, return 'true'.
             return true;
         };
-        // Retrieve the leader certificate ID.
-        let leader_certificate_id = leader_certificate.id();
         // Compute the stake for the leader certificate.
         let (stake_with_leader, stake_without_leader) =
-            self.compute_stake_for_leader_certificate(leader_certificate_id, current_certificates, &committee_lookback);
+            self.compute_stake_for_leader_certificate(leader_certificate.id(), current_certificates, &committee_lookback);
         // Return 'true' if any of the following conditions hold:
         stake_with_leader >= committee_lookback.availability_threshold()
             || stake_without_leader >= committee_lookback.quorum_threshold()

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -381,7 +381,7 @@ impl<N: Network> BFT<N> {
         // Retrieve the authors of the current certificates. 
         let authors = current_certificates.clone().into_iter().map(|c| c.author()).collect();
         // Check if quorum threshold is reached. 
-        let is_quorum = previous_committee.clone().is_quorum_threshold_reached(&authors); 
+        let is_quorum = committee_lookback.clone().is_quorum_threshold_reached(&authors); 
         if !is_quorum { 
             info!("BFT failed to advance to the next round - quorum threshold not reached in odd round {current_round}. ");
             return false; 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -323,7 +323,7 @@ impl<N: Network> BFT<N> {
         self.is_even_round_ready_for_next_round(current_certificates, committee_lookback, current_round)
     }
 
-    /// Returns 'true' if the quorum threshold is reached for this round under one of the following conditions:
+    /// Returns 'true' if the quorum threshold `(2f + 1)` is reached for this round under one of the following conditions:
     ///  - If the leader certificate is set for the current even round.
     ///  - The timer for the leader certificate has expired.
     fn is_even_round_ready_for_next_round(

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -399,8 +399,11 @@ impl<N: Network> BFT<N> {
             return true;
         };
         // Compute the stake for the leader certificate.
-        let (stake_with_leader, stake_without_leader) =
-            self.compute_stake_for_leader_certificate(leader_certificate.id(), current_certificates, &committee_lookback);
+        let (stake_with_leader, stake_without_leader) = self.compute_stake_for_leader_certificate(
+            leader_certificate.id(),
+            current_certificates,
+            &committee_lookback,
+        );
         // Return 'true' if any of the following conditions hold:
         stake_with_leader >= committee_lookback.availability_threshold()
             || stake_without_leader >= committee_lookback.quorum_threshold()

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -226,7 +226,7 @@ impl<N: Network> BFT<N> {
             if let Some(leader_certificate) = self.leader_certificate.read().as_ref() {
                 // Ensure the state of the leader certificate is consistent with the BFT being ready.
                 if !is_ready {
-                    error!(is_ready, "BFT - A leader certificate was found, but 'is_ready' is false");
+                    debug!(is_ready, "BFT - A leader certificate was found, but 'is_ready' is false");
                 }
                 // Log the leader election.
                 let leader_round = leader_certificate.round();

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -359,7 +359,7 @@ impl<N: Network> BFT<N> {
         self.leader_certificate_timer.load(Ordering::SeqCst) + MAX_LEADER_CERTIFICATE_DELAY_IN_SECS <= now()
     }
 
-    /// Returns 'true' if the quorum threshold is reached for this round under one of the following conditions:
+    /// Returns 'true' if the quorum threshold `(2f + 1)` is reached for this round under one of the following conditions:
     ///  - The leader certificate is `None`.
     ///  - The leader certificate is not included up to availability threshold `(f + 1)` (in the previous certificates of the current round).
     ///  - The leader certificate timer has expired.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -326,9 +326,7 @@ impl<N: Network> BFT<N> {
         let authors = certificates.into_iter().map(|c| c.author()).collect();
         // Check if quorum threshold is reached.
         if !committee.is_quorum_threshold_reached(&authors) {
-            info!(
-                "BFT failed to advance to the next round - quorum threshold not reached in even round {current_round}. "
-            );
+            debug!("BFT failed to reach quorum threshold in even round {current_round}");
             return false;
         }
         // If the leader certificate is set for the current even round, return 'true'.
@@ -383,9 +381,7 @@ impl<N: Network> BFT<N> {
         let authors = current_certificates.clone().into_iter().map(|c| c.author()).collect();
         // Check if quorum threshold is reached.
         if !committee_lookback.is_quorum_threshold_reached(&authors) {
-            info!(
-                "BFT failed to advance to the next round - quorum threshold not reached in odd round {current_round}. "
-            );
+            debug!("BFT failed reach quorum threshold in odd round {current_round}. ");
             return false;
         }
         // Retrieve the leader certificate.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -322,13 +322,14 @@ impl<N: Network> BFT<N> {
         committee: Committee<N>,
         current_round: u64,
     ) -> bool {
-        // Retrieve the authors for the current round. 
+        // Retrieve the authors for the current round.
         let authors = certificates.into_iter().map(|c| c.author()).collect();
-        // Check if quorum threshold is reached. 
-        let is_quorum = committee.is_quorum_threshold_reached(&authors); 
-        if !is_quorum { 
-            info!("BFT failed to advance to the next round - quorum threshold not reached in even round {current_round}. ");
-            return false; 
+        // Check if quorum threshold is reached.
+        if !committee.is_quorum_threshold_reached(&authors) {
+            info!(
+                "BFT failed to advance to the next round - quorum threshold not reached in even round {current_round}. "
+            );
+            return false;
         }
         // If the leader certificate is set for the current even round, return 'true'.
         if let Some(leader_certificate) = self.leader_certificate.read().as_ref() {
@@ -339,7 +340,7 @@ impl<N: Network> BFT<N> {
         // If the timer has expired, and we can achieve quorum threshold (2f + 1) without the leader, return 'true'.
         if self.is_timer_expired() {
             debug!("BFT (timer expired) - Advancing from round {current_round} to the next round (without the leader)");
-            return true; 
+            return true;
         }
         // Otherwise, return 'false'.
         false
@@ -378,13 +379,14 @@ impl<N: Network> BFT<N> {
                 return false;
             }
         };
-        // Retrieve the authors of the current certificates. 
+        // Retrieve the authors of the current certificates.
         let authors = current_certificates.clone().into_iter().map(|c| c.author()).collect();
-        // Check if quorum threshold is reached. 
-        let is_quorum = committee_lookback.clone().is_quorum_threshold_reached(&authors); 
-        if !is_quorum { 
-            info!("BFT failed to advance to the next round - quorum threshold not reached in odd round {current_round}. ");
-            return false; 
+        // Check if quorum threshold is reached.
+        if !committee_lookback.is_quorum_threshold_reached(&authors) {
+            info!(
+                "BFT failed to advance to the next round - quorum threshold not reached in odd round {current_round}. "
+            );
+            return false;
         }
         // Retrieve the leader certificate.
         let Some(leader_certificate) = self.leader_certificate.read().clone() else {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the conditions to advance from odd and even rounds by adding a quorum check. Previously, in odd rounds the code would return ‘true’ if the previous even round leader was unseen [1]. In some scenarios, this would cause nodes to pre-maturely increment rounds before seeing ‘2f+1’ certificates, the quorum threshold to increment rounds in Bullshark. For example, if the leader in even round ‘r’ was unseen, in odd round ‘r+1’ a malicious node could send a batch header with a round number beyond the GC limit. When nodes try to sync with the batch header [2], they will increment their BFT to the next round since the previous leader was unseen. 

[1] https://github.com/AleoHQ/snarkOS/blob/mainnet/node/bft/src/bft.rs#L370 
[2] https://github.com/AleoHQ/snarkOS/blob/mainnet/node/bft/src/primary.rs#L1249 
