### PR TITLE
[Optimize] Add sync leniency for skipping REST solutions and transctions

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -388,6 +388,11 @@ impl<N: Network> Sync<N> {
         self.block_sync.is_block_synced()
     }
 
+    /// Returns the number of blocks the node is behind the greatest peer height.
+    pub fn num_blocks_behind(&self) -> u32 {
+        self.block_sync.num_blocks_behind()
+    }
+
     /// Returns `true` if the node is in gateway mode.
     pub const fn is_gateway_mode(&self) -> bool {
         self.block_sync.mode().is_gateway()

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -330,7 +330,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Json(tx): Json<Transaction<N>>,
     ) -> Result<ErasedJson, RestError> {
         // Do not process the transaction if the node is too far behind.
-        if !rest.routing.num_blocks_behind() > SYNC_LENIENCY {
+        if rest.routing.num_blocks_behind() > SYNC_LENIENCY {
             return Err(RestError(format!("Unable to broadcast transaction '{}' (node is syncing)", fmt_id(tx.id()))));
         }
 
@@ -359,7 +359,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Json(solution): Json<Solution<N>>,
     ) -> Result<ErasedJson, RestError> {
         // Do not process the solution if the node is too far behind.
-        if !rest.routing.num_blocks_behind() > SYNC_LENIENCY {
+        if rest.routing.num_blocks_behind() > SYNC_LENIENCY {
             return Err(RestError(format!(
                 "Unable to broadcast solution '{}' (node is syncing)",
                 fmt_id(solution.id())

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::*;
-use snarkos_node_router::messages::UnconfirmedSolution;
+use snarkos_node_router::{messages::UnconfirmedSolution, SYNC_LENIENCY};
 use snarkvm::{
     ledger::puzzle::Solution,
     prelude::{block::Transaction, Identifier, Plaintext},
@@ -38,10 +38,6 @@ pub(crate) struct BlockRange {
 pub(crate) struct Metadata {
     metadata: bool,
 }
-
-/// The maximum number of blocks the client can be behind it's latest peer before it skips
-/// processing incoming transactions and solutions.
-const SYNC_LENIENCY: u32 = 10;
 
 impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // ----------------- DEPRECATED FUNCTIONS -----------------

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -31,6 +31,9 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
     /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
     fn is_block_synced(&self) -> bool;
 
+    /// Returns the number of blocks this node is behind its furthest peer.
+    fn num_blocks_behind(&self) -> u32;
+
     /// Sends a "Ping" message to the given peer.
     fn send_ping(&self, peer_ip: SocketAddr, block_locators: Option<BlockLocators<N>>) {
         self.send(peer_ip, Message::Ping(Ping::new(self.router().node_type(), block_locators)));

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -31,7 +31,7 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
     /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
     fn is_block_synced(&self) -> bool;
 
-    /// Returns the number of blocks this node is behind its furthest peer.
+    /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32;
 
     /// Sends a "Ping" message to the given peer.

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -154,6 +154,11 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
     fn is_block_synced(&self) -> bool {
         true
     }
+
+    /// Returns the number of blocks this node is behind its furthest peer.
+    fn num_blocks_behind(&self) -> u32 {
+        0
+    }
 }
 
 #[async_trait]

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -155,7 +155,7 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
         true
     }
 
-    /// Returns the number of blocks this node is behind its furthest peer.
+    /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32 {
         0
     }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -168,6 +168,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
     fn is_block_synced(&self) -> bool {
         self.sync.is_block_synced()
     }
+
+    /// Returns the number of blocks this node is behind its furthest peer.
+    fn num_blocks_behind(&self) -> u32 {
+        self.sync.num_blocks_behind()
+    }
 }
 
 #[async_trait]

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -169,7 +169,7 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
         self.sync.is_block_synced()
     }
 
-    /// Returns the number of blocks this node is behind its furthest peer.
+    /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32 {
         self.sync.num_blocks_behind()
     }

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -140,6 +140,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
     fn is_block_synced(&self) -> bool {
         true
     }
+
+    /// Returns the number of blocks this node is behind its furthest peer.
+    fn num_blocks_behind(&self) -> u32 {
+        0
+    }
 }
 
 #[async_trait]

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -141,7 +141,7 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
         true
     }
 
-    /// Returns the number of blocks this node is behind its furthest peer.
+    /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32 {
         0
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -143,7 +143,7 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
         self.sync.is_block_synced()
     }
 
-    /// Returns the number of blocks this node is behind its furthest peer.
+    /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32 {
         self.sync.num_blocks_behind()
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -142,6 +142,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
     fn is_block_synced(&self) -> bool {
         self.sync.is_block_synced()
     }
+
+    /// Returns the number of blocks this node is behind its furthest peer.
+    fn num_blocks_behind(&self) -> u32 {
+        self.sync.num_blocks_behind()
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Previously we were skipping incoming REST transactions and solutions if the node was not synced. This adds a bit of leniency, so that these solutions/transactions will be processed as long as the node is within `SYNC_LENIENCY` of being synced.

Currently the `SYNC_LENIENCY` is set to 10 blocks.
