### PR TITLE
[Feature] feat: difficulty metrics to Grafana

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -422,6 +422,8 @@ impl<N: Network> Consensus<N> {
             let num_sol = next_block.solutions().len();
             let num_tx = next_block.transactions().len();
             let num_transmissions = num_tx + num_sol;
+            let proof_target = next_block.header().proof_target();
+            let coinbase_target = next_block.header().coinbase_target();
 
             metrics::gauge(metrics::blocks::HEIGHT, next_block.height() as f64);
             metrics::increment_gauge(metrics::blocks::SOLUTIONS, num_sol as f64);
@@ -431,6 +433,8 @@ impl<N: Network> Consensus<N> {
             metrics::gauge(metrics::consensus::COMMITTED_CERTIFICATES, num_committed_certificates as f64);
             metrics::histogram(metrics::consensus::CERTIFICATE_COMMIT_LATENCY, elapsed.as_secs_f64());
             metrics::histogram(metrics::consensus::BLOCK_LATENCY, block_latency as f64);
+            metrics::gauge(metrics::blocks::PROOF_TARGET, proof_target as f64);
+            metrics::gauge(metrics::blocks::COINBASE_TARGET, coinbase_target as f64);
         }
         Ok(())
     }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -424,6 +424,7 @@ impl<N: Network> Consensus<N> {
             let num_transmissions = num_tx + num_sol;
             let proof_target = next_block.header().proof_target();
             let coinbase_target = next_block.header().coinbase_target();
+            let cumulative_proof_target = next_block.header().cumulative_proof_target();
 
             metrics::gauge(metrics::blocks::HEIGHT, next_block.height() as f64);
             metrics::increment_gauge(metrics::blocks::SOLUTIONS, num_sol as f64);
@@ -435,6 +436,7 @@ impl<N: Network> Consensus<N> {
             metrics::histogram(metrics::consensus::BLOCK_LATENCY, block_latency as f64);
             metrics::gauge(metrics::blocks::PROOF_TARGET, proof_target as f64);
             metrics::gauge(metrics::blocks::COINBASE_TARGET, coinbase_target as f64);
+            metrics::gauge(metrics::blocks::CUMULATIVE_PROOF_TARGET, cumulative_proof_target as f64);
         }
         Ok(())
     }

--- a/node/metrics/snarkOS-grafana.json
+++ b/node/metrics/snarkOS-grafana.json
@@ -604,7 +604,39 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -613,6 +645,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -621,28 +657,24 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 4,
+        "w": 12,
         "x": 12,
         "y": 17
       },
-      "id": 50,
+      "id": 53,
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "11.0.0-68643",
       "targets": [
         {
           "datasource": {
@@ -651,154 +683,45 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(snarkos_blocks_coinbase_target)",
+          "expr": "max(snarkos_blocks_coinbase_target)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "interval": "",
+          "legendFormat": "Coinbase Target",
           "range": true,
           "refId": "A",
           "useBackend": false
-        }
-      ],
-      "title": "Coinbase Target",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 16,
-        "y": 17
-      },
-      "id": 52,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0-68643",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(snarkos_blocks_proof_target)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "max(snarkos_blocks_proof_target)",
+          "hide": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "Proof Target",
           "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Proof Target",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
+          "refId": "B"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 20,
-        "y": 17
-      },
-      "id": 51,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0-68643",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(snarkos_blocks_cumulative_proof_target)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "max(snarkos_blocks_cumulative_proof_target)",
+          "hide": false,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "Cumulative Proof Target",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "C"
         }
       ],
-      "title": "Cumulative Proof Target",
-      "type": "stat"
+      "title": "Difficulty",
+      "type": "timeseries"
     },
     {
       "datasource": {

--- a/node/metrics/snarkOS-grafana.json
+++ b/node/metrics/snarkOS-grafana.json
@@ -604,6 +604,210 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 12,
+        "y": 17
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-68643",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(snarkos_blocks_coinbase_target)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Coinbase Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 16,
+        "y": 17
+      },
+      "id": 52,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-68643",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(snarkos_blocks_proof_target)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Proof Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 17
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-68643",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(snarkos_blocks_cumulative_proof_target)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cumulative Proof Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -656,7 +860,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 17
+        "y": 25
       },
       "id": 42,
       "options": {

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -14,7 +14,7 @@
 
 pub(super) const COUNTER_NAMES: [&str; 1] = [bft::LEADERS_ELECTED];
 
-pub(super) const GAUGE_NAMES: [&str; 20] = [
+pub(super) const GAUGE_NAMES: [&str; 21] = [
     bft::CONNECTED,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
@@ -26,6 +26,7 @@ pub(super) const GAUGE_NAMES: [&str; 20] = [
     blocks::TRANSMISSIONS,
     blocks::PROOF_TARGET,
     blocks::COINBASE_TARGET,
+    blocks::CUMULATIVE_PROOF_TARGET,
     consensus::COMMITTED_CERTIFICATES,
     consensus::LAST_COMMITTED_ROUND,
     consensus::UNCONFIRMED_SOLUTIONS,
@@ -64,6 +65,7 @@ pub mod blocks {
     pub const SOLUTIONS: &str = "snarkos_blocks_solutions_total";
     pub const PROOF_TARGET: &str = "snarkos_blocks_proof_target";
     pub const COINBASE_TARGET: &str = "snarkos_blocks_coinbase_target";
+    pub const CUMULATIVE_PROOF_TARGET: &str = "snarkos_blocks_cumulative_proof_target";
 }
 
 pub mod consensus {

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -14,7 +14,7 @@
 
 pub(super) const COUNTER_NAMES: [&str; 1] = [bft::LEADERS_ELECTED];
 
-pub(super) const GAUGE_NAMES: [&str; 18] = [
+pub(super) const GAUGE_NAMES: [&str; 20] = [
     bft::CONNECTED,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
@@ -24,6 +24,8 @@ pub(super) const GAUGE_NAMES: [&str; 18] = [
     blocks::SOLUTIONS,
     blocks::TRANSACTIONS,
     blocks::TRANSMISSIONS,
+    blocks::PROOF_TARGET,
+    blocks::COINBASE_TARGET,
     consensus::COMMITTED_CERTIFICATES,
     consensus::LAST_COMMITTED_ROUND,
     consensus::UNCONFIRMED_SOLUTIONS,
@@ -60,6 +62,8 @@ pub mod blocks {
     pub const TRANSACTIONS: &str = "snarkos_blocks_transactions_total";
     pub const TRANSMISSIONS: &str = "snarkos_blocks_transmissions_total";
     pub const SOLUTIONS: &str = "snarkos_blocks_solutions_total";
+    pub const PROOF_TARGET: &str = "snarkos_blocks_proof_target";
+    pub const COINBASE_TARGET: &str = "snarkos_blocks_coinbase_target";
 }
 
 pub mod consensus {


### PR DESCRIPTION
## Motivation
Adds coinbase target, proof target, and cumulative proof target to the prometheus metrics, and these metrics to the basic Grafana dashboard json file.

The metric update block in `try_advance_to_next_block` is getting a little weighty, might be worth making this a separate function? 

## Test Plan

Metrics Visualized w Grafana Match that of the block metadata from the REST endpoint
<img width="412" alt="Screenshot 2024-03-27 at 2 03 57 PM" src="https://github.com/AleoHQ/snarkOS/assets/93600681/8e6bb9b4-f543-4b93-a752-fc5cb58bc462">


<img width="361" alt="Screenshot 2024-03-27 at 1 35 49 PM" src="https://github.com/AleoHQ/snarkOS/assets/93600681/cb0b6b2a-295c-4293-a87c-6c2fdf2a148b">

