### PR TITLE
Introduce proposal expiration

### DIFF
--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -28,6 +28,7 @@ use snarkvm::{
 use indexmap::{IndexMap, IndexSet};
 use std::collections::HashSet;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Proposal<N: Network> {
     /// The proposed batch header.
     batch_header: BatchHeader<N>,

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -28,7 +28,6 @@ use snarkvm::{
 use indexmap::{IndexMap, IndexSet};
 use std::collections::HashSet;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Proposal<N: Network> {
     /// The proposed batch header.
     batch_header: BatchHeader<N>,

--- a/node/bft/src/helpers/timestamp.rs
+++ b/node/bft/src/helpers/timestamp.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::MAX_TIMESTAMP_DELTA_IN_SECS;
+use crate::{MAX_TIMESTAMP_DELTA_IN_SECS, PROPOSAL_EXPIRATION_IN_SECS};
 use snarkvm::prelude::{bail, Result};
 
 use time::OffsetDateTime;
@@ -29,6 +29,15 @@ pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
         bail!("Timestamp {timestamp} is too far in the future")
     }
     Ok(())
+}
+
+/// Returns whether the proposal is expired.
+pub fn is_proposal_expired(current_timestamp: i64, proposal_timestamp: i64) -> bool {
+    debug_assert!(
+        current_timestamp >= proposal_timestamp,
+        "Current timestamp must be greater or equal to the proposal timestamp"
+    );
+    current_timestamp.saturating_sub(proposal_timestamp) >= PROPOSAL_EXPIRATION_IN_SECS
 }
 
 #[cfg(test)]

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -59,7 +59,12 @@ pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds
 pub const MAX_WORKERS: u8 = 1; // worker(s)
 
 /// The number of seconds a proposal is valid for before it expires.
+#[cfg(not(any(test, feature = "test")))]
 pub const PROPOSAL_EXPIRATION_IN_SECS: i64 = 60; // seconds
+/// The number of seconds a proposal is valid for before it expires.
+/// This is set to a deliberately low value (5) for testing purposes only.
+#[cfg(any(test, feature = "test"))]
+pub const PROPOSAL_EXPIRATION_IN_SECS: i64 = 5; // seconds
 
 /// The frequency at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -58,6 +58,9 @@ pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds
 /// The maximum number of workers that can be spawned.
 pub const MAX_WORKERS: u8 = 1; // worker(s)
 
+/// The number of seconds a proposal is valid for before it expires.
+pub const PROPOSAL_EXPIRATION_IN_SECS: i64 = 60; // seconds
+
 /// The frequency at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.
 pub const PRIMARY_PING_IN_MS: u64 = 2 * MAX_BATCH_DELAY_IN_MS; // ms

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1945,20 +1945,20 @@ mod tests {
 
         // Propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
-        let original_proposed_batch = primary.proposed_batch.read().clone().unwrap();
+        let original_proposed_batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
 
         // Try to propose the batch again. This time, it should return the same proposal.
         assert!(primary.propose_batch().await.is_ok());
-        let proposal = primary.proposed_batch.read().clone().unwrap();
-        assert_eq!(proposal, original_proposed_batch);
+        let proposal_batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
+        assert_eq!(proposal_batch_id, original_proposed_batch_id);
 
         // Sleep until the proposal is expired.
         tokio::time::sleep(Duration::from_secs(PROPOSAL_EXPIRATION_IN_SECS as u64)).await;
 
         // Try to propose a batch again. This time the proposal should be expired and a new proposal should be created.
         assert!(primary.propose_batch().await.is_ok());
-        let new_proposal = primary.proposed_batch.read().clone().unwrap();
-        assert_ne!(new_proposal, proposal);
+        let new_proposal_batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
+        assert_ne!(new_proposal_batch_id, original_proposed_batch_id);
     }
 
     #[tokio::test]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1936,6 +1936,9 @@ mod tests {
         assert!(primary.propose_batch().await.is_ok());
         assert!(primary.proposed_batch.read().is_none());
 
+        // Sleep for a while to ensure the primary is ready to propose the next round.
+        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
+
         // Generate a solution and a transaction.
         let (solution_id, solution) = sample_unconfirmed_solution(&mut rng);
         let (transaction_id, transaction) = sample_unconfirmed_transaction(&mut rng);
@@ -2119,6 +2122,9 @@ mod tests {
         // Generate certificates.
         let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
 
+        // Sleep for a while to ensure the primary is ready to propose the next round.
+        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
+
         // Create a valid proposal with an author that isn't the primary.
         let peer_account = &accounts[1];
         let peer_address = peer_account.1.address();
@@ -2181,6 +2187,9 @@ mod tests {
 
         // Generate certificates.
         let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
+
+        // Sleep for a while to ensure the primary is ready to propose the next round.
+        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
 
         // Create a valid proposal with an author that isn't the primary.
         let peer_account = &accounts[1];
@@ -2332,6 +2341,9 @@ mod tests {
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
 
+        // Sleep for a while to ensure the primary is ready to process the proposal.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
 
@@ -2370,6 +2382,9 @@ mod tests {
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
 
+        // Sleep for a while to ensure the primary is ready to process the proposal.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
 
@@ -2404,6 +2419,9 @@ mod tests {
 
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
+
+        // Sleep for a while to ensure the primary is ready to process the proposal.
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
@@ -2441,6 +2459,9 @@ mod tests {
 
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
+
+        // Sleep for a while to ensure the primary is ready to process the proposal.
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR introduces an expiration time for proposals, where nodes expire their own proposal and no longer track other validator proposals past the expiration time. The current expiration time is 1 minute.

This is needed to mitigate the concerns where validator nodes that reboot lose their in-memory proposal and other validator nodes will no longer accept new proposals for that validator. 

There are two cases:
1. If a validator's  own proposal is not certified after the expiration time, it is thrown away and a new proposal is created.
2. Validators can sign new proposals on the same round and author if the original proposal has expired.


This is one of the solutions to address a portion of https://github.com/AleoHQ/snarkOS/issues/3171.