### PR TITLE
[Feature] Add additional REST endpoints

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -172,24 +172,24 @@ impl<N: Network> BFT<N> {
 }
 
 impl<N: Network> BFT<N> {
-    /// Returns the unconfirmed transmission IDs.
-    pub fn unconfirmed_transmission_ids(&self) -> impl '_ + Iterator<Item = TransmissionID<N>> {
-        self.primary.unconfirmed_transmission_ids()
+    /// Returns the worker transmission IDs.
+    pub fn worker_transmission_ids(&self) -> impl '_ + Iterator<Item = TransmissionID<N>> {
+        self.primary.worker_transmission_ids()
     }
 
-    /// Returns the unconfirmed transmissions.
-    pub fn unconfirmed_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
-        self.primary.unconfirmed_transmissions()
+    /// Returns the worker transmissions.
+    pub fn worker_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
+        self.primary.worker_transmissions()
     }
 
-    /// Returns the unconfirmed solutions.
-    pub fn unconfirmed_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
-        self.primary.unconfirmed_solutions()
+    /// Returns the worker solutions.
+    pub fn worker_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
+        self.primary.worker_solutions()
     }
 
-    /// Returns the unconfirmed transactions.
-    pub fn unconfirmed_transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
-        self.primary.unconfirmed_transactions()
+    /// Returns the worker transactions.
+    pub fn worker_transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
+        self.primary.worker_transactions()
     }
 }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -253,23 +253,23 @@ impl<N: Network> Primary<N> {
 }
 
 impl<N: Network> Primary<N> {
-    /// Returns the unconfirmed transmission IDs.
-    pub fn unconfirmed_transmission_ids(&self) -> impl '_ + Iterator<Item = TransmissionID<N>> {
+    /// Returns the worker transmission IDs.
+    pub fn worker_transmission_ids(&self) -> impl '_ + Iterator<Item = TransmissionID<N>> {
         self.workers.iter().flat_map(|worker| worker.transmission_ids())
     }
 
-    /// Returns the unconfirmed transmissions.
-    pub fn unconfirmed_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
+    /// Returns the worker transmissions.
+    pub fn worker_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
         self.workers.iter().flat_map(|worker| worker.transmissions())
     }
 
-    /// Returns the unconfirmed solutions.
-    pub fn unconfirmed_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
+    /// Returns the worker solutions.
+    pub fn worker_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
         self.workers.iter().flat_map(|worker| worker.solutions())
     }
 
-    /// Returns the unconfirmed transactions.
-    pub fn unconfirmed_transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
+    /// Returns the worker transactions.
+    pub fn worker_transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
         self.workers.iter().flat_map(|worker| worker.transactions())
     }
 }

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -200,22 +200,22 @@ impl<N: Network> Consensus<N> {
 impl<N: Network> Consensus<N> {
     /// Returns the unconfirmed transmission IDs.
     pub fn unconfirmed_transmission_ids(&self) -> impl '_ + Iterator<Item = TransmissionID<N>> {
-        self.bft.worker_transmission_ids().chain(self.inbound_transmission_ids())
+        self.worker_transmission_ids().chain(self.inbound_transmission_ids())
     }
 
     /// Returns the unconfirmed transmissions.
     pub fn unconfirmed_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
-        self.bft.worker_transmissions().chain(self.inbound_transmissions())
+        self.worker_transmissions().chain(self.inbound_transmissions())
     }
 
     /// Returns the unconfirmed solutions.
     pub fn unconfirmed_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
-        self.bft.worker_solutions().chain(self.inbound_solutions())
+        self.worker_solutions().chain(self.inbound_solutions())
     }
 
     /// Returns the unconfirmed transactions.
     pub fn unconfirmed_transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
-        self.bft.worker_transactions().chain(self.inbound_transactions())
+        self.worker_transactions().chain(self.inbound_transactions())
     }
 }
 

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -220,6 +220,27 @@ impl<N: Network> Consensus<N> {
 }
 
 impl<N: Network> Consensus<N> {
+    /// Returns the solutions in the pending queue.
+    pub fn pending_queue_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
+        // Return an iterator over the solutions in the pending queue.
+        self.solutions_queue.lock().clone().into_iter().map(|(id, solution)| (id, Data::Object(solution)))
+    }
+
+    /// Returns the transactions in the pending queue.
+    pub fn pending_queue_transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
+        // Acquire the lock on the transactions queue.
+        let tx_queue = self.transactions_queue.lock();
+        // Return an iterator over the deployment and execution transactions in the pending queue.
+        tx_queue
+            .deployments
+            .clone()
+            .into_iter()
+            .chain(tx_queue.executions.clone())
+            .map(|(id, tx)| (id, Data::Object(tx)))
+    }
+}
+
+impl<N: Network> Consensus<N> {
     /// Adds the given unconfirmed solution to the memory pool.
     pub async fn add_unconfirmed_solution(&self, solution: Solution<N>) -> Result<()> {
         #[cfg(feature = "metrics")]

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -247,6 +247,16 @@ impl<N: Network> Consensus<N> {
         self.inbound_transmissions().map(|(id, _)| id)
     }
 
+    /// Returns the transmissions in the inbound queue.
+    pub fn inbound_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
+        self.inbound_transactions()
+            .map(|(id, tx)| (TransmissionID::Transaction(id), Transmission::Transaction(tx)))
+            .chain(
+                self.inbound_solutions()
+                    .map(|(id, solution)| (TransmissionID::Solution(id), Transmission::Solution(solution))),
+            )
+    }
+
     /// Returns the solutions in the inbound queue.
     pub fn inbound_solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
         // Return an iterator over the solutions in the inbound queue.
@@ -264,16 +274,6 @@ impl<N: Network> Consensus<N> {
             .into_iter()
             .chain(tx_queue.executions.clone())
             .map(|(id, tx)| (id, Data::Object(tx)))
-    }
-
-    /// Returns the transmissions in the inbound queue.
-    pub fn inbound_transmissions(&self) -> impl '_ + Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
-        self.inbound_transactions()
-            .map(|(id, tx)| (TransmissionID::Transaction(id), Transmission::Transaction(tx)))
-            .chain(
-                self.inbound_solutions()
-                    .map(|(id, solution)| (TransmissionID::Solution(id), Transmission::Solution(solution))),
-            )
     }
 }
 

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -166,10 +166,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
             // GET ../find/..
             .route(&format!("/{network}/find/blockHash/:tx_id"), get(Self::find_block_hash))
+            .route(&format!("/{network}/find/blockHeight/:state_root"), get(Self::find_block_height_from_state_root))
             .route(&format!("/{network}/find/transactionID/deployment/:program_id"), get(Self::find_transaction_id_from_program_id))
             .route(&format!("/{network}/find/transactionID/:transition_id"), get(Self::find_transaction_id_from_transition_id))
             .route(&format!("/{network}/find/transitionID/:input_or_output_id"), get(Self::find_transition_id))
-            .route(&format!("/{network}/find/blockHeight/:state_root"), get(Self::find_block_height_from_state_root))
 
             // GET ../peers/..
             .route(&format!("/{network}/peers/count"), get(Self::get_peers_count))

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -188,8 +188,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/memoryPool/solutions"), get(Self::get_memory_pool_solutions))
             .route(&format!("/{network}/memoryPool/transactions"), get(Self::get_memory_pool_transactions))
             .route(&format!("/{network}/statePath/:commitment"), get(Self::get_state_path_for_commitment))
-            .route(&format!("/{network}/stateRoot/:height"), get(Self::get_state_root))
             .route(&format!("/{network}/stateRoot/latest"), get(Self::get_state_root_latest))
+            .route(&format!("/{network}/stateRoot/:height"), get(Self::get_state_root))
             .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
 
             // Pass in `Rest` to make things convenient.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -169,6 +169,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/find/transactionID/deployment/:program_id"), get(Self::find_transaction_id_from_program_id))
             .route(&format!("/{network}/find/transactionID/:transition_id"), get(Self::find_transaction_id_from_transition_id))
             .route(&format!("/{network}/find/transitionID/:input_or_output_id"), get(Self::find_transition_id))
+            .route(&format!("/{network}/find/blockHeight/stateRoot/:state_root"), get(Self::find_block_height_from_state_root))
 
             // GET ../peers/..
             .route(&format!("/{network}/peers/count"), get(Self::get_peers_count))
@@ -187,6 +188,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/memoryPool/solutions"), get(Self::get_memory_pool_solutions))
             .route(&format!("/{network}/memoryPool/transactions"), get(Self::get_memory_pool_transactions))
             .route(&format!("/{network}/statePath/:commitment"), get(Self::get_state_path_for_commitment))
+            .route(&format!("/{network}/stateRoot/:height"), get(Self::get_state_root))
             .route(&format!("/{network}/stateRoot/latest"), get(Self::get_state_root_latest))
             .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
 

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -169,7 +169,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/find/transactionID/deployment/:program_id"), get(Self::find_transaction_id_from_program_id))
             .route(&format!("/{network}/find/transactionID/:transition_id"), get(Self::find_transaction_id_from_transition_id))
             .route(&format!("/{network}/find/transitionID/:input_or_output_id"), get(Self::find_transition_id))
-            .route(&format!("/{network}/find/blockHeight/stateRoot/:state_root"), get(Self::find_block_height_from_state_root))
+            .route(&format!("/{network}/find/blockHeight/:state_root"), get(Self::find_block_height_from_state_root))
 
             // GET ../peers/..
             .route(&format!("/{network}/peers/count"), get(Self::get_peers_count))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -187,12 +187,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /<network>/memoryPool/solutions
     pub(crate) async fn get_memory_pool_solutions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
-            Some(consensus) => Ok(ErasedJson::pretty(
-                consensus
-                    .unconfirmed_solutions()
-                    .chain(consensus.pending_queue_solutions())
-                    .collect::<IndexMap<_, _>>(),
-            )),
+            Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_solutions().collect::<IndexMap<_, _>>())),
             None => Err(RestError("Route isn't available for this node type".to_string())),
         }
     }
@@ -200,12 +195,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /<network>/memoryPool/transactions
     pub(crate) async fn get_memory_pool_transactions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
-            Some(consensus) => Ok(ErasedJson::pretty(
-                consensus
-                    .unconfirmed_transactions()
-                    .chain(consensus.pending_queue_transactions())
-                    .collect::<IndexMap<_, _>>(),
-            )),
+            Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_transactions().collect::<IndexMap<_, _>>())),
             None => Err(RestError("Route isn't available for this node type".to_string())),
         }
     }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -326,7 +326,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.find_transition_id(&input_or_output_id)?))
     }
 
-    // GET /<network>/find/blockHeight/stateRoot/{stateRoot}
+    // GET /<network>/find/blockHeight/{stateRoot}
     pub(crate) async fn find_block_height_from_state_root(
         State(rest): State<Self>,
         Path(state_root): Path<N::StateRoot>,

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -97,7 +97,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(height_or_hash): Path<String>,
     ) -> Result<ErasedJson, RestError> {
-        // Manually parse the height or the height or the hash, axum doesn't support different types
+        // Manually parse the height or the height of the hash, axum doesn't support different types
         // for the same path param.
         let block = if let Ok(height) = height_or_hash.parse::<u32>() {
             rest.ledger.get_block(height)?
@@ -150,7 +150,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_height(&hash)?))
     }
 
-    // GET /<NETWORK>/block/{height}/transactions
+    // GET /<network>/block/{height}/transactions
     pub(crate) async fn get_block_transactions(
         State(rest): State<Self>,
         Path(height): Path<u32>,
@@ -256,6 +256,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_state_path_for_commitment(&commitment)?))
     }
 
+    // GET /<network>/stateRoot/{height}
+    pub(crate) async fn get_state_root(
+        State(rest): State<Self>,
+        Path(height): Path<u32>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.get_state_root(height)?))
+    }
+
     // GET /<network>/stateRoot/latest
     pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_state_root())
@@ -316,6 +324,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Path(input_or_output_id): Path<Field<N>>,
     ) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.find_transition_id(&input_or_output_id)?))
+    }
+
+    // GET /<network>/find/blockHeight/stateRoot/{stateRoot}
+    pub(crate) async fn find_block_height_from_state_root(
+        State(rest): State<Self>,
+        Path(state_root): Path<N::StateRoot>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.find_block_height_from_state_root(state_root)?))
     }
 
     // POST /<network>/transaction/broadcast

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -246,17 +246,17 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_state_path_for_commitment(&commitment)?))
     }
 
+    // GET /<network>/stateRoot/latest
+    pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
+        ErasedJson::pretty(rest.ledger.latest_state_root())
+    }
+
     // GET /<network>/stateRoot/{height}
     pub(crate) async fn get_state_root(
         State(rest): State<Self>,
         Path(height): Path<u32>,
     ) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.get_state_root(height)?))
-    }
-
-    // GET /<network>/stateRoot/latest
-    pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_state_root())
     }
 
     // GET /<network>/committee/latest

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -187,7 +187,12 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /<network>/memoryPool/solutions
     pub(crate) async fn get_memory_pool_solutions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
-            Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_solutions().collect::<IndexMap<_, _>>())),
+            Some(consensus) => Ok(ErasedJson::pretty(
+                consensus
+                    .unconfirmed_solutions()
+                    .chain(consensus.pending_queue_solutions())
+                    .collect::<IndexMap<_, _>>(),
+            )),
             None => Err(RestError("Route isn't available for this node type".to_string())),
         }
     }
@@ -195,7 +200,12 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /<network>/memoryPool/transactions
     pub(crate) async fn get_memory_pool_transactions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
-            Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_transactions().collect::<IndexMap<_, _>>())),
+            Some(consensus) => Ok(ErasedJson::pretty(
+                consensus
+                    .unconfirmed_transactions()
+                    .chain(consensus.pending_queue_transactions())
+                    .collect::<IndexMap<_, _>>(),
+            )),
             None => Err(RestError("Route isn't available for this node type".to_string())),
         }
     }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -292,6 +292,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.find_block_hash(&tx_id)?))
     }
 
+    // GET /<network>/find/blockHeight/{stateRoot}
+    pub(crate) async fn find_block_height_from_state_root(
+        State(rest): State<Self>,
+        Path(state_root): Path<N::StateRoot>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.find_block_height_from_state_root(state_root)?))
+    }
+
     // GET /<network>/find/transactionID/deployment/{programID}
     pub(crate) async fn find_transaction_id_from_program_id(
         State(rest): State<Self>,
@@ -314,14 +322,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Path(input_or_output_id): Path<Field<N>>,
     ) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.find_transition_id(&input_or_output_id)?))
-    }
-
-    // GET /<network>/find/blockHeight/{stateRoot}
-    pub(crate) async fn find_block_height_from_state_root(
-        State(rest): State<Self>,
-        Path(state_root): Path<N::StateRoot>,
-    ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_block_height_from_state_root(state_root)?))
     }
 
     // POST /<network>/transaction/broadcast


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the REST API routes with the following updates:

- `GET /memoryPool/solutions` will now include the solutions in the inbound queue.
- `GET /memoryPool/transactions` will now include the transactions in the inbound queue.
- `GET /memoryPool/transmissions` will now include the transmissions in the inbound queue.
- Added `GET /stateRoot/:height` to return a state root at the given block height
- Added `GET /find/blockHeight/:state_root` to return the block height the given state root was created.


The getter functions `unconfirmed_*` has been renamed to `worker_*`. And new `unconfirmed_*` functions now include both the objects from the worker and the inbound queue.
