### PR TITLE
[Go/No-Go] ARC-0037 - Introduce withdrawal address for stakers #2385

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "indexmap 2.2.5",
  "itertools 0.11.0",
@@ -3425,12 +3425,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3515,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3563,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "rand",
  "rayon",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "anyhow",
  "rand",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3899,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "indexmap 2.2.5",
  "serde_json",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3950,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3972,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4047,11 +4047,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap 2.2.5",
+ "itertools 0.11.0",
  "lru",
  "parking_lot",
  "rand",
@@ -4072,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4095,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "indexmap 2.2.5",
  "paste",
@@ -4109,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4122,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4143,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=7c6798a#7c6798aff6ed82748470bbce64fff7498d01187f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3379,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3409,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "indexmap 2.2.3",
  "itertools 0.11.0",
@@ -3472,12 +3472,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3488,7 +3488,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3531,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3540,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3634,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3741,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "rand",
  "rayon",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "anyhow",
  "rand",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-coinbase"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "indexmap 2.2.3",
  "serde_json",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "indexmap 2.2.3",
  "rayon",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-coinbase",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4069,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "indexmap 2.2.3",
  "paste",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4169,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=46f2625#46f2625223c0ce162d43552f03426cad422f2aed"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=2fd006a#2fd006aa26aabfa8238d3e4a369f0dbfcb42d696"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "2fd006a"
+rev = "7c6798a"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "46f2625"
+rev = "2fd006a"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -53,8 +53,9 @@ const DEVELOPMENT_MODE_RNG_SEED: u64 = 1234567890u64;
 /// The development mode number of genesis committee members.
 const DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS: u16 = 4;
 
+/// A mapping of `staker_address` to `(validator_address, withdrawal_address, amount)`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-struct BondedBalances(IndexMap<String, (String, u64)>);
+struct BondedBalances(IndexMap<String, (String, String, u64)>);
 
 impl FromStr for BondedBalances {
     type Err = serde_json::Error;
@@ -342,16 +343,17 @@ impl Start {
                     let bonded_balances = bonded_balances
                         .0
                         .iter()
-                        .map(|(staker_address, (validator_address, amount))| {
+                        .map(|(staker_address, (validator_address, withdrawal_address, amount))| {
                             let staker_addr = Address::<N>::from_str(staker_address)?;
                             let validator_addr = Address::<N>::from_str(validator_address)?;
-                            Ok((staker_addr, (validator_addr, *amount)))
+                            let withdrawal_addr = Address::<N>::from_str(withdrawal_address)?;
+                            Ok((staker_addr, (validator_addr, withdrawal_addr, *amount)))
                         })
                         .collect::<Result<IndexMap<_, _>>>()?;
 
                     // Construct the committee members.
                     let mut members = IndexMap::new();
-                    for (staker_address, (validator_address, amount)) in bonded_balances.iter() {
+                    for (staker_address, (validator_address, _, amount)) in bonded_balances.iter() {
                         // Ensure that the staking amount is sufficient.
                         match staker_address == validator_address {
                             true => ensure!(amount >= &MIN_VALIDATOR_STAKE, "Validator stake is too low"),
@@ -387,9 +389,10 @@ impl Start {
                         .collect::<IndexMap<_, _>>();
 
                     // Construct the bonded balances.
+                    // Note: The withdrawal address is set to the staker address.
                     let bonded_balances = members
                         .iter()
-                        .map(|(address, (stake, _))| (*address, (*address, *stake)))
+                        .map(|(address, (stake, _))| (*address, (*address, *address, *stake)))
                         .collect::<IndexMap<_, _>>();
                     // Construct the committee.
                     let committee = Committee::<N>::new(0u64, members)?;
@@ -587,7 +590,7 @@ fn load_or_compute_genesis<N: Network>(
     genesis_private_key: PrivateKey<N>,
     committee: Committee<N>,
     public_balances: indexmap::IndexMap<Address<N>, u64>,
-    bonded_balances: indexmap::IndexMap<Address<N>, (Address<N>, u64)>,
+    bonded_balances: indexmap::IndexMap<Address<N>, (Address<N>, Address<N>, u64)>,
     rng: &mut ChaChaRng,
 ) -> Result<Block<N>> {
     // Construct the preimage.
@@ -597,7 +600,12 @@ fn load_or_compute_genesis<N: Network>(
     preimage.extend(genesis_private_key.to_bytes_le()?);
     preimage.extend(committee.to_bytes_le()?);
     preimage.extend(&to_bytes_le![public_balances.iter().collect::<Vec<(_, _)>>()]?);
-    preimage.extend(&to_bytes_le![bonded_balances.iter().collect::<Vec<(_, _)>>()]?);
+    preimage.extend(&to_bytes_le![
+        bonded_balances
+            .iter()
+            .flat_map(|(staker, (validator, withdrawal, amount))| to_bytes_le![staker, validator, withdrawal, amount])
+            .collect::<Vec<_>>()
+    ]?);
 
     // Input the parameters' metadata.
     preimage.extend(snarkvm::parameters::mainnet::BondPublicVerifier::METADATA.as_bytes());

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -131,8 +131,11 @@ impl TestNetwork {
         }
 
         let (accounts, committee) = new_test_committee(config.num_nodes);
-        let bonded_balances: IndexMap<_, _> =
-            committee.members().iter().map(|(address, (amount, _))| (*address, (*address, *amount))).collect();
+        let bonded_balances: IndexMap<_, _> = committee
+            .members()
+            .iter()
+            .map(|(address, (amount, _))| (*address, (*address, *address, *amount)))
+            .collect();
         let gen_key = *accounts[0].private_key();
         let public_balance_per_validator =
             (1_500_000_000_000_000 - (config.num_nodes as u64) * 1_000_000_000_000) / (config.num_nodes as u64);
@@ -350,7 +353,7 @@ pub fn genesis_block(
     genesis_private_key: PrivateKey<CurrentNetwork>,
     committee: Committee<CurrentNetwork>,
     public_balances: IndexMap<Address<CurrentNetwork>, u64>,
-    bonded_balances: IndexMap<Address<CurrentNetwork>, (Address<CurrentNetwork>, u64)>,
+    bonded_balances: IndexMap<Address<CurrentNetwork>, (Address<CurrentNetwork>, Address<CurrentNetwork>, u64)>,
     rng: &mut (impl Rng + CryptoRng),
 ) -> Block<CurrentNetwork> {
     // Initialize the store.
@@ -365,7 +368,7 @@ pub fn genesis_ledger(
     genesis_private_key: PrivateKey<CurrentNetwork>,
     committee: Committee<CurrentNetwork>,
     public_balances: IndexMap<Address<CurrentNetwork>, u64>,
-    bonded_balances: IndexMap<Address<CurrentNetwork>, (Address<CurrentNetwork>, u64)>,
+    bonded_balances: IndexMap<Address<CurrentNetwork>, (Address<CurrentNetwork>, Address<CurrentNetwork>, u64)>,
     rng: &mut (impl Rng + CryptoRng),
 ) -> CurrentLedger {
     let cache_key =

--- a/node/bft/tests/components/mod.rs
+++ b/node/bft/tests/components/mod.rs
@@ -39,7 +39,7 @@ pub fn sample_ledger(
 ) -> Arc<TranslucentLedgerService<CurrentNetwork, ConsensusMemory<CurrentNetwork>>> {
     let (accounts, committee) = primary::new_test_committee(num_nodes);
     let bonded_balances: IndexMap<_, _> =
-        committee.members().iter().map(|(address, (amount, _))| (*address, (*address, *amount))).collect();
+        committee.members().iter().map(|(address, (amount, _))| (*address, (*address, *address, *amount))).collect();
     let gen_key = *accounts[0].private_key();
     let public_balance_per_validator =
         (1_500_000_000_000_000 - (num_nodes as u64) * 1_000_000_000_000) / (num_nodes as u64);


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This is the Sister PR to https://github.com/AleoHQ/snarkVM/pull/2385 that implements ARC-0037 with withdrawal addresses.

The changes here are simply to enable the addition of the `withdrawal_address` in the CLI for custom genesis blocks for development networks and to fix compilation of tests for the updated `BondedBalances` type in snarkVM.