### PR TITLE
[Fix] Initialize the BFT DAG with the correct certificates at bootup

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -813,6 +813,7 @@ mod tests {
     use snarkos_node_bft_ledger_service::MockLedgerService;
     use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkvm::{
+        console::account::{Address, PrivateKey},
         ledger::{
             committee::Committee,
             narwhal::batch_certificate::test_helpers::{sample_batch_certificate, sample_batch_certificate_for_round},
@@ -821,7 +822,7 @@ mod tests {
     };
 
     use anyhow::Result;
-    use indexmap::IndexSet;
+    use indexmap::{IndexMap, IndexSet};
     use std::sync::{atomic::Ordering, Arc};
 
     type CurrentNetwork = snarkvm::console::network::MainnetV0;
@@ -1341,9 +1342,7 @@ mod tests {
         2. Run a separate bootup BFT that syncs with a set of pre shutdown certificates, and then commits a second leader normally over a set of post shutdown certificates.
         3. Observe that the uninterrupted BFT and the bootup BFT end in the same state.
         */
-
         use indexmap::{IndexMap, IndexSet};
-        use snarkvm::console::account::{Address, PrivateKey};
 
         let rng = &mut TestRng::default();
 
@@ -1562,9 +1561,6 @@ mod tests {
         2. Add post shutdown certificates to the bootup BFT.
         2. Observe that in the commit subdag of the second leader certificate, there are no repeated vertices from the pre shutdown certificates.
         */
-
-        use indexmap::{IndexMap, IndexSet};
-        use snarkvm::console::account::{Address, PrivateKey};
 
         let rng = &mut TestRng::default();
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -807,10 +807,9 @@ impl<N: Network> BFT<N> {
     /// Syncs the BFT DAG with the given batch certificates. These batch certificates **must**
     /// already exist in the ledger.
     ///
-    /// This method commits all the certificates into the dag.
+    /// This method commits all the certificates into the DAG.
     /// Note that there is no need to insert the certificates into the DAG, because these certificates
-    /// already exist in the ledger and therefor do not need to be re-ordered into future
-    /// committed subdags.
+    /// already exist in the ledger and therefore do not need to be re-ordered into future committed subdags.
     async fn sync_bft_dag_at_bootup(&self, certificates: Vec<BatchCertificate<N>>) {
         // Acquire the BFT write lock.
         let mut dag = self.dag.write();

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -1331,4 +1331,208 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_sync_bft_dag_at_bootup_shutdown() -> Result<()> {
+
+        /* 
+        BFT bootup unit test - 
+        1. Run one uninterrupted BFT on a set of certificates for 2 leader commits.
+        2. Run a separate bootup BFT that syncs with a set of pre shutdown certificates, and then commits a second leader normally over a set of post shutdown certificates. 
+        3. Observe that the uninterrupted BFT and the bootup BFT end in the same state. 
+        */
+
+        use snarkvm::console::{
+            account::PrivateKey,
+            account::Address, 
+        };
+        use indexmap::{IndexMap, IndexSet};
+
+        let rng = &mut TestRng::default();
+
+        // Initialize the round parameters.
+        let max_gc_rounds = snarkvm::ledger::narwhal::BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64; 
+        let committee_round = 0;
+        let commit_round = 2;
+        let current_round = commit_round + 1;
+        let next_round = current_round + 1; 
+
+        // Sample 5 rounds of batch certificates starting at the genesis round from a static set of 4 authors.  
+        let (round_to_certificates_map, committee) = {
+            let private_keys = vec![
+                PrivateKey::new(rng).unwrap(), 
+                PrivateKey::new(rng).unwrap(), 
+                PrivateKey::new(rng).unwrap(), 
+                PrivateKey::new(rng).unwrap()
+            ]; 
+            let addresses = vec![
+                Address::try_from(private_keys[0])?, 
+                Address::try_from(private_keys[1])?,
+                Address::try_from(private_keys[2])?,
+                Address::try_from(private_keys[3])?,
+            ]; 
+            let committee = snarkvm::ledger::committee::test_helpers::sample_committee_for_round_and_members(
+                committee_round,
+                addresses, 
+                rng,
+            );
+            // Initialize a mapping from the round number to the set of batch certificates in the round. 
+            let mut round_to_certificates_map: IndexMap<u64, IndexSet<snarkvm::ledger::narwhal::BatchCertificate<CurrentNetwork>>> = IndexMap::new();
+            let mut previous_certificates = IndexSet::with_capacity(4);
+            // Initialize the genesis batch certificates. 
+            for _ in 0..4 {
+                previous_certificates.insert(sample_batch_certificate(rng));
+            }
+            for round in 0..commit_round+3 { 
+                let mut current_certificates = IndexSet::new(); 
+                let previous_certificate_ids: IndexSet<_> = if round == 0 || round == 1 {
+                    IndexSet::new() 
+                } else {
+                    previous_certificates.iter().map(|c| c.id()).collect()
+                };
+                let transmission_ids = snarkvm::ledger::narwhal::transmission_id::test_helpers::sample_transmission_ids(rng).into_iter().collect::<IndexSet<_>>();
+                let timestamp = time::OffsetDateTime::now_utc().unix_timestamp();
+                let committee_id = committee.id(); 
+                for i in 0..4 { 
+                    let batch_header = snarkvm::ledger::narwhal::BatchHeader::new(&private_keys[i], round, timestamp, committee_id, transmission_ids.clone(), previous_certificate_ids.clone(), rng).unwrap(); 
+                    let mut signatures = IndexSet::with_capacity(4);
+                    for j in 0..4 {
+                        if i != j {
+                            signatures.insert(private_keys[j].sign(&[batch_header.batch_id()], rng).unwrap());
+                        }
+                    }
+                    let certificate = snarkvm::ledger::narwhal::BatchCertificate::from(batch_header, signatures).unwrap(); 
+                    current_certificates.insert(certificate); 
+                }
+                // Update the mapping. 
+                round_to_certificates_map.insert(round, current_certificates.clone()); 
+                previous_certificates = current_certificates.clone(); 
+            }
+            (round_to_certificates_map, committee)
+        };
+
+        // Initialize the ledger.
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+        // Initialize the storage.
+        let storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        // Get the leaders for the next 2 commit rounds. 
+        let leader = committee.get_leader(commit_round).unwrap();
+        let next_leader = committee.get_leader(next_round).unwrap(); 
+        // Insert the pre shutdown certificates into the storage. 
+        let mut pre_shutdown_certificates: Vec<snarkvm::ledger::narwhal::BatchCertificate<CurrentNetwork>> = Vec::new();
+        for i in 1..=commit_round { 
+            let certificates = (*round_to_certificates_map.get(&i).unwrap()).clone(); 
+            if i == commit_round { // Only insert the leader certificate for the commit round. 
+                let leader_certificate = certificates.iter().find(|certificate| certificate.author() == leader).clone();
+                if let Some(c) = leader_certificate{ 
+                    pre_shutdown_certificates.push(c.clone()); 
+                }
+                continue; 
+            }
+            pre_shutdown_certificates.extend(certificates); 
+        }
+        for certificate in pre_shutdown_certificates.iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+        // Insert the post shutdown certificates into the storage. 
+        let mut post_shutdown_certificates: Vec<snarkvm::ledger::narwhal::BatchCertificate<CurrentNetwork>> = Vec::new();
+        for j in commit_round..=commit_round+2 { 
+            let certificate = (*round_to_certificates_map.get(&j).unwrap()).clone(); 
+            post_shutdown_certificates.extend(certificate); 
+        }
+        for certificate in post_shutdown_certificates.iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+        // Get the leader certificates. 
+        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader).unwrap();
+        let next_leader_certificate = storage.get_certificate_for_round_with_author(next_round, next_leader).unwrap();
+        
+        // Initialize the BFT without bootup. 
+        let account = Account::new(rng)?;
+        let bft = BFT::new(account.clone(), storage, ledger.clone(), None, &[], None)?;
+        
+        // Insert a mock DAG in the BFT without bootup.
+        *bft.dag.write() = crate::helpers::dag::test_helpers::mock_dag_with_modified_last_committed_round(0);
+
+        // Insert the certificates into the BFT without bootup.
+        for certificate in pre_shutdown_certificates.clone() {
+            assert!(bft.update_dag::<false>(certificate).await.is_ok());
+        }
+
+        // Insert the post shutdown certificates into the BFT without bootup.
+        for certificate in post_shutdown_certificates.clone() {
+            assert!(bft.update_dag::<false>(certificate).await.is_ok());
+        }
+        // Commit the second leader certificate. 
+        let commit_subdag = bft.order_dag_with_dfs::<false>(next_leader_certificate.clone()).unwrap();
+        let commit_subdag_metadata = commit_subdag.iter().map(|(round, c)| (*round, c.len())).collect::<Vec<_>>();
+        bft.commit_leader_certificate::<false>(next_leader_certificate.clone()).await.unwrap();
+
+        // Simulate a bootup of the BFT.
+
+        // Initialize a new instance of storage.
+        let bootup_storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        
+        // Initialize a new instance of BFT with bootup. 
+        let bootup_bft = BFT::new(account, bootup_storage.clone(), ledger.clone(), None, &[], None)?;
+
+        // Sync the BFT DAG at bootup. 
+        bootup_bft.sync_bft_dag_at_bootup(pre_shutdown_certificates.clone()).await;
+
+        // Insert the post shutdown certificates to the storage and BFT with bootup. 
+        for certificate in post_shutdown_certificates.iter() {
+            bootup_bft.storage().testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+        for certificate in post_shutdown_certificates.clone() {
+            assert!(bootup_bft.update_dag::<false>(certificate).await.is_ok());
+        }
+        // Commit the second leader certificate. 
+        let commit_subdag_bootup = bootup_bft.order_dag_with_dfs::<false>(next_leader_certificate.clone()).unwrap();
+        let commit_subdag_metadata_bootup = commit_subdag_bootup.iter().map(|(round, c)| (*round, c.len())).collect::<Vec<_>>();
+        let committed_certificates_bootup = commit_subdag_bootup.values().flatten();
+        bootup_bft.commit_leader_certificate::<false>(next_leader_certificate.clone()).await.unwrap();
+
+        // Check that the final state of both BFTs is the same. 
+
+        // Check that both BFTs start from the same last committed round.
+        assert_eq!(bft.dag.read().last_committed_round(), bootup_bft.dag.read().last_committed_round());
+
+        // Ensure that both BFTs have committed the leader certificates. 
+        assert!(bft.dag.read().is_recently_committed(leader_certificate.round(), leader_certificate.id()));
+        assert!(bft.dag.read().is_recently_committed(next_leader_certificate.round(), next_leader_certificate.id()));
+        assert!(bootup_bft.dag.read().is_recently_committed(leader_certificate.round(), leader_certificate.id()));
+        assert!(bootup_bft.dag.read().is_recently_committed(next_leader_certificate.round(), next_leader_certificate.id()));
+
+        // Check that the bootup BFT has committed the pre shutdown certificates. 
+        for certificate in pre_shutdown_certificates.clone() {
+            let certificate_round = certificate.round();
+            let certificate_id = certificate.id();
+            // Check that both BFTs have committed the certificates.
+            assert!(bft.dag.read().is_recently_committed(certificate_round, certificate_id));
+            assert!(bootup_bft.dag.read().is_recently_committed(certificate_round, certificate_id));
+            // Check that the bootup BFT does not contain the certificates in its graph, because
+            // it should not need to order them again in subsequent subdags.
+            assert!(!bft.dag.read().contains_certificate_in_round(certificate_round, certificate_id));
+            assert!(!bootup_bft.dag.read().contains_certificate_in_round(certificate_round, certificate_id));
+        }
+
+        // Check that that the bootup BFT has committed the subdag stemming from the second leader certificate in consensus. 
+        for certificate in committed_certificates_bootup.clone() {
+            let certificate_round = certificate.round();
+            let certificate_id = certificate.id();
+            // Check that the both BFTs have committed the certificates.
+            assert!(bft.dag.read().is_recently_committed(certificate_round, certificate_id));
+            assert!(bootup_bft.dag.read().is_recently_committed(certificate_round, certificate_id));
+            // Check that the bootup BFT does not contain the certificates in its graph, because
+            // it should not need to order them again in subsequent subdags.
+            assert!(!bft.dag.read().contains_certificate_in_round(certificate_round, certificate_id));
+            assert!(!bootup_bft.dag.read().contains_certificate_in_round(certificate_round, certificate_id));
+        }
+
+        // Check that the commit subdag metadata for the second leader is the same for both BFTs. 
+        assert_eq!(commit_subdag_metadata_bootup, commit_subdag_metadata);
+
+        Ok(())
+    }
 }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -1242,4 +1242,93 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_sync_bft_dag_at_bootup() -> Result<()> {
+        let rng = &mut TestRng::default();
+
+        // Initialize the round parameters.
+        let max_gc_rounds = 1;
+        let committee_round = 0;
+        let commit_round = 2;
+        let current_round = commit_round + 1;
+
+        // Sample the current certificate and previous certificates.
+        let (_, certificates) = snarkvm::ledger::narwhal::batch_certificate::test_helpers::sample_batch_certificate_with_previous_certificates(
+            current_round,
+            rng,
+        );
+
+        // Initialize the committee.
+        let committee = snarkvm::ledger::committee::test_helpers::sample_committee_for_round_and_members(
+            committee_round,
+            vec![
+                certificates[0].author(),
+                certificates[1].author(),
+                certificates[2].author(),
+                certificates[3].author(),
+            ],
+            rng,
+        );
+
+        // Initialize the ledger.
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+
+        // Initialize the storage.
+        let storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        // Insert the certificates into the storage.
+        for certificate in certificates.iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+
+        // Get the leader certificate.
+        let leader = committee.get_leader(commit_round).unwrap();
+        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader).unwrap();
+
+        // Initialize the BFT.
+        let account = Account::new(rng)?;
+        let bft = BFT::new(account.clone(), storage, ledger.clone(), None, &[], None)?;
+
+        // Insert a mock DAG in the BFT.
+        *bft.dag.write() = crate::helpers::dag::test_helpers::mock_dag_with_modified_last_committed_round(commit_round);
+
+        // Insert the previous certificates into the BFT.
+        for certificate in certificates.clone() {
+            assert!(bft.update_dag::<false>(certificate).await.is_ok());
+        }
+
+        // Commit the leader certificate.
+        bft.commit_leader_certificate::<false>(leader_certificate.clone()).await.unwrap();
+
+        // Simulate a bootup of the BFT.
+
+        // Initialize a new instance of storage.
+        let storage_2 = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        // Initialize a new instance of BFT.
+        let bootup_bft = BFT::new(account, storage_2, ledger, None, &[], None)?;
+
+        // Sync the BFT DAG at bootup.
+        bootup_bft.sync_bft_dag_at_bootup(certificates.clone()).await;
+
+        // Check that the BFT starts from the same last committed round.
+        assert_eq!(bft.dag.read().last_committed_round(), bootup_bft.dag.read().last_committed_round());
+
+        // Ensure that both BFTs have committed the leader certificate.
+        assert!(bft.dag.read().is_recently_committed(leader_certificate.round(), leader_certificate.id()));
+        assert!(bootup_bft.dag.read().is_recently_committed(leader_certificate.round(), leader_certificate.id()));
+
+        // Check the state of the bootup BFT.
+        for certificate in certificates {
+            let certificate_round = certificate.round();
+            let certificate_id = certificate.id();
+            // Check that the bootup BFT has committed the certificates.
+            assert!(bootup_bft.dag.read().is_recently_committed(certificate_round, certificate_id));
+            // Check that the bootup BFT does not contain the certificates in its graph, because
+            // it should not need to order them again in subsequent subdags.
+            assert!(!bootup_bft.dag.read().contains_certificate_in_round(certificate_round, certificate_id));
+        }
+
+        Ok(())
+    }
 }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -1337,12 +1337,10 @@ mod tests {
     #[tracing_test::traced_test]
     async fn test_sync_bft_dag_at_bootup_shutdown() -> Result<()> {
         /*
-        BFT bootup unit test -
         1. Run one uninterrupted BFT on a set of certificates for 2 leader commits.
         2. Run a separate bootup BFT that syncs with a set of pre shutdown certificates, and then commits a second leader normally over a set of post shutdown certificates.
         3. Observe that the uninterrupted BFT and the bootup BFT end in the same state.
         */
-        use indexmap::{IndexMap, IndexSet};
 
         let rng = &mut TestRng::default();
 
@@ -1556,7 +1554,6 @@ mod tests {
     #[tracing_test::traced_test]
     async fn test_sync_bft_dag_at_bootup_dfs() -> Result<()> {
         /*
-        BFT bootup unit test -
         1. Run a bootup BFT that syncs with a set of pre shutdown certificates.
         2. Add post shutdown certificates to the bootup BFT.
         2. Observe that in the commit subdag of the second leader certificate, there are no repeated vertices from the pre shutdown certificates.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -1535,4 +1535,145 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_sync_bft_dag_at_bootup_dfs() -> Result<()> {
+
+        /* 
+        BFT bootup unit test - 
+        1. Run a bootup BFT that syncs with a set of pre shutdown certificates. 
+        2. Add post shutdown certificates to the bootup BFT. 
+        2. Observe that in the commit subdag of the second leader certificate, there are no repeated vertices from the pre shutdown certificates. 
+        */
+
+        use snarkvm::console::{
+            account::PrivateKey,
+            account::Address, 
+        };
+        use indexmap::{IndexMap, IndexSet};
+
+        let rng = &mut TestRng::default();
+
+        // Initialize the round parameters.
+        let max_gc_rounds = snarkvm::ledger::narwhal::BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64; 
+        let committee_round = 0;
+        let commit_round = 2;
+        let current_round = commit_round + 1;
+        let next_round = current_round + 1; 
+
+        // Sample 5 rounds of batch certificates starting at the genesis round from a static set of 4 authors.  
+        let (round_to_certificates_map, committee) = {
+            let private_keys = vec![
+                PrivateKey::new(rng).unwrap(), 
+                PrivateKey::new(rng).unwrap(), 
+                PrivateKey::new(rng).unwrap(), 
+                PrivateKey::new(rng).unwrap()
+            ]; 
+            let addresses = vec![
+                Address::try_from(private_keys[0])?, 
+                Address::try_from(private_keys[1])?,
+                Address::try_from(private_keys[2])?,
+                Address::try_from(private_keys[3])?,
+            ]; 
+            let committee = snarkvm::ledger::committee::test_helpers::sample_committee_for_round_and_members(
+                committee_round,
+                addresses, 
+                rng,
+            );
+            // Initialize a mapping from the round number to the set of batch certificates in the round. 
+            let mut round_to_certificates_map: IndexMap<u64, IndexSet<snarkvm::ledger::narwhal::BatchCertificate<CurrentNetwork>>> = IndexMap::new();
+            let mut previous_certificates = IndexSet::with_capacity(4);
+            // Initialize the genesis batch certificates. 
+            for _ in 0..4 {
+                previous_certificates.insert(sample_batch_certificate(rng));
+            }
+            for round in 0..=commit_round+2 { 
+                let mut current_certificates = IndexSet::new(); 
+                let previous_certificate_ids: IndexSet<_> = if round == 0 || round == 1 {
+                    IndexSet::new() 
+                } else {
+                    previous_certificates.iter().map(|c| c.id()).collect()
+                };
+                let transmission_ids = snarkvm::ledger::narwhal::transmission_id::test_helpers::sample_transmission_ids(rng).into_iter().collect::<IndexSet<_>>();
+                let timestamp = time::OffsetDateTime::now_utc().unix_timestamp();
+                let committee_id = committee.id(); 
+                for i in 0..4 { 
+                    let batch_header = snarkvm::ledger::narwhal::BatchHeader::new(&private_keys[i], round, timestamp, committee_id, transmission_ids.clone(), previous_certificate_ids.clone(), rng).unwrap(); 
+                    let mut signatures = IndexSet::with_capacity(4);
+                    for j in 0..4 {
+                        if i != j {
+                            signatures.insert(private_keys[j].sign(&[batch_header.batch_id()], rng).unwrap());
+                        }
+                    }
+                    let certificate = snarkvm::ledger::narwhal::BatchCertificate::from(batch_header, signatures).unwrap(); 
+                    current_certificates.insert(certificate); 
+                }
+                // Update the mapping. 
+                round_to_certificates_map.insert(round, current_certificates.clone()); 
+                previous_certificates = current_certificates.clone(); 
+            }
+            (round_to_certificates_map, committee)
+        };
+
+        // Initialize the ledger.
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+        // Initialize the storage.
+        let storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        // Get the leaders for the next 2 commit rounds. 
+        let leader = committee.get_leader(commit_round).unwrap(); 
+        let next_leader = committee.get_leader(next_round).unwrap(); 
+        // Insert the pre shutdown certificates into the storage. 
+        let mut pre_shutdown_certificates: Vec<snarkvm::ledger::narwhal::BatchCertificate<CurrentNetwork>> = Vec::new();
+        for i in 1..=commit_round { 
+            let certificates = (*round_to_certificates_map.get(&i).unwrap()).clone(); 
+            if i == commit_round { // Only insert the leader certificate for the commit round. 
+                let leader_certificate = certificates.iter().find(|certificate| certificate.author() == leader).clone();
+                if let Some(c) = leader_certificate{ 
+                    pre_shutdown_certificates.push(c.clone()); 
+                }
+                continue; 
+            }
+            pre_shutdown_certificates.extend(certificates); 
+        }
+        for certificate in pre_shutdown_certificates.iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+        // Initialize the bootup BFT. 
+        let account = Account::new(rng)?;
+        let bootup_bft = BFT::new(account.clone(), storage.clone(), ledger.clone(), None, &[], None)?;
+        // Insert a mock DAG in the BFT without bootup.
+        *bootup_bft.dag.write() = crate::helpers::dag::test_helpers::mock_dag_with_modified_last_committed_round(0);
+        // Sync the BFT DAG at bootup. 
+        bootup_bft.sync_bft_dag_at_bootup(pre_shutdown_certificates.clone()).await;
+
+        // Insert the post shutdown certificates into the storage. 
+        let mut post_shutdown_certificates: Vec<snarkvm::ledger::narwhal::BatchCertificate<CurrentNetwork>> = Vec::new();
+        for j in commit_round..=commit_round+2 { 
+            let certificate = (*round_to_certificates_map.get(&j).unwrap()).clone(); 
+            post_shutdown_certificates.extend(certificate); 
+        }
+        for certificate in post_shutdown_certificates.iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+
+        // Insert the post shutdown certificates into the DAG. 
+        for certificate in post_shutdown_certificates.clone() {
+            assert!(bootup_bft.update_dag::<false>(certificate).await.is_ok());
+        }
+        
+        // Get the next leader certificate to commit. 
+        let next_leader_certificate = storage.get_certificate_for_round_with_author(next_round, next_leader).unwrap();
+        let commit_subdag = bootup_bft.order_dag_with_dfs::<false>(next_leader_certificate).unwrap();
+        let committed_certificates = commit_subdag.values().flatten();
+
+        // Check that none of the certificates synced from the bootup appear in the subdag for the next commit round.
+        for pre_shutdown_certificate in pre_shutdown_certificates.clone() { 
+            for committed_certificate in committed_certificates.clone(){ 
+                assert_ne!(pre_shutdown_certificate.id(), committed_certificate.id());
+            }
+        }
+        Ok(())
+
+    }
 }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -789,51 +789,24 @@ impl<N: Network> BFT<N> {
         });
     }
 
-    /// Syncs the BFT DAG with the given leader certificates and batch certificates.
+    /// Syncs the BFT DAG with the given batch certificates. These batch certificates **must**
+    /// already exist in the ledger.
     ///
-    /// This method starts by inserting all certificates (except the latest leader certificate)
-    /// into the DAG. Then, it commits all leader certificates (except the latest leader certificate).
-    /// Finally, it updates the DAG with the latest leader certificate.
+    /// This method commits all the certificates into the dag.
+    /// Note that there is no need to insert the certificates into the DAG, because these certificates
+    /// already exist in the ledger and therefor do not need to be re-ordered into future
+    /// committed subdags.
     async fn sync_bft_dag_at_bootup(
         &self,
-        leader_certificates: Vec<BatchCertificate<N>>,
+        _leader_certificates: Vec<BatchCertificate<N>>,
         certificates: Vec<BatchCertificate<N>>,
     ) {
-        // Split the leader certificates into past leader certificates and the latest leader certificate.
-        let (past_leader_certificates, leader_certificate) = {
-            // Compute the penultimate index.
-            let index = leader_certificates.len().saturating_sub(1);
-            // Split the leader certificates.
-            let (past, latest) = leader_certificates.split_at(index);
-            debug_assert!(latest.len() == 1, "There should only be one latest leader certificate");
-            // Retrieve the latest leader certificate.
-            match latest.first() {
-                Some(leader_certificate) => (past, leader_certificate.clone()),
-                // If there is no latest leader certificate, return early.
-                None => return,
-            }
-        };
-        {
-            // Acquire the BFT write lock.
-            let mut dag = self.dag.write();
-            // Iterate over the certificates.
-            for certificate in certificates {
-                // If the certificate is not the latest leader certificate, insert it.
-                if leader_certificate.id() != certificate.id() {
-                    // Insert the certificate into the DAG.
-                    dag.insert(certificate);
-                }
-            }
+        // Acquire the BFT write lock.
+        let mut dag = self.dag.write();
 
-            // Iterate over the leader certificates.
-            for leader_certificate in past_leader_certificates {
-                // Commit the leader certificate.
-                dag.commit(leader_certificate, self.storage().max_gc_rounds());
-            }
-        }
-        // Commit the latest leader certificate.
-        if let Err(e) = self.commit_leader_certificate::<true, true>(leader_certificate).await {
-            error!("BFT failed to update the DAG with the latest leader certificate - {e}");
+        // Commit all the certificates excluding the latest leader certificate.
+        for certificate in certificates {
+            dag.commit(&certificate, self.storage().max_gc_rounds());
         }
     }
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -759,8 +759,8 @@ impl<N: Network> BFT<N> {
         // Process the request to sync the BFT DAG at bootup.
         let self_ = self.clone();
         self.spawn(async move {
-            while let Some((leader_certificates, certificates)) = rx_sync_bft_dag_at_bootup.recv().await {
-                self_.sync_bft_dag_at_bootup(leader_certificates, certificates).await;
+            while let Some(certificates) = rx_sync_bft_dag_at_bootup.recv().await {
+                self_.sync_bft_dag_at_bootup(certificates).await;
             }
         });
 
@@ -784,11 +784,7 @@ impl<N: Network> BFT<N> {
     /// Note that there is no need to insert the certificates into the DAG, because these certificates
     /// already exist in the ledger and therefor do not need to be re-ordered into future
     /// committed subdags.
-    async fn sync_bft_dag_at_bootup(
-        &self,
-        _leader_certificates: Vec<BatchCertificate<N>>,
-        certificates: Vec<BatchCertificate<N>>,
-    ) {
+    async fn sync_bft_dag_at_bootup(&self, certificates: Vec<BatchCertificate<N>>) {
         // Acquire the BFT write lock.
         let mut dag = self.dag.write();
 

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -63,7 +63,7 @@ pub fn init_consensus_channels<N: Network>() -> (ConsensusSender<N>, ConsensusRe
 pub struct BFTSender<N: Network> {
     pub tx_primary_round: mpsc::Sender<(u64, oneshot::Sender<bool>)>,
     pub tx_primary_certificate: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
-    pub tx_sync_bft_dag_at_bootup: mpsc::Sender<(Vec<BatchCertificate<N>>, Vec<BatchCertificate<N>>)>,
+    pub tx_sync_bft_dag_at_bootup: mpsc::Sender<Vec<BatchCertificate<N>>>,
     pub tx_sync_bft: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
 }
 
@@ -103,7 +103,7 @@ impl<N: Network> BFTSender<N> {
 pub struct BFTReceiver<N: Network> {
     pub rx_primary_round: mpsc::Receiver<(u64, oneshot::Sender<bool>)>,
     pub rx_primary_certificate: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
-    pub rx_sync_bft_dag_at_bootup: mpsc::Receiver<(Vec<BatchCertificate<N>>, Vec<BatchCertificate<N>>)>,
+    pub rx_sync_bft_dag_at_bootup: mpsc::Receiver<Vec<BatchCertificate<N>>>,
     pub rx_sync_bft: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
 }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -236,22 +236,6 @@ impl<N: Network> Sync<N> {
 
         /* Sync the BFT DAG */
 
-        // Retrieve the leader certificates.
-        let leader_certificates = blocks
-            .iter()
-            .flat_map(|block| {
-                match block.authority() {
-                    // If the block authority is a beacon, then skip the block.
-                    Authority::Beacon(_) => None,
-                    // If the block authority is a subdag, then retrieve the certificates.
-                    Authority::Quorum(subdag) => Some(subdag.leader_certificate().clone()),
-                }
-            })
-            .collect::<Vec<_>>();
-        if leader_certificates.is_empty() {
-            return Ok(());
-        }
-
         // Construct a list of the certificates.
         let certificates = blocks
             .iter()
@@ -266,10 +250,10 @@ impl<N: Network> Sync<N> {
             .flatten()
             .collect::<Vec<_>>();
 
-        // If a BFT sender was provided, send the certificate to the BFT.
+        // If a BFT sender was provided, send the certificates to the BFT.
         if let Some(bft_sender) = self.bft_sender.get() {
             // Await the callback to continue.
-            if let Err(e) = bft_sender.tx_sync_bft_dag_at_bootup.send((leader_certificates, certificates)).await {
+            if let Err(e) = bft_sender.tx_sync_bft_dag_at_bootup.send(certificates).await {
                 bail!("Failed to update the BFT DAG from sync: {e}");
             }
         }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR initializes the BFT `DAG` with the correct committed certificate state by updating `sync_bft_dag_at_bootup` to simply commit all the `certificates` that were fetched from ledger. Previously, we were calling `DAG::insert` and `BFT::commit_leader_certificate` to simulate the commit process, but because we can guarantee these certificates have already been committed (exist in the ledger), this logic was incorrect. 

In addition, we've updated `order_dag_with_dfs` to skip certificates that already exist in the ledger for the same reason. There is no need to reorder certificates that have been ordered before in previous subdags.

With the removal of the extraneous logic, we could also simplify the `sync_bft_dag_at_bootup` channel and remove the `IS_SYNCING` const generic.

## Test Plan

Unit tests have been added to check that the DAG state of the BFT after bootup has the correct commit state.

