### PR TITLE
[Optimize] Further blocking tweaks

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -325,17 +325,21 @@ impl<N: Network> Sync<N> {
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
 
-        // Check the next block.
-        self.ledger.check_next_block(&block)?;
-        // Attempt to advance to the next block.
-        self.ledger.advance_to_next_block(&block)?;
+        let self_ = self.clone();
+        tokio::task::spawn_blocking(move || {
+            // Check the next block.
+            self_.ledger.check_next_block(&block)?;
+            // Attempt to advance to the next block.
+            self_.ledger.advance_to_next_block(&block)?;
 
-        // Sync the height with the block.
-        self.storage.sync_height_with_block(block.height());
-        // Sync the round with the block.
-        self.storage.sync_round_with_block(block.round());
+            // Sync the height with the block.
+            self_.storage.sync_height_with_block(block.height());
+            // Sync the round with the block.
+            self_.storage.sync_round_with_block(block.round());
 
-        Ok(())
+            Ok(())
+        })
+        .await?
     }
 
     /// Syncs the storage with the given blocks.


### PR DESCRIPTION
This PR moves 2 additional potentially blocking operations into blocking tasks; they were found to be significant using `tokio-console`, which was also used to double-check that these changes decrease the `Busy` time of the associated tasks.