### PR TITLE
[Cleanup] Timestamp GC 

### DIFF
--- a/node/bft/src/helpers/timestamp.rs
+++ b/node/bft/src/helpers/timestamp.rs
@@ -28,11 +28,6 @@ pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
     if timestamp > (now() + MAX_TIMESTAMP_DELTA_IN_SECS) {
         bail!("Timestamp {timestamp} is too far in the future")
     }
-    // TODO (howardwu): Ensure the timestamp is after the previous timestamp. (Needs Bullshark committee)
-    // // Ensure the timestamp is after the previous timestamp.
-    // if timestamp <= committee.previous_timestamp() {
-    //     bail!("Timestamp {timestamp} for the proposed batch must be after the previous round timestamp")
-    // }
     Ok(())
 }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

In Bullshark, timestamps on certificates are used during garbage collection to ensure that slow validators are still able to contribute to the DAG, rather than having their certificates dropped due to a slow network. To accomplish this, Bullshark garbage collects entire rounds rather than individual certificates. In particular, during GC, Bullshark will check if the difference between the median timestamp of a round and the timestamp of the leader being committed exceeds a specified upper bound. If it does, the entire round and those preceding it are garbage collected. Bullshark uses this algorithm to reach a balance between fairness and bounded memory. 

