### PR TITLE
Update rev on mitigate-free-verification branch for integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "1f7cf54"
+rev = "dcc3018"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
## Motivation

This updates the rev on the mitigate-free-verification branch to the latest rev so an integration test can be run on the latest changes.
