### PR TITLE
[Optimize] Primary and Worker configuration tweaks

### DIFF
--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -48,8 +48,6 @@ impl<N: Network> Proposal<N> {
         ensure!(batch_header.round() >= committee.starting_round(), "Batch round must be >= the committee round");
         // Ensure the batch author is a member of the committee.
         ensure!(committee.is_committee_member(batch_header.author()), "The batch author is not a committee member");
-        // Ensure the transmissions are not empty.
-        ensure!(!transmissions.is_empty(), "The transmissions are empty");
         // Ensure the transmission IDs match in the batch header and transmissions.
         ensure!(
             batch_header.transmission_ids().len() == transmissions.len(),

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -104,7 +104,7 @@ pub struct Primary<N: Network> {
 
 impl<N: Network> Primary<N> {
     /// The maximum number of unconfirmed transmissions to send to the primary.
-    pub const MAX_TRANSMISSIONS_TOLERANCE: usize = 1 << 10;
+    pub const MAX_TRANSMISSIONS_TOLERANCE: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * 2;
 
     /// Initializes a new primary instance.
     pub fn new(

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -404,8 +404,6 @@ impl<N: Network> Primary<N> {
         let num_transmissions_per_worker = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH / self.num_workers() as usize;
         // Initialize the map of transmissions.
         let mut transmissions: IndexMap<_, _> = Default::default();
-        // Initialize a tracker for the number of transactions.
-        let mut num_transactions = 0;
         // Take the transmissions from the workers.
         for worker in self.workers.iter() {
             // Initialize a tracker for included transmissions for the current worker.
@@ -450,8 +448,6 @@ impl<N: Network> Primary<N> {
                                 trace!("Proposing - Skipping transaction '{}' - {e}", fmt_id(transaction_id));
                                 continue 'inner;
                             }
-                            // Increment the number of transactions.
-                            num_transactions += 1;
                         }
                         // Note: We explicitly forbid including ratifications,
                         // as the protocol currently does not support ratifications.
@@ -468,11 +464,6 @@ impl<N: Network> Primary<N> {
         // If there are no unconfirmed transmissions to propose, return early.
         if transmissions.is_empty() {
             debug!("Primary is safely skipping a batch proposal {}", "(no unconfirmed transmissions)".dimmed());
-            return Ok(());
-        }
-        // If there are no unconfirmed transactions to propose, return early.
-        if num_transactions == 0 {
-            debug!("Primary is safely skipping a batch proposal {}", "(no unconfirmed transactions)".dimmed());
             return Ok(());
         }
         // Ditto if the batch had already been proposed and not expired.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -461,11 +461,6 @@ impl<N: Network> Primary<N> {
                 }
             }
         }
-        // If there are no unconfirmed transmissions to propose, return early.
-        if transmissions.is_empty() {
-            debug!("Primary is safely skipping a batch proposal {}", "(no unconfirmed transmissions)".dimmed());
-            return Ok(());
-        }
         // Ditto if the batch had already been proposed and not expired.
         ensure!(round > 0, "Round 0 cannot have transaction batches");
         // Determine the current timestamp.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -104,7 +104,7 @@ pub struct Primary<N: Network> {
 
 impl<N: Network> Primary<N> {
     /// The maximum number of unconfirmed transmissions to send to the primary.
-    pub const MAX_TRANSMISSIONS_TOLERANCE: usize = BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH * 2;
+    pub const MAX_TRANSMISSIONS_TOLERANCE: usize = 1 << 10;
 
     /// Initializes a new primary instance.
     pub fn new(

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -474,6 +474,8 @@ impl<N: Network> Primary<N> {
         let is_expired = is_proposal_expired(current_timestamp, lock_guard.1);
         if lock_guard.0 == round && !is_expired {
             warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
+            // Reinsert the transmissions back into the ready queue for the next proposal.
+            self.reinsert_transmissions_into_workers(transmissions)?;
             return Ok(());
         }
 
@@ -777,7 +779,7 @@ impl<N: Network> Primary<N> {
         // If there was an error storing the certificate, reinsert the transmissions back into the ready queue.
         if let Err(e) = self.store_and_broadcast_certificate(&proposal, &committee_lookback).await {
             // Reinsert the transmissions back into the ready queue for the next proposal.
-            self.reinsert_transmissions_into_workers(proposal)?;
+            self.reinsert_transmissions_into_workers(proposal.into_transmissions())?;
             return Err(e);
         }
 
@@ -1138,7 +1140,7 @@ impl<N: Network> Primary<N> {
             let proposal = self.proposed_batch.write().take();
             if let Some(proposal) = proposal {
                 debug!("Cleared expired proposal for round {}", proposal.round());
-                self.reinsert_transmissions_into_workers(proposal)?;
+                self.reinsert_transmissions_into_workers(proposal.into_transmissions())?;
             }
         }
         Ok(())
@@ -1287,15 +1289,14 @@ impl<N: Network> Primary<N> {
     }
 
     /// Re-inserts the transmissions from the proposal into the workers.
-    fn reinsert_transmissions_into_workers(&self, proposal: Proposal<N>) -> Result<()> {
+    fn reinsert_transmissions_into_workers(
+        &self,
+        transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
+    ) -> Result<()> {
         // Re-insert the transmissions into the workers.
-        assign_to_workers(
-            &self.workers,
-            proposal.into_transmissions().into_iter(),
-            |worker, transmission_id, transmission| {
-                worker.reinsert(transmission_id, transmission);
-            },
-        )
+        assign_to_workers(&self.workers, transmissions.into_iter(), |worker, transmission_id, transmission| {
+            worker.reinsert(transmission_id, transmission);
+        })
     }
 
     /// Recursively stores a given batch certificate, after ensuring:

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -33,6 +33,7 @@ use snarkvm::{
 
 use indexmap::{IndexMap, IndexSet};
 use parking_lot::Mutex;
+use rand::seq::IteratorRandom;
 use std::{future::Future, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{sync::oneshot, task::JoinHandle, time::timeout};
 
@@ -223,7 +224,8 @@ impl<N: Network> Worker<N> {
             .ready
             .transmission_ids()
             .into_iter()
-            .take(Self::MAX_TRANSMISSIONS_PER_WORKER_PING)
+            .choose_multiple(&mut rand::thread_rng(), Self::MAX_TRANSMISSIONS_PER_WORKER_PING)
+            .into_iter()
             .collect::<IndexSet<_>>();
 
         // Broadcast the ping event.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the configurations with the following changes:

1. Randomly select transmissions for the worker ping
    - Previously, we would always take the first 5
    - This changes gives a better distribution of transmissions.

2. Relax the proposal requirement to allow proposals with no transmissions.
    - Blocks with no transactions is already allowed, this relaxes the requirements on the snarkOS side

3. Reinsert transmissions to the worker if a proposal fails
   - Previously we were erroneously discarding transmissions if the proposal fails, now we keep them around.


