### PR TITLE
Update fetch timeouts as a factor of committee size

### DIFF
--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -321,8 +321,8 @@ mod tests {
         assert_eq!(pending.num_callbacks(commitment_2), 1);
         assert_eq!(pending.len(), 2);
 
-        // Wait for ` CALLBACK_EXPIRATION_IN_MS + 1` milliseconds.
-        thread::sleep(Duration::from_millis(CALLBACK_EXPIRATION_IN_MS + 1));
+        // Wait for ` CALLBACK_EXPIRATION_IN_MS + 1000` milliseconds.
+        thread::sleep(Duration::from_millis(CALLBACK_EXPIRATION_IN_MS + 1000));
 
         // Expire the pending callbacks.
         pending.clear_expired_callbacks(None);

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::MAX_FETCH_TIMEOUT_IN_MS;
+use crate::max_fetch_timeout_in_ms;
 
 use parking_lot::{Mutex, RwLock};
 use std::{
@@ -29,8 +29,11 @@ pub const NUM_REDUNDANT_REQUESTS: usize = 2;
 pub const NUM_REDUNDANT_REQUESTS: usize = 10;
 
 /// The maximum number of seconds to wait before expiring a callback.
-/// We ensure that we don't truncate `MAX_FETCH_TIMEOUT_IN_MS` when converting to seconds.
-const CALLBACK_EXPIRATION_IN_SECS: i64 = (MAX_FETCH_TIMEOUT_IN_MS as i64 + (1000 - 1)) / 1000;
+/// The default value is set to the maximum fetch timeout assuming 200 validators.
+#[cfg(not(test))]
+const CALLBACK_EXPIRATION_IN_SECS: i64 = (max_fetch_timeout_in_ms(200) as i64) / 1000;
+#[cfg(test)]
+const CALLBACK_EXPIRATION_IN_SECS: i64 = (max_fetch_timeout_in_ms(10) as i64) / 1000;
 
 #[derive(Debug)]
 pub struct Pending<T: PartialEq + Eq + Hash, V: Clone> {
@@ -82,7 +85,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
     pub fn num_callbacks(&self, item: impl Into<T>) -> usize {
         let item = item.into();
         // Clear the callbacks that have expired.
-        self.clear_expired_callbacks_for_item(item);
+        self.clear_expired_callbacks_for_item(item, None);
         // Return the number of live callbacks.
         self.callbacks.lock().get(&item).map_or(0, |callbacks| callbacks.len())
     }
@@ -103,7 +106,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
         }
 
         // Clear the callbacks that have expired.
-        self.clear_expired_callbacks_for_item(item);
+        self.clear_expired_callbacks_for_item(item, None);
 
         // Return the result.
         result
@@ -130,8 +133,12 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
     }
 
     /// Removes the callbacks for the specified `item` that have expired.
-    pub fn clear_expired_callbacks_for_item(&self, item: impl Into<T>) {
+    pub fn clear_expired_callbacks_for_item(&self, item: impl Into<T>, custom_expiration_time_in_secs: Option<i64>) {
         let item = item.into();
+
+        // Set the custom expiration time in seconds.
+        let expiration_time_in_secs = custom_expiration_time_in_secs.unwrap_or(CALLBACK_EXPIRATION_IN_SECS);
+
         // Acquire the callbacks lock.
         let mut callbacks = self.callbacks.lock();
         // Clear the callbacks that have expired.
@@ -139,7 +146,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
             // Fetch the current timestamp.
             let now = OffsetDateTime::now_utc().unix_timestamp();
             // Remove the callbacks that have expired.
-            callback_values.retain(|(_, timestamp)| now - *timestamp <= CALLBACK_EXPIRATION_IN_SECS);
+            callback_values.retain(|(_, timestamp)| now - *timestamp <= expiration_time_in_secs);
 
             // If there are no more remaining callbacks for the item, remove the item from the pending queue.
             if callback_values.is_empty() {
@@ -150,10 +157,10 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
     }
 
     /// Removes the callbacks for all items have that expired.
-    pub fn clear_expired_callbacks(&self) {
+    pub fn clear_expired_callbacks(&self, custom_expiration_time_in_secs: Option<i64>) {
         let items = self.pending.read().keys().copied().collect::<Vec<T>>();
         for item in items.into_iter() {
-            self.clear_expired_callbacks_for_item(item);
+            self.clear_expired_callbacks_for_item(item, custom_expiration_time_in_secs);
         }
     }
 }
@@ -316,7 +323,7 @@ mod tests {
         thread::sleep(Duration::from_secs(CALLBACK_EXPIRATION_IN_SECS as u64 + 1));
 
         // Expire the pending callbacks.
-        pending.clear_expired_callbacks();
+        pending.clear_expired_callbacks(None);
 
         // Ensure that the items have been expired.
         assert_eq!(pending.num_callbacks(commitment_1), 0);

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -48,14 +48,14 @@ pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
 /// The maximum number of milliseconds to wait before proposing a batch.
 pub const MAX_BATCH_DELAY_IN_MS: u64 = 2500; // ms
-/// The maximum number of milliseconds to wait before timing out on a fetch.
-pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
 /// The maximum number of seconds allowed for the leader to send their certificate.
 pub const MAX_LEADER_CERTIFICATE_DELAY_IN_SECS: i64 = 2 * MAX_BATCH_DELAY_IN_MS as i64 / 1000; // seconds
 /// The maximum number of seconds before the timestamp is considered expired.
 pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds
 /// The maximum number of workers that can be spawned.
 pub const MAX_WORKERS: u8 = 1; // worker(s)
+/// The base number of milliseconds to wait before timing out on a fetch.
+pub const BASE_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
 
 /// The frequency at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.
@@ -72,4 +72,10 @@ macro_rules! spawn_blocking {
             Err(error) => Err(anyhow::anyhow!("[tokio::spawn_blocking] {error}")),
         }
     };
+}
+
+/// Returns the maximum fetch timeout in ms as a factor of the number of validators.
+/// The value is set to `BASE_FETCH_TIMEOUT_IN_MS` + 100ms per validator in the committee.
+pub const fn max_fetch_timeout_in_ms(num_validators: u64) -> u64 {
+    100 * num_validators + BASE_FETCH_TIMEOUT_IN_MS
 }

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -75,7 +75,17 @@ macro_rules! spawn_blocking {
 }
 
 /// Returns the maximum fetch timeout in ms as a factor of the number of validators.
-/// The value is set to `BASE_FETCH_TIMEOUT_IN_MS` + 100ms per validator in the committee.
+/// The value is set to `BASE_FETCH_TIMEOUT_IN_MS` + 200ms per validator in the committee
+/// with a maximum of 30000ms.
 pub const fn max_fetch_timeout_in_ms(num_validators: u64) -> u64 {
-    100 * num_validators + BASE_FETCH_TIMEOUT_IN_MS
+    const MAX_FETCH_TIMEOUT_IN_MS: u64 = 30000; // 30 seconds
+
+    // Calculate the timeout.
+    let timeout = BASE_FETCH_TIMEOUT_IN_MS + 200 * num_validators;
+
+    // Bound the timeout to the maximum allowed fetch timeout.
+    match timeout > MAX_FETCH_TIMEOUT_IN_MS {
+        true => MAX_FETCH_TIMEOUT_IN_MS,
+        false => timeout,
+    }
 }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -120,14 +120,12 @@ impl<N: Network> Sync<N> {
                     .get_committee_lookback_for_round(self_.storage.current_round())
                     .map_or(Committee::<N>::MAX_COMMITTEE_SIZE as u64, |committee| committee.num_members() as u64);
                 let timeout_in_ms = max_fetch_timeout_in_ms(num_validators);
-                // Calculate the custom callback expiration in seconds.
-                let expiration_in_secs = timeout_in_ms.div_ceil(1000) as i64;
 
                 // Sleep briefly.
                 tokio::time::sleep(Duration::from_millis(timeout_in_ms)).await;
 
                 // Remove the expired pending transmission requests.
-                self_.pending.clear_expired_callbacks(Some(expiration_in_secs));
+                self_.pending.clear_expired_callbacks(Some(timeout_in_ms));
             }
         });
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -558,10 +558,12 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let gateway = MockGateway::default();
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_solution_basic().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -591,6 +593,7 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -599,6 +602,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_ensure_transmission_id_matches().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
         // Initialize the storage.
@@ -626,6 +630,7 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -634,6 +639,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_solution_basic().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -664,6 +670,7 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -672,6 +679,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_solution_basic().returning(|_, _| Err(anyhow!("")));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -702,6 +710,7 @@ mod tests {
         let mut rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -710,6 +719,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_transaction_basic().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -740,6 +750,7 @@ mod tests {
         let mut rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -748,6 +759,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_transaction_basic().returning(|_, _| Err(anyhow!("")));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -361,14 +361,12 @@ impl<N: Network> Worker<N> {
                     .get_committee_lookback_for_round(self_.storage.current_round())
                     .map_or(Committee::<N>::MAX_COMMITTEE_SIZE as u64, |committee| committee.num_members() as u64);
                 let timeout_in_ms = max_fetch_timeout_in_ms(num_validators);
-                // Calculate the custom callback expiration in seconds.
-                let expiration_in_secs = timeout_in_ms.div_ceil(1000) as i64;
 
                 // Sleep briefly.
                 tokio::time::sleep(Duration::from_millis(timeout_in_ms)).await;
 
                 // Remove the expired pending certificate requests.
-                self_.pending.clear_expired_callbacks(Some(expiration_in_secs));
+                self_.pending.clear_expired_callbacks(Some(timeout_in_ms));
             }
         });
 

--- a/node/bft/tests/bft_e2e.rs
+++ b/node/bft/tests/bft_e2e.rs
@@ -18,7 +18,7 @@ mod common;
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
 use deadline::deadline;
 use itertools::Itertools;
-use snarkos_node_bft::MAX_FETCH_TIMEOUT_IN_MS;
+use snarkos_node_bft::BASE_FETCH_TIMEOUT_IN_MS;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -114,7 +114,7 @@ async fn test_quorum_threshold() {
     // Start the cannons for node 0.
     network.fire_transmissions_at(0, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(Duration::from_millis(BASE_FETCH_TIMEOUT_IN_MS)).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {
@@ -125,7 +125,7 @@ async fn test_quorum_threshold() {
     network.connect_validators(0, 1).await;
     network.fire_transmissions_at(1, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(Duration::from_millis(BASE_FETCH_TIMEOUT_IN_MS)).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {

--- a/node/bft/tests/narwhal_e2e.rs
+++ b/node/bft/tests/narwhal_e2e.rs
@@ -16,7 +16,7 @@
 mod common;
 
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
-use snarkos_node_bft::MAX_FETCH_TIMEOUT_IN_MS;
+use snarkos_node_bft::BASE_FETCH_TIMEOUT_IN_MS;
 
 use std::time::Duration;
 
@@ -72,7 +72,7 @@ async fn test_quorum_threshold() {
     // Start the cannons for node 0.
     network.fire_transmissions_at(0, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(Duration::from_millis(BASE_FETCH_TIMEOUT_IN_MS)).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {
@@ -83,7 +83,7 @@ async fn test_quorum_threshold() {
     network.connect_validators(0, 1).await;
     network.fire_transmissions_at(1, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(Duration::from_millis(BASE_FETCH_TIMEOUT_IN_MS)).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `MAX_FETCH_TIMEOUT_IN_MS` to a dynamic timeout based on the number of validators in the committee set. 

The proposed formula for the fetch timeout is `BASE_FETCH_TIMEOUT_IN_MS` + `X`ms per validator in the committee set with a maximum of 30 seconds. This `X` is currently set to 200ms, but can be adjusted based on need. 


 The `BASE_FETCH_TIMEOUT_IN_MS` is the original `MAX_FETCH_TIMEOUT_IN_MS` from before the change, so some example values for timeouts would be:

10 validators => 200 * 10 + 7500 = 9500ms
50 validators => 200 * 50 + 7500 = 17500ms
100 validators => 200 * 100 + 7500 = 27500ms
113+ validators => 30000ms

## Related PRs

Based on https://github.com/AleoHQ/snarkOS/pull/3135
