### PR TITLE
Reduce the number of lookups in update_peer_locators

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -381,11 +381,11 @@ impl<N: Network> BlockSync<N> {
 
         // Compute the common ancestor with this node.
         let mut ancestor = 0;
-        for (height, hash) in locators.clone().into_iter() {
+        for (height, hash) in locators.clone().into_iter().rev() {
             if let Ok(canon_hash) = self.canon.get_block_hash(height) {
-                match canon_hash == hash {
-                    true => ancestor = height,
-                    false => break, // fork
+                if canon_hash == hash {
+                    ancestor = height;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
The `update_peer_locators` method is quite prominent in heap profiles, and tweaking it could yield considerable improvements.

This PR proposes a simple change: instead of starting from height 0 and "going up" the received list of locators (which would be most optimal in case of a deep fork) it starts with the last locator and, if it's not found in the local storage, goes over the remaining locators in reverse order, stopping once the most recent ancestor is found (which is much faster in the "happy path" scenario).

In a local `--dev` run with 4 validator nodes, this reduces the number of allocations in a non-tx-producing node by ~1/3 after 1h. Also, while this is presented as a memory-related improvement, this change should result in reduced (peer) block sync time as well.

As for whether this is as safe as the current setup; a malicious node that knows the most recent valid locator would also be able to provide valid past locators (and it would take longer to process those as well). As mentioned before, the one downside that I see is that this change would make this operation slower for very deep forks, where the number of diverging blocks is larger than the number of canonical ones.