### PR TITLE
[Test] Add unit test for validator Router connections

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -17,7 +17,6 @@ use crate::{
     Peer,
     Router,
 };
-use snarkos_node_router_messages::NodeType;
 use snarkos_node_tcp::{ConnectionSide, Tcp, P2P};
 use snarkvm::{
     ledger::narwhal::Data,
@@ -203,7 +202,7 @@ impl<N: Network> Router<N> {
         let peer_ip = peer_ip.unwrap();
 
         // Knowing the peer's listening address, ensure it is allowed to connect.
-        if let Err(forbidden_message) = self.ensure_peer_is_allowed(peer_ip, peer_request.node_type) {
+        if let Err(forbidden_message) = self.ensure_peer_is_allowed(peer_ip) {
             return Err(error(format!("{forbidden_message}")));
         }
         // Verify the challenge request. If a disconnect reason was returned, send the disconnect message and abort.
@@ -252,7 +251,7 @@ impl<N: Network> Router<N> {
     }
 
     /// Ensure the peer is allowed to connect.
-    fn ensure_peer_is_allowed(&self, peer_ip: SocketAddr, node_type: NodeType) -> Result<()> {
+    fn ensure_peer_is_allowed(&self, peer_ip: SocketAddr) -> Result<()> {
         // Ensure the peer IP is not this node.
         if self.is_local_ip(&peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (attempted to self-connect)")
@@ -266,7 +265,7 @@ impl<N: Network> Router<N> {
             bail!("Dropping connection request from '{peer_ip}' (already connected)")
         }
         // Only allow trusted peers to connect if allow_external_peers is set
-        if !node_type.is_validator() && !self.allow_external_peers() && !self.is_trusted(&peer_ip) {
+        if !self.allow_external_peers() && !self.is_trusted(&peer_ip) {
             bail!("Dropping connection request from '{peer_ip}' (untrusted)")
         }
         // Ensure the peer is not restricted.

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -43,7 +43,7 @@ async fn test_connection_cleanups() {
         let node = match rng.gen_range(0..3) % 3 {
             0 => client(0, 1).await,
             1 => prover(0, 1).await,
-            2 => validator(0, 1, true).await,
+            2 => validator(0, 1, &[], true).await,
             _ => unreachable!(),
         };
 

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -43,7 +43,7 @@ async fn test_connection_cleanups() {
         let node = match rng.gen_range(0..3) % 3 {
             0 => client(0, 1).await,
             1 => prover(0, 1).await,
-            2 => validator(0, 1).await,
+            2 => validator(0, 1, true).await,
             _ => unreachable!(),
         };
 

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -104,14 +104,14 @@ pub async fn prover(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
 
 /// Initializes a validator router. Setting the `listening_port = 0` will result in a random port being assigned.
 #[allow(dead_code)]
-pub async fn validator(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
+pub async fn validator(listening_port: u16, max_peers: u16, allow_external_peers: bool) -> TestRouter<CurrentNetwork> {
     Router::new(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
         NodeType::Validator,
         sample_account(),
         &[],
         max_peers,
-        true, // Router tests require validators to connect to peers.
+        allow_external_peers,
         true,
     )
     .await

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -104,12 +104,17 @@ pub async fn prover(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
 
 /// Initializes a validator router. Setting the `listening_port = 0` will result in a random port being assigned.
 #[allow(dead_code)]
-pub async fn validator(listening_port: u16, max_peers: u16, allow_external_peers: bool) -> TestRouter<CurrentNetwork> {
+pub async fn validator(
+    listening_port: u16,
+    max_peers: u16,
+    trusted_peers: &[SocketAddr],
+    allow_external_peers: bool,
+) -> TestRouter<CurrentNetwork> {
     Router::new(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
         NodeType::Validator,
         sample_account(),
-        &[],
+        trusted_peers,
         max_peers,
         allow_external_peers,
         true,

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -22,7 +22,7 @@ use core::time::Duration;
 #[tokio::test]
 async fn test_disconnect_without_handshake() {
     // Create 2 routers.
-    let node0 = validator(0, 1, true).await;
+    let node0 = validator(0, 1, &[], true).await;
     let node1 = client(0, 1).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
@@ -64,7 +64,7 @@ async fn test_disconnect_without_handshake() {
 #[tokio::test]
 async fn test_disconnect_with_handshake() {
     // Create 2 routers.
-    let node0 = validator(0, 1, true).await;
+    let node0 = validator(0, 1, &[], true).await;
     let node1 = client(0, 1).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -22,7 +22,7 @@ use core::time::Duration;
 #[tokio::test]
 async fn test_disconnect_without_handshake() {
     // Create 2 routers.
-    let node0 = validator(0, 1).await;
+    let node0 = validator(0, 1, true).await;
     let node1 = client(0, 1).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
@@ -64,7 +64,7 @@ async fn test_disconnect_without_handshake() {
 #[tokio::test]
 async fn test_disconnect_with_handshake() {
     // Create 2 routers.
-    let node0 = validator(0, 1).await;
+    let node0 = validator(0, 1, true).await;
     let node1 = client(0, 1).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);


### PR DESCRIPTION
## Motivation

Due to the recently introduced `--allow-external-peers` flag, validator Routers do not by default accept connections from other validator Routers. We noticed on tests with only validators that the `snarkos_router_connected_total` metric returned 0.

To make this behavior clear, added a unit test `test_validator_connection`. In order for validator's Routers to connect to one another, their address has to be explicitly passed via `--peers`.

Note that if we want to change that behaviour, we need to either:
- add Gateway features to Router (e.g. a `Resolver` to track whether we are not connected to the same address twice)
- do a bigger refactor to merge Gateway and Router so the validator has just one TCP stack

## Related PRs

Closes https://github.com/AleoHQ/snarkOS/issues/3196
Corrects yet another regression from https://github.com/AleoHQ/snarkOS/pull/3163
Improves on https://github.com/AleoHQ/snarkOS/pull/3192