### PR TITLE
[Deprecate] Remove the unused noise codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,41 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,30 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,17 +529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
 dependencies = [
  "envmnt",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -784,17 +714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -825,33 +745,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "fiat-crypto",
- "platforms",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -1005,12 +898,6 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "flate2"
@@ -1209,16 +1096,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -1589,15 +1466,6 @@ name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "instant"
@@ -2138,12 +2006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "open"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,35 +2182,6 @@ name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
-
-[[package]]
-name = "platforms"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
-
-[[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -3271,7 +3104,6 @@ dependencies = [
  "snarkos-node-sync",
  "snarkos-node-tcp",
  "snarkvm",
- "snow",
  "test-strategy",
  "time",
  "tokio",
@@ -3296,7 +3128,6 @@ dependencies = [
  "snarkos-node-metrics",
  "snarkos-node-sync-locators",
  "snarkvm",
- "snow",
  "test-strategy",
  "time",
  "tokio-util",
@@ -3455,7 +3286,6 @@ dependencies = [
  "snarkos-node-bft-events",
  "snarkos-node-sync-locators",
  "snarkvm",
- "snow",
  "test-strategy",
  "tokio",
  "tokio-util",
@@ -4368,22 +4198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snow"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
-dependencies = [
- "aes-gcm",
- "blake2",
- "chacha20poly1305",
- "curve25519-dalek",
- "rand_core",
- "rustc_version",
- "sha2",
- "subtle",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5052,16 +4866,6 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
 
 [[package]]
 name = "untrusted"

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -97,9 +97,6 @@ version = "=2.2.7"
 [dependencies.snarkvm]
 workspace = true
 
-[dependencies.snow]
-version = "0.9"
-
 [dependencies.time]
 version = "0.3"
 

--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -49,9 +49,6 @@ version = "=2.2.7"
 [dependencies.snarkvm]
 workspace = true
 
-[dependencies.snow]
-version = "0.9"
-
 [dependencies.tokio-util]
 version = "0.7"
 features = [ "codec" ]

--- a/node/bft/events/src/helpers/codec.rs
+++ b/node/bft/events/src/helpers/codec.rs
@@ -15,14 +15,8 @@
 use crate::Event;
 use snarkvm::prelude::{FromBytes, Network, ToBytes};
 
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use core::marker::PhantomData;
-use rayon::{
-    iter::{IndexedParallelIterator, ParallelIterator},
-    prelude::ParallelSlice,
-};
-use snow::{HandshakeState, StatelessTransportState};
-use std::{io, sync::Arc};
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 use tracing::*;
 
@@ -96,297 +90,25 @@ impl<N: Network> Decoder for EventCodec<N> {
     }
 }
 
-/* NOISE CODEC */
-
-// The maximum message size for noise messages. If the data to be encrypted exceeds it, it is chunked.
-const MAX_MESSAGE_LEN: usize = 65535;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum EventOrBytes<N: Network> {
-    Bytes(Bytes),
-    Event(Event<N>),
-}
-
-impl<N: Network> ToBytes for EventOrBytes<N> {
-    fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
-        match self {
-            Self::Bytes(bytes) => {
-                0u8.write_le(&mut writer)?;
-                writer.write_all(bytes)
-            }
-            Self::Event(event) => {
-                1u8.write_le(&mut writer)?;
-                event.write_le(writer)
-            }
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct PostHandshakeState {
-    state: Arc<StatelessTransportState>,
-    tx_nonce: u64,
-    rx_nonce: u64,
-}
-
-pub enum NoiseState {
-    Handshake(Box<HandshakeState>),
-    PostHandshake(PostHandshakeState),
-    Failed,
-}
-
-impl Clone for NoiseState {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Handshake(..) => unreachable!(),
-            Self::PostHandshake(ph_state) => Self::PostHandshake(ph_state.clone()),
-            Self::Failed => unreachable!("Forbidden: cloning noise handshake"),
-        }
-    }
-}
-
-impl NoiseState {
-    pub fn into_post_handshake_state(self) -> Self {
-        if let Self::Handshake(noise_state) = self {
-            match noise_state.into_stateless_transport_mode() {
-                Ok(new_state) => {
-                    return Self::PostHandshake(PostHandshakeState {
-                        state: Arc::new(new_state),
-                        tx_nonce: 0,
-                        rx_nonce: 0,
-                    });
-                }
-                Err(error) => {
-                    warn!("Handshake not finished - {error}");
-                }
-            }
-        } else {
-            warn!("Handshake in wrong state");
-        }
-
-        NoiseState::Failed
-    }
-}
-
-pub struct NoiseCodec<N: Network> {
-    codec: LengthDelimitedCodec,
-    event_codec: EventCodec<N>,
-    pub noise_state: NoiseState,
-}
-
-impl<N: Network> NoiseCodec<N> {
-    pub fn new(noise_state: NoiseState) -> Self {
-        Self { codec: LengthDelimitedCodec::new(), event_codec: EventCodec::default(), noise_state }
-    }
-}
-
-impl<N: Network> Encoder<EventOrBytes<N>> for NoiseCodec<N> {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, message_or_bytes: EventOrBytes<N>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        #[cfg(feature = "metrics")]
-        let start = std::time::Instant::now();
-
-        let ciphertext = match self.noise_state {
-            NoiseState::Handshake(ref mut noise) => {
-                match message_or_bytes {
-                    // Don't allow message sending before the noise handshake has completed.
-                    EventOrBytes::Event(_) => unimplemented!(),
-                    EventOrBytes::Bytes(bytes) => {
-                        let mut buffer = [0u8; MAX_MESSAGE_LEN];
-                        let len = noise
-                            .write_message(&bytes, &mut buffer[..])
-                            .map_err(|e| Self::Error::new(io::ErrorKind::InvalidInput, e))?;
-
-                        #[cfg(feature = "metrics")]
-                        metrics::histogram(metrics::tcp::NOISE_CODEC_ENCRYPTION_SIZE, len as f64);
-
-                        buffer[..len].into()
-                    }
-                }
-            }
-
-            NoiseState::PostHandshake(ref mut noise) => {
-                // Encode the message using the event codec.
-                let mut bytes = BytesMut::new();
-                match message_or_bytes {
-                    // Don't allow sending raw bytes after the noise handshake has completed.
-                    EventOrBytes::Bytes(_) => panic!("Unsupported post-handshake"),
-                    EventOrBytes::Event(event) => self.event_codec.encode(event, &mut bytes)?,
-                }
-
-                #[cfg(feature = "metrics")]
-                metrics::histogram(metrics::tcp::NOISE_CODEC_ENCRYPTION_SIZE, bytes.len() as f64);
-
-                // Chunk the payload if necessary and encrypt with Noise.
-                //
-                // A Noise transport message is simply an AEAD ciphertext that is less than or
-                // equal to 65535 bytes in length, and that consists of an encrypted payload plus
-                // 16 bytes of authentication data.
-                //
-                // See: https://noiseprotocol.org/noise.html#the-handshakestate-object
-                const TAG_LEN: usize = 16;
-                let encrypted_chunks = bytes
-                    .par_chunks(MAX_MESSAGE_LEN - TAG_LEN)
-                    .enumerate()
-                    .map(|(nonce_offset, plaintext_chunk)| {
-                        let mut buffer = vec![0u8; MAX_MESSAGE_LEN];
-                        let len = noise
-                            .state
-                            .write_message(noise.tx_nonce + nonce_offset as u64, plaintext_chunk, &mut buffer)
-                            .map_err(|e| Self::Error::new(io::ErrorKind::InvalidInput, e))?;
-
-                        buffer.truncate(len);
-
-                        Ok(buffer)
-                    })
-                    .collect::<io::Result<Vec<Vec<u8>>>>()?;
-
-                let mut buffer = BytesMut::with_capacity(encrypted_chunks.len());
-                for chunk in encrypted_chunks {
-                    buffer.extend_from_slice(&chunk);
-                    noise.tx_nonce += 1;
-                }
-
-                buffer
-            }
-
-            NoiseState::Failed => unreachable!("Noise handshake failed to encode"),
-        };
-
-        // Encode the resulting ciphertext using the length-delimited codec.
-        #[allow(clippy::let_and_return)]
-        let result = self.codec.encode(ciphertext.freeze(), dst);
-
-        #[cfg(feature = "metrics")]
-        metrics::histogram(metrics::tcp::NOISE_CODEC_ENCRYPTION_TIME, start.elapsed().as_micros() as f64);
-        result
-    }
-}
-
-impl<N: Network> Decoder for NoiseCodec<N> {
-    type Error = io::Error;
-    type Item = EventOrBytes<N>;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        #[cfg(feature = "metrics")]
-        metrics::histogram(metrics::tcp::NOISE_CODEC_DECRYPTION_SIZE, src.len() as f64);
-        #[cfg(feature = "metrics")]
-        let start = std::time::Instant::now();
-
-        // Decode the ciphertext with the length-delimited codec.
-        let Some(bytes) = self.codec.decode(src)? else {
-            return Ok(None);
-        };
-
-        let msg = match self.noise_state {
-            NoiseState::Handshake(ref mut noise) => {
-                // Decrypt the ciphertext in handshake mode.
-                let mut buffer = [0u8; MAX_MESSAGE_LEN];
-                let len = noise.read_message(&bytes, &mut buffer).map_err(|_| io::ErrorKind::InvalidData)?;
-
-                Some(EventOrBytes::Bytes(Bytes::copy_from_slice(&buffer[..len])))
-            }
-
-            NoiseState::PostHandshake(ref mut noise) => {
-                // Noise decryption.
-                let decrypted_chunks = bytes
-                    .par_chunks(MAX_MESSAGE_LEN)
-                    .enumerate()
-                    .map(|(nonce_offset, encrypted_chunk)| {
-                        let mut buffer = vec![0u8; MAX_MESSAGE_LEN];
-
-                        // Decrypt the ciphertext in post-handshake mode.
-                        let len = noise
-                            .state
-                            .read_message(noise.rx_nonce + nonce_offset as u64, encrypted_chunk, &mut buffer)
-                            .map_err(|_| io::ErrorKind::InvalidData)?;
-
-                        buffer.truncate(len);
-                        Ok(buffer)
-                    })
-                    .collect::<io::Result<Vec<Vec<u8>>>>()?;
-
-                // Collect chunks into plaintext to be passed to the message codecs.
-                let mut plaintext = BytesMut::new();
-                for chunk in decrypted_chunks {
-                    plaintext.extend_from_slice(&chunk);
-                    noise.rx_nonce += 1;
-                }
-
-                // Decode with message codecs.
-                self.event_codec.decode(&mut plaintext)?.map(|msg| EventOrBytes::Event(msg))
-            }
-
-            NoiseState::Failed => unreachable!("Noise handshake failed to decode"),
-        };
-
-        #[cfg(feature = "metrics")]
-        metrics::histogram(metrics::tcp::NOISE_CODEC_DECRYPTION_TIME, start.elapsed().as_micros() as f64);
-        Ok(msg)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::prop_tests::any_event;
-
-    use snow::{params::NoiseParams, Builder};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
-    fn handshake_xx() -> (NoiseCodec<CurrentNetwork>, NoiseCodec<CurrentNetwork>) {
-        let params: NoiseParams = NOISE_HANDSHAKE_TYPE.parse().unwrap();
-        let initiator_builder = Builder::new(params.clone());
-        let initiator_kp = initiator_builder.generate_keypair().unwrap();
-        let initiator = initiator_builder.local_private_key(&initiator_kp.private).build_initiator().unwrap();
+    fn assert_roundtrip(msg: Event<CurrentNetwork>) {
+        let mut codec: EventCodec<CurrentNetwork> = Default::default();
+        let mut encoded_event = BytesMut::new();
 
-        let responder_builder = Builder::new(params);
-        let responder_kp = responder_builder.generate_keypair().unwrap();
-        let responder = responder_builder.local_private_key(&responder_kp.private).build_responder().unwrap();
-
-        let mut initiator_codec = NoiseCodec::new(NoiseState::Handshake(Box::new(initiator)));
-        let mut responder_codec = NoiseCodec::new(NoiseState::Handshake(Box::new(responder)));
-
-        let mut ciphertext = BytesMut::new();
-
-        // -> e
-        assert!(initiator_codec.encode(EventOrBytes::Bytes(Bytes::new()), &mut ciphertext).is_ok());
-        assert!(
-            matches!(responder_codec.decode(&mut ciphertext).unwrap().unwrap(), EventOrBytes::Bytes(bytes) if bytes.is_empty())
-        );
-
-        // <- e, ee, s, es
-        assert!(responder_codec.encode(EventOrBytes::Bytes(Bytes::new()), &mut ciphertext).is_ok());
-        assert!(
-            matches!(initiator_codec.decode(&mut ciphertext).unwrap().unwrap(), EventOrBytes::Bytes(bytes) if bytes.is_empty())
-        );
-
-        // -> s, se
-        assert!(initiator_codec.encode(EventOrBytes::Bytes(Bytes::new()), &mut ciphertext).is_ok());
-        assert!(
-            matches!(responder_codec.decode(&mut ciphertext).unwrap().unwrap(), EventOrBytes::Bytes(bytes) if bytes.is_empty())
-        );
-
-        initiator_codec.noise_state = initiator_codec.noise_state.into_post_handshake_state();
-        responder_codec.noise_state = responder_codec.noise_state.into_post_handshake_state();
-
-        (initiator_codec, responder_codec)
-    }
-
-    fn assert_roundtrip(msg: EventOrBytes<CurrentNetwork>) {
-        let (mut initiator_codec, mut responder_codec) = handshake_xx();
-        let mut ciphertext = BytesMut::new();
-
-        assert!(initiator_codec.encode(msg.clone(), &mut ciphertext).is_ok());
-        let decoded = responder_codec.decode(&mut ciphertext).unwrap().unwrap();
+        assert!(codec.encode(msg.clone(), &mut encoded_event).is_ok());
+        let decoded = codec.decode(&mut encoded_event).unwrap().unwrap();
         assert_eq!(decoded.to_bytes_le().unwrap(), msg.to_bytes_le().unwrap());
     }
 
     #[proptest]
     fn event_roundtrip(#[strategy(any_event())] event: Event<CurrentNetwork>) {
-        assert_roundtrip(EventOrBytes::Event(event))
+        assert_roundtrip(event)
     }
 }

--- a/node/router/messages/Cargo.toml
+++ b/node/router/messages/Cargo.toml
@@ -47,9 +47,6 @@ version = "=2.2.7"
 [dependencies.snarkvm]
 workspace = true
 
-[dependencies.snow]
-version = "0.9.6"
-
 [dependencies.tokio]
 version = "1.28"
 features = [


### PR DESCRIPTION
A little cleanup, as noise encryption has been postponed until after mainnet launch. Related: #2700. 
Also repurposes the property-based tests to cover the `EventCodec`. 