### PR TITLE
[Optimize] Update `MAXIMUM_NUMBER_OF_BLOCKS` and `MAX_EVENT_SIZE`

### DIFF
--- a/node/bft/events/src/block_response.rs
+++ b/node/bft/events/src/block_response.rs
@@ -64,7 +64,7 @@ pub struct DataBlocks<N: Network>(pub Vec<Block<N>>);
 
 impl<N: Network> DataBlocks<N> {
     /// The maximum number of blocks that can be sent in a single message.
-    pub const MAXIMUM_NUMBER_OF_BLOCKS: u8 = 1;
+    pub const MAXIMUM_NUMBER_OF_BLOCKS: u8 = 10;
 
     /// Ensures that the blocks are well-formed in a block response.
     pub fn ensure_response_is_well_formed(

--- a/node/bft/events/src/helpers/codec.rs
+++ b/node/bft/events/src/helpers/codec.rs
@@ -23,7 +23,7 @@ use tracing::*;
 /// The maximum size of an event that can be transmitted during the handshake.
 const MAX_HANDSHAKE_SIZE: usize = 1024 * 1024; // 1 MiB
 /// The maximum size of an event that can be transmitted in the network.
-const MAX_EVENT_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
+const MAX_EVENT_SIZE: usize = 256 * 1024 * 1024; // 256 MiB
 
 /// The type of noise handshake to use for network encryption.
 pub const NOISE_HANDSHAKE_TYPE: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds some configuration tweaks:

1. `DataBlocks::MAXIMUM_NUMBER_OF_BLOCKS` from 1 to 10, to allow `BlockResponses` to include up to 10 blocks. 
2. `MAX_EVENT_SIZE` from 128 MB to 256 MB
