### PR TITLE
[Bump] Update snarkVM rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "indexmap 2.2.5",
  "itertools 0.11.0",
@@ -3425,12 +3425,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3515,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3563,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "rand",
  "rayon",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "anyhow",
  "rand",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "anyhow",
  "colored",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "indexmap 2.2.5",
  "paste",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=39282a1#39282a1b53527b98f746b51014c41fb0377b17a4"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "indexmap 2.2.5",
  "itertools 0.11.0",
@@ -3425,12 +3425,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3515,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3527,7 +3527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3538,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3563,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3715,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3726,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3737,7 +3737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "rand",
  "rayon",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3804,7 +3804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "anyhow",
  "rand",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "indexmap 2.2.5",
  "rayon",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "anyhow",
  "colored",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "indexmap 2.2.5",
  "paste",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=36a1e0f#36a1e0fb285762eae8e15e93270845fc86938336"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=ed20562#ed20562d6f97ef593f051ce3cc848644e785f817"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "39282a1"
+rev = "36a1e0f"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "36a1e0f"
+rev = "ed20562"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR simply updates the snarkVM rev to https://github.com/AleoHQ/snarkVM/pull/2421/commits/36a1e0fb285762eae8e15e93270845fc86938336. 
This change is to ensure that: 
- transactions going into `VM::speculate` have the same ordering as the original list of transactions.
- the previous block is used to calculate the next targets.


The sister PRs are here:
 - https://github.com/AleoHQ/snarkVM/pull/2421.
 - https://github.com/AleoHQ/snarkVM/pull/2422.
