### PR TITLE
[Fix] Increase the inbound queue capacity (that leads into the memory pool)

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -55,7 +55,7 @@ use tokio::{
 
 /// The capacity of the queue reserved for deployments.
 /// Note: This is an inbound queue capacity, not a Narwhal-enforced capacity.
-const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 4;
+const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 10;
 /// The capacity of the queue reserved for executions.
 /// Note: This is an inbound queue capacity, not a Narwhal-enforced capacity.
 const CAPACITY_FOR_EXECUTIONS: usize = 1 << 10;

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -53,14 +53,18 @@ use tokio::{
     task::JoinHandle,
 };
 
-/// The capacity of the mempool reserved for deployments.
-const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 5;
-/// The capacity of the mempool reserved for executions.
+/// The capacity of the queue reserved for deployments.
+/// Note: This is an inbound queue capacity, not a Narwhal-enforced capacity.
+const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 4;
+/// The capacity of the queue reserved for executions.
+/// Note: This is an inbound queue capacity, not a Narwhal-enforced capacity.
 const CAPACITY_FOR_EXECUTIONS: usize = 1 << 10;
-/// The capacity of the mempool reserved for solutions.
+/// The capacity of the queue reserved for solutions.
+/// Note: This is an inbound queue capacity, not a Narwhal-enforced capacity.
 const CAPACITY_FOR_SOLUTIONS: usize = 1 << 10;
-/// The percentage of the transmissions being processed that are deployments.
-const DEPLOYMENT_VERIFICATION_RATE: usize = 15;
+/// The **suggested** maximum number of deployments in each interval.
+/// Note: This is an inbound queue limit, not a Narwhal-enforced limit.
+const MAX_DEPLOYMENTS_PER_INTERVAL: usize = 1;
 
 /// Helper struct to track incoming transactions.
 struct TransactionsQueue<N: Network> {
@@ -301,7 +305,7 @@ impl<N: Network> Consensus<N> {
             // Acquire the lock on the transactions queue.
             let mut tx_queue = self.transactions_queue.lock();
             // Determine the number of deployments to send.
-            let num_deployments = tx_queue.deployments.len().min(capacity * DEPLOYMENT_VERIFICATION_RATE / 100);
+            let num_deployments = tx_queue.deployments.len().min(capacity).min(MAX_DEPLOYMENTS_PER_INTERVAL);
             // Determine the number of executions to send.
             let num_executions = tx_queue.executions.len().min(capacity.saturating_sub(num_deployments));
             // Create an iterator which will select interleaved deployments and executions within the capacity.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -54,11 +54,13 @@ use tokio::{
 };
 
 /// The capacity of the mempool reserved for deployments.
-const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 8;
+const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 5;
 /// The capacity of the mempool reserved for executions.
 const CAPACITY_FOR_EXECUTIONS: usize = 1 << 10;
 /// The capacity of the mempool reserved for solutions.
 const CAPACITY_FOR_SOLUTIONS: usize = 1 << 10;
+/// The maximum number of deployments the primary processes from the mempool at any given round.
+const CAPACITY_FOR_DEPLOYMENT_VERIFICATION: usize = 1 << 3;
 
 /// Helper struct to track incoming transactions.
 struct TransactionsQueue<N: Network> {
@@ -299,7 +301,7 @@ impl<N: Network> Consensus<N> {
             // Acquire the lock on the transactions queue.
             let mut tx_queue = self.transactions_queue.lock();
             // Determine the number of deployments to send.
-            let num_deployments = tx_queue.deployments.len().min(capacity * CAPACITY_FOR_DEPLOYMENTS / 100);
+            let num_deployments = tx_queue.deployments.len().min(CAPACITY_FOR_DEPLOYMENT_VERIFICATION);
             // Determine the number of executions to send.
             let num_executions = tx_queue.executions.len().min(capacity.saturating_sub(num_deployments));
             // Create an iterator which will select interleaved deployments and executions within the capacity.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -59,8 +59,8 @@ const CAPACITY_FOR_DEPLOYMENTS: usize = 1 << 5;
 const CAPACITY_FOR_EXECUTIONS: usize = 1 << 10;
 /// The capacity of the mempool reserved for solutions.
 const CAPACITY_FOR_SOLUTIONS: usize = 1 << 10;
-/// The maximum number of deployments the primary processes from the mempool at any given round.
-const CAPACITY_FOR_DEPLOYMENT_VERIFICATION: usize = 1 << 3;
+/// The percentage of the transmissions being processed that are deployments.
+const DEPLOYMENT_VERIFICATION_RATE: usize = 15;
 
 /// Helper struct to track incoming transactions.
 struct TransactionsQueue<N: Network> {
@@ -301,7 +301,7 @@ impl<N: Network> Consensus<N> {
             // Acquire the lock on the transactions queue.
             let mut tx_queue = self.transactions_queue.lock();
             // Determine the number of deployments to send.
-            let num_deployments = tx_queue.deployments.len().min(CAPACITY_FOR_DEPLOYMENT_VERIFICATION);
+            let num_deployments = tx_queue.deployments.len().min(capacity * DEPLOYMENT_VERIFICATION_RATE / 100);
             // Determine the number of executions to send.
             let num_executions = tx_queue.executions.len().min(capacity.saturating_sub(num_deployments));
             // Create an iterator which will select interleaved deployments and executions within the capacity.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR increases the capacity of the inbound queue (that leads into the memory pool) to the following:

 - Deployments: 10 -> 1024
 - Executions: 40 -> 1024
 - Solutions: 50 -> 1024
 
And bounds the number of deployments the BFT processes at **any given interval to 1 deployment from the inbound queue entering into the memory pool.**

Previously the capacity was too low and would cause the nodes to drop transactions during times of high load. These numbers are not final, and should be tuned to support the expected network throughputs.