### PR TITLE
[Optimize] Add guards for processing unconfirmed solutions

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -224,3 +224,13 @@ async fn log_middleware(
 
     Ok(next.run(request).await)
 }
+
+/// Formats an ID into a truncated identifier (for logging purposes).
+pub fn fmt_id(id: impl ToString) -> String {
+    let id = id.to_string();
+    let mut formatted_id = id.chars().take(16).collect::<String>();
+    if id.chars().count() > 16 {
+        formatted_id.push_str("..");
+    }
+    formatted_id
+}

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -315,7 +315,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<ErasedJson, RestError> {
         // Do not process the transaction if the node is syncing.
         if !rest.routing.is_block_synced() {
-            return Err(RestError(format!("Unable to broadcast transaction {} - node is syncing.", fmt_id(tx.id()))));
+            return Err(RestError(format!("Unable to broadcast transaction '{}' (node is syncing)", fmt_id(tx.id()))));
         }
 
         // If the consensus module is enabled, add the unconfirmed transaction to the memory pool.
@@ -345,7 +345,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // Do not process the solution if the node is syncing.
         if !rest.routing.is_block_synced() {
             return Err(RestError(format!(
-                "Unable to broadcast solution {} - node is syncing.",
+                "Unable to broadcast solution '{}' (node is syncing)",
                 fmt_id(solution.id())
             )));
         }
@@ -369,9 +369,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 {
                     Ok(Ok(())) => {}
                     Ok(Err(err)) => {
-                        return Err(RestError(format!("Invalid solution `{}` - {err}", fmt_id(solution.id()))));
+                        return Err(RestError(format!("Invalid solution '{}' - {err}", fmt_id(solution.id()))));
                     }
-                    Err(err) => return Err(RestError(format!("Invalid solution `{}` - {err}", fmt_id(solution.id())))),
+                    Err(err) => return Err(RestError(format!("Invalid solution '{}' - {err}", fmt_id(solution.id())))),
                 }
             }
         }

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -237,6 +237,11 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
             }
             Message::UnconfirmedTransaction(message) => {
+                // Do not process unconfirmed transactions if the node is syncing.
+                if !self.is_block_synced() {
+                    trace!("Skipped processing unconfirmed transaction '{}' (node is syncing)", message.transaction_id);
+                    return Ok(());
+                }
                 // Update the timestamp for the unconfirmed transaction.
                 let seen_before =
                     self.router().cache.insert_inbound_transaction(peer_ip, message.transaction_id).is_some();

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -207,8 +207,6 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
             }
             Message::UnconfirmedSolution(message) => {
-                // Clone the serialized message.
-                let serialized = message.clone();
                 // Update the timestamp for the unconfirmed solution.
                 let seen_before = self.router().cache.insert_inbound_solution(peer_ip, message.solution_id).is_some();
                 // Determine whether to propagate the solution.
@@ -216,6 +214,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                     trace!("Skipping 'UnconfirmedSolution' from '{peer_ip}'");
                     return Ok(());
                 }
+                // Clone the serialized message.
+                let serialized = message.clone();
                 // Perform the deferred non-blocking deserialization of the solution.
                 let solution = match message.solution.deserialize().await {
                     Ok(solution) => solution,
@@ -232,8 +232,6 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
             }
             Message::UnconfirmedTransaction(message) => {
-                // Clone the serialized message.
-                let serialized = message.clone();
                 // Update the timestamp for the unconfirmed transaction.
                 let seen_before =
                     self.router().cache.insert_inbound_transaction(peer_ip, message.transaction_id).is_some();
@@ -242,6 +240,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                     trace!("Skipping 'UnconfirmedTransaction' from '{peer_ip}'");
                     return Ok(());
                 }
+                // Clone the serialized message.
+                let serialized = message.clone();
                 // Perform the deferred non-blocking deserialization of the transaction.
                 let transaction = match message.transaction.deserialize().await {
                     Ok(transaction) => transaction,

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -207,6 +207,11 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
             }
             Message::UnconfirmedSolution(message) => {
+                // Do not process unconfirmed solutions if the node is syncing.
+                if !self.is_block_synced() {
+                    trace!("Skipped processing unconfirmed solution '{}' (node is syncing)", message.solution_id);
+                    return Ok(());
+                }
                 // Update the timestamp for the unconfirmed solution.
                 let seen_before = self.router().cache.insert_inbound_solution(peer_ip, message.solution_id).is_some();
                 // Determine whether to propagate the solution.

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -28,6 +28,9 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
     /// Returns a reference to the router.
     fn router(&self) -> &Router<N>;
 
+    /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
+    fn is_block_synced(&self) -> bool;
+
     /// Sends a "Ping" message to the given peer.
     fn send_ping(&self, peer_ip: SocketAddr, block_locators: Option<BlockLocators<N>>) {
         self.send(peer_ip, Message::Ping(Ping::new(self.router().node_type(), block_locators)));

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -149,6 +149,11 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
     fn router(&self) -> &Router<N> {
         &self.0
     }
+
+    /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
+    fn is_block_synced(&self) -> bool {
+        true
+    }
 }
 
 #[async_trait]

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -163,6 +163,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
     fn router(&self) -> &Router<N> {
         &self.router
     }
+
+    /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
+    fn is_block_synced(&self) -> bool {
+        self.sync.is_block_synced()
+    }
 }
 
 #[async_trait]

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -135,6 +135,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
     fn router(&self) -> &Router<N> {
         &self.router
     }
+
+    /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
+    fn is_block_synced(&self) -> bool {
+        true
+    }
 }
 
 #[async_trait]

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -137,6 +137,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
     fn router(&self) -> &Router<N> {
         &self.router
     }
+
+    /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
+    fn is_block_synced(&self) -> bool {
+        self.sync.is_block_synced()
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds a few changes to improve syncing and reduce network spam:

1. Clients perform solution verification in `POST /broadcast/solution` prior to solution propagation.
    - This reduces the propagation of invalid solutions on the network.
2. Nodes do not process incoming unconfirmed solutions if they are syncing.
    - This reduces the resource load of nodes and lets them focus on syncing.
3. Nodes do not process incoming unconfirmed transactions if they are syncing
    - This reduces the resource load of nodes and lets them focus on syncing.
