### PR TITLE
[Fix] Make --node optional to ensure it has an influence even when using --dev; renames `--storage_path` to `--storage`

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -128,9 +128,9 @@ pub struct Start {
     #[clap(default_value = "false", long = "metrics")]
     pub metrics: bool,
 
-    /// Specify the path to a directory containing the ledger
-    #[clap(long = "storage_path")]
-    pub storage_path: Option<PathBuf>,
+    /// Specify the path to a directory containing the storage database for the ledger
+    #[clap(long = "storage")]
+    pub storage: Option<PathBuf>,
     /// Enables the node to prefetch initial blocks from a CDN
     #[clap(default_value = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase3", long = "cdn")]
     pub cdn: String,
@@ -541,7 +541,7 @@ impl Start {
         }
 
         // Initialize the storage mode.
-        let storage_mode = match &self.storage_path {
+        let storage_mode = match &self.storage {
             Some(path) => StorageMode::Custom(path.clone()),
             None => StorageMode::from(self.dev),
         };


### PR DESCRIPTION
## Motivation

Previously, when using `--dev`, the node ports would automatically be incremented alongside the the dev index. This makes it hard to indicate `--peers` on other machines, as you'll need to know the dev index / port number before it works. This design is similar to the `--bft` flag.

This PR also renames `--storage_path` to `--storage` in the CLI `start` command.

## Test Plan

This only changes a node's behaviour when both `--node` and `--dev` are used.

Tested manually locally and on aws.

## Related PRs

Needed because we're testing: https://github.com/AleoHQ/snarkOS/pull/3163