### PR TITLE
[Fix] Lower bound the batch proposal production time

### DIFF
--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -49,6 +49,8 @@ pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
 /// The maximum number of milliseconds to wait before proposing a batch.
 pub const MAX_BATCH_DELAY_IN_MS: u64 = 2500; // ms
+/// The maximum number of seconds to wait before proposing a batch (rounded down to the nearest second).
+pub const MAX_BATCH_DELAY_IN_SECS: u64 = MAX_BATCH_DELAY_IN_MS / 1000; // seconds
 /// The maximum number of milliseconds to wait before timing out on a fetch.
 pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
 /// The maximum number of seconds allowed for the leader to send their certificate.

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -49,8 +49,8 @@ pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
 /// The maximum number of milliseconds to wait before proposing a batch.
 pub const MAX_BATCH_DELAY_IN_MS: u64 = 2500; // ms
-/// The maximum number of seconds to wait before proposing a batch (rounded down to the nearest second).
-pub const MAX_BATCH_DELAY_IN_SECS: u64 = MAX_BATCH_DELAY_IN_MS / 1000; // seconds
+/// The minimum number of seconds to wait before proposing a batch.
+pub const MIN_BATCH_DELAY_IN_SECS: u64 = 1; // seconds
 /// The maximum number of milliseconds to wait before timing out on a fetch.
 pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
 /// The maximum number of seconds allowed for the leader to send their certificate.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2038,6 +2038,78 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_batch_propose_from_peer_with_invalid_timestamp() {
+        let round = 2;
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng).await;
+
+        // Generate certificates.
+        let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
+
+        // Create a valid proposal with an author that isn't the primary.
+        let peer_account = &accounts[1];
+        let peer_ip = peer_account.0;
+        let invalid_timestamp = now(); // Use a timestamp that is too early.
+        let proposal = create_test_proposal(
+            &peer_account.1,
+            primary.ledger.current_committee().unwrap(),
+            round,
+            previous_certificates,
+            invalid_timestamp,
+            &mut rng,
+        );
+
+        // Make sure the primary is aware of the transmissions in the proposal.
+        for (transmission_id, transmission) in proposal.transmissions() {
+            primary.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
+        }
+
+        // The author must be known to resolver to pass propose checks.
+        primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+
+        // Try to process the batch proposal from the peer, should error.
+        assert!(
+            primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_propose_from_peer_with_past_timestamp() {
+        let round = 2;
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng).await;
+
+        // Generate certificates.
+        let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
+
+        // Create a valid proposal with an author that isn't the primary.
+        let peer_account = &accounts[1];
+        let peer_ip = peer_account.0;
+        let past_timestamp = now() - 5; // Use a timestamp that is in the past.
+        let proposal = create_test_proposal(
+            &peer_account.1,
+            primary.ledger.current_committee().unwrap(),
+            round,
+            previous_certificates,
+            past_timestamp,
+            &mut rng,
+        );
+
+        // Make sure the primary is aware of the transmissions in the proposal.
+        for (transmission_id, transmission) in proposal.transmissions() {
+            primary.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
+        }
+
+        // The author must be known to resolver to pass propose checks.
+        primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+
+        // Try to process the batch proposal from the peer, should error.
+        assert!(
+            primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.is_err()
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_signature_from_peer() {
         let mut rng = TestRng::default();

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1806,6 +1806,9 @@ mod tests {
         // Fill primary storage.
         store_certificate_chain(&primary, &accounts, round, &mut rng);
 
+        // Sleep for a while to ensure the primary is ready to propose the next round.
+        tokio::time::sleep(Duration::from_secs(MAX_BATCH_DELAY_IN_SECS + 1)).await;
+
         // Try to propose a batch. There are no transmissions in the workers so the method should
         // just return without proposing a batch.
         assert!(primary.propose_batch().await.is_ok());
@@ -1873,6 +1876,9 @@ mod tests {
             num_transmissions_in_previous_round += transmissions.len();
             primary.storage.insert_certificate(certificate, transmissions).unwrap();
         }
+
+        // Sleep for a while to ensure the primary is ready to propose the next round.
+        tokio::time::sleep(Duration::from_secs(MAX_BATCH_DELAY_IN_SECS + 1)).await;
 
         // Advance to the next round.
         assert!(primary.storage.increment_to_next_round(round).is_ok());

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1214,13 +1214,11 @@ impl<N: Network> Primary<N> {
             Some(certificate) => {
                 // Determine the elapsed time since the previous certificate.
                 let elapsed = timestamp.checked_sub(certificate.timestamp()).ok_or_else(|| {
-                    anyhow!("Proposed batch has a timestamp earlier than the certificate at round {previous_round}")
+                    anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}")
                 })?;
                 // Ensure the elapsed time is within the expected range.
                 match elapsed < MAX_BATCH_DELAY_IN_SECS as i64 {
-                    true => {
-                        bail!("Proposed batch was created too quickly after the certificate at round {previous_round}")
-                    }
+                    true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
                     false => Ok(()),
                 }
             }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR lower bounds the production and signing of batch proposals. Previously this was unguarded, so blocks could be produced as fast as validators could find subdags to commit. This could lead to much shorter block times, especially if malicious validators decide to keep proposals empty to bring down block times.

This is important, because lowering the block time increases the number of blocks produced, which in turn advances the amount of block rewards paid out. The fix is to enforce that the difference in time between an author's proposals must be at least `MAX_BATCH_DELAY_IN_SECS`.

## Test Plan

Existing tests have been updated to reflect the rule change for a minimum elapsed time between batch proposals.
New tests have also been added to enforce that batch proposals that are created too quickly are not signed.
