### PR TITLE
[Fix] Skip aborted transmissions in certificates during block sync

### DIFF
--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -662,8 +662,10 @@ impl<N: Network> Storage<N> {
                             Ok(solution) => missing_transmissions.insert(*transmission_id, solution.into()),
                             // Check if the solution is in the aborted solutions.
                             Err(_) => {
-                                // Insert the aborted solution if it exists in the block.
-                                match block.aborted_solution_ids().contains(solution_id) {
+                                // Insert the aborted solution if it exists in the block or ledger.
+                                match block.aborted_solution_ids().contains(solution_id)
+                                    || self.ledger.contains_transmission(transmission_id).unwrap_or(false)
+                                {
                                     true => {
                                         aborted_transmissions.insert(*transmission_id);
                                     }
@@ -685,8 +687,10 @@ impl<N: Network> Storage<N> {
                             Ok(transaction) => missing_transmissions.insert(*transmission_id, transaction.into()),
                             // Check if the transaction is in the aborted transactions.
                             Err(_) => {
-                                // Insert the aborted transaction if it exists in the block.
-                                match block.aborted_transaction_ids().contains(transaction_id) {
+                                // Insert the aborted transaction if it exists in the block or ledger.
+                                match block.aborted_transaction_ids().contains(transaction_id)
+                                    || self.ledger.contains_transmission(transmission_id).unwrap_or(false)
+                                {
                                     true => {
                                         aborted_transmissions.insert(*transmission_id);
                                     }

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -638,6 +638,10 @@ impl<N: Network> Storage<N> {
         // Retrieve the aborted transmissions for the certificate.
         let mut aborted_transmissions = HashSet::new();
 
+        // Track the block's aborted solutions and transactions.
+        let aborted_solutions: IndexSet<_> = block.aborted_solution_ids().iter().collect();
+        let aborted_transactions: IndexSet<_> = block.aborted_transaction_ids().iter().collect();
+
         // Iterate over the transmission IDs.
         for transmission_id in certificate.transmission_ids() {
             // If the transmission ID already exists in the map, skip it.
@@ -663,7 +667,7 @@ impl<N: Network> Storage<N> {
                             // Check if the solution is in the aborted solutions.
                             Err(_) => {
                                 // Insert the aborted solution if it exists in the block or ledger.
-                                match block.aborted_solution_ids().contains(solution_id)
+                                match aborted_solutions.contains(solution_id)
                                     || self.ledger.contains_transmission(transmission_id).unwrap_or(false)
                                 {
                                     true => {
@@ -688,7 +692,7 @@ impl<N: Network> Storage<N> {
                             // Check if the transaction is in the aborted transactions.
                             Err(_) => {
                                 // Insert the aborted transaction if it exists in the block or ledger.
-                                match block.aborted_transaction_ids().contains(transaction_id)
+                                match aborted_transactions.contains(transaction_id)
                                     || self.ledger.contains_transmission(transmission_id).unwrap_or(false)
                                 {
                                     true => {

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -18,7 +18,10 @@ use snarkvm::{
 };
 
 use indexmap::IndexSet;
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+};
 
 pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// Returns `true` if the storage contains the specified `transmission ID`.
@@ -33,6 +36,7 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
         &self,
         batch_header: &BatchHeader<N>,
         transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
+        aborted_transmissions: HashSet<TransmissionID<N>>,
     ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>>;
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds support for processing certificates that have aborted transmissions. This change allows nodes that are syncing  via `Storage::sync_certificate_with_block` to properly accept and process certificates that have transmission IDs that refer to aborted solutions/transmissions. Previously, these certificates could not be processed because they are expecting the full aborted transmission, but nodes do not store aborted transmissions past GC.

## Test Plan

A test has been added to ensure that we can process and insert certificates as long as we declare which transmissions are aborted.
