### PR TITLE
Smooth out sync-to-tip

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -40,6 +40,7 @@ use crate::{
 use snarkos_account::Account;
 use snarkos_node_bft_events::PrimaryPing;
 use snarkos_node_bft_ledger_service::LedgerService;
+use snarkos_node_sync::MAX_BLOCKS_BEHIND;
 use snarkvm::{
     console::{
         account::Signature,
@@ -1005,8 +1006,9 @@ impl<N: Network> Primary<N> {
         let self_ = self.clone();
         self.spawn(async move {
             while let Some((peer_ip, batch_certificate)) = rx_batch_certified.recv().await {
-                // If the primary is not synced, then do not store the certificate.
-                if !self_.sync.is_synced() {
+                // If the primary is not synced and lagging by more than `MAX_BLOCKS_BEHIND`, then do not store the certificate.
+                // This allows us to start processing the certificate as soon as we are within `MAX_BLOCKS_BEHIND` blocks.
+                if !self_.sync.is_synced() && self_.sync.num_blocks_behind() > MAX_BLOCKS_BEHIND {
                     trace!("Skipping a certified batch from '{peer_ip}' {}", "(node is syncing)".dimmed());
                     continue;
                 }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1006,9 +1006,9 @@ impl<N: Network> Primary<N> {
         let self_ = self.clone();
         self.spawn(async move {
             while let Some((peer_ip, batch_certificate)) = rx_batch_certified.recv().await {
-                // If the primary is not synced and lagging by more than `MAX_BLOCKS_BEHIND`, then do not store the certificate.
-                // This allows us to start processing the certificate as soon as we are within `MAX_BLOCKS_BEHIND` blocks.
-                if !self_.sync.is_synced() && self_.sync.num_blocks_behind() > MAX_BLOCKS_BEHIND {
+                // If the primary is not synced and lagging by more than `MAX_BLOCKS_BEHIND + 1`, then do not store the certificate.
+                // This allows us to start processing the certificate as soon as we are within `MAX_BLOCKS_BEHIND + 1` blocks.
+                if !self_.sync.is_synced() && self_.sync.num_blocks_behind() > MAX_BLOCKS_BEHIND.saturating_add(1) {
                     trace!("Skipping a certified batch from '{peer_ip}' {}", "(node is syncing)".dimmed());
                     continue;
                 }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -379,6 +379,11 @@ impl<N: Network> Sync<N> {
         self.block_sync.is_block_synced()
     }
 
+    /// Returns the number of blocks the node is behind the greatest peer height.
+    pub fn num_blocks_behind(&self) -> u32 {
+        self.block_sync.num_blocks_behind()
+    }
+
     /// Returns `true` if the node is in gateway mode.
     pub const fn is_gateway_mode(&self) -> bool {
         self.block_sync.mode().is_gateway()

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -30,7 +30,7 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
         Arc,
     },
     time::Instant,
@@ -109,6 +109,8 @@ pub struct BlockSync<N: Network> {
     request_timeouts: Arc<RwLock<IndexMap<SocketAddr, Vec<Instant>>>>,
     /// The boolean indicator of whether the node is synced up to the latest block (within the given tolerance).
     is_block_synced: Arc<AtomicBool>,
+    /// The number of blocks the peer is behind the greatest peer height.
+    num_blocks_behind: Arc<AtomicU32>,
     /// The lock to guarantee advance_with_sync_blocks() is called only once at a time.
     advance_with_sync_blocks_lock: Arc<Mutex<()>>,
 }
@@ -126,6 +128,7 @@ impl<N: Network> BlockSync<N> {
             request_timestamps: Default::default(),
             request_timeouts: Default::default(),
             is_block_synced: Default::default(),
+            num_blocks_behind: Default::default(),
             advance_with_sync_blocks_lock: Default::default(),
         }
     }
@@ -140,6 +143,12 @@ impl<N: Network> BlockSync<N> {
     #[inline]
     pub fn is_block_synced(&self) -> bool {
         self.is_block_synced.load(Ordering::SeqCst)
+    }
+
+    /// Returns the number of blocks the node is behind the greatest peer height.
+    #[inline]
+    pub fn num_blocks_behind(&self) -> u32 {
+        self.num_blocks_behind.load(Ordering::SeqCst)
     }
 }
 
@@ -439,6 +448,8 @@ impl<N: Network> BlockSync<N> {
         let num_blocks_behind = greatest_peer_height.saturating_sub(canon_height);
         // Determine if the primary is synced.
         let is_synced = num_blocks_behind <= max_blocks_behind;
+        // Update the num blocks behind.
+        self.num_blocks_behind.store(num_blocks_behind, Ordering::SeqCst);
         // Update the sync status.
         self.is_block_synced.store(is_synced, Ordering::SeqCst);
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR allows syncing nodes to start processing peer certificates slightly earlier. Previously, the syncing node needed to be synced up in order to be processing incoming batch certificates. Which puts the node behind all the peers, who should have already constructed new rounds past the last commit. This causes a cycle of lagging just out of reach of the latest round and preventing the node from quickly rejoining consensus. Breaking the cycle relies on the node and message timing such that it can fetch the certificates before new ones can be formed on the network.

The change here allows the node to start processing certificates 1 block earlier, in preparation of reaching tip. 
