### PR TITLE
[ZKS-04] Properly set the `gc_round` on `Storage` initialization

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -1226,4 +1226,71 @@ mod tests {
         assert_eq!(result.unwrap_err().to_string(), error_msg);
         Ok(())
     }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_bft_gc_on_commit() -> Result<()> {
+        let rng = &mut TestRng::default();
+
+        // Initialize the round parameters.
+        let max_gc_rounds = 1;
+        let committee_round = 0;
+        let commit_round = 2;
+        let current_round = commit_round + 1;
+
+        // Sample the certificates.
+        let (_, certificates) = snarkvm::ledger::narwhal::batch_certificate::test_helpers::sample_batch_certificate_with_previous_certificates(
+            current_round,
+            rng,
+        );
+
+        // Initialize the committee.
+        let committee = snarkvm::ledger::committee::test_helpers::sample_committee_for_round_and_members(
+            committee_round,
+            vec![
+                certificates[0].author(),
+                certificates[1].author(),
+                certificates[2].author(),
+                certificates[3].author(),
+            ],
+            rng,
+        );
+
+        // Initialize the ledger.
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+
+        // Initialize the storage.
+        let transmissions = Arc::new(BFTMemoryService::new());
+        let storage = Storage::new(ledger.clone(), transmissions, max_gc_rounds);
+        // Insert the certificates into the storage.
+        for certificate in certificates.iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+
+        // Get the leader certificate.
+        let leader = committee.get_leader(commit_round).unwrap();
+        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader).unwrap();
+
+        // Initialize the BFT.
+        let account = Account::new(rng)?;
+        let bft = BFT::new(account, storage.clone(), ledger, None, &[], None)?;
+        // Insert a mock DAG in the BFT.
+        *bft.dag.write() = crate::helpers::dag::test_helpers::mock_dag_with_modified_last_committed_round(commit_round);
+
+        // Ensure that the `gc_round` has not been updated yet.
+        assert_eq!(bft.storage().gc_round(), committee_round.saturating_sub(max_gc_rounds));
+
+        // Insert the certificates into the BFT.
+        for certificate in certificates {
+            assert!(bft.update_dag::<false>(certificate).await.is_ok());
+        }
+
+        // Commit the leader certificate.
+        bft.commit_leader_certificate::<false, false>(leader_certificate).await.unwrap();
+
+        // Ensure that the `gc_round` has been updated.
+        assert_eq!(bft.storage().gc_round(), commit_round - max_gc_rounds);
+
+        Ok(())
+    }
 }

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -114,6 +114,8 @@ impl<N: Network> Storage<N> {
         }));
         // Update the storage to the current round.
         storage.update_current_round(current_round);
+        // Perform GC on the current round.
+        storage.garbage_collect_certificates(current_round);
         // Return the storage.
         storage
     }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -212,6 +212,8 @@ impl<N: Network> Sync<N> {
         self.storage.sync_height_with_block(latest_block.height());
         // Sync the round with the block.
         self.storage.sync_round_with_block(latest_block.round());
+        // Perform GC on the latest block round.
+        self.storage.garbage_collect_certificates(latest_block.round());
         // Iterate over the blocks.
         for block in &blocks {
             // If the block authority is a subdag, then sync the batch certificates with the block.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR calls GC on `Storage` initialization to properly set the `gc_round` variable set in `Storage`. By default this value was set to 0, which is incorrect and would cause bootup to look too far back for certificates.


## Test Plan

Tests hav been added to ensure that the storage has the proper `gc_round` during initialization and that the BFT calls GC when committing a leader certificate.

## Related PRs

Related to https://github.com/AleoHQ/snarkOS/pull/3144
