### PR TITLE
[Fix] Update fetch redundancy as a factor of committee size

### DIFF
--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -27,7 +27,10 @@ const CALLBACK_TIMEOUT_IN_SECS: i64 = MAX_FETCH_TIMEOUT_IN_MS as i64 / 1000;
 
 /// Returns the maximum number of redundant requests for the specified number of validators.
 pub const fn max_redundant_requests(num_validators: usize) -> usize {
-    num_validators.saturating_div(2)
+    // Note: It is adequate to set this value to the availability threshold,
+    // as with high probability one will respond honestly (in the best and worst case
+    // with stake spread across the validators evenly and unevenly, respectively).
+    1 + num_validators.saturating_div(3)
 }
 
 #[derive(Debug)]

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -29,7 +29,7 @@ use tokio::sync::oneshot;
 const CALLBACK_TIMEOUT_IN_SECS: i64 = MAX_FETCH_TIMEOUT_IN_MS as i64 / 1000;
 
 /// Returns the maximum number of redundant requests for the number of validators in the specified round.
-pub fn max_redundant_requests<N: Network>(ledger: &Arc<dyn LedgerService<N>>, round: u64) -> usize {
+pub fn max_redundant_requests<N: Network>(ledger: Arc<dyn LedgerService<N>>, round: u64) -> usize {
     // Determine the number of validators in the committee lookback for the given round.
     let num_validators = ledger
         .get_committee_lookback_for_round(round)

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -23,12 +23,12 @@ use std::{
 use time::OffsetDateTime;
 use tokio::sync::oneshot;
 
+const CALLBACK_TIMEOUT_IN_SECS: i64 = MAX_FETCH_TIMEOUT_IN_MS as i64 / 1000;
+
 /// Returns the maximum number of redundant requests for the specified number of validators.
 pub const fn max_redundant_requests(num_validators: usize) -> usize {
     num_validators.saturating_div(2)
 }
-
-const CALLBACK_TIMEOUT_IN_SECS: i64 = MAX_FETCH_TIMEOUT_IN_MS as i64 / 1000;
 
 #[derive(Debug)]
 pub struct Pending<T: PartialEq + Eq + Hash, V: Clone> {

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -80,11 +80,6 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
         self.pending.read().get(&item.into()).cloned()
     }
 
-    /// Returns the number of pending peer IPs for the specified `item`.
-    pub fn num_pending_peers(&self, item: impl Into<T>) -> usize {
-        self.pending.read().get(&item.into()).map_or(0, |peer_ips| peer_ips.len())
-    }
-
     /// Returns the number of pending callbacks for the specified `item`.
     pub fn num_callbacks(&self, item: impl Into<T>) -> usize {
         let item = item.into();

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -23,10 +23,10 @@ use std::{
 use time::OffsetDateTime;
 use tokio::sync::oneshot;
 
-#[cfg(not(test))]
-pub const NUM_REDUNDANT_REQUESTS: usize = 2;
-#[cfg(test)]
-pub const NUM_REDUNDANT_REQUESTS: usize = 10;
+/// Returns the maximum number of redundant requests for the specified number of validators.
+pub const fn max_redundant_requests(num_validators: usize) -> usize {
+    num_validators.saturating_div(2)
+}
 
 const CALLBACK_TIMEOUT_IN_SECS: i64 = MAX_FETCH_TIMEOUT_IN_MS as i64 / 1000;
 
@@ -74,6 +74,11 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
     /// Returns the peer IPs for the specified `item`.
     pub fn get(&self, item: impl Into<T>) -> Option<HashSet<SocketAddr>> {
         self.pending.read().get(&item.into()).cloned()
+    }
+
+    /// Returns the number of pending peer IPs for the specified `item`.
+    pub fn num_pending_peers(&self, item: impl Into<T>) -> usize {
+        self.pending.read().get(&item.into()).map_or(0, |peer_ips| peer_ips.len())
     }
 
     /// Returns the number of pending callbacks for the specified `item`.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -398,6 +398,11 @@ impl<N: Network> Sync<N> {
     pub fn get_block_locators(&self) -> Result<BlockLocators<N>> {
         self.block_sync.get_block_locators()
     }
+
+    /// Returns the number of validators in the committee lookback for the given round.
+    pub fn num_validators_in_committee_lookback(&self, round: u64) -> Option<usize> {
+        self.ledger.get_committee_lookback_for_round(round).map(|committee| committee.num_members()).ok()
+    }
 }
 
 // Methods to assist with fetching batch certificates from peers.
@@ -417,9 +422,8 @@ impl<N: Network> Sync<N> {
 
             // Calculate the max number of redundant requests.
             let num_validators = self
-                .ledger
-                .get_committee_lookback_for_round(self.storage.current_round())
-                .map_or(Committee::<N>::MAX_COMMITTEE_SIZE as usize, |committee| committee.num_members());
+                .num_validators_in_committee_lookback(self.storage.current_round())
+                .unwrap_or(Committee::<N>::MAX_COMMITTEE_SIZE as usize);
             let num_redundant_requests = max_redundant_requests(num_validators);
 
             // If the number of requests is less than or equal to the redundancy factor, send the certificate request to the peer.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -25,7 +25,7 @@ use snarkos_node_sync::{locators::BlockLocators, BlockSync, BlockSyncMode};
 use snarkvm::{
     console::{network::Network, types::Field},
     ledger::{authority::Authority, block::Block, narwhal::BatchCertificate},
-    prelude::{cfg_into_iter, cfg_iter, committee::Committee},
+    prelude::{cfg_into_iter, cfg_iter},
 };
 
 use anyhow::{bail, Result};
@@ -398,11 +398,6 @@ impl<N: Network> Sync<N> {
     pub fn get_block_locators(&self) -> Result<BlockLocators<N>> {
         self.block_sync.get_block_locators()
     }
-
-    /// Returns the number of validators in the committee lookback for the given round.
-    pub fn num_validators_in_committee_lookback(&self, round: u64) -> Option<usize> {
-        self.ledger.get_committee_lookback_for_round(round).map(|committee| committee.num_members()).ok()
-    }
 }
 
 // Methods to assist with fetching batch certificates from peers.
@@ -417,11 +412,8 @@ impl<N: Network> Sync<N> {
         let (callback_sender, callback_receiver) = oneshot::channel();
         // Determine how many sent requests are pending.
         let num_sent_requests = self.pending.num_sent_requests(certificate_id);
-        // Calculate the max number of redundant requests.
-        let num_validators = self
-            .num_validators_in_committee_lookback(self.storage.current_round())
-            .unwrap_or(Committee::<N>::MAX_COMMITTEE_SIZE as usize);
-        let num_redundant_requests = max_redundant_requests(num_validators);
+        // Determine the maximum number of redundant requests.
+        let num_redundant_requests = max_redundant_requests(&self.ledger, self.storage.current_round());
         // Determine if we should send a certificate request to the peer.
         let should_send_request = num_sent_requests < num_redundant_requests;
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -413,7 +413,7 @@ impl<N: Network> Sync<N> {
         // Determine how many sent requests are pending.
         let num_sent_requests = self.pending.num_sent_requests(certificate_id);
         // Determine the maximum number of redundant requests.
-        let num_redundant_requests = max_redundant_requests(&self.ledger, self.storage.current_round());
+        let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round());
         // Determine if we should send a certificate request to the peer.
         let should_send_request = num_sent_requests < num_redundant_requests;
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -428,7 +428,7 @@ impl<N: Network> Sync<N> {
             }
         } else {
             debug!(
-                "Skipped sending redundant request for certificate {} to '{peer_ip}' (Already pending {num_sent_requests} requests)",
+                "Skipped sending request for certificate {} to '{peer_ip}' ({num_sent_requests} redundant requests)",
                 fmt_id(certificate_id)
             );
         }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -143,6 +143,11 @@ impl<N: Network> Worker<N> {
     pub fn transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
         self.ready.transactions()
     }
+
+    /// Returns the number of validators in the committee lookback for the given round.
+    pub fn num_validators_in_committee_lookback(&self, round: u64) -> Option<usize> {
+        self.ledger.get_committee_lookback_for_round(round).map(|committee| committee.num_members()).ok()
+    }
 }
 
 impl<N: Network> Worker<N> {
@@ -392,9 +397,8 @@ impl<N: Network> Worker<N> {
 
         // Calculate the max number of redundant requests.
         let num_validators = self
-            .ledger
-            .get_committee_lookback_for_round(self.storage.current_round())
-            .map_or(Committee::<N>::MAX_COMMITTEE_SIZE as usize, |committee| committee.num_members());
+            .num_validators_in_committee_lookback(self.storage.current_round())
+            .unwrap_or(Committee::<N>::MAX_COMMITTEE_SIZE as usize);
         let num_redundant_requests = max_redundant_requests(num_validators);
 
         // If the number of requests is less than or equal to the the redundancy factor, send the transmission request to the peer.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -411,7 +411,7 @@ impl<N: Network> Worker<N> {
             }
         } else {
             debug!(
-                "Skipped sending redundant request for transmission {} to '{peer_ip}' (Already pending {num_sent_requests} requests)",
+                "Skipped sending request for transmission {} to '{peer_ip}' ({num_sent_requests} redundant requests)",
                 fmt_id(transmission_id)
             );
         }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -544,10 +544,12 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let gateway = MockGateway::default();
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_solution_basic().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -577,6 +579,7 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -585,6 +588,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_ensure_transmission_id_matches().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
         // Initialize the storage.
@@ -612,6 +616,7 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -620,6 +625,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_solution_basic().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -650,6 +656,7 @@ mod tests {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -658,6 +665,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_solution_basic().returning(|_, _| Err(anyhow!("")));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -688,6 +696,7 @@ mod tests {
         let mut rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -696,6 +705,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_transaction_basic().returning(|_, _| Ok(()));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
@@ -726,6 +736,7 @@ mod tests {
         let mut rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
         // Setup the mock gateway and ledger.
         let mut gateway = MockGateway::default();
         gateway.expect_send().returning(|_, _| {
@@ -734,6 +745,7 @@ mod tests {
         });
         let mut mock_ledger = MockLedger::default();
         mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
         mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
         mock_ledger.expect_check_transaction_basic().returning(|_, _| Err(anyhow!("")));
         let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -90,6 +90,11 @@ impl<N: Network> Worker<N> {
     pub const fn id(&self) -> u8 {
         self.id
     }
+
+    /// Returns a reference to the pending transmissions queue.
+    pub fn pending(&self) -> &Arc<Pending<TransmissionID<N>, Transmission<N>>> {
+        &self.pending
+    }
 }
 
 impl<N: Network> Worker<N> {
@@ -387,7 +392,7 @@ impl<N: Network> Worker<N> {
         // Determine how many sent requests are pending.
         let num_sent_requests = self.pending.num_sent_requests(transmission_id);
         // Determine the maximum number of redundant requests.
-        let num_redundant_requests = max_redundant_requests(&self.ledger, self.storage.current_round());
+        let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round());
         // Determine if we should send a transmission request to the peer.
         let should_send_request = num_sent_requests < num_redundant_requests;
 
@@ -534,6 +539,24 @@ mod tests {
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
         }
+    }
+
+    #[tokio::test]
+    async fn test_max_redundant_requests() {
+        let rng = &mut TestRng::default();
+        // Sample a committee.
+        let committee = snarkvm::ledger::committee::test_helpers::sample_committee_for_round_and_size(0, 100, rng);
+        let committee_clone = committee.clone();
+        // Setup the mock ledger.
+        let mut mock_ledger = MockLedger::default();
+        mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
+        mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
+        mock_ledger.expect_check_solution_basic().returning(|_, _| Ok(()));
+        let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
+
+        // Ensure the maximum number of redundant requests is correct and consistent across iterations.
+        assert_eq!(max_redundant_requests(ledger, 0), 34, "Update me if the formula changes");
     }
 
     #[tokio::test]
@@ -796,7 +819,7 @@ mod tests {
         let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
 
         // Determine the number of redundant requests are sent.
-        let num_redundant_requests = max_redundant_requests(&worker.ledger, worker.storage.current_round());
+        let num_redundant_requests = max_redundant_requests(worker.ledger.clone(), worker.storage.current_round());
         let num_flood_requests = num_redundant_requests * 10;
         // Flood the pending queue with transmission requests.
         for i in 1..=num_flood_requests {

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -767,6 +767,77 @@ mod tests {
         assert!(!worker.pending.contains(transmission_id));
         assert!(!worker.ready.contains(transmission_id));
     }
+
+    #[tokio::test]
+    async fn test_flood_transmission_requests() {
+        let mut rng = &mut TestRng::default();
+        // Sample a committee.
+        let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
+        // Setup the mock gateway and ledger.
+        let mut gateway = MockGateway::default();
+        gateway.expect_send().returning(|_, _| {
+            let (_tx, rx) = oneshot::channel();
+            Some(rx)
+        });
+        let mut mock_ledger = MockLedger::default();
+        mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
+        mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
+        mock_ledger.expect_check_transaction_basic().returning(|_, _| Ok(()));
+        let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
+        // Initialize the storage.
+        let storage = Storage::<CurrentNetwork>::new(ledger.clone(), Arc::new(BFTMemoryService::new()), 1);
+
+        // Create the Worker.
+        let worker = Worker::new(0, Arc::new(gateway), storage, ledger, Default::default()).unwrap();
+        let transaction_id: <CurrentNetwork as Network>::TransactionID = Field::<CurrentNetwork>::rand(&mut rng).into();
+        let transmission_id = TransmissionID::Transaction(transaction_id);
+        let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
+
+        // Determine the number of redundant requests are sent.
+        let num_redundant_requests = max_redundant_requests(&worker.ledger, worker.storage.current_round());
+        // Flood the pending queue with transmission requests.
+        for _ in 0..(num_redundant_requests * 10) {
+            let worker_ = worker.clone();
+            tokio::spawn(async move {
+                let _ = worker_.send_transmission_request(peer_ip, transmission_id).await;
+            });
+            // Check that the number of sent requests does not exceed the maximum number of redundant requests.
+            assert!(worker.pending.num_sent_requests(transmission_id) <= num_redundant_requests);
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        // Check that the number of sent requests does not exceed the maximum number of redundant requests.
+        assert_eq!(worker.pending.num_sent_requests(transmission_id), num_redundant_requests);
+
+        // Let all the requests expire.
+        tokio::time::sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+        assert_eq!(worker.pending.num_sent_requests(transmission_id), 0);
+
+        // Flood the pending queue with transmission requests again.
+        for _ in 0..(num_redundant_requests * 10) {
+            let worker_ = worker.clone();
+            tokio::spawn(async move {
+                let _ = worker_.send_transmission_request(peer_ip, transmission_id).await;
+            });
+            assert!(worker.pending.num_sent_requests(transmission_id) <= num_redundant_requests);
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        // Check that the number of sent requests does not exceed the maximum number of redundant requests.
+        assert_eq!(worker.pending.num_sent_requests(transmission_id), num_redundant_requests);
+
+        // Check that fulfilling a transmission request clears the pending queue.
+        let result = worker
+            .process_unconfirmed_transaction(
+                transaction_id,
+                Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>())),
+            )
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(worker.pending.num_sent_requests(transmission_id), 0);
+        assert!(!worker.pending.contains(transmission_id));
+        assert!(worker.ready.contains(transmission_id));
+    }
 }
 
 #[cfg(test)]

--- a/node/bft/tests/bft_e2e.rs
+++ b/node/bft/tests/bft_e2e.rs
@@ -14,6 +14,8 @@
 
 #[allow(dead_code)]
 mod common;
+#[allow(dead_code)]
+mod components;
 
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
 use deadline::deadline;

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -324,7 +324,7 @@ impl TestNetwork {
 }
 
 // Initializes a new test committee.
-fn new_test_committee(n: u16) -> (Vec<Account<CurrentNetwork>>, Committee<CurrentNetwork>) {
+pub fn new_test_committee(n: u16) -> (Vec<Account<CurrentNetwork>>, Committee<CurrentNetwork>) {
     let mut accounts = Vec::with_capacity(n as usize);
     let mut members = IndexMap::with_capacity(n as usize);
     for i in 0..n {
@@ -346,7 +346,7 @@ fn genesis_cache() -> &'static Mutex<HashMap<Vec<u8>, Block<CurrentNetwork>>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn genesis_block(
+pub fn genesis_block(
     genesis_private_key: PrivateKey<CurrentNetwork>,
     committee: Committee<CurrentNetwork>,
     public_balances: IndexMap<Address<CurrentNetwork>, u64>,
@@ -361,7 +361,7 @@ fn genesis_block(
     vm.genesis_quorum(&genesis_private_key, committee, public_balances, bonded_balances, rng).unwrap()
 }
 
-fn genesis_ledger(
+pub fn genesis_ledger(
     genesis_private_key: PrivateKey<CurrentNetwork>,
     committee: Committee<CurrentNetwork>,
     public_balances: IndexMap<Address<CurrentNetwork>, u64>,

--- a/node/bft/tests/components/mod.rs
+++ b/node/bft/tests/components/mod.rs
@@ -1,0 +1,80 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod pending;
+pub mod worker;
+
+use crate::common::{primary, CurrentNetwork, TranslucentLedgerService};
+use snarkos_account::Account;
+use snarkos_node_bft::{helpers::Storage, Gateway, Worker};
+use snarkos_node_bft_ledger_service::LedgerService;
+use snarkos_node_bft_storage_service::BFTMemoryService;
+use snarkvm::{
+    console::{account::Address, network::Network},
+    ledger::{narwhal::BatchHeader, store::helpers::memory::ConsensusMemory},
+    prelude::TestRng,
+};
+
+use indexmap::IndexMap;
+use parking_lot::RwLock;
+use std::{str::FromStr, sync::Arc};
+
+const ITERATIONS: u32 = 100;
+
+/// Samples a new ledger with the given number of nodes.
+pub fn sample_ledger(
+    num_nodes: u16,
+    rng: &mut TestRng,
+) -> Arc<TranslucentLedgerService<CurrentNetwork, ConsensusMemory<CurrentNetwork>>> {
+    let (accounts, committee) = primary::new_test_committee(num_nodes);
+    let bonded_balances: IndexMap<_, _> =
+        committee.members().iter().map(|(address, (amount, _))| (*address, (*address, *amount))).collect();
+    let gen_key = *accounts[0].private_key();
+    let public_balance_per_validator =
+        (1_500_000_000_000_000 - (num_nodes as u64) * 1_000_000_000_000) / (num_nodes as u64);
+    let mut balances = IndexMap::<Address<CurrentNetwork>, u64>::new();
+    for account in accounts.iter() {
+        balances.insert(account.address(), public_balance_per_validator);
+    }
+
+    let gen_ledger =
+        primary::genesis_ledger(gen_key, committee.clone(), balances.clone(), bonded_balances.clone(), rng);
+    Arc::new(TranslucentLedgerService::new(gen_ledger, Default::default()))
+}
+
+/// Samples a new storage with the given ledger.
+pub fn sample_storage<N: Network>(ledger: Arc<TranslucentLedgerService<N, ConsensusMemory<N>>>) -> Storage<N> {
+    Storage::new(ledger, Arc::new(BFTMemoryService::new()), BatchHeader::<N>::MAX_GC_ROUNDS as u64)
+}
+
+/// Samples a new gateway with the given ledger.
+pub fn sample_gateway<N: Network>(ledger: Arc<TranslucentLedgerService<N, ConsensusMemory<N>>>) -> Gateway<N> {
+    let num_nodes: u16 = ledger.current_committee().unwrap().num_members().try_into().unwrap();
+    let (accounts, _committee) = primary::new_test_committee(num_nodes);
+    let account = Account::from_str(&accounts[0].private_key().to_string()).unwrap();
+    // Initialize the gateway.
+    Gateway::new(account, ledger, None, &[], None).unwrap()
+}
+
+/// Samples a new worker with the given ledger.
+pub fn sample_worker<N: Network>(id: u8, ledger: Arc<TranslucentLedgerService<N, ConsensusMemory<N>>>) -> Worker<N> {
+    // Sample a storage.
+    let storage = sample_storage(ledger.clone());
+    // Sample a gateway.
+    let gateway = sample_gateway(ledger.clone());
+    // Sample a dummy proposed batch.
+    let proposed_batch = Arc::new(RwLock::new(None));
+    // Construct the worker instance.
+    Worker::new(id, Arc::new(gateway.clone()), storage.clone(), ledger, proposed_batch).unwrap()
+}

--- a/node/bft/tests/components/pending.rs
+++ b/node/bft/tests/components/pending.rs
@@ -1,0 +1,29 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::components::sample_ledger;
+use snarkos_node_bft::helpers::max_redundant_requests;
+use snarkvm::prelude::TestRng;
+
+#[test]
+fn test_max_redundant_requests() {
+    const NUM_NODES: u16 = 100;
+
+    // Initialize the RNG.
+    let rng = &mut TestRng::default();
+    // Sample a ledger.
+    let ledger = sample_ledger(NUM_NODES, rng);
+    // Ensure the maximum number of redundant requests is correct and consistent across iterations.
+    assert_eq!(max_redundant_requests(ledger, 0), 34, "Update me if the formula changes");
+}

--- a/node/bft/tests/components/worker.rs
+++ b/node/bft/tests/components/worker.rs
@@ -1,0 +1,141 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    common::CurrentNetwork,
+    components::{sample_ledger, sample_worker},
+};
+use snarkos_node_bft::helpers::max_redundant_requests;
+use snarkvm::{
+    ledger::narwhal::TransmissionID,
+    prelude::{Network, TestRng},
+};
+
+use std::net::SocketAddr;
+
+#[tokio::test]
+#[rustfmt::skip]
+async fn test_resend_transmission_request() {
+    const NUM_NODES: u16 = 100;
+
+    // Initialize the RNG.
+    let rng = &mut TestRng::default();
+    // Sample a ledger.
+    let ledger = sample_ledger(NUM_NODES, rng);
+    // Sample a worker.
+    let worker = sample_worker(0, ledger.clone());
+
+    // Prepare a dummy transmission ID.
+    let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
+    let transmission_id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::default());
+
+    // Ensure the worker does not have the dummy transmission ID.
+    assert!(!worker.contains_transmission(transmission_id), "Transmission should not exist");
+
+    // Send a request to fetch the dummy transmission.
+    let worker_ = worker.clone();
+    tokio::spawn(async move { worker_.get_or_fetch_transmission(peer_ip, transmission_id).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let pending = worker.pending();
+    // Ensure the transmission ID exists in the pending queue.
+    assert!(pending.contains(transmission_id), "Missing a transmission in the pending queue");
+    // Ensure the peer IP is in the pending queue for the transmission ID.
+    assert!(pending.contains_peer(transmission_id, peer_ip), "Missing a peer IP for transmission in the pending queue");
+    assert_eq!(pending.get(transmission_id), Some([peer_ip].into_iter().collect()), "Missing a peer IP for transmission in the pending queue");
+    // Ensure the number of callbacks is correct.
+    assert_eq!(pending.num_callbacks(transmission_id), 1, "Incorrect number of callbacks for transmission");
+    // Ensure the number of sent requests is correct.
+    assert_eq!(pending.num_sent_requests(transmission_id), 1, "Incorrect number of sent requests for transmission");
+
+    // Rebroadcast the same request to fetch the dummy transmission.
+    for i in 1..=10 {
+        let worker_ = worker.clone();
+        tokio::spawn(async move { worker_.get_or_fetch_transmission(peer_ip, transmission_id).await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Ensure the transmission ID exists in the pending queue.
+        assert!(pending.contains(transmission_id), "Missing a transmission in the pending queue");
+        // Ensure the peer IP is in the pending queue for the transmission ID.
+        assert!(pending.contains_peer(transmission_id, peer_ip), "Missing a peer IP for transmission in the pending queue");
+        assert_eq!(pending.get(transmission_id), Some([peer_ip].into_iter().collect()), "Missing a peer IP for transmission in the pending queue");
+        // Ensure the number of callbacks is correct.
+        assert_eq!(pending.num_callbacks(transmission_id), 1 + i, "Incorrect number of callbacks for transmission");
+        // Ensure the number of sent requests is correct.
+        assert_eq!(pending.num_sent_requests(transmission_id), 1 + i, "Incorrect number of sent requests for transmission");
+    }
+}
+
+#[tokio::test]
+#[rustfmt::skip]
+async fn test_flood_transmission_requests() {
+    const NUM_NODES: u16 = 100;
+
+    // Initialize the RNG.
+    let rng = &mut TestRng::default();
+    // Sample a ledger.
+    let ledger = sample_ledger(NUM_NODES, rng);
+    // Sample a worker.
+    let worker = sample_worker(0, ledger.clone());
+
+    // Determine the maximum number of redundant requests.
+    let max_redundancy = max_redundant_requests(ledger.clone(), 0);
+    assert_eq!(max_redundancy, 34, "Update me if the formula changes");
+
+    // Prepare a dummy transmission ID.
+    let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
+    let transmission_id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::default());
+
+    // Ensure the worker does not have the dummy transmission ID.
+    assert!(!worker.contains_transmission(transmission_id), "Transmission should not exist");
+
+    // Send the maximum number of redundant requests to fetch the dummy transmission.
+    for _ in 0..max_redundancy {
+        let worker_ = worker.clone();
+        tokio::spawn(async move { worker_.get_or_fetch_transmission(peer_ip, transmission_id).await });
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let pending = worker.pending();
+    // Ensure the transmission ID exists in the pending queue.
+    assert!(pending.contains(transmission_id), "Missing a transmission in the pending queue");
+    // Ensure the peer IP is in the pending queue for the transmission ID.
+    assert!(pending.contains_peer(transmission_id, peer_ip), "Missing a peer IP for transmission in the pending queue");
+    assert_eq!(pending.get(transmission_id), Some([peer_ip].into_iter().collect()), "Missing a peer IP for transmission in the pending queue");
+    // Ensure the number of callbacks is correct.
+    assert_eq!(pending.num_callbacks(transmission_id), max_redundancy, "Incorrect number of callbacks for transmission");
+    // Ensure the number of sent requests is correct.
+    assert_eq!(pending.num_sent_requests(transmission_id), max_redundancy, "Incorrect number of sent requests for transmission");
+
+    // Ensure any further redundant requests are not sent.
+    for i in 1..=20 {
+        let worker_ = worker.clone();
+        tokio::spawn(async move { worker_.get_or_fetch_transmission(peer_ip, transmission_id).await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Ensure the transmission ID exists in the pending queue.
+        assert!(pending.contains(transmission_id), "Missing a transmission in the pending queue");
+        // Ensure the peer IP is in the pending queue for the transmission ID.
+        assert!(pending.contains_peer(transmission_id, peer_ip), "Missing a peer IP for transmission in the pending queue");
+        assert_eq!(pending.get(transmission_id), Some([peer_ip].into_iter().collect()), "Missing a peer IP for transmission in the pending queue");
+        // Ensure the number of callbacks is correct.
+        assert_eq!(pending.num_callbacks(transmission_id), max_redundancy + i, "Incorrect number of callbacks for transmission");
+        // Ensure the number of sent requests is correct.
+        assert_eq!(pending.num_sent_requests(transmission_id), max_redundancy, "Incorrect number of sent requests for transmission");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `NUM_REDUNDANT_REQUESTS` to a dynamic number based on the number of validators in the committee set.

The current formula for maximum allowed request redundancy is  `1 + (num_validators_in_committee_lookback / 3)`. This can be adjusted if it is too lenient or too aggressive.

Additionally, the `num_pending_requests` that was used to measure redundancy is now adjusted to the number of sent `Event::TransmissionRequest`/`Event::CertificateRequest`. Previously we were using the number of callbacks, which was not a good gauge of how many request messages were actually being sent out to peers.

## Related PRs

Related to #3135 and #3139