### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,6 @@ cd snarkOS
 ./build_ubuntu.sh
 ```
 
-Lastly, install `snarkOS`:
-```
-cargo install --locked --path .
-```
-
 Please ensure ports `4130/tcp` and `3030/tcp` are open on your router and OS firewall.
 
 ## 3. Run an Aleo Node


### PR DESCRIPTION
Since the cargo install script is already been included in the build_ubuntu.sh, the guid will let user to reinstall again, it's a wast of time, so delete it.

<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

make developer experience better. 

## Test Plan

it works as planned. 
![image](https://github.com/AleoHQ/snarkOS/assets/5017612/1299d302-5731-4fcb-bf73-cf0bc338b88c)


## Related PRs

(Link any related PRs here)
