### PR TITLE
[Fix] Perform block advancement after quorum check

### DIFF
--- a/.devnet/start_sync_test.sh
+++ b/.devnet/start_sync_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Determine the number of AWS EC2 instances by checking ~/.ssh/config
+NODE_ID=0
+while [ -n "$(grep "aws-n${NODE_ID}" ~/.ssh/config)" ]; do
+    NODE_ID=$((NODE_ID + 1))
+done
+
+# Read the number of AWS EC2 instances to query from the user
+read -p "Enter the number of AWS EC2 instances to query (default: $NODE_ID): " NUM_INSTANCES
+NUM_INSTANCES="${NUM_INSTANCES:-$NODE_ID}"
+
+echo "Using $NUM_INSTANCES AWS EC2 instances for querying."
+
+# Read the verbosity level from the user (default: 1)
+read -p "Enter the verbosity level (default: 1): " VERBOSITY
+VERBOSITY="${VERBOSITY:-1}"
+
+echo "Using verbosity level $VERBOSITY."
+
+# Get the IP address of NODE 0 from the SSH config for aws-n0
+NODE_0_IP=$(awk '/Host aws-n0/{f=1} f&&/HostName/{print $2; exit}' ~/.ssh/config)
+
+# Define a function to start snarkOS in a tmux session on a node
+start_snarkos_in_tmux() {
+  local NODE_ID=$1
+  local NODE_IP=$2
+
+  # SSH into the node and start snarkOS in a new tmux session
+  ssh -o StrictHostKeyChecking=no aws-n$NODE_ID << EOF
+    # Commands to run on the remote instance
+    sudo -i  # Switch to root user
+    WORKSPACE=~/snarkOS
+    cd \$WORKSPACE
+
+    # Start snarkOS within a new tmux session named "snarkos-session"
+    tmux new-session -d -s snarkos-session
+
+    # Send the snarkOS start command to the tmux session with the NODE_ID
+    tmux send-keys -t "snarkos-session" "snarkos start --client --nocdn --nodisplay --rest 0.0.0.0:3030 --node 0.0.0.0:4130 --verbosity 4 --metrics --logfile "/tmp/snarkos-syncing-range-3.log" --peers 167.71.249.65:4130,157.245.218.195:4130,167.71.249.55:4130" C-m
+
+    exit  # Exit root user
+EOF
+
+  # Check the exit status of the SSH command
+  if [ $? -eq 0 ]; then
+    echo "snarkOS started successfully in a tmux session on aws-n$NODE_ID."
+  else
+    echo "Failed to start snarkOS in a tmux session on aws-n$NODE_ID."
+  fi
+}
+
+# Loop through aws-n nodes and start snarkOS in tmux sessions in parallel
+for NODE_ID in $(seq 0 $(($NUM_INSTANCES - 1))); do
+  start_snarkos_in_tmux $NODE_ID "$NODE_0_IP" &
+done
+
+# Wait for all background jobs to finish
+wait

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3367,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3388,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3398,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3416,12 +3416,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3462,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "rand",
  "rayon",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "anyhow",
  "rand",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "anyhow",
  "colored",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=43abe1b#43abe1ba7cdb4de6a435905a1688cca4caf0c7e3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "43abe1b"
+rev = "aef07da"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -615,3 +615,239 @@ impl<N: Network> Sync<N> {
         self.handles.lock().iter().for_each(|handle| handle.abort());
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{helpers::now, ledger_service::CoreLedgerService, storage_service::BFTMemoryService};
+    use snarkos_account::Account;
+    use snarkvm::{
+        console::{
+            account::{Address, PrivateKey},
+            network::MainnetV0,
+        },
+        ledger::{
+            narwhal::{BatchCertificate, BatchHeader, Subdag},
+            store::{helpers::memory::ConsensusMemory, ConsensusStore},
+        },
+        prelude::{Ledger, VM},
+        utilities::TestRng,
+    };
+
+    use aleo_std::StorageMode;
+    use indexmap::IndexSet;
+    use rand::Rng;
+    use std::collections::BTreeMap;
+
+    type CurrentNetwork = MainnetV0;
+    type CurrentLedger = Ledger<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
+    type CurrentConsensusStore = ConsensusStore<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_commit_via_is_linked() -> anyhow::Result<()> {
+        let rng = &mut TestRng::default();
+        // Initialize the round parameters.
+        let max_gc_rounds = BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64;
+        let commit_round = 2;
+
+        // Initialize the store.
+        let store = CurrentConsensusStore::open(None).unwrap();
+        let account: Account<CurrentNetwork> = Account::new(rng)?;
+
+        // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
+        let seed: u64 = rng.gen();
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let genesis = VM::from(store).unwrap().genesis_beacon(account.private_key(), genesis_rng).unwrap();
+
+        // Extract the private keys from the genesis committee by using the same RNG to sample private keys.
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let private_keys = [
+            *account.private_key(),
+            PrivateKey::new(genesis_rng)?,
+            PrivateKey::new(genesis_rng)?,
+            PrivateKey::new(genesis_rng)?,
+        ];
+
+        // Initialize the ledger with the genesis block.
+        let ledger = CurrentLedger::load(genesis.clone(), StorageMode::Production).unwrap();
+        // Initialize the ledger.
+        let core_ledger = Arc::new(CoreLedgerService::new(ledger.clone(), Default::default()));
+
+        // Sample 5 rounds of batch certificates starting at the genesis round from a static set of 4 authors.
+        let (round_to_certificates_map, committee) = {
+            let addresses = vec![
+                Address::try_from(private_keys[0])?,
+                Address::try_from(private_keys[1])?,
+                Address::try_from(private_keys[2])?,
+                Address::try_from(private_keys[3])?,
+            ];
+
+            let committee = ledger.latest_committee().unwrap();
+
+            // Initialize a mapping from the round number to the set of batch certificates in the round.
+            let mut round_to_certificates_map: HashMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> =
+                HashMap::new();
+            let mut previous_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::with_capacity(4);
+
+            for round in 0..=commit_round + 8 {
+                let mut current_certificates = IndexSet::new();
+                let previous_certificate_ids: IndexSet<_> = if round == 0 || round == 1 {
+                    IndexSet::new()
+                } else {
+                    previous_certificates.iter().map(|c| c.id()).collect()
+                };
+                let committee_id = committee.id();
+
+                // Create a certificate for the leader.
+                if round <= 5 {
+                    let leader = committee.get_leader(round).unwrap();
+                    let i = addresses.iter().position(|&address| address == leader).unwrap();
+                    let batch_header = BatchHeader::new(
+                        &private_keys[i],
+                        round,
+                        now(),
+                        committee_id,
+                        Default::default(),
+                        previous_certificate_ids.clone(),
+                        rng,
+                    )
+                    .unwrap();
+                    // Sign the batch header.
+                    let mut signatures = IndexSet::with_capacity(4);
+                    for (j, private_key_2) in private_keys.iter().enumerate() {
+                        if i != j {
+                            signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
+                        }
+                    }
+                    current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
+                }
+
+                // Create a certificate for each validator.
+                if round > 5 {
+                    for (i, private_key_1) in private_keys.iter().enumerate() {
+                        let batch_header = BatchHeader::new(
+                            private_key_1,
+                            round,
+                            now(),
+                            committee_id,
+                            Default::default(),
+                            previous_certificate_ids.clone(),
+                            rng,
+                        )
+                        .unwrap();
+                        // Sign the batch header.
+                        let mut signatures = IndexSet::with_capacity(4);
+                        for (j, private_key_2) in private_keys.iter().enumerate() {
+                            if i != j {
+                                signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
+                            }
+                        }
+                        current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
+                    }
+                }
+                // Update the map of certificates.
+                round_to_certificates_map.insert(round, current_certificates.clone());
+                previous_certificates = current_certificates.clone();
+            }
+            (round_to_certificates_map, committee)
+        };
+
+        // Initialize the storage.
+        let storage = Storage::new(core_ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        // Insert certificates into storage.
+        let mut certificates: Vec<BatchCertificate<CurrentNetwork>> = Vec::new();
+        for i in 1..=commit_round + 8 {
+            let c = (*round_to_certificates_map.get(&i).unwrap()).clone();
+            certificates.extend(c);
+        }
+        for certificate in certificates.clone().iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+
+        // Create block 1.
+        let leader_round_1 = commit_round;
+        let leader_1 = committee.get_leader(leader_round_1).unwrap();
+        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader_1).unwrap();
+        let block_1 = {
+            let mut subdag_map: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
+            let mut leader_cert_map = IndexSet::new();
+            leader_cert_map.insert(leader_certificate.clone());
+            let mut previous_cert_map = IndexSet::new();
+            for cert in storage.get_certificates_for_round(commit_round - 1) {
+                previous_cert_map.insert(cert);
+            }
+            subdag_map.insert(commit_round, leader_cert_map.clone());
+            subdag_map.insert(commit_round - 1, previous_cert_map.clone());
+            let subdag = Subdag::from(subdag_map.clone())?;
+            core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?
+        };
+        // Insert block 1.
+        core_ledger.advance_to_next_block(&block_1)?;
+
+        // Create block 2.
+        let leader_round_2 = commit_round + 2;
+        let leader_2 = committee.get_leader(leader_round_2).unwrap();
+        let leader_certificate_2 = storage.get_certificate_for_round_with_author(leader_round_2, leader_2).unwrap();
+        let block_2 = {
+            let mut subdag_map_2: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
+            let mut leader_cert_map_2 = IndexSet::new();
+            leader_cert_map_2.insert(leader_certificate_2.clone());
+            let mut previous_cert_map_2 = IndexSet::new();
+            for cert in storage.get_certificates_for_round(leader_round_2 - 1) {
+                previous_cert_map_2.insert(cert);
+            }
+            subdag_map_2.insert(leader_round_2, leader_cert_map_2.clone());
+            subdag_map_2.insert(leader_round_2 - 1, previous_cert_map_2.clone());
+            let subdag_2 = Subdag::from(subdag_map_2.clone())?;
+            core_ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default())?
+        };
+        // Insert block 2.
+        core_ledger.advance_to_next_block(&block_2)?;
+
+        // Create block 3
+        let leader_round_3 = commit_round + 4;
+        let leader_3 = committee.get_leader(leader_round_3).unwrap();
+        let leader_certificate_3 = storage.get_certificate_for_round_with_author(leader_round_3, leader_3).unwrap();
+        let block_3 = {
+            let mut subdag_map_3: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
+            let mut leader_cert_map_3 = IndexSet::new();
+            leader_cert_map_3.insert(leader_certificate_3.clone());
+            let mut previous_cert_map_3 = IndexSet::new();
+            for cert in storage.get_certificates_for_round(leader_round_3 - 1) {
+                previous_cert_map_3.insert(cert);
+            }
+            subdag_map_3.insert(leader_round_3, leader_cert_map_3.clone());
+            subdag_map_3.insert(leader_round_3 - 1, previous_cert_map_3.clone());
+            let subdag_3 = Subdag::from(subdag_map_3.clone())?;
+            core_ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default())?
+        };
+        // Insert block 3.
+        core_ledger.advance_to_next_block(&block_3)?;
+
+        // Initialize the syncing ledger.
+        let syncing_ledger = Arc::new(CoreLedgerService::new(
+            CurrentLedger::load(genesis, StorageMode::Production).unwrap(),
+            Default::default(),
+        ));
+        // Initialize the gateway.
+        let gateway = Gateway::new(account.clone(), storage.clone(), syncing_ledger.clone(), None, &[], None)?;
+        // Initialize the sync module.
+        let sync = Sync::new(gateway.clone(), storage.clone(), syncing_ledger.clone());
+        // Try to sync block 1.
+        sync.sync_storage_with_block(block_1).await?;
+        // Ensure that the sync ledger has not advanced.
+        assert_eq!(syncing_ledger.latest_block_height(), 0);
+        // Try to sync block 2.
+        sync.sync_storage_with_block(block_2).await?;
+        // Ensure that the sync ledger has not advanced.
+        assert_eq!(syncing_ledger.latest_block_height(), 0);
+        // Try to sync block 3.
+        sync.sync_storage_with_block(block_3).await?;
+        // Ensure blocks 1 and 2 were added to the ledger.
+        assert!(syncing_ledger.contains_block_height(1));
+        assert!(syncing_ledger.contains_block_height(2));
+
+        Ok(())
+    }
+}

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -421,6 +421,7 @@ impl<N: Network> Sync<N> {
                 })
                 .collect();
 
+            debug!("Validating sync block {next_block_height} at round {commit_round}...");
             // Check if the leader is ready to be committed.
             if committee_lookback.is_availability_threshold_reached(&authors) {
                 // Initialize the current certificate.
@@ -442,6 +443,7 @@ impl<N: Network> Sync<N> {
                     };
                     // Determine if there is a path between the previous certificate and the current certificate.
                     if self.is_linked(previous_certificate.clone(), current_certificate.clone())? {
+                        debug!("Previous sync block {height} is linked to the current block {next_block_height}");
                         // Add the previous leader certificate to the list of certificates to commit.
                         blocks_to_add.insert(0, previous_block.clone());
                         // Update the current certificate to the previous leader certificate.
@@ -478,7 +480,9 @@ impl<N: Network> Sync<N> {
                     latest_block_responses.remove(&block_height);
                 }
             } else {
-                trace!("Availability threshold was not reached for block {next_block_height} at round {commit_round}");
+                debug!(
+                    "Availability threshold was not reached for block {next_block_height} at round {commit_round}. Checking next block..."
+                );
             }
         }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -57,6 +57,8 @@ pub struct Sync<N: Network> {
     response_lock: Arc<TMutex<()>>,
     /// The sync lock.
     sync_lock: Arc<TMutex<()>>,
+    /// The latest block received by a peer.
+    latest_block_response: Arc<TMutex<Option<Block<N>>>>,
 }
 
 impl<N: Network> Sync<N> {
@@ -75,6 +77,7 @@ impl<N: Network> Sync<N> {
             handles: Default::default(),
             response_lock: Default::default(),
             sync_lock: Default::default(),
+            latest_block_response: Default::default(),
         }
     }
 
@@ -106,6 +109,11 @@ impl<N: Network> Sync<N> {
                 // Sync the storage with the blocks.
                 if let Err(e) = self_.sync_storage_with_blocks().await {
                     error!("Unable to sync storage with blocks - {e}");
+                }
+
+                // If the node is synced, clear the `latest_block_response`.
+                if self_.is_synced() {
+                    *self_.latest_block_response.lock().await = None;
                 }
             }
         }));
@@ -293,69 +301,11 @@ impl<N: Network> Sync<N> {
             }
         }
 
-        // Track the previous block.
-        let mut previous_block = None;
         // Try to advance the ledger with sync blocks.
         while let Some(block) = self.block_sync.process_next_block(current_height) {
             info!("Syncing the BFT to block {}...", block.height());
             // Sync the storage with the block.
-            self.sync_storage_with_block(&block).await?;
-
-            // Check if the previous block is ready to be added to the ledger.
-            // Ensure that the previous block's leader certificate meets the quorum threshold based
-            // on the certificates in the current block.
-            // Note: We do not advance to the last block in the loop because we would be unable to
-            // validate if the leader certificate in the block has been certified properly.
-            if let Some(previous_block) = previous_block.replace(block) {
-                // Retrieve the subdag from the block.
-                let Authority::Quorum(subdag) = previous_block.authority() else {
-                    bail!("Received a block with an unexpected authority type");
-                };
-
-                // Fetch the leader certificate and the relevant rounds.
-                let leader_certificate = subdag.leader_certificate();
-                let commit_round = leader_certificate.round();
-                let certificate_round = commit_round.saturating_add(1);
-
-                // Get the committee lookback for the commit round.
-                let committee_lookback = self.ledger.get_committee_lookback_for_round(commit_round)?;
-                // Retrieve all of the certificates for the **certificate** round.
-                let certificates = self.storage.get_certificates_for_round(certificate_round);
-                // Construct a set over the authors who included the leader's certificate in the certificate round.
-                let authors = certificates
-                    .iter()
-                    .filter_map(|c| match c.previous_certificate_ids().contains(&leader_certificate.id()) {
-                        true => Some(c.author()),
-                        false => None,
-                    })
-                    .collect();
-
-                // Check if the leader is ready to be committed.
-                match committee_lookback.is_quorum_threshold_reached(&authors) {
-                    // Advance to the next block if quorum threshold was reached.
-                    true => {
-                        let self_ = self.clone();
-                        tokio::task::spawn_blocking(move || {
-                            // Check the next block.
-                            self_.ledger.check_next_block(&previous_block)?;
-                            // Attempt to advance to the next block.
-                            self_.ledger.advance_to_next_block(&previous_block)?;
-
-                            // Sync the height with the block.
-                            self_.storage.sync_height_with_block(previous_block.height());
-                            // Sync the round with the block.
-                            self_.storage.sync_round_with_block(previous_block.round());
-
-                            Ok::<(), anyhow::Error>(())
-                        })
-                        .await??;
-                    }
-                    false => {
-                        bail!("Quorum was not reached for block {} at round {commit_round}", previous_block.height())
-                    }
-                }
-            }
-
+            self.sync_storage_with_block(block).await?;
             // Update the current height.
             current_height += 1;
         }
@@ -385,9 +335,11 @@ impl<N: Network> Sync<N> {
     }
 
     /// Syncs the storage with the given blocks.
-    pub async fn sync_storage_with_block(&self, block: &Block<N>) -> Result<()> {
+    pub async fn sync_storage_with_block(&self, block: Block<N>) -> Result<()> {
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
+        // Acquire the latest block response lock.
+        let mut latest_block_response = self.latest_block_response.lock().await;
 
         // If the block authority is a subdag, then sync the batch certificates with the block.
         if let Authority::Quorum(subdag) = block.authority() {
@@ -402,7 +354,7 @@ impl<N: Network> Sync<N> {
             for certificates in subdag.values().cloned() {
                 cfg_into_iter!(certificates.clone()).for_each(|certificate| {
                     // Sync the batch certificate with the block.
-                    self.storage.sync_certificate_with_block(block, certificate.clone(), &unconfirmed_transactions);
+                    self.storage.sync_certificate_with_block(&block, certificate.clone(), &unconfirmed_transactions);
                 });
 
                 // Sync the BFT DAG with the certificates.
@@ -414,6 +366,66 @@ impl<N: Network> Sync<N> {
                             bail!("Sync - {e}");
                         };
                     }
+                }
+            }
+        }
+
+        // Check if the previous block is ready to be added to the ledger.
+        // Ensure that the previous block's leader certificate meets the quorum threshold based
+        // on the certificates in the current block.
+        // Note: We do not advance to the last block in the loop because we would be unable to
+        // validate if the leader certificate in the block has been certified properly.
+        if let Some(previous_block) = latest_block_response.replace(block) {
+            // Return early if this block has already been processed.
+            if self.ledger.contains_block_height(previous_block.height()) {
+                return Ok(());
+            }
+
+            // Retrieve the subdag from the block.
+            let Authority::Quorum(subdag) = previous_block.authority() else {
+                bail!("Received a block with an unexpected authority type");
+            };
+
+            // Fetch the leader certificate and the relevant rounds.
+            let leader_certificate = subdag.leader_certificate();
+            let commit_round = leader_certificate.round();
+            let certificate_round = commit_round.saturating_add(1);
+
+            // Get the committee lookback for the commit round.
+            let committee_lookback = self.ledger.get_committee_lookback_for_round(commit_round)?;
+            // Retrieve all of the certificates for the **certificate** round.
+            let certificates = self.storage.get_certificates_for_round(certificate_round);
+            // Construct a set over the authors who included the leader's certificate in the certificate round.
+            let authors = certificates
+                .iter()
+                .filter_map(|c| match c.previous_certificate_ids().contains(&leader_certificate.id()) {
+                    true => Some(c.author()),
+                    false => None,
+                })
+                .collect();
+
+            // Check if the leader is ready to be committed.
+            match committee_lookback.is_quorum_threshold_reached(&authors) {
+                // Advance to the next block if quorum threshold was reached.
+                true => {
+                    let self_ = self.clone();
+                    tokio::task::spawn_blocking(move || {
+                        // Check the next block.
+                        self_.ledger.check_next_block(&previous_block)?;
+                        // Attempt to advance to the next block.
+                        self_.ledger.advance_to_next_block(&previous_block)?;
+
+                        // Sync the height with the block.
+                        self_.storage.sync_height_with_block(previous_block.height());
+                        // Sync the round with the block.
+                        self_.storage.sync_round_with_block(previous_block.round());
+
+                        Ok::<(), anyhow::Error>(())
+                    })
+                    .await??;
+                }
+                false => {
+                    bail!("Quorum was not reached for block {} at round {commit_round}", previous_block.height())
                 }
             }
         }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -111,7 +111,7 @@ impl<N: Network> Sync<N> {
                     error!("Unable to sync storage with blocks - {e}");
                 }
 
-                // If the node is synced, clear the `latest_block_response`.
+                // If the node is synced, clear the `last_block_response`.
                 if self_.is_synced() {
                     *self_.last_block_response.lock().await = None;
                 }
@@ -338,8 +338,8 @@ impl<N: Network> Sync<N> {
     pub async fn sync_storage_with_block(&self, block: Block<N>) -> Result<()> {
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
-        // Acquire the latest block response lock.
-        let mut latest_block_response = self.last_block_response.lock().await;
+        // Acquire the last block response lock.
+        let mut last_block_response = self.last_block_response.lock().await;
 
         // If the block authority is a subdag, then sync the batch certificates with the block.
         if let Authority::Quorum(subdag) = block.authority() {
@@ -375,7 +375,7 @@ impl<N: Network> Sync<N> {
         // on the certificates in the current block.
         // Note: We do not advance to the last block in the loop because we would be unable to
         // validate if the leader certificate in the block has been certified properly.
-        if let Some(previous_block) = latest_block_response.replace(block) {
+        if let Some(previous_block) = last_block_response.replace(block) {
             // Return early if this block has already been processed.
             if self.ledger.contains_block_height(previous_block.height()) {
                 return Ok(());

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -376,7 +376,7 @@ impl<N: Network> Sync<N> {
         // Note: We do not advance to the last block in the loop because we would be unable to
         // validate if the leader certificate in the block has been certified properly.
         if let Some(previous_block) = latest_block_response.replace(block) {
-            // Return early if this block has already been processed or is not the next block to add.
+            // Return early if this block has already been processed.
             if self.ledger.contains_block_height(previous_block.height()) {
                 return Ok(());
             }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -451,7 +451,14 @@ impl<N: Network> Sync<N> {
 
                 // Add the blocks to the ledger.
                 for block in blocks_to_add {
+                    // Check that the blocks are sequential and can be added to the ledger.
                     let block_height = block.height();
+                    if block_height != self.ledger.latest_block_height().saturating_add(1) {
+                        debug!("Removing block {block_height} from the latest block responses - not sequential.");
+                        latest_block_responses.remove(&block_height);
+                        continue;
+                    }
+
                     let self_ = self.clone();
                     tokio::task::spawn_blocking(move || {
                         // Check the next block.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -57,8 +57,8 @@ pub struct Sync<N: Network> {
     response_lock: Arc<TMutex<()>>,
     /// The sync lock.
     sync_lock: Arc<TMutex<()>>,
-    /// The last block response.
-    last_block_response: Arc<TMutex<Option<Block<N>>>>,
+    /// The latest block responses.
+    latest_block_responses: Arc<TMutex<HashMap<u32, Block<N>>>>,
 }
 
 impl<N: Network> Sync<N> {
@@ -77,7 +77,7 @@ impl<N: Network> Sync<N> {
             handles: Default::default(),
             response_lock: Default::default(),
             sync_lock: Default::default(),
-            last_block_response: Default::default(),
+            latest_block_responses: Default::default(),
         }
     }
 
@@ -111,9 +111,9 @@ impl<N: Network> Sync<N> {
                     error!("Unable to sync storage with blocks - {e}");
                 }
 
-                // If the node is synced, clear the `last_block_response`.
+                // If the node is synced, clear the `latest_block_responses`.
                 if self_.is_synced() {
-                    *self_.last_block_response.lock().await = None;
+                    self_.latest_block_responses.lock().await.clear();
                 }
             }
         }));
@@ -338,8 +338,13 @@ impl<N: Network> Sync<N> {
     pub async fn sync_storage_with_block(&self, block: Block<N>) -> Result<()> {
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
-        // Acquire the last block response lock.
-        let mut last_block_response = self.last_block_response.lock().await;
+        // Acquire the latest block responses lock.
+        let mut latest_block_responses = self.latest_block_responses.lock().await;
+
+        // If this block has already been processed, return early.
+        if self.ledger.contains_block_height(block.height()) || latest_block_responses.contains_key(&block.height()) {
+            return Ok(());
+        }
 
         // If the block authority is a subdag, then sync the batch certificates with the block.
         if let Authority::Quorum(subdag) = block.authority() {
@@ -370,28 +375,36 @@ impl<N: Network> Sync<N> {
             }
         }
 
-        // Check if the last block response is ready to be added to the ledger.
+        // Fetch the latest block height.
+        let latest_block_height = self.ledger.latest_block_height();
+        let next_block_height = latest_block_height.saturating_add(1);
+
+        // Insert the latest block response.
+        latest_block_responses.insert(block.height(), block);
+        // Clear the latest block responses of older blocks.
+        latest_block_responses.retain(|height, _| *height > latest_block_height);
+
+        // Get a list of contiguous blocks from the latest block responses.
+        let contiguous_blocks: Vec<Block<N>> = (next_block_height..)
+            .take_while(|&k| latest_block_responses.contains_key(&k))
+            .filter_map(|k| latest_block_responses.get(&k).cloned())
+            .collect();
+
+        // Check if the block response is ready to be added to the ledger.
         // Ensure that the previous block's leader certificate meets the availability threshold
         // based on the certificates in the current block.
+        // If the availability threshold is not met, process the next block and check if it is linked to the current block.
         // Note: We do not advance to the most recent block response because we would be unable to
         // validate if the leader certificate in the block has been certified properly.
-        if let Some(last_block) = last_block_response.replace(block) {
-            // Retrieve the height of the last block.
-            let last_block_height = last_block.height();
-            // Return early if this block has already been processed or is not the next block to add.
-            if self.ledger.contains_block_height(last_block_height)
-                || self.ledger.latest_block_height().saturating_add(1) != last_block_height
-            {
-                return Ok(());
-            }
-
-            // Retrieve the subdag from the block.
-            let Authority::Quorum(subdag) = last_block.authority() else {
-                bail!("Received a block with an unexpected authority type");
-            };
+        for next_block in contiguous_blocks.into_iter() {
+            // Retrieve the height of the next block.
+            let next_block_height = next_block.height();
 
             // Fetch the leader certificate and the relevant rounds.
-            let leader_certificate = subdag.leader_certificate();
+            let leader_certificate = match next_block.authority() {
+                Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
+                _ => bail!("Received a block with an unexpected authority type."),
+            };
             let commit_round = leader_certificate.round();
             let certificate_round = commit_round.saturating_add(1);
 
@@ -409,35 +422,81 @@ impl<N: Network> Sync<N> {
                 .collect();
 
             // Check if the leader is ready to be committed.
-            match committee_lookback.is_availability_threshold_reached(&authors) {
-                // Advance to the next block if quorum threshold was reached.
-                true => {
+            if committee_lookback.is_availability_threshold_reached(&authors) {
+                // Initialize the current certificate.
+                let mut current_certificate = leader_certificate;
+                // Check if there are any linked blocks that need to be added.
+                let mut blocks_to_add = vec![next_block];
+
+                // Check if there are other blocks to process based on `is_linked`.
+                for height in (self.ledger.latest_block_height().saturating_add(1)..next_block_height).rev() {
+                    // Retrieve the previous block.
+                    let previous_block = match latest_block_responses.get(&height) {
+                        Some(block) => block,
+                        None => bail!("Block {height} is missing from the latest block responses."),
+                    };
+                    // Retrieve the previous certificate.
+                    let previous_certificate = match previous_block.authority() {
+                        Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
+                        _ => bail!("Received a block with an unexpected authority type."),
+                    };
+                    // Determine if there is a path between the previous certificate and the current certificate.
+                    if self.is_linked(previous_certificate.clone(), current_certificate.clone())? {
+                        // Add the previous leader certificate to the list of certificates to commit.
+                        blocks_to_add.insert(0, previous_block.clone());
+                        // Update the current certificate to the previous leader certificate.
+                        current_certificate = previous_certificate;
+                    }
+                }
+
+                // Add the blocks to the ledger.
+                for block in blocks_to_add {
+                    let block_height = block.height();
                     let self_ = self.clone();
                     tokio::task::spawn_blocking(move || {
                         // Check the next block.
-                        self_.ledger.check_next_block(&last_block)?;
+                        self_.ledger.check_next_block(&block)?;
                         // Attempt to advance to the next block.
-                        self_.ledger.advance_to_next_block(&last_block)?;
+                        self_.ledger.advance_to_next_block(&block)?;
 
                         // Sync the height with the block.
-                        self_.storage.sync_height_with_block(last_block.height());
+                        self_.storage.sync_height_with_block(block.height());
                         // Sync the round with the block.
-                        self_.storage.sync_round_with_block(last_block.round());
+                        self_.storage.sync_round_with_block(block.round());
 
                         Ok::<(), anyhow::Error>(())
                     })
                     .await??;
+                    // Remove the block height from the latest block responses.
+                    latest_block_responses.remove(&block_height);
                 }
-                false => {
-                    debug!(
-                        "Availability threshold was not reached for block {last_block_height} at round {commit_round}",
-                    );
-                    return Ok(());
-                }
+            } else {
+                trace!("Availability threshold was not reached for block {next_block_height} at round {commit_round}");
             }
         }
 
         Ok(())
+    }
+
+    /// Returns `true` if there is a path from the previous certificate to the current certificate.
+    fn is_linked(
+        &self,
+        previous_certificate: BatchCertificate<N>,
+        current_certificate: BatchCertificate<N>,
+    ) -> Result<bool> {
+        // Initialize the list containing the traversal.
+        let mut traversal = vec![current_certificate.clone()];
+        // Iterate over the rounds from the current certificate to the previous certificate.
+        for round in (previous_certificate.round()..current_certificate.round()).rev() {
+            // Retrieve all of the certificates for this past round.
+            let certificates = self.storage.get_certificates_for_round(round);
+            // Filter the certificates to only include those that are in the traversal.
+            traversal = certificates
+                .into_iter()
+                .filter(|p| traversal.iter().any(|c| c.previous_certificate_ids().contains(&p.id())))
+                .collect();
+        }
+        Ok(traversal.contains(&previous_certificate))
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the final stage of validator syncing by adding an additional quorum check. Instead of blindly adding the block to ledger, we now check that each block's leader certificate reached quorum based on the certificates in the subsequent block. 

This solves 2 problems:

### Naive validator sync
1. A validator synced up to tip and added the last block (`X`) without performing any quorum checks. 
2. The validator would start processing consensus messages and process incoming certificates.
3. It would reach a commit state and try to construct `X` through the standard non-sync procedure. 
4. However the ledger already stored `X`.
5. An error would repeat, halting block advancement on this node until the node was rebooted.

```
`Unable to advance to the next block - Failed to speculate on transactions - Failed to post-ratify - Next round {} must be greater than current round {}`
```

The change now skips adding the latest block because we can't guarantee the block meets the quorum. So we will process the block through consensus instead of the sync process.

### Malicious validator sync

The malicious sync case is defined in a hackerOne finding: https://github.com/AleoHQ/snarkOS/issues/3226

The new quorum checks should ensure that we are not processing blocks blindly.
