### PR TITLE
[ZKS-04] Do not perform GC on bootup

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -624,8 +624,10 @@ impl<N: Network> BFT<N> {
             }
         }
 
-        // Perform garbage collection based on the latest committed leader round.
-        self.storage().garbage_collect_certificates(latest_leader_round);
+        // Perform garbage collection based on the latest committed leader round if the node is not syncing.
+        if !IS_SYNCING {
+            self.storage().garbage_collect_certificates(latest_leader_round);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR just updates the `commit_leader_certificate` function to not perform GC during the bootup sync, as it should only be performing garbage collection during actual BFT consensus.



Audit Finding: **[zksecurity 04] Garbage Collection Can Block Commits From Happening**