### PR TITLE
use tcmalloc allocator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get dist-upgrade -y -o DPkg::Options::=--force-confold
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev libgoogle-perftools-dev
       - restore_cache:
           keys:
             - << parameters.cache_key >>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "tcmalloc"
 version = "0.3.0"
-source = "git+https://github.com/bhansconnect/tcmalloc-rs?branch=master#b3c33ac6d2a760e05fc3c263d172f3910e6a80ed"
+source = "git+https://github.com/joske/tcmalloc-rs?tag=v2.9.1#bec41cb0f246001c444c13792bc279c818e302e4"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
- "tikv-jemallocator",
+ "tcmalloc",
  "walkdir",
 ]
 
@@ -4343,6 +4343,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcmalloc"
+version = "0.3.0"
+source = "git+https://github.com/bhansconnect/tcmalloc-rs?branch=master#b3c33ac6d2a760e05fc3c263d172f3910e6a80ed"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,26 +4405,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ path = "./node/tcp"
 version = "=2.2.7"
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
-tcmalloc = { git = "https://github.com/bhansconnect/tcmalloc-rs", branch = "master" }
+tcmalloc = { git = "https://github.com/joske/tcmalloc-rs", tag = "v2.9.1" }
 
 [dev-dependencies.rusty-hook]
 version = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ path = "./node/tcp"
 version = "=2.2.7"
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
-tikv-jemallocator = "0.5"
+tcmalloc = { git = "https://github.com/bhansconnect/tcmalloc-rs", branch = "master" }
 
 [dev-dependencies.rusty-hook]
 version = "0.11.2"

--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -18,8 +18,8 @@ sudo apt-get install -y \
 	pkg-config \
 	tmux \
 	xz-utils \
-	ufw
-
+	ufw \
+	libgoogle-perftools-dev
 
 # Install Rust
 

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -18,11 +18,11 @@ use clap::Parser;
 use std::process::exit;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-use tikv_jemallocator::Jemalloc;
+use tcmalloc::TCMalloc;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: TCMalloc = TCMalloc;
 
 fn main() -> anyhow::Result<()> {
     // Parse the given arguments.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

switch to tcmalloc allocator.

Note that libtcmalloc must be installed on the target (build) machine. On ubuntu systems this means installing `libgoogle-perftools-dev`