### PR TITLE
[Fix] Add aborted transmission IDs to storage service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3319,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3349,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3374,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3394,7 +3394,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3412,12 +3412,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3561,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3647,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3724,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "rand",
  "rayon",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "rand",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "colored",
@@ -3963,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3319,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3349,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3374,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3394,7 +3394,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3412,12 +3412,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3561,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3647,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3681,7 +3681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3702,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3724,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "rand",
  "rayon",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "anyhow",
  "rand",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3854,7 +3854,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3880,7 +3880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "anyhow",
  "colored",
@@ -3963,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=d48f6fb#d48f6fb7d7ca36d134407baebcc59952fe58c546"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=69c25a8#69c25a89f1e53e66294339bfa0c038761b60dda3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "d48f6fb"
+rev = "69c25a8"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "69c25a8"
+rev = "da3d78a"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -785,7 +785,12 @@ impl<N: Network> Storage<N> {
             .map(|id| (*id, Transmission::Transaction(snarkvm::ledger::narwhal::Data::Buffer(bytes::Bytes::new()))))
             .collect::<HashMap<_, _>>();
         // Insert the certificate ID for each of the transmissions into storage.
-        self.transmissions.insert_transmissions(certificate_id, transmission_ids, missing_transmissions);
+        self.transmissions.insert_transmissions(
+            certificate_id,
+            transmission_ids,
+            Default::default(),
+            missing_transmissions,
+        );
     }
 }
 
@@ -894,7 +899,7 @@ mod tests {
         let (missing_transmissions, transmissions) = sample_transmissions(&certificate, rng);
 
         // Insert the certificate.
-        storage.insert_certificate_atomic(certificate.clone(), missing_transmissions);
+        storage.insert_certificate_atomic(certificate.clone(), Default::default(), missing_transmissions);
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Ensure the certificate is stored in the correct round.
@@ -966,21 +971,21 @@ mod tests {
         let (missing_transmissions, transmissions) = sample_transmissions(&certificate, rng);
 
         // Insert the certificate.
-        storage.insert_certificate_atomic(certificate.clone(), missing_transmissions.clone());
+        storage.insert_certificate_atomic(certificate.clone(), Default::default(), missing_transmissions.clone());
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Check that the underlying storage representation is correct.
         assert_storage(&storage, &rounds, &certificates, &batch_ids, &transmissions);
 
         // Insert the certificate again - without any missing transmissions.
-        storage.insert_certificate_atomic(certificate.clone(), Default::default());
+        storage.insert_certificate_atomic(certificate.clone(), Default::default(), Default::default());
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Check that the underlying storage representation remains unchanged.
         assert_storage(&storage, &rounds, &certificates, &batch_ids, &transmissions);
 
         // Insert the certificate again - with all of the original missing transmissions.
-        storage.insert_certificate_atomic(certificate, missing_transmissions);
+        storage.insert_certificate_atomic(certificate, Default::default(), missing_transmissions);
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Check that the underlying storage representation remains unchanged.
@@ -1212,21 +1217,21 @@ pub mod prop_tests {
         // Insert the certificate.
         let missing_transmissions: HashMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>> =
             transmission_map.into_iter().collect();
-        storage.insert_certificate_atomic(certificate.clone(), missing_transmissions.clone());
+        storage.insert_certificate_atomic(certificate.clone(), Default::default(), missing_transmissions.clone());
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Check that the underlying storage representation is correct.
         assert_storage(&storage, &rounds, &certificates, &batch_ids, &internal_transmissions);
 
         // Insert the certificate again - without any missing transmissions.
-        storage.insert_certificate_atomic(certificate.clone(), Default::default());
+        storage.insert_certificate_atomic(certificate.clone(), Default::default(), Default::default());
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Check that the underlying storage representation remains unchanged.
         assert_storage(&storage, &rounds, &certificates, &batch_ids, &internal_transmissions);
 
         // Insert the certificate again - with all of the original missing transmissions.
-        storage.insert_certificate_atomic(certificate, missing_transmissions);
+        storage.insert_certificate_atomic(certificate, Default::default(), missing_transmissions);
         // Ensure the certificate exists in storage.
         assert!(storage.contains_certificate(certificate_id));
         // Check that the underlying storage representation remains unchanged.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2552,7 +2552,7 @@ mod tests {
 
         // Ensure the certificate exists in storage.
         assert!(primary.storage.contains_certificate(certificate_id));
-        // Ensure that the aborted transmissions are exist in the storage.
+        // Ensure that the aborted transmission IDs exist in storage.
         for aborted_transmission_id in aborted_transmissions {
             assert!(primary.storage.contains_transmission(aborted_transmission_id));
             assert!(primary.storage.get_transmission(aborted_transmission_id).is_none());

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2545,9 +2545,17 @@ mod tests {
         );
 
         // Insert the certificate to storage.
-        primary.storage.insert_certificate(certificate, transmissions_without_aborted, aborted_transmissions).unwrap();
+        primary
+            .storage
+            .insert_certificate(certificate, transmissions_without_aborted, aborted_transmissions.clone())
+            .unwrap();
 
         // Ensure the certificate exists in storage.
         assert!(primary.storage.contains_certificate(certificate_id));
+        // Ensure that the aborted transmissions are exist in the storage.
+        for aborted_transmission_id in aborted_transmissions {
+            assert!(primary.storage.contains_transmission(aborted_transmission_id));
+            assert!(primary.storage.get_transmission(aborted_transmission_id).is_none());
+        }
     }
 }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -360,12 +360,21 @@ impl<N: Network> Sync<N> {
             }
         }
 
-        // Sync the height with the block.
-        self.storage.sync_height_with_block(block.height());
-        // Sync the round with the block.
-        self.storage.sync_round_with_block(block.round());
+        let self_ = self.clone();
+        tokio::task::spawn_blocking(move || {
+            // Check the next block.
+            self_.ledger.check_next_block(&block)?;
+            // Attempt to advance to the next block.
+            self_.ledger.advance_to_next_block(&block)?;
 
-        Ok(())
+            // Sync the height with the block.
+            self_.storage.sync_height_with_block(block.height());
+            // Sync the round with the block.
+            self_.storage.sync_round_with_block(block.round());
+
+            Ok(())
+        })
+        .await?
     }
 }
 

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -120,7 +120,9 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                 Entry::Vacant(vacant_entry) => {
                     // Retrieve the missing transmission.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
-                        error!("Failed to provide a missing transmission {transmission_id}");
+                        if !aborted_transmission_ids.contains(&transmission_id) {
+                            error!("Failed to provide a missing transmission {transmission_id}");
+                        }
                         continue 'outer;
                     };
                     // Prepare the set of certificate IDs.

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -171,7 +171,9 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                 Ok(None) => {
                     // Retrieve the missing transmission.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
-                        error!("Failed to provide a missing transmission {transmission_id}");
+                        if !aborted_transmission_ids.contains(&transmission_id) {
+                            error!("Failed to provide a missing transmission {transmission_id}");
+                        }
                         continue 'outer;
                     };
                     // Prepare the set of certificate IDs.

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -44,19 +44,37 @@ use tracing::error;
 pub struct BFTPersistentStorage<N: Network> {
     /// The map of `transmission ID` to `(transmission, certificate IDs)` entries.
     transmissions: DataMap<TransmissionID<N>, (Transmission<N>, IndexSet<Field<N>>)>,
+    /// The map of `aborted transmission ID` to `certificate IDs` entries.
+    aborted_transmission_ids: DataMap<TransmissionID<N>, IndexSet<Field<N>>>,
 }
 
 impl<N: Network> BFTPersistentStorage<N> {
     /// Initializes a new BFT persistent storage service.
     pub fn open(storage_mode: StorageMode) -> Result<Self> {
-        Ok(Self { transmissions: internal::RocksDB::open_map(N::ID, storage_mode, MapID::BFT(BFTMap::Transmissions))? })
+        Ok(Self {
+            transmissions: internal::RocksDB::open_map(N::ID, storage_mode.clone(), MapID::BFT(BFTMap::Transmissions))?,
+            aborted_transmission_ids: internal::RocksDB::open_map(
+                N::ID,
+                storage_mode,
+                MapID::BFT(BFTMap::AbortedTransmissionIDs),
+            )?,
+        })
     }
 
     /// Initializes a new BFT persistent storage service.
     #[cfg(any(test, feature = "test"))]
     pub fn open_testing(temp_dir: std::path::PathBuf, dev: Option<u16>) -> Result<Self> {
         Ok(Self {
-            transmissions: internal::RocksDB::open_map_testing(temp_dir, dev, MapID::BFT(BFTMap::Transmissions))?,
+            transmissions: internal::RocksDB::open_map_testing(
+                temp_dir.clone(),
+                dev,
+                MapID::BFT(BFTMap::Transmissions),
+            )?,
+            aborted_transmission_ids: internal::RocksDB::open_map_testing(
+                temp_dir,
+                dev,
+                MapID::BFT(BFTMap::AbortedTransmissionIDs),
+            )?,
         })
     }
 }
@@ -65,13 +83,19 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
     /// Returns `true` if the storage contains the specified `transmission ID`.
     fn contains_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
         // Check if the transmission ID exists in storage.
-        let result = self.transmissions.contains_key_confirmed(&transmission_id);
-        // If the result is an error, log the error.
-        if let Err(error) = &result {
-            error!("Failed to check if transmission ID exists in storage - {error}");
+        match self.transmissions.contains_key_confirmed(&transmission_id) {
+            Ok(true) => return true,
+            Ok(false) => (),
+            Err(error) => error!("Failed to check if transmission ID exists in confirmed storage - {error}"),
         }
-        // Return the result.
-        result.unwrap_or(false)
+        // Check if the transmission ID is in aborted storage.
+        match self.aborted_transmission_ids.contains_key_confirmed(&transmission_id) {
+            Ok(result) => result,
+            Err(error) => {
+                error!("Failed to check if aborted transmission ID exists in storage - {error}");
+                false
+            }
+        }
     }
 
     /// Returns the transmission for the given `transmission ID`.
@@ -125,6 +149,7 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         &self,
         certificate_id: Field<N>,
         transmission_ids: IndexSet<TransmissionID<N>>,
+        aborted_transmission_ids: HashSet<TransmissionID<N>>,
         mut missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     ) {
         // Inserts the following:
@@ -163,6 +188,34 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                 }
             }
         }
+        // Inserts the aborted transmission IDs.
+        for aborted_transmission_id in aborted_transmission_ids {
+            // Retrieve the transmission entry.
+            match self.aborted_transmission_ids.get_confirmed(&aborted_transmission_id) {
+                Ok(Some(entry)) => {
+                    let mut certificate_ids = cow_to_cloned!(entry);
+                    // Insert the certificate ID into the set.
+                    certificate_ids.insert(certificate_id);
+                    // Update the transmission entry.
+                    if let Err(e) = self.aborted_transmission_ids.insert(aborted_transmission_id, certificate_ids) {
+                        error!("Failed to insert aborted transmission ID {aborted_transmission_id} into storage - {e}");
+                    }
+                }
+                Ok(None) => {
+                    // Prepare the set of certificate IDs.
+                    let certificate_ids = indexset! { certificate_id };
+                    // Insert the transmission and a new set with the certificate ID.
+                    if let Err(e) = self.aborted_transmission_ids.insert(aborted_transmission_id, certificate_ids) {
+                        error!("Failed to insert aborted transmission ID {aborted_transmission_id} into storage - {e}");
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to process the 'insert' for aborted transmission ID {aborted_transmission_id} into storage - {e}"
+                    );
+                }
+            }
+        }
     }
 
     /// Removes the certificate ID for the transmissions from storage.
@@ -170,7 +223,7 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
     /// If the transmission no longer references any certificate IDs, the entry is removed from storage.
     fn remove_transmissions(&self, certificate_id: &Field<N>, transmission_ids: &IndexSet<TransmissionID<N>>) {
         // If this is the last certificate ID for the transmission ID, remove the transmission.
-        'outer: for transmission_id in transmission_ids {
+        for transmission_id in transmission_ids {
             // Retrieve the transmission entry.
             match self.transmissions.get_confirmed(transmission_id) {
                 Ok(Some(entry)) => {
@@ -182,7 +235,6 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                         // Remove the transmission entry.
                         if let Err(e) = self.transmissions.remove(transmission_id) {
                             error!("Failed to remove transmission {transmission_id} (now empty) from storage - {e}");
-                            continue 'outer;
                         }
                     }
                     // Otherwise, update the transmission entry.
@@ -192,14 +244,44 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                             error!(
                                 "Failed to remove transmission {transmission_id} for certificate {certificate_id} from storage - {e}"
                             );
-                            continue 'outer;
                         }
                     }
                 }
                 Ok(None) => { /* no-op */ }
                 Err(e) => {
                     error!("Failed to process the 'remove' for transmission {transmission_id} from storage - {e}");
-                    continue 'outer;
+                }
+            }
+            // Retrieve the aborted transmission ID entry.
+            match self.aborted_transmission_ids.get_confirmed(transmission_id) {
+                Ok(Some(entry)) => {
+                    let mut certificate_ids = cow_to_cloned!(entry);
+                    // Insert the certificate ID into the set.
+                    certificate_ids.swap_remove(certificate_id);
+                    // If there are no more certificate IDs for the transmission ID, remove the transmission.
+                    if certificate_ids.is_empty() {
+                        // Remove the transmission entry.
+                        if let Err(e) = self.aborted_transmission_ids.remove(transmission_id) {
+                            error!(
+                                "Failed to remove aborted transmission ID {transmission_id} (now empty) from storage - {e}"
+                            );
+                        }
+                    }
+                    // Otherwise, update the transmission entry.
+                    else {
+                        // Update the transmission entry.
+                        if let Err(e) = self.aborted_transmission_ids.insert(*transmission_id, certificate_ids) {
+                            error!(
+                                "Failed to remove aborted transmission ID {transmission_id} for certificate {certificate_id} from storage - {e}"
+                            );
+                        }
+                    }
+                }
+                Ok(None) => { /* no-op */ }
+                Err(e) => {
+                    error!(
+                        "Failed to process the 'remove' for aborted transmission ID {transmission_id} from storage - {e}"
+                    );
                 }
             }
         }

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -44,6 +44,7 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
         &self,
         certificate_id: Field<N>,
         transmission_ids: IndexSet<TransmissionID<N>>,
+        aborted_transmission_ids: HashSet<TransmissionID<N>>,
         missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     );
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds support for tracking aborted transmission IDs in storage. This solves an edge case in syncing via BFT when there are aborted transmissions in certificates:

1. We can’t find a transmission  in block `X` because it was aborted in block `X-1`
2. BFT block sync requires certificates from block `X` in order to commit block `X-1`
3. We have not added Block `X-1` into our ledger and started tracking that the transmission was indeed aborted
4. When we process certificates in block `X`, we don’t know where the transmission is and that it was supposed to be aborted in block `X-1`, which causes an error.


The sister PR is here - https://github.com/AleoHQ/snarkVM/pull/2433

## Test Plan

The tests have been updated to check that we properly track aborted transmissions in storage.
