### PR TITLE
[ZKS-02] Add committee ID checks when processing proposals and certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3548,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3592,7 +3592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3623,7 +3623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "indexmap 2.2.3",
  "itertools 0.11.0",
@@ -3641,12 +3641,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3687,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3790,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3953,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "rand",
  "rayon",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "anyhow",
  "rand",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4115,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "indexmap 2.2.3",
  "serde_json",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4138,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4229,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "indexmap 2.2.3",
  "paste",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=569cf5a#569cf5a6c7169875c3d3a480eaefe987653870f6"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3593,7 +3593,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3624,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "indexmap 2.2.3",
  "itertools 0.11.0",
@@ -3642,12 +3642,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3767,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "rand",
  "rayon",
@@ -3979,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3996,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "anyhow",
  "rand",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "indexmap 2.2.3",
  "serde_json",
@@ -4128,7 +4128,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4176,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4264,7 +4264,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "indexmap 2.2.3",
  "paste",
@@ -4326,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ee10658#ee10658cd589de8af56d7e4162ce11af0bb71804"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "569cf5a"
+rev = "ee10658"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "ee10658"
+rev = "46f2625"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/events/src/certificate_response.rs
+++ b/node/bft/events/src/certificate_response.rs
@@ -86,11 +86,20 @@ pub mod prop_tests {
         (Just(committee.clone()), any::<Selector>(), vec(any_transmission(), 0..16))
             .prop_map(|(committee, selector, transmissions)| {
                 let mut rng = TestRng::default();
-                let CommitteeContext(_, ValidatorSet(validators)) = committee;
+                let CommitteeContext(committee, ValidatorSet(validators)) = committee;
                 let signer = selector.select(validators);
                 let transmission_ids = transmissions.into_iter().map(|(id, _)| id).collect();
 
-                BatchHeader::new(&signer.private_key, 0, now(), transmission_ids, Default::default(), &mut rng).unwrap()
+                BatchHeader::new(
+                    &signer.private_key,
+                    0,
+                    now(),
+                    committee.id(),
+                    transmission_ids,
+                    Default::default(),
+                    &mut rng,
+                )
+                .unwrap()
             })
             .boxed()
     }

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -205,6 +205,7 @@ mod prop_tests {
             &signer.private_key,
             committee.starting_round(),
             now(),
+            committee.id(),
             transmission_map.keys().cloned().collect(),
             Default::default(),
             &mut rng,

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -1107,6 +1107,7 @@ pub mod prop_tests {
         selector: Selector,
     ) {
         let CommitteeContext(committee, ValidatorSet(validators)) = context;
+        let committee_id = committee.id();
 
         // Initialize the storage.
         let ledger = Arc::new(MockLedgerService::new(committee));
@@ -1128,6 +1129,7 @@ pub mod prop_tests {
             &signer.private_key,
             0,
             now(),
+            committee_id,
             transmission_map.keys().cloned().collect(),
             Default::default(),
             &mut rng,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds an additional committee ID check when processing batch proposals and batch certificates from peers. This check guarantees that the proposal/certificate from a validator must have the same committee id that your validator node expects for the given round, which means both validators have consistent committee state.

If this committee ID from a peer's batch proposal is not what was expected, that means the peer is either being malicious or has deviated state. The new logic will now ignore the proposal and disconnect from the peer in an attempt to not perpetuate a subdag based on deviated committee state.


The sister PR can be found here: https://github.com/AleoHQ/snarkVM/pull/2374

Audit Finding: **[zksecurity 02] Dynamic Committee Feature is Not Safe**