### PR TITLE
Moving height, round,solutions, and transactions to bft for clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "rand",
+ "snarkos-node-metrics",
  "snarkvm",
  "tokio",
  "tracing",

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [features]
 default = [ ]
-metrics = [ "dep:metrics", "snarkos-node-bft-events/metrics" ]
+metrics = [ "dep:metrics", "snarkos-node-bft-events/metrics", "snarkos-node-bft-ledger-service/metrics" ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2021"
 default = [ ]
 ledger = [ "lru", "parking_lot", "rand", "tokio", "tracing" ]
 ledger-write = [ ]
+metrics = ["dep:metrics", "snarkvm/metrics"]
 mock = [ "parking_lot", "tracing" ]
 prover = [ ]
 test = [ "mock", "translucent" ]
@@ -34,6 +35,12 @@ features = [ "serde", "rayon" ]
 
 [dependencies.lru]
 version = "0.12"
+optional = true
+
+[dependencies.metrics]
+package = "snarkos-node-metrics"
+path = "../../metrics"
+version = "=2.2.7"
 optional = true
 
 [dependencies.parking_lot]

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -343,8 +343,8 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     #[cfg(feature = "metrics")]
     fn update_bft_metrics(&self, block: &Block<N>) {
-        let num_sol = next_block.solutions().len();
-        let num_tx = next_block.transactions().len();
+        let num_sol = block.solutions().len();
+        let num_tx = block.transactions().len();
 
         metrics::gauge(metrics::bft::HEIGHT, block.height() as f64);
         metrics::gauge(metrics::bft::LAST_COMMITTED_ROUND, block.round() as f64);

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -333,6 +333,10 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         }
         // Advance to the next block.
         self.ledger.advance_to_next_block(block)?;
+        // Update BFT metrics.
+        #[cfg(feature = "metrics")]
+        self.update_bft_metrics(block);
+
         tracing::info!("\n\nAdvanced to block {} at round {} - {}\n", block.height(), block.round(), block.hash());
         Ok(())
     }

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -336,4 +336,15 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         tracing::info!("\n\nAdvanced to block {} at round {} - {}\n", block.height(), block.round(), block.hash());
         Ok(())
     }
+
+    #[cfg(feature = "metrics")]
+    fn update_bft_metrics(&self, block: &Block<N>) {
+        let num_sol = next_block.solutions().len();
+        let num_tx = next_block.transactions().len();
+
+        metrics::gauge(metrics::bft::HEIGHT, block.height() as f64);
+        metrics::gauge(metrics::bft::LAST_COMMITTED_ROUND, block.round() as f64);
+        metrics::increment_gauge(metrics::blocks::SOLUTIONS, num_sol as f64);
+        metrics::increment_gauge(metrics::blocks::TRANSACTIONS, num_tx as f64);
+    }
 }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -225,7 +225,6 @@ impl<N: Network> Consensus<N> {
         #[cfg(feature = "metrics")]
         {
             metrics::increment_gauge(metrics::consensus::UNCONFIRMED_SOLUTIONS, 1f64);
-            metrics::increment_gauge(metrics::consensus::UNCONFIRMED_TRANSMISSIONS, 1f64);
             let timestamp = snarkos_node_bft::helpers::now();
             self.transmissions_queue_timestamps.lock().insert(TransmissionID::Solution(solution.id()), timestamp);
         }
@@ -291,7 +290,6 @@ impl<N: Network> Consensus<N> {
         #[cfg(feature = "metrics")]
         {
             metrics::increment_gauge(metrics::consensus::UNCONFIRMED_TRANSACTIONS, 1f64);
-            metrics::increment_gauge(metrics::consensus::UNCONFIRMED_TRANSMISSIONS, 1f64);
             let timestamp = snarkos_node_bft::helpers::now();
             self.transmissions_queue_timestamps.lock().insert(TransmissionID::Transaction(transaction.id()), timestamp);
         }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -435,20 +435,12 @@ impl<N: Network> Consensus<N> {
             let elapsed = std::time::Duration::from_secs((snarkos_node_bft::helpers::now() - start) as u64);
             let next_block_timestamp = next_block.header().metadata().timestamp();
             let block_latency = next_block_timestamp - current_block_timestamp;
-            let num_sol = next_block.solutions().len();
-            let num_tx = next_block.transactions().len();
-            let num_transmissions = num_tx + num_sol;
             let proof_target = next_block.header().proof_target();
             let coinbase_target = next_block.header().coinbase_target();
             let cumulative_proof_target = next_block.header().cumulative_proof_target();
 
             self.add_transmission_latency_metric(&next_block);
 
-            metrics::gauge(metrics::blocks::HEIGHT, next_block.height() as f64);
-            metrics::increment_gauge(metrics::blocks::SOLUTIONS, num_sol as f64);
-            metrics::increment_gauge(metrics::blocks::TRANSACTIONS, num_tx as f64);
-            metrics::increment_gauge(metrics::blocks::TRANSMISSIONS, num_transmissions as f64);
-            metrics::gauge(metrics::consensus::LAST_COMMITTED_ROUND, next_block.round() as f64);
             metrics::gauge(metrics::consensus::COMMITTED_CERTIFICATES, num_committed_certificates as f64);
             metrics::histogram(metrics::consensus::CERTIFICATE_COMMIT_LATENCY, elapsed.as_secs_f64());
             metrics::histogram(metrics::consensus::BLOCK_LATENCY, block_latency as f64);

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -14,7 +14,7 @@
 
 pub(super) const COUNTER_NAMES: [&str; 2] = [bft::LEADERS_ELECTED, consensus::STALE_UNCONFIRMED_TRANSMISSIONS];
 
-pub(super) const GAUGE_NAMES: [&str; 20] = [
+pub(super) const GAUGE_NAMES: [&str; 19] = [
     bft::CONNECTED,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
@@ -30,7 +30,6 @@ pub(super) const GAUGE_NAMES: [&str; 20] = [
     consensus::COMMITTED_CERTIFICATES,
     consensus::UNCONFIRMED_SOLUTIONS,
     consensus::UNCONFIRMED_TRANSACTIONS,
-    consensus::UNCONFIRMED_TRANSMISSIONS,
     router::CONNECTED,
     router::CANDIDATE,
     router::RESTRICTED,
@@ -72,7 +71,6 @@ pub mod consensus {
     pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
     pub const BLOCK_LATENCY: &str = "snarkos_consensus_block_latency_secs";
     pub const UNCONFIRMED_TRANSACTIONS: &str = "snarkos_consensus_unconfirmed_transactions_total";
-    pub const UNCONFIRMED_TRANSMISSIONS: &str = "snarkos_consensus_unconfirmed_transmissions_total";
     pub const UNCONFIRMED_SOLUTIONS: &str = "snarkos_consensus_unconfirmed_solutions_total";
     pub const TRANSMISSION_LATENCY: &str = "snarkos_consensus_transmission_latency";
     pub const STALE_UNCONFIRMED_TRANSMISSIONS: &str = "snarkos_consensus_stale_unconfirmed_transmissions";

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -14,21 +14,20 @@
 
 pub(super) const COUNTER_NAMES: [&str; 2] = [bft::LEADERS_ELECTED, consensus::STALE_UNCONFIRMED_TRANSMISSIONS];
 
-pub(super) const GAUGE_NAMES: [&str; 21] = [
+pub(super) const GAUGE_NAMES: [&str; 20] = [
     bft::CONNECTED,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
     bft::PROPOSAL_ROUND,
     bft::CERTIFIED_BATCHES,
-    blocks::HEIGHT,
+    bft::HEIGHT,
+    bft::LAST_COMMITTED_ROUND,
     blocks::SOLUTIONS,
     blocks::TRANSACTIONS,
-    blocks::TRANSMISSIONS,
     blocks::PROOF_TARGET,
     blocks::COINBASE_TARGET,
     blocks::CUMULATIVE_PROOF_TARGET,
     consensus::COMMITTED_CERTIFICATES,
-    consensus::LAST_COMMITTED_ROUND,
     consensus::UNCONFIRMED_SOLUTIONS,
     consensus::UNCONFIRMED_TRANSACTIONS,
     consensus::UNCONFIRMED_TRANSMISSIONS,
@@ -56,12 +55,12 @@ pub mod bft {
     pub const LEADERS_ELECTED: &str = "snarkos_bft_leaders_elected_total";
     pub const PROPOSAL_ROUND: &str = "snarkos_bft_primary_proposal_round";
     pub const CERTIFIED_BATCHES: &str = "snarkos_bft_primary_certified_batches";
+    pub const HEIGHT: &str = "snarkos_bft_height_total";
+    pub const LAST_COMMITTED_ROUND: &str = "snarkos_bft_last_committed_round";
 }
 
 pub mod blocks {
-    pub const HEIGHT: &str = "snarkos_blocks_height_total";
     pub const TRANSACTIONS: &str = "snarkos_blocks_transactions_total";
-    pub const TRANSMISSIONS: &str = "snarkos_blocks_transmissions_total";
     pub const SOLUTIONS: &str = "snarkos_blocks_solutions_total";
     pub const PROOF_TARGET: &str = "snarkos_blocks_proof_target";
     pub const COINBASE_TARGET: &str = "snarkos_blocks_coinbase_target";
@@ -71,7 +70,6 @@ pub mod blocks {
 pub mod consensus {
     pub const CERTIFICATE_COMMIT_LATENCY: &str = "snarkos_consensus_certificate_commit_latency_secs";
     pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
-    pub const LAST_COMMITTED_ROUND: &str = "snarkos_consensus_last_committed_round";
     pub const BLOCK_LATENCY: &str = "snarkos_consensus_block_latency_secs";
     pub const UNCONFIRMED_TRANSACTIONS: &str = "snarkos_consensus_unconfirmed_transactions_total";
     pub const UNCONFIRMED_TRANSMISSIONS: &str = "snarkos_consensus_unconfirmed_transmissions_total";


### PR DESCRIPTION
## Motivation
Right now, we only track height, round, solutions and transactions in consensus, and not in the `node/bft` `CoreLedgerService`, therefore we cannot track what height clients are at. This PR moves those metrics into the `CoreLedgerService`. 

Also removed the numTransmissions metric, as you can just `sum` the numTransactions and numSolutions in the end analytics service (metrics/prometheus or visualization/Grafana) if needed.

## Test Plan
These graphs show where I add 5 clients to the network.
<img width="568" alt="Screenshot 2024-04-10 at 8 22 03 AM" src="https://github.com/AleoHQ/snarkOS/assets/93600681/0ce7caa8-3210-4d5b-8223-0383d237b604">