### PR TITLE
[Feature] Update shell script to prevent resetting existing Rust environment.

### DIFF
--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -21,10 +21,18 @@ sudo apt-get install -y \
 	ufw
 
 
-# Install Rust
+# Check if Rust is installed, if not, install Rust.
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source $HOME/.cargo/env
+if command -v rustc &> /dev/null
+then
+    echo "Rust is already installed. Skipping installation."
+else
+    # Install Rust
+    echo "Rust is not installed. Installing now..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME"/.cargo/env
+    echo "Rust installation complete."
+fi
 
 # Install snarkOS
 # cargo clean


### PR DESCRIPTION
This PR updates the shell script used to download and install Rust to prevent resetting the existing Rust environment on installed machines.

Previously, the shell script would reinstall Rust even if it was already installed, potentially causing the existing Rust environment to be reset. This PR modifies the script to first check if Rust is already installed before attempting to reinstall it.

Changes Made:
- Added a check to verify if Rust is already installed before running the installation command.
- Improved script behavior to avoid resetting existing Rust environment on installed machines.

This change ensures that the script only installs Rust if it is not already present, preserving the user's existing Rust environment.