### PR TITLE
Disconnect from requests decreasing in height

### DIFF
--- a/node/router/messages/src/block_request.rs
+++ b/node/router/messages/src/block_request.rs
@@ -18,7 +18,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 
 use std::borrow::Cow;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct BlockRequest {
     /// The starting block height (inclusive).
     pub start_height: u32,

--- a/node/router/messages/src/block_request.rs
+++ b/node/router/messages/src/block_request.rs
@@ -18,7 +18,7 @@ use snarkvm::prelude::{FromBytes, ToBytes};
 
 use std::borrow::Cow;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BlockRequest {
     /// The starting block height (inclusive).
     pub start_height: u32,

--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -244,7 +244,7 @@ impl<N: Network> Cache<N> {
             timestamps.pop_front();
         }
         // Check whether the request is higher than the last.
-        let incrementing = timestamps.back().map(|(_, last)| request.start_height > last.end_height).unwrap_or(true);
+        let incrementing = timestamps.back().map(|(_, last)| request.start_height >= last.end_height).unwrap_or(true);
         // Insert the new timestamp and request if its higher than the last.
         if incrementing {
             timestamps.push_back((now, request));
@@ -340,7 +340,7 @@ mod tests {
         assert_eq!(cache.seen_inbound_block_requests.read().len(), 0);
 
         // Insert a block request.
-        let request = BlockRequest { start_height: 1, end_height: 1 };
+        let request = BlockRequest { start_height: 1, end_height: 2 };
         assert_eq!(cache.insert_inbound_block_request(peer_ip, request), (1, true));
         // Check that the cache contains the block request.
         assert!(cache.contains_inbound_block_request(&peer_ip));
@@ -352,13 +352,13 @@ mod tests {
         assert!(cache.contains_inbound_block_request(&peer_ip));
 
         // Insert another block request for the same peer with a lower start height.
-        let request = BlockRequest { start_height: 1, end_height: 3 };
+        let request = BlockRequest { start_height: 2, end_height: 3 };
         assert_eq!(cache.insert_inbound_block_request(peer_ip, request), (2, false));
         // Check that the cache does contains the block requests.
         assert!(cache.contains_inbound_block_request(&peer_ip));
 
         // Insert another block request for the same peer with a low start height.
-        let request = BlockRequest { start_height: 1, end_height: 1 };
+        let request = BlockRequest { start_height: 1, end_height: 2 };
         assert_eq!(cache.insert_inbound_block_request(peer_ip, request), (2, false));
         // Check that the cache does contains the block requests.
         assert!(cache.contains_inbound_block_request(&peer_ip));
@@ -369,7 +369,7 @@ mod tests {
         ));
 
         // Insert another block request for the same peer with a low start height.
-        let request = BlockRequest { start_height: 1, end_height: 1 };
+        let request = BlockRequest { start_height: 1, end_height: 2 };
         assert_eq!(cache.insert_inbound_block_request(peer_ip, request), (1, true));
         // Check that the cache does contains the block requests.
         assert!(cache.contains_inbound_block_request(&peer_ip));


### PR DESCRIPTION
## Motivation

Prevents a DoS attack by a peer who keeps requesting large amounts of the same blocks. We disconnect as soon as we encounter a repetitive request, and it is allowed again after `INBOUND_BLOCK_REQUEST_INTERVAL = 60 seconds`.

I tried to re-use the Cache abstraction without imposing too many additional assumptions.

## Test Plan

Added some unit tests, but this should definitely be tested on a running network.

## Related PRs

Extends: https://github.com/AleoHQ/snarkOS/pull/3223