### PR TITLE
Add get_delegators_for_validator

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -189,6 +189,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/statePath/:commitment"), get(Self::get_state_path_for_commitment))
             .route(&format!("/{network}/stateRoot/latest"), get(Self::get_state_root_latest))
             .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
+            .route(&format!("/{network}/delegators/:validator"), get(Self::get_delegators_for_validator))
 
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -16,7 +16,7 @@ use super::*;
 use snarkos_node_router::messages::UnconfirmedSolution;
 use snarkvm::{
     ledger::puzzle::Solution,
-    prelude::{block::Transaction, Identifier, Plaintext},
+    prelude::{block::Transaction, Address, Identifier, Plaintext},
 };
 
 use indexmap::IndexMap;
@@ -254,6 +254,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /<network>/committee/latest
     pub(crate) async fn get_committee_latest(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
+    }
+
+    // GET /<network>/delegators/{validator}
+    pub(crate) async fn get_delegators_for_validator(
+        State(rest): State<Self>,
+        Path(validator): Path<Address<N>>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.get_delegators_for_validator(&validator)?))
     }
 
     // GET /<network>/peers/count


### PR DESCRIPTION
## Motivation

Adds an endpoint to get all delegators for a particular validator.

## Test Plan

See the sister PR: https://github.com/AleoHQ/snarkVM/pull/2434