### PR TITLE
[Fix] Make --rest optional to prevent auto-change of REST port with --dev

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -506,8 +506,8 @@ impl Start {
         };
         // Parse the REST IP.
             let rest_ip = match self.norest {
-                true => None,
-                false => self.rest,
+            true => None,
+            false => self.rest,
         };
 
         // If the display is not enabled, render the welcome message.
@@ -856,7 +856,7 @@ mod tests {
         config.parse_development(&mut trusted_peers, &mut trusted_validators).unwrap();
         let expected_genesis = config.parse_genesis::<CurrentNetwork>().unwrap();
         assert_eq!(config.node, Some(SocketAddr::from_str("0.0.0.0:4130").unwrap()));
-        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3030").unwrap());
+        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3030").unwrap()));
         assert_eq!(trusted_peers.len(), 0);
         assert_eq!(trusted_validators.len(), 1);
         assert!(!config.validator);
@@ -871,7 +871,7 @@ mod tests {
         config.parse_development(&mut trusted_peers, &mut trusted_validators).unwrap();
         let genesis = config.parse_genesis::<CurrentNetwork>().unwrap();
         assert_eq!(config.node, Some(SocketAddr::from_str("0.0.0.0:4131").unwrap()));
-        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3031").unwrap());
+        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3031").unwrap()));
         assert_eq!(trusted_peers.len(), 1);
         assert_eq!(trusted_validators.len(), 1);
         assert!(config.validator);
@@ -886,7 +886,7 @@ mod tests {
         config.parse_development(&mut trusted_peers, &mut trusted_validators).unwrap();
         let genesis = config.parse_genesis::<CurrentNetwork>().unwrap();
         assert_eq!(config.node, Some(SocketAddr::from_str("0.0.0.0:4132").unwrap()));
-        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3032").unwrap());
+        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3032").unwrap()));
         assert_eq!(trusted_peers.len(), 2);
         assert_eq!(trusted_validators.len(), 2);
         assert!(!config.validator);
@@ -901,7 +901,7 @@ mod tests {
         config.parse_development(&mut trusted_peers, &mut trusted_validators).unwrap();
         let genesis = config.parse_genesis::<CurrentNetwork>().unwrap();
         assert_eq!(config.node, Some(SocketAddr::from_str("0.0.0.0:4133").unwrap()));
-        assert_eq!(config.rest, SocketAddr::from_str("0.0.0.0:3033").unwrap());
+        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3033").unwrap()));
         assert_eq!(trusted_peers.len(), 3);
         assert_eq!(trusted_validators.len(), 2);
         assert!(!config.validator);

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -938,7 +938,7 @@ mod tests {
             assert!(start.validator);
             assert_eq!(start.private_key.as_deref(), Some("PRIVATE_KEY"));
             assert_eq!(start.cdn, "CDN");
-            assert_eq!(start.rest, "127.0.0.1:3030".parse().unwrap());
+            assert_eq!(start.rest, Some("127.0.0.1:3030".parse().unwrap()));
             assert_eq!(start.network, 0);
             assert_eq!(start.peers, "IP1,IP2,IP3");
             assert_eq!(start.validators, "IP1,IP2,IP3");

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -852,6 +852,14 @@ mod tests {
         // Test specified REST IP when passed in prod mode
         let config = Start::try_parse_from(["snarkos", "--rest", "192.168.1.1:8080"].iter()).unwrap();
         assert_eq!(config.rest, Some(SocketAddr::from_str("192.168.1.1:8080").unwrap()));
+
+        // Test default REST IP when no rest flag is passed in dev mode
+        let config = Start::try_parse_from(["snarkos", "--dev", "1", "--norest"].iter()).unwrap();
+        assert!(config.rest.is_none());
+
+        // Test default REST IP when no rest flag is passed in prod mode
+        let config = Start::try_parse_from(["snarkos", "--norest"].iter()).unwrap();
+        assert!(config.rest.is_none());
     }
 
     #[test]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -505,9 +505,9 @@ impl Start {
             false => None
         };
         // Parse the REST IP.
-        let rest_ip = match self.norest {
-            true => None,
-            false => Some(self.rest),
+            let rest_ip = match self.norest {
+                true => None,
+                false => self.rest,
         };
 
         // If the display is not enabled, render the welcome message.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -836,6 +836,25 @@ mod tests {
     }
 
     #[test]
+    fn test_rest_ip_behavior() {
+        // Test default REST IP when not specified in dev mode
+        let config = Start::try_parse_from(["snarkos", "--dev", "1"].iter()).unwrap();
+        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3030").unwrap()));
+
+        // Test specified REST IP when passed in dev mode
+        let config = Start::try_parse_from(["snarkos", "--dev", "1", "--rest", "127.0.0.1:8080"].iter()).unwrap();
+        assert_eq!(config.rest, Some(SocketAddr::from_str("127.0.0.1:8080").unwrap()));
+
+        // Test default REST IP when REST flag is not passed in prod mode
+        let config = Start::try_parse_from(["snarkos"].iter()).unwrap();
+        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3030").unwrap()));
+
+        // Test specified REST IP when passed in prod mode
+        let config = Start::try_parse_from(["snarkos", "--rest", "192.168.1.1:8080"].iter()).unwrap();
+        assert_eq!(config.rest, Some(SocketAddr::from_str("192.168.1.1:8080").unwrap()));
+    }
+
+    #[test]
     fn test_parse_development_and_genesis() {
         let prod_genesis = Block::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -106,8 +106,8 @@ pub struct Start {
     pub allow_external_peers: bool,
 
     /// Specify the IP address and port for the REST server
-    #[clap(default_value = "0.0.0.0:3030", long = "rest")]
-    pub rest: SocketAddr,
+    #[clap(long = "rest")]
+    pub rest: Option<SocketAddr>,
     /// Specify the requests per second (RPS) rate limit per IP for the REST server
     #[clap(default_value = "10", long = "rest-rps")]
     pub rest_rps: u32,
@@ -320,12 +320,10 @@ impl Start {
             if self.node.is_none() {
                 self.node = Some(SocketAddr::from_str(&format!("0.0.0.0:{}", 4130 + dev))?);
             }
-            // If the `norest` flag is not set, and the `bft` flag was not overridden,
-            // then set the REST IP to `3030 + dev`.
-            //
-            // Note: the `bft` flag is an option to detect remote devnet testing.
-            if !self.norest && self.bft.is_none() {
-                self.rest = SocketAddr::from_str(&format!("0.0.0.0:{}", 3030 + dev))?;
+
+            // If the `norest` flag is not set and the REST IP is not already specified set the REST IP to `3030 + dev`.
+            if !self.norest && self.rest.is_none() {
+                self.rest = Some(SocketAddr::from_str(&format!("0.0.0.0:{}", 3030 + dev)).unwrap());
             }
         }
         Ok(())

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -505,7 +505,7 @@ impl Start {
             false => None
         };
         // Parse the REST IP.
-            let rest_ip = match self.norest {
+        let rest_ip = match self.norest {
             true => None,
             false => self.rest,
         };

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -507,7 +507,7 @@ impl Start {
         // Parse the REST IP.
         let rest_ip = match self.norest {
             true => None,
-            false => self.rest,
+            false => self.rest.or_else(|| Some("0.0.0.0:3030".parse().unwrap())),
         };
 
         // If the display is not enabled, render the welcome message.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Solves Issue #3220 wherein specified rest port was overwritten by the default when the `--dev` flag was being used. 

## Test Plan

This will only change a node's behavior when both `--dev` and `--rest` are used. 

Tested locally. 


## Related PRs

(Link any related PRs here)
