### PR TITLE
[Optimize] Skip proposing duplicated transmissions

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -99,6 +99,9 @@ pub struct Primary<N: Network> {
 }
 
 impl<N: Network> Primary<N> {
+    /// The maximum number of unconfirmed transmissions to send to the primary.
+    pub const MAX_TRANSMISSIONS_IN_MEMORY_POOL: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * 2;
+
     /// Initializes a new primary instance.
     pub fn new(
         account: Account<N>,

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -100,7 +100,7 @@ pub struct Primary<N: Network> {
 
 impl<N: Network> Primary<N> {
     /// The maximum number of unconfirmed transmissions to send to the primary.
-    pub const MAX_TRANSMISSIONS_IN_MEMORY_POOL: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * 2;
+    pub const MAX_TRANSMISSIONS_TOLERANCE: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * 2;
 
     /// Initializes a new primary instance.
     pub fn new(

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -241,8 +241,8 @@ impl<N: Network> Consensus<N> {
         // If the memory pool of this node is full, return early.
         let num_unconfirmed_solutions = self.num_unconfirmed_solutions();
         let num_unconfirmed_transmissions = self.num_unconfirmed_transmissions();
-        if num_unconfirmed_solutions > N::MAX_SOLUTIONS
-            || num_unconfirmed_transmissions > Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE
+        if num_unconfirmed_solutions >= N::MAX_SOLUTIONS
+            || num_unconfirmed_transmissions >= Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE
         {
             return Ok(());
         }
@@ -309,7 +309,7 @@ impl<N: Network> Consensus<N> {
 
         // If the memory pool of this node is full, return early.
         let num_unconfirmed_transmissions = self.num_unconfirmed_transmissions();
-        if num_unconfirmed_transmissions > Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE {
+        if num_unconfirmed_transmissions >= Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE {
             return Ok(());
         }
         // Retrieve the transactions.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -28,6 +28,7 @@ use snarkos_node_bft::{
         Storage as NarwhalStorage,
     },
     spawn_blocking,
+    Primary,
     BFT,
 };
 use snarkos_node_bft_ledger_service::LedgerService;
@@ -305,13 +306,13 @@ impl<N: Network> Consensus<N> {
 
         // If the memory pool of this node is full, return early.
         let num_unconfirmed = self.num_unconfirmed_transmissions();
-        if num_unconfirmed > BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH {
+        if num_unconfirmed > Primary::<N>::MAX_TRANSMISSIONS_IN_MEMORY_POOL {
             return Ok(());
         }
         // Retrieve the transactions.
         let transactions = {
             // Determine the available capacity.
-            let capacity = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH.saturating_sub(num_unconfirmed);
+            let capacity = Primary::<N>::MAX_TRANSMISSIONS_IN_MEMORY_POOL.saturating_sub(num_unconfirmed);
             // Acquire the lock on the transactions queue.
             let mut tx_queue = self.transactions_queue.lock();
             // Determine the number of deployments to send.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -239,14 +239,17 @@ impl<N: Network> Consensus<N> {
         }
 
         // If the memory pool of this node is full, return early.
-        let num_unconfirmed = self.num_unconfirmed_transmissions();
-        if num_unconfirmed > N::MAX_SOLUTIONS || num_unconfirmed > BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH {
+        let num_unconfirmed_solutions = self.num_unconfirmed_solutions();
+        let num_unconfirmed_transmissions = self.num_unconfirmed_transmissions();
+        if num_unconfirmed_solutions > N::MAX_SOLUTIONS
+            || num_unconfirmed_transmissions > Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE
+        {
             return Ok(());
         }
         // Retrieve the solutions.
         let solutions = {
             // Determine the available capacity.
-            let capacity = N::MAX_SOLUTIONS.saturating_sub(num_unconfirmed);
+            let capacity = N::MAX_SOLUTIONS.saturating_sub(num_unconfirmed_solutions);
             // Acquire the lock on the queue.
             let mut queue = self.solutions_queue.lock();
             // Determine the number of solutions to send.
@@ -305,14 +308,14 @@ impl<N: Network> Consensus<N> {
         }
 
         // If the memory pool of this node is full, return early.
-        let num_unconfirmed = self.num_unconfirmed_transmissions();
-        if num_unconfirmed > Primary::<N>::MAX_TRANSMISSIONS_IN_MEMORY_POOL {
+        let num_unconfirmed_transmissions = self.num_unconfirmed_transmissions();
+        if num_unconfirmed_transmissions > Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE {
             return Ok(());
         }
         // Retrieve the transactions.
         let transactions = {
             // Determine the available capacity.
-            let capacity = Primary::<N>::MAX_TRANSMISSIONS_IN_MEMORY_POOL.saturating_sub(num_unconfirmed);
+            let capacity = Primary::<N>::MAX_TRANSMISSIONS_TOLERANCE.saturating_sub(num_unconfirmed_transmissions);
             // Acquire the lock on the transactions queue.
             let mut tx_queue = self.transactions_queue.lock();
             // Determine the number of deployments to send.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR skips adding transmissions to proposals if the transmission was included in storage. This is because if the node's proposal/certificate gets included in a subdag, it must also include the previous certificates, meaning we'd have duplicated transmission ids. 

This optimization reduces state bloat in blocks and also opens more space in proposals for unique transmissions, which would allow more TPS. The second change in this PR processes more transmissions from the worker in case there were some in the initial `num_transmissions_per_worker` that were skipped.

This PR also increase the number of unconfirmed transmissions we pass into the memory pool. Previously it was bounded by `MAX_TRANSMISSIONS_PER_BATCH`, however if any of these transmissions are invalid or duplicated, then we effectively limit the theoretical throughput. We still only include `MAX_TRANSMISSIONS_PER_BATCH` in each proposal, however we now have a larger pool of transmissions to choose from.

TLDR - The changes are:

1. Skip transmissions that are already included in storage.
2. Increase number of transmissions sent into the mempool.

This PR needs to be validated with internal devnet testing, particularly with the mempool change.

## Test Plan

A test has been added that we properly skip the transmissions that already exist in storage.

