### PR TITLE
Store batch proposal to disk on shutdown

### DIFF
--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -16,6 +16,7 @@ use aleo_std::StorageMode;
 use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
+use snarkos_node::bft::batch_proposal_path;
 use std::path::PathBuf;
 
 /// Cleans the snarkOS node storage.
@@ -35,6 +36,13 @@ pub struct Clean {
 impl Clean {
     /// Cleans the snarkOS node storage.
     pub fn parse(self) -> Result<String> {
+        // Remove the current batch proposal file, if it exists.
+        let proposal_path = batch_proposal_path(self.network, self.dev);
+        if proposal_path.exists() {
+            if let Err(err) = std::fs::remove_file(&proposal_path) {
+                bail!("Failed to remove the current batch proposal file at {}: {err}", proposal_path.display());
+            }
+        }
         // Remove the specified ledger from storage.
         Self::remove_ledger(self.network, match self.path {
             Some(path) => StorageMode::Custom(path),

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -261,6 +261,11 @@ impl<N: Network> Gateway<N> {
         &self.account
     }
 
+    /// Returns the dev identifier of the node.
+    pub const fn dev(&self) -> Option<u16> {
+        self.dev
+    }
+
     /// Returns the IP address of this node.
     pub fn local_ip(&self) -> SocketAddr {
         self.tcp.listening_addr().expect("The TCP listener is not enabled")

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -22,11 +22,11 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, BatchHeader, Transmission, TransmissionID},
     },
-    prelude::{bail, ensure, Itertools, Result},
+    prelude::{bail, ensure, FromBytes, Itertools, Result, ToBytes},
 };
 
 use indexmap::{IndexMap, IndexSet};
-use std::collections::HashSet;
+use std::{collections::HashSet, io};
 
 pub struct Proposal<N: Network> {
     /// The proposed batch header.
@@ -166,6 +166,42 @@ impl<N: Network> Proposal<N> {
         let certificate = BatchCertificate::from(self.batch_header.clone(), self.signatures.clone())?;
         // Return the certificate and transmissions.
         Ok((certificate, self.transmissions.clone()))
+    }
+}
+
+impl<N: Network> ToBytes for Proposal<N> {
+    fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+        self.batch_header.write_le(&mut writer)?;
+        u32::try_from(self.transmissions.len()).map_err(|_| io::ErrorKind::Other)?.write_le(&mut writer)?;
+        for (transmission_id, transmission) in &self.transmissions {
+            transmission_id.write_le(&mut writer)?;
+            transmission.write_le(&mut writer)?;
+        }
+        u32::try_from(self.signatures.len()).map_err(|_| io::ErrorKind::Other)?.write_le(&mut writer)?;
+        for signature in &self.signatures {
+            signature.write_le(&mut writer)?;
+        }
+        Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for Proposal<N> {
+    fn read_le<R: io::Read>(mut reader: R) -> io::Result<Self> {
+        let batch_header = FromBytes::read_le(&mut reader)?;
+        let num_transmissions = u32::read_le(&mut reader)?;
+        let mut transmissions = IndexMap::default();
+        for _ in 0..num_transmissions {
+            let transmission_id = FromBytes::read_le(&mut reader)?;
+            let transmission = FromBytes::read_le(&mut reader)?;
+            transmissions.insert(transmission_id, transmission);
+        }
+        let num_signatures = u32::read_le(&mut reader)?;
+        let mut signatures = IndexSet::default();
+        for _ in 0..num_signatures {
+            signatures.insert(FromBytes::read_le(&mut reader)?);
+        }
+
+        Ok(Self { batch_header, transmissions, signatures })
     }
 }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -39,6 +39,7 @@ use crate::{
     PRIMARY_PING_IN_MS,
     WORKER_PING_IN_MS,
 };
+use aleo_std::{aleo_ledger_dir, StorageMode};
 use snarkos_account::Account;
 use snarkos_node_bft_events::PrimaryPing;
 use snarkos_node_bft_ledger_service::LedgerService;
@@ -53,7 +54,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, BatchHeader, Data, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::committee::Committee,
+    prelude::{committee::Committee, ToBytes},
 };
 
 use colored::Colorize;
@@ -63,8 +64,10 @@ use parking_lot::{Mutex, RwLock};
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
+    fs,
     future::Future,
     net::SocketAddr,
+    path::PathBuf,
     sync::Arc,
     time::Duration,
 };
@@ -75,6 +78,21 @@ use tokio::{
 
 /// A helper type for an optional proposed batch.
 pub type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
+
+// Returns the path where a batch proposal file may be stored.
+pub fn batch_proposal_path(network: u16, dev: Option<u16>) -> PathBuf {
+    // Obtain the path to the ledger.
+    let mut path = aleo_ledger_dir(network, StorageMode::from(dev));
+    // Go to the folder right above the ledger.
+    path.pop();
+    // Append the proposal's file name.
+    path.push(&format!(
+        "current_batch_proposal-{network}{}",
+        if let Some(id) = dev { format!("-{id}") } else { "".into() }
+    ));
+
+    path
+}
 
 #[derive(Clone)]
 pub struct Primary<N: Network> {
@@ -119,6 +137,19 @@ impl<N: Network> Primary<N> {
         let gateway = Gateway::new(account, storage.clone(), ledger.clone(), ip, trusted_validators, dev)?;
         // Initialize the sync module.
         let sync = Sync::new(gateway.clone(), storage.clone(), ledger.clone());
+        // Check for the existence of a batch proposal file.
+        let proposed_batch = ProposedBatch::<N>::default();
+        let proposal_path = batch_proposal_path(N::ID, dev);
+        if let Ok(serialized_proposal) = fs::read(&proposal_path) {
+            match Proposal::<N>::from_bytes_le(&serialized_proposal) {
+                Ok(proposal) => *proposed_batch.write() = Some(proposal),
+                Err(_) => bail!("Couldn't deserialize the proposal stored at {}", proposal_path.display()),
+            }
+            if let Err(err) = fs::remove_file(&proposal_path) {
+                bail!("Failed to remove the current batch proposal file at {}: {err}", proposal_path.display());
+            }
+        }
+
         // Initialize the primary instance.
         Ok(Self {
             sync,
@@ -127,7 +158,7 @@ impl<N: Network> Primary<N> {
             ledger,
             workers: Arc::from(vec![]),
             bft_sender: Default::default(),
-            proposed_batch: Default::default(),
+            proposed_batch: Arc::new(proposed_batch),
             latest_proposed_batch_timestamp: Default::default(),
             signed_proposals: Default::default(),
             handles: Default::default(),
@@ -1549,6 +1580,21 @@ impl<N: Network> Primary<N> {
         self.workers.iter().for_each(|worker| worker.shut_down());
         // Abort the tasks.
         self.handles.lock().iter().for_each(|handle| handle.abort());
+        // Save the current batch proposal to disk.
+        if let Some(proposal) = self.proposed_batch.write().take() {
+            let proposal_path = batch_proposal_path(N::ID, self.gateway.dev());
+
+            match proposal.to_bytes_le() {
+                Ok(proposal) => {
+                    if let Err(err) = fs::write(&proposal_path, proposal) {
+                        error!("Couldn't store the current proposal at {}: {err}.", proposal_path.display());
+                    }
+                }
+                Err(err) => {
+                    error!("Couldn't serialize the current proposal: {err}.");
+                }
+            };
+        }
         // Close the gateway.
         self.gateway.shut_down().await;
     }


### PR DESCRIPTION
This PR persists the current batch proposal to the disk on shutdown, and loads it on startup when available, deleting it afterwards.

Filing as a draft until it's sufficiently tested.

Closes https://github.com/AleoHQ/snarkOS/issues/3171.