### PR TITLE
[Fix] Add correct flag for local devnet client node

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -87,7 +87,7 @@ for client_index in "${client_indices[@]}"; do
   tmux new-window -t "devnet:$window_index" -n "window-$window_index"
 
   # Send the command to start the validator to the new window and capture output to the log file
-  tmux send-keys -t "devnet:window-$window_index" "snarkos start --nodisplay --dev $window_index --client --logfile $log_file" C-m
+  tmux send-keys -t "devnet:window-$window_index" "snarkos start --nodisplay --dev $window_index --dev-num-validators $total_validators --client --logfile $log_file" C-m
 done
 
 # Attach to the tmux session to view and interact with the windows


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds the `--dev-num-validator` flag to the local devnet client nodes, which will enforce that they use the same genesis block as the validators. Previously, we were fixed at 4, so if a devnet was spun up with more than 4 validators, the clients would be unable to connect due to a difference in the genesis block.
