### PR TITLE
[Fix] Fix flaky connection cleanup case

### DIFF
--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -111,7 +111,7 @@ pub async fn validator(listening_port: u16, max_peers: u16) -> TestRouter<Curren
         sample_account(),
         &[],
         max_peers,
-        false,
+        true,
         true,
     )
     .await

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -111,7 +111,7 @@ pub async fn validator(listening_port: u16, max_peers: u16) -> TestRouter<Curren
         sample_account(),
         &[],
         max_peers,
-        true,
+        true, // Router tests require validators to connect to peers.
         true,
     )
     .await


### PR DESCRIPTION
Stricter peering rules were introduced in https://github.com/AleoHQ/snarkOS/pull/3163 which caused connections to fail if peers were not in the validator's trusted peer set (which we are not setting in these cases). Relaxing the requirements in this particular case should fix the flakiness. 

Closes #3190. 