### PR TITLE
Feature-gated committee size configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
+ "snarkvm",
  "tikv-jemallocator",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ path = "snarkos/main.rs"
 
 [features]
 metrics = [ "snarkos-node-metrics", "snarkos-node/metrics" ]
+test-committee = [ "snarkvm/test-helpers" ]
 
 [dependencies.anyhow]
 version = "1.0.79"
@@ -118,6 +119,10 @@ version = "=2.2.7"
 [dependencies.snarkos-node-tcp]
 path = "./node/tcp"
 version = "=2.2.7"
+
+[dependencies.snarkvm]
+workspace = true
+optional = true
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.5"


### PR DESCRIPTION
This PR exposes a `test-committee` feature on OS that compiles in VM test helpers including the appropriate constants for running larger networks. Running snarkOS with `--features test-committee` will build with a `MAX_COMMITTEE_SIZE` of 100 rather than the standard 10. 

@raychu86 please let me know if we need more granular control over the constants vs all `test-helpers` in VM. For now, I've opted for the simplest possible change. 
