### PR TITLE
[HackerOne-2452182] Store `Proposal` and `SignedProposals` to disk and remove proposal expiration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3323,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3367,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3388,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3398,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3416,12 +3416,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3462,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "rand",
  "rayon",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "anyhow",
  "rand",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "anyhow",
  "colored",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM.git?rev=aef07da#aef07da8ed38aa4c3cdb2d946e0b6c783cc72cd3"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=57641ca#57641caff674ed383a49ae0edd8c52dec835c22b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoHQ/snarkVM.git"
-rev = "aef07da"
+rev = "57641ca"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -16,7 +16,7 @@ use aleo_std::StorageMode;
 use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
-use snarkos_node::bft::batch_proposal_path;
+use snarkos_node::bft::helpers::proposal_cache_path;
 use std::path::PathBuf;
 
 /// Cleans the snarkOS node storage.
@@ -36,11 +36,11 @@ pub struct Clean {
 impl Clean {
     /// Cleans the snarkOS node storage.
     pub fn parse(self) -> Result<String> {
-        // Remove the current batch proposal file, if it exists.
-        let proposal_path = batch_proposal_path(self.network, self.dev);
-        if proposal_path.exists() {
-            if let Err(err) = std::fs::remove_file(&proposal_path) {
-                bail!("Failed to remove the current batch proposal file at {}: {err}", proposal_path.display());
+        // Remove the current proposal cache file, if it exists.
+        let proposal_cache_path = proposal_cache_path(self.network, self.dev);
+        if proposal_cache_path.exists() {
+            if let Err(err) = std::fs::remove_file(&proposal_cache_path) {
+                bail!("Failed to remove the current proposal cache file at {}: {err}", proposal_cache_path.display());
             }
         }
         // Remove the specified ledger from storage.

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snarkos_node::bft::helpers::proposal_cache_path;
+
 use aleo_std::StorageMode;
 use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
-use snarkos_node::bft::helpers::proposal_cache_path;
 use std::path::PathBuf;
 
 /// Cleans the snarkOS node storage.

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -16,6 +16,7 @@ use aleo_std::StorageMode;
 use anyhow::{bail, Result};
 use clap::Parser;
 use colored::Colorize;
+use snarkos_node::bft::batch_proposal_path;
 use std::path::PathBuf;
 
 /// Cleans the snarkOS node storage.
@@ -35,6 +36,13 @@ pub struct Clean {
 impl Clean {
     /// Cleans the snarkOS node storage.
     pub fn parse(self) -> Result<String> {
+        // Remove the current batch proposal file, if it exists.
+        let proposal_path = batch_proposal_path(self.network, self.dev);
+        if proposal_path.exists() {
+            if let Err(err) = std::fs::remove_file(&proposal_path) {
+                bail!("Failed to remove the current batch proposal file at {}: {err}", proposal_path.display());
+            }
+        }
         // Remove the specified ledger from storage.
         Self::remove_ledger(self.network, match self.path {
             Some(path) => StorageMode::Custom(path),

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -261,6 +261,11 @@ impl<N: Network> Gateway<N> {
         &self.account
     }
 
+    /// Returns the dev identifier of the node.
+    pub const fn dev(&self) -> Option<u16> {
+        self.dev
+    }
+
     /// Returns the IP address of this node.
     pub fn local_ip(&self) -> SocketAddr {
         self.tcp.listening_addr().expect("The TCP listener is not enabled")

--- a/node/bft/src/helpers/mod.rs
+++ b/node/bft/src/helpers/mod.rs
@@ -36,6 +36,9 @@ pub use ready::*;
 pub mod resolver;
 pub use resolver::*;
 
+pub mod signed_proposals;
+pub use signed_proposals::*;
+
 pub mod storage;
 pub use storage::*;
 

--- a/node/bft/src/helpers/mod.rs
+++ b/node/bft/src/helpers/mod.rs
@@ -30,6 +30,9 @@ pub use pending::*;
 pub mod proposal;
 pub use proposal::*;
 
+pub mod proposal_cache;
+pub use proposal_cache::*;
+
 pub mod ready;
 pub use ready::*;
 

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -170,13 +170,18 @@ impl<N: Network> Proposal<N> {
 
 impl<N: Network> ToBytes for Proposal<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Write the batch header.
         self.batch_header.write_le(&mut writer)?;
+        // Write the number of transmissions.
         u32::try_from(self.transmissions.len()).map_err(error)?.write_le(&mut writer)?;
+        // Write the transmissions.
         for (transmission_id, transmission) in &self.transmissions {
             transmission_id.write_le(&mut writer)?;
             transmission.write_le(&mut writer)?;
         }
+        // Write the number of signatures.
         u32::try_from(self.signatures.len()).map_err(error)?.write_le(&mut writer)?;
+        // Write the signatures.
         for signature in &self.signatures {
             signature.write_le(&mut writer)?;
         }
@@ -186,15 +191,20 @@ impl<N: Network> ToBytes for Proposal<N> {
 
 impl<N: Network> FromBytes for Proposal<N> {
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Read the batch header.
         let batch_header = FromBytes::read_le(&mut reader)?;
+        // Read the number of transmissions.
         let num_transmissions = u32::read_le(&mut reader)?;
+        // Read the transmissions.
         let mut transmissions = IndexMap::default();
         for _ in 0..num_transmissions {
             let transmission_id = FromBytes::read_le(&mut reader)?;
             let transmission = FromBytes::read_le(&mut reader)?;
             transmissions.insert(transmission_id, transmission);
         }
+        // Read the number of signatures.
         let num_signatures = u32::read_le(&mut reader)?;
+        // Read the signatures.
         let mut signatures = IndexSet::default();
         for _ in 0..num_signatures {
             signatures.insert(FromBytes::read_le(&mut reader)?);

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -195,6 +195,10 @@ impl<N: Network> FromBytes for Proposal<N> {
         let batch_header = FromBytes::read_le(&mut reader)?;
         // Read the number of transmissions.
         let num_transmissions = u32::read_le(&mut reader)?;
+        // Ensure the number of transmissions is within bounds (this is an early safety check).
+        if num_transmissions as usize > BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH {
+            return Err(error("Invalid number of transmissions in the proposal"));
+        }
         // Read the transmissions.
         let mut transmissions = IndexMap::default();
         for _ in 0..num_transmissions {
@@ -204,6 +208,10 @@ impl<N: Network> FromBytes for Proposal<N> {
         }
         // Read the number of signatures.
         let num_signatures = u32::read_le(&mut reader)?;
+        // Ensure the number of signatures is within bounds (this is an early safety check).
+        if num_signatures as usize > Committee::<N>::MAX_COMMITTEE_SIZE as usize {
+            return Err(error("Invalid number of signatures in the proposal"));
+        }
         // Read the signatures.
         let mut signatures = IndexSet::default();
         for _ in 0..num_signatures {

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -1,0 +1,141 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::helpers::{Proposal, SignedProposals};
+
+use snarkvm::{
+    console::{account::Address, network::Network},
+    prelude::{anyhow, bail, FromBytes, IoResult, Read, Result, ToBytes, Write},
+};
+
+use aleo_std::{aleo_ledger_dir, StorageMode};
+use std::{fs, path::PathBuf};
+
+// Returns the path where a proposal cache file may be stored.
+pub fn proposal_cache_path(network: u16, dev: Option<u16>) -> PathBuf {
+    // Obtain the path to the ledger.
+    let mut path = aleo_ledger_dir(network, StorageMode::from(dev));
+    // Go to the folder right above the ledger.
+    path.pop();
+    // Append the proposal store's file name.
+    path.push(&format!(
+        "current-proposal-cache-{network}{}",
+        if let Some(id) = dev { format!("-{id}") } else { "".into() }
+    ));
+
+    path
+}
+
+/// A helper type for the cache of proposal and signed proposals.
+pub struct ProposalCache<N: Network> {
+    proposal: Option<Proposal<N>>,
+    signed_proposals: SignedProposals<N>,
+}
+
+impl<N: Network> ProposalCache<N> {
+    /// Initializes a new instance of the proposal cache.
+    pub fn new(proposal: Option<Proposal<N>>, signed_proposals: SignedProposals<N>) -> Self {
+        Self { proposal, signed_proposals }
+    }
+
+    /// Ensure that the proposal and every signed proposal is associated with the `expected_signer`.
+    pub fn is_valid(&self, expected_signer: Address<N>) -> bool {
+        self.proposal.as_ref().map(|proposal| proposal.batch_header().author() == expected_signer).unwrap_or(true)
+            && self.signed_proposals.is_valid(expected_signer)
+    }
+
+    /// Returns `true` if a proposal cache exists for the given network and `dev`.
+    pub fn exists(dev: Option<u16>) -> bool {
+        proposal_cache_path(N::ID, dev).exists()
+    }
+
+    /// Load the proposal cache from the file system and ensure that the proposal cache is valid.
+    pub fn load(expected_signer: Address<N>, dev: Option<u16>) -> Result<Self> {
+        // Load the proposal cache from the file system.
+        let proposal_path = proposal_cache_path(N::ID, dev);
+
+        // Deserialize the proposal cache from the file system.
+        let proposal_cache = match fs::read(&proposal_path) {
+            Ok(bytes) => match Self::from_bytes_le(&bytes) {
+                Ok(proposal_cache) => proposal_cache,
+                Err(_) => bail!("Couldn't deserialize the proposal stored at {}", proposal_path.display()),
+            },
+            Err(_) => {
+                bail!("Couldn't read the proposal stored at {}", proposal_path.display());
+            }
+        };
+
+        // Ensure the proposal cache is valid.
+        if !proposal_cache.is_valid(expected_signer) {
+            bail!("The proposal cache is invalid for the given address {expected_signer}");
+        }
+
+        Ok(proposal_cache)
+    }
+
+    /// Store the proposal cache to the file system.
+    pub fn store(&self, dev: Option<u16>) -> Result<()> {
+        let path = proposal_cache_path(N::ID, dev);
+        info!("Storing the proposal cache to {}...", path.display());
+
+        // Serialize the proposal cache.
+        let bytes = self.to_bytes_le()?;
+        // Store the proposal cache to the file system.
+        fs::write(&path, bytes)
+            .map_err(|err| anyhow!("Couldn't write the proposal cache to {} - {err}", path.display()))?;
+
+        Ok(())
+    }
+
+    /// Returns the proposal and signed proposals.
+    pub fn into(self) -> (Option<Proposal<N>>, SignedProposals<N>) {
+        (self.proposal, self.signed_proposals)
+    }
+}
+
+impl<N: Network> ToBytes for ProposalCache<N> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        // Serialize the `proposal`.
+        self.proposal.is_some().write_le(&mut writer)?;
+        if let Some(proposal) = &self.proposal {
+            proposal.write_le(&mut writer)?;
+        }
+        // Serialize the `signed_proposals`.
+        self.signed_proposals.write_le(&mut writer)?;
+
+        Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for ProposalCache<N> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        // Deserialize `proposal`.
+        let has_proposal: bool = FromBytes::read_le(&mut reader)?;
+        let proposal = match has_proposal {
+            true => Some(Proposal::read_le(&mut reader)?),
+            false => None,
+        };
+        // Deserialize `signed_proposals`.
+        let signed_proposals = SignedProposals::read_le(&mut reader)?;
+
+        Ok(Self::new(proposal, signed_proposals))
+    }
+}
+
+impl<N: Network> Default for ProposalCache<N> {
+    /// Initializes a new instance of the proposal cache.
+    fn default() -> Self {
+        Self::new(None, Default::default())
+    }
+}

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -24,15 +24,17 @@ use std::{fs, path::PathBuf};
 
 // Returns the path where a proposal cache file may be stored.
 pub fn proposal_cache_path(network: u16, dev: Option<u16>) -> PathBuf {
+    const PROPOSAL_CACHE_FILE_NAME: &str = "current-proposal-cache";
+
     // Obtain the path to the ledger.
     let mut path = aleo_ledger_dir(network, StorageMode::from(dev));
     // Go to the folder right above the ledger.
     path.pop();
     // Append the proposal store's file name.
-    path.push(&format!(
-        "current-proposal-cache-{network}{}",
-        if let Some(id) = dev { format!("-{id}") } else { "".into() }
-    ));
+    match dev {
+        Some(id) => path.push(&format!(".{PROPOSAL_CACHE_FILE_NAME}-{}-{}", network, id)),
+        None => path.push(&format!("{PROPOSAL_CACHE_FILE_NAME}-{}", network)),
+    }
 
     path
 }

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -74,7 +74,7 @@ impl<N: Network> ProposalCache<N> {
 
     /// Load the proposal cache from the file system and ensure that the proposal cache is valid.
     pub fn load(expected_signer: Address<N>, dev: Option<u16>) -> Result<Self> {
-        // Load the proposal cache from the file system.
+        // Construct the proposal cache file system path.
         let path = proposal_cache_path(N::ID, dev);
 
         // Deserialize the proposal cache from the file system.

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -63,17 +63,16 @@ impl<N: Network> ProposalCache<N> {
     /// Load the proposal cache from the file system and ensure that the proposal cache is valid.
     pub fn load(expected_signer: Address<N>, dev: Option<u16>) -> Result<Self> {
         // Load the proposal cache from the file system.
-        let proposal_path = proposal_cache_path(N::ID, dev);
+        let path = proposal_cache_path(N::ID, dev);
+        info!("Loading the proposal cache from {}...", path.display(),);
 
         // Deserialize the proposal cache from the file system.
-        let proposal_cache = match fs::read(&proposal_path) {
+        let proposal_cache = match fs::read(&path) {
             Ok(bytes) => match Self::from_bytes_le(&bytes) {
                 Ok(proposal_cache) => proposal_cache,
-                Err(_) => bail!("Couldn't deserialize the proposal stored at {}", proposal_path.display()),
+                Err(_) => bail!("Couldn't deserialize the proposal stored at {}", path.display()),
             },
-            Err(_) => {
-                bail!("Couldn't read the proposal stored at {}", proposal_path.display());
-            }
+            Err(_) => bail!("Couldn't read the proposal stored at {}", path.display()),
         };
 
         // Ensure the proposal cache is valid.

--- a/node/bft/src/helpers/signed_proposals.rs
+++ b/node/bft/src/helpers/signed_proposals.rs
@@ -1,0 +1,97 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm::{
+    console::{
+        account::{Address, Signature},
+        network::Network,
+        types::Field,
+    },
+    prelude::{FromBytes, ToBytes},
+};
+
+use std::{collections::HashMap, io, ops::Deref};
+
+/// A helper type for the signed proposals.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SignedProposals<N: Network>(pub HashMap<Address<N>, (u64, i64, Field<N>, Signature<N>)>);
+
+impl<N: Network> SignedProposals<N> {
+    /// Ensure that every signed proposal is associated with the `expected_signer`.
+    pub fn is_valid(&self, expected_signer: Address<N>) -> bool {
+        self.0.iter().all(|(_, (_, _, _, signature))| signature.to_address() == expected_signer)
+    }
+}
+
+impl<N: Network> ToBytes for SignedProposals<N> {
+    fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+        // Write the number of signed proposals.
+        u32::try_from(self.0.len()).map_err(|_| io::ErrorKind::Other)?.write_le(&mut writer)?;
+        // Serialize the signed proposals.
+        for (address, (round, timestamp, batch_id, signature)) in &self.0 {
+            // Write the address.
+            address.write_le(&mut writer)?;
+            // Write the round.
+            round.write_le(&mut writer)?;
+            // Write the timestamp.
+            timestamp.write_le(&mut writer)?;
+            // Write the batch id.
+            batch_id.write_le(&mut writer)?;
+            // Write the signature.
+            signature.write_le(&mut writer)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<N: Network> FromBytes for SignedProposals<N> {
+    fn read_le<R: io::Read>(mut reader: R) -> io::Result<Self> {
+        // Read the number of signed proposals.
+        let num_signed_proposals = u32::read_le(&mut reader)?;
+        // Deserialize the signed proposals.
+        let mut signed_proposals = HashMap::default();
+        for _ in 0..num_signed_proposals {
+            // Read the address.
+            let address = FromBytes::read_le(&mut reader)?;
+            // Read the round.
+            let round = FromBytes::read_le(&mut reader)?;
+            // Read the timestamp.
+            let timestamp = FromBytes::read_le(&mut reader)?;
+            // Read the batch id.
+            let batch_id = FromBytes::read_le(&mut reader)?;
+            // Read the signature.
+            let signature = FromBytes::read_le(&mut reader)?;
+            // Insert the signed proposal.
+            signed_proposals.insert(address, (round, timestamp, batch_id, signature));
+        }
+
+        Ok(Self(signed_proposals))
+    }
+}
+
+impl<N: Network> Deref for SignedProposals<N> {
+    type Target = HashMap<Address<N>, (u64, i64, Field<N>, Signature<N>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<N: Network> Default for SignedProposals<N> {
+    /// Initializes a new instance of the signed proposals.
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}

--- a/node/bft/src/helpers/signed_proposals.rs
+++ b/node/bft/src/helpers/signed_proposals.rs
@@ -18,10 +18,10 @@ use snarkvm::{
         network::Network,
         types::Field,
     },
-    prelude::{FromBytes, ToBytes},
+    prelude::{error, FromBytes, IoResult, Read, ToBytes, Write},
 };
 
-use std::{collections::HashMap, io, ops::Deref};
+use std::{collections::HashMap, ops::Deref};
 
 /// A helper type for the signed proposals.
 #[derive(Clone, PartialEq, Eq)]
@@ -35,9 +35,9 @@ impl<N: Network> SignedProposals<N> {
 }
 
 impl<N: Network> ToBytes for SignedProposals<N> {
-    fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the number of signed proposals.
-        u32::try_from(self.0.len()).map_err(|_| io::ErrorKind::Other)?.write_le(&mut writer)?;
+        u32::try_from(self.0.len()).map_err(error)?.write_le(&mut writer)?;
         // Serialize the signed proposals.
         for (address, (round, timestamp, batch_id, signature)) in &self.0 {
             // Write the address.
@@ -57,7 +57,7 @@ impl<N: Network> ToBytes for SignedProposals<N> {
 }
 
 impl<N: Network> FromBytes for SignedProposals<N> {
-    fn read_le<R: io::Read>(mut reader: R) -> io::Result<Self> {
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the number of signed proposals.
         let num_signed_proposals = u32::read_le(&mut reader)?;
         // Deserialize the signed proposals.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -795,7 +795,7 @@ impl<N: Network> Storage<N> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use snarkos_node_bft_ledger_service::MockLedgerService;
     use snarkos_node_bft_storage_service::BFTMemoryService;
@@ -841,7 +841,7 @@ mod tests {
     }
 
     /// Samples the random transmissions, returning the missing transmissions and the transmissions.
-    fn sample_transmissions(
+    pub(crate) fn sample_transmissions(
         certificate: &BatchCertificate<CurrentNetwork>,
         rng: &mut TestRng,
     ) -> (

--- a/node/bft/src/helpers/timestamp.rs
+++ b/node/bft/src/helpers/timestamp.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{MAX_TIMESTAMP_DELTA_IN_SECS, PROPOSAL_EXPIRATION_IN_SECS};
+use crate::MAX_TIMESTAMP_DELTA_IN_SECS;
 use snarkvm::prelude::{bail, Result};
 
 use time::OffsetDateTime;
@@ -29,15 +29,6 @@ pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
         bail!("Timestamp {timestamp} is too far in the future")
     }
     Ok(())
-}
-
-/// Returns whether the proposal is expired.
-pub fn is_proposal_expired(current_timestamp: i64, proposal_timestamp: i64) -> bool {
-    debug_assert!(
-        current_timestamp >= proposal_timestamp,
-        "Current timestamp must be greater or equal to the proposal timestamp"
-    );
-    current_timestamp.saturating_sub(proposal_timestamp) >= PROPOSAL_EXPIRATION_IN_SECS
 }
 
 #[cfg(test)]

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -60,14 +60,6 @@ pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds
 /// The maximum number of workers that can be spawned.
 pub const MAX_WORKERS: u8 = 1; // worker(s)
 
-/// The number of seconds a proposal is valid for before it expires.
-#[cfg(not(any(test, feature = "test")))]
-pub const PROPOSAL_EXPIRATION_IN_SECS: i64 = 60; // seconds
-/// The number of seconds a proposal is valid for before it expires.
-/// This is set to a deliberately low value (5) for testing purposes only.
-#[cfg(any(test, feature = "test"))]
-pub const PROPOSAL_EXPIRATION_IN_SECS: i64 = 5; // seconds
-
 /// The frequency at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.
 pub const PRIMARY_PING_IN_MS: u64 = 2 * MAX_BATCH_DELAY_IN_MS; // ms

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -20,7 +20,6 @@ use crate::{
         fmt_id,
         init_sync_channels,
         init_worker_channels,
-        is_proposal_expired,
         now,
         BFTSender,
         PrimaryReceiver,
@@ -95,12 +94,12 @@ pub struct Primary<N: Network> {
     proposed_batch: Arc<ProposedBatch<N>>,
     /// The timestamp of the most recent proposed batch.
     latest_proposed_batch_timestamp: Arc<RwLock<i64>>,
-    /// The recently-signed batch proposals (a map from the address to the round, timestamp, batch ID, and signature).
+    /// The recently-signed batch proposals.
     signed_proposals: Arc<RwLock<SignedProposals<N>>>,
     /// The spawned handles.
     handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     /// The lock for propose_batch.
-    propose_lock: Arc<TMutex<(u64, i64)>>,
+    propose_lock: Arc<TMutex<u64>>,
 }
 
 impl<N: Network> Primary<N> {
@@ -133,6 +132,8 @@ impl<N: Network> Primary<N> {
         };
         // Extract the proposal and signed proposals.
         let (proposed_batch, signed_proposals) = proposal_cache.into();
+        // Construct the propose lock based on the proposed batch round.
+        let propose_lock = Arc::new(TMutex::new(proposed_batch.as_ref().map(Proposal::round).unwrap_or(0)));
 
         // Initialize the primary instance.
         Ok(Self {
@@ -146,7 +147,7 @@ impl<N: Network> Primary<N> {
             latest_proposed_batch_timestamp: Default::default(),
             signed_proposals: Arc::new(RwLock::new(signed_proposals)),
             handles: Default::default(),
-            propose_lock: Default::default(),
+            propose_lock,
         })
     }
 
@@ -481,15 +482,14 @@ impl<N: Network> Primary<N> {
         // Determine the current timestamp.
         let current_timestamp = now();
         // Determine if the current proposal is expired.
-        let is_expired = is_proposal_expired(current_timestamp, lock_guard.1);
-        if lock_guard.0 == round && !is_expired {
+        if *lock_guard == round {
             warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
             // Reinsert the transmissions back into the ready queue for the next proposal.
             self.reinsert_transmissions_into_workers(transmissions)?;
             return Ok(());
         }
 
-        *lock_guard = (round, current_timestamp);
+        *lock_guard = round;
 
         /* Proceeding to sign & propose the batch. */
         info!("Proposing a batch with {} transmissions for round {round}...", transmissions.len());
@@ -591,24 +591,21 @@ impl<N: Network> Primary<N> {
         }
 
         // Retrieve the cached round and batch ID for this validator.
-        let signed_proposal = self.signed_proposals.read().get(&batch_author).copied();
-        if let Some((signed_round, timestamp, signed_batch_id, signature)) = signed_proposal {
-            // If the signed round is ahead of the peer's batch round, then then ignore the proposal.
+        if let Some((signed_round, signed_batch_id, signature)) =
+            self.signed_proposals.read().get(&batch_author).copied()
+        {
+            // If the signed round is ahead of the peer's batch round, then the validator is malicious.
             if signed_round > batch_header.round() {
-                bail!("Proposed a batch for a previous round ({})", batch_header.round());
+                // Proceed to disconnect the validator.
+                self.gateway.disconnect(peer_ip);
+                bail!("Malicious peer - proposed a batch for a previous round ({})", batch_header.round());
             }
-            // If the round matches and the batch ID differs, then check if the proposal is expired.
+
+            // If the round matches and the batch ID differs, then the validator is malicious.
             if signed_round == batch_header.round() && signed_batch_id != batch_header.batch_id() {
-                // Check if the proposal has expired.
-                match is_proposal_expired(now(), timestamp) {
-                    // If the proposal has expired, then remove the cached signature.
-                    true => self.signed_proposals.write().0.remove(&batch_author),
-                    // If the proposal has not expired, then disconnect the validator.
-                    false => {
-                        self.gateway.disconnect(peer_ip);
-                        bail!("Proposed another batch for the same round ({signed_round}) prior to expiration");
-                    }
-                };
+                // Proceed to disconnect the validator.
+                self.gateway.disconnect(peer_ip);
+                bail!("Malicious peer - proposed another batch for the same round ({signed_round})");
             }
             // If the round and batch ID matches, then skip signing the batch a second time.
             // Instead, rebroadcast the cached signature to the peer.
@@ -668,8 +665,6 @@ impl<N: Network> Primary<N> {
 
         // Retrieve the batch ID.
         let batch_id = batch_header.batch_id();
-        // Retrieve the proposal timestamp.
-        let timestamp = batch_header.timestamp();
         // Sign the batch ID.
         let account = self.gateway.account().clone();
         let signature = spawn_blocking!(account.sign(&[batch_id], &mut rand::thread_rng()))?;
@@ -688,13 +683,13 @@ impl<N: Network> Primary<N> {
                 if entry.get().0 == batch_round {
                     return Ok(());
                 }
-                // Otherwise, cache the round, timestamp, batch ID, and signature for this validator.
-                entry.insert((batch_round, timestamp, batch_id, signature));
+                // Otherwise, cache the round, batch ID, and signature for this validator.
+                entry.insert((batch_round, batch_id, signature));
             }
             // If the validator has not signed a batch before, then continue.
             std::collections::hash_map::Entry::Vacant(entry) => {
-                // Cache the round, timestamp, batch ID, and signature for this validator.
-                entry.insert((batch_round, timestamp, batch_id, signature));
+                // Cache the round, batch ID, and signature for this validator.
+                entry.insert((batch_round, batch_id, signature));
             }
         };
 
@@ -1144,14 +1139,7 @@ impl<N: Network> Primary<N> {
     async fn check_proposed_batch_for_expiration(&self) -> Result<()> {
         // Check if the proposed batch is timed out or stale.
         let is_expired = match self.proposed_batch.read().as_ref() {
-            Some(proposal) => {
-                // Determine if the proposal is stale.
-                let is_stale = proposal.round() < self.current_round();
-                // Determine if the proposal is timed out.
-                let is_timed_out = is_proposal_expired(now(), proposal.timestamp());
-                // Determine if the proposal is expired.
-                is_stale || is_timed_out
-            }
+            Some(proposal) => proposal.round() < self.current_round(),
             None => false,
         };
         // If the batch is expired, clear the proposed batch.
@@ -1575,7 +1563,6 @@ impl<N: Network> Primary<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PROPOSAL_EXPIRATION_IN_SECS;
     use snarkos_node_bft_ledger_service::MockLedgerService;
     use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkvm::{
@@ -1944,49 +1931,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_propose_batch_expired() {
-        let round = 3;
-        let mut rng = TestRng::default();
-        let (primary, accounts) = primary_without_handlers(&mut rng).await;
-
-        // Fill primary storage.
-        store_certificate_chain(&primary, &accounts, round, &mut rng);
-
-        // Try to propose a batch. There are no transmissions in the workers so the method should
-        // just return without proposing a batch.
-        assert!(primary.propose_batch().await.is_ok());
-        assert!(primary.proposed_batch.read().is_none());
-
-        // Sleep for a while to ensure the primary is ready to propose the next round.
-        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
-
-        // Generate a solution and a transaction.
-        let (solution_id, solution) = sample_unconfirmed_solution(&mut rng);
-        let (transaction_id, transaction) = sample_unconfirmed_transaction(&mut rng);
-
-        // Store it on one of the workers.
-        primary.workers[0].process_unconfirmed_solution(solution_id, solution).await.unwrap();
-        primary.workers[0].process_unconfirmed_transaction(transaction_id, transaction).await.unwrap();
-
-        // Propose a batch again. This time, it should succeed.
-        assert!(primary.propose_batch().await.is_ok());
-        let original_proposed_batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
-
-        // Try to propose the batch again. This time, it should return the same proposal.
-        assert!(primary.propose_batch().await.is_ok());
-        let proposal_batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
-        assert_eq!(proposal_batch_id, original_proposed_batch_id);
-
-        // Sleep until the proposal is expired.
-        tokio::time::sleep(Duration::from_secs(PROPOSAL_EXPIRATION_IN_SECS as u64)).await;
-
-        // Try to propose a batch again. This time the proposal should be expired and a new proposal should be created.
-        assert!(primary.propose_batch().await.is_ok());
-        let new_proposal_batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
-        assert_ne!(new_proposal_batch_id, original_proposed_batch_id);
-    }
-
-    #[tokio::test]
     async fn test_batch_propose_from_peer() {
         let mut rng = TestRng::default();
         let (primary, accounts) = primary_without_handlers(&mut rng).await;
@@ -2135,141 +2079,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_batch_propose_from_peer_expired() {
-        let round = 2;
-        let mut rng = TestRng::default();
-        let (primary, accounts) = primary_without_handlers(&mut rng).await;
-
-        // Generate certificates.
-        let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
-
-        // Sleep for a while to ensure the primary is ready to propose the next round.
-        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
-
-        // Create a valid proposal with an author that isn't the primary.
-        let peer_account = &accounts[1];
-        let peer_address = peer_account.1.address();
-        let peer_ip = peer_account.0;
-        let timestamp = now();
-        let proposal = create_test_proposal(
-            &peer_account.1,
-            primary.ledger.current_committee().unwrap(),
-            round,
-            previous_certificates.clone(),
-            timestamp,
-            &mut rng,
-        );
-
-        // Make sure the primary is aware of the transmissions in the proposal.
-        for (transmission_id, transmission) in proposal.transmissions() {
-            primary.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
-        }
-
-        // The author must be known to resolver to pass propose checks.
-        primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
-
-        // Try to process the batch proposal from the peer, should succeed.
-        primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.unwrap();
-
-        // Fetch the original round and  batch ID of the signed proposal.
-        let original_round = primary.signed_proposals.read().get(&peer_address).unwrap().0;
-        let original_batch_id = primary.signed_proposals.read().get(&peer_address).unwrap().2;
-
-        // Construct a new proposal.
-        let new_proposal = create_test_proposal(
-            &peer_account.1,
-            primary.ledger.current_committee().unwrap(),
-            round,
-            previous_certificates.clone(),
-            now(),
-            &mut rng,
-        );
-
-        // Try to process the batch proposal from the peer again, should error.
-        assert!(
-            primary
-                .process_batch_propose_from_peer(peer_ip, (*new_proposal.batch_header()).clone().into())
-                .await
-                .is_err()
-        );
-
-        // Ensure that the round and batch ID of the signed proposal did not change.
-        let round = primary.signed_proposals.read().get(&peer_address).unwrap().0;
-        let batch_id = primary.signed_proposals.read().get(&peer_address).unwrap().2;
-        assert_eq!(round, original_round);
-        assert_eq!(batch_id, original_batch_id);
-    }
-
-    #[tokio::test]
-    async fn test_batch_propose_from_peer_after_expiration() {
-        let round = 2;
-        let mut rng = TestRng::default();
-        let (primary, accounts) = primary_without_handlers(&mut rng).await;
-
-        // Generate certificates.
-        let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
-
-        // Sleep for a while to ensure the primary is ready to propose the next round.
-        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
-
-        // Create a valid proposal with an author that isn't the primary.
-        let peer_account = &accounts[1];
-        let peer_address = peer_account.1.address();
-        let peer_ip = peer_account.0;
-        let timestamp = now();
-        let proposal = create_test_proposal(
-            &peer_account.1,
-            primary.ledger.current_committee().unwrap(),
-            round,
-            previous_certificates.clone(),
-            timestamp,
-            &mut rng,
-        );
-
-        // Make sure the primary is aware of the transmissions in the proposal.
-        for (transmission_id, transmission) in proposal.transmissions() {
-            primary.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
-        }
-
-        // The author must be known to resolver to pass propose checks.
-        primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
-
-        // Try to process the batch proposal from the peer, should succeed.
-        primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.unwrap();
-
-        // Fetch the original round and  batch ID of the signed proposal.
-        let original_round = primary.signed_proposals.read().get(&peer_address).unwrap().0;
-        let original_batch_id = primary.signed_proposals.read().get(&peer_address).unwrap().2;
-
-        // Sleep until the current proposal is expired.
-        tokio::time::sleep(Duration::from_secs(PROPOSAL_EXPIRATION_IN_SECS as u64)).await;
-
-        // Create a new proposal after the previous one has expired.
-        let new_proposal = create_test_proposal(
-            &peer_account.1,
-            primary.ledger.current_committee().unwrap(),
-            round,
-            previous_certificates,
-            now(),
-            &mut rng,
-        );
-
-        // Make sure the primary is aware of the transmissions in the proposal.
-        for (transmission_id, transmission) in new_proposal.transmissions() {
-            primary.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
-        }
-
-        // Try to process the batch proposal from the peer, should succeed.
-        primary.process_batch_propose_from_peer(peer_ip, (*new_proposal.batch_header()).clone().into()).await.unwrap();
-
-        // Ensure that the batch ID of the signed proposal has changed, but the round has not.
-        let round = primary.signed_proposals.read().get(&peer_address).unwrap().0;
-        let batch_id = primary.signed_proposals.read().get(&peer_account.1.address()).unwrap().2;
-        assert_eq!(round, original_round);
-        assert_ne!(batch_id, original_batch_id);
-    }
-
-    #[tokio::test]
     async fn test_batch_propose_from_peer_with_invalid_timestamp() {
         let round = 2;
         let mut rng = TestRng::default();
@@ -2362,9 +2171,6 @@ mod tests {
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
 
-        // Sleep for a while to ensure the primary is ready to process the proposal.
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
 
@@ -2403,9 +2209,6 @@ mod tests {
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
 
-        // Sleep for a while to ensure the primary is ready to process the proposal.
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
 
@@ -2440,9 +2243,6 @@ mod tests {
 
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
-
-        // Sleep for a while to ensure the primary is ready to process the proposal.
-        tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
@@ -2480,9 +2280,6 @@ mod tests {
 
         // Store the proposal on the primary.
         *primary.proposed_batch.write() = Some(proposal);
-
-        // Sleep for a while to ensure the primary is ready to process the proposal.
-        tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -26,6 +26,7 @@ use crate::{
         PrimaryReceiver,
         PrimarySender,
         Proposal,
+        ProposalCache,
         SignedProposals,
         Storage,
     },
@@ -40,7 +41,6 @@ use crate::{
     PRIMARY_PING_IN_MS,
     WORKER_PING_IN_MS,
 };
-use aleo_std::{aleo_ledger_dir, StorageMode};
 use snarkos_account::Account;
 use snarkos_node_bft_events::PrimaryPing;
 use snarkos_node_bft_ledger_service::LedgerService;
@@ -54,7 +54,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, BatchHeader, Data, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{committee::Committee, ToBytes},
+    prelude::committee::Committee,
 };
 
 use colored::Colorize;
@@ -64,10 +64,8 @@ use parking_lot::{Mutex, RwLock};
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
-    fs,
     future::Future,
     net::SocketAddr,
-    path::PathBuf,
     sync::Arc,
     time::Duration,
 };
@@ -78,21 +76,6 @@ use tokio::{
 
 /// A helper type for an optional proposed batch.
 pub type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
-
-// Returns the path where a batch proposal file may be stored.
-pub fn batch_proposal_path(network: u16, dev: Option<u16>) -> PathBuf {
-    // Obtain the path to the ledger.
-    let mut path = aleo_ledger_dir(network, StorageMode::from(dev));
-    // Go to the folder right above the ledger.
-    path.pop();
-    // Append the proposal's file name.
-    path.push(&format!(
-        "current_batch_proposal-{network}{}",
-        if let Some(id) = dev { format!("-{id}") } else { "".into() }
-    ));
-
-    path
-}
 
 #[derive(Clone)]
 pub struct Primary<N: Network> {
@@ -137,18 +120,19 @@ impl<N: Network> Primary<N> {
         let gateway = Gateway::new(account, storage.clone(), ledger.clone(), ip, trusted_validators, dev)?;
         // Initialize the sync module.
         let sync = Sync::new(gateway.clone(), storage.clone(), ledger.clone());
-        // Check for the existence of a batch proposal file.
-        let proposed_batch = ProposedBatch::<N>::default();
-        let proposal_path = batch_proposal_path(N::ID, dev);
-        if let Ok(serialized_proposal) = fs::read(&proposal_path) {
-            match Proposal::<N>::from_bytes_le(&serialized_proposal) {
-                Ok(proposal) => *proposed_batch.write() = Some(proposal),
-                Err(_) => bail!("Couldn't deserialize the proposal stored at {}", proposal_path.display()),
-            }
-            if let Err(err) = fs::remove_file(&proposal_path) {
-                bail!("Failed to remove the current batch proposal file at {}: {err}", proposal_path.display());
-            }
-        }
+
+        // Fetch the signed proposals from the file system if it exists.
+        let proposal_cache = match ProposalCache::<N>::exists(dev) {
+            true => match ProposalCache::<N>::load(gateway.account().address(), dev) {
+                Ok(proposal) => proposal,
+                Err(err) => {
+                    bail!("Failed to read the signed proposals from the file system - {err}.");
+                }
+            },
+            false => ProposalCache::default(),
+        };
+        // Extract the proposal and signed proposals.
+        let (proposed_batch, signed_proposals) = proposal_cache.into();
 
         // Initialize the primary instance.
         Ok(Self {
@@ -158,9 +142,9 @@ impl<N: Network> Primary<N> {
             ledger,
             workers: Arc::from(vec![]),
             bft_sender: Default::default(),
-            proposed_batch: Arc::new(proposed_batch),
+            proposed_batch: Arc::new(RwLock::new(proposed_batch)),
             latest_proposed_batch_timestamp: Default::default(),
-            signed_proposals: Default::default(),
+            signed_proposals: Arc::new(RwLock::new(signed_proposals)),
             handles: Default::default(),
             propose_lock: Default::default(),
         })
@@ -1577,20 +1561,11 @@ impl<N: Network> Primary<N> {
         self.workers.iter().for_each(|worker| worker.shut_down());
         // Abort the tasks.
         self.handles.lock().iter().for_each(|handle| handle.abort());
-        // Save the current batch proposal to disk.
-        if let Some(proposal) = self.proposed_batch.write().take() {
-            let proposal_path = batch_proposal_path(N::ID, self.gateway.dev());
-
-            match proposal.to_bytes_le() {
-                Ok(proposal) => {
-                    if let Err(err) = fs::write(&proposal_path, proposal) {
-                        error!("Couldn't store the current proposal at {}: {err}.", proposal_path.display());
-                    }
-                }
-                Err(err) => {
-                    error!("Couldn't serialize the current proposal: {err}.");
-                }
-            };
+        // Save the current proposal cache to disk.
+        let proposal_cache =
+            ProposalCache::new(self.proposed_batch.write().take(), self.signed_proposals.write().clone());
+        if let Err(err) = proposal_cache.store(self.gateway.dev()) {
+            error!("Failed to store the current proposal cache: {err}");
         }
         // Close the gateway.
         self.gateway.shut_down().await;

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1128,11 +1128,11 @@ impl<N: Network> Primary<N> {
                     if certificates.is_empty() {
                         continue;
                     }
-                    let authors = certificates.iter().map(BatchCertificate::author).collect();
                     let Ok(committee_lookback) = self_.ledger.get_committee_lookback_for_round(next_round) else {
                         warn!("Failed to retrieve the committee lookback for round {next_round}");
                         continue;
                     };
+                    let authors = certificates.iter().map(BatchCertificate::author).collect();
                     committee_lookback.is_quorum_threshold_reached(&authors)
                 };
                 // Attempt to increment to the next round if the quorum threshold is reached.
@@ -1606,7 +1606,7 @@ impl<N: Network> Primary<N> {
         // Save the current proposal cache to disk.
         let proposal_cache = {
             let proposal = self.proposed_batch.write().take();
-            let signed_proposals = self.signed_proposals.write().clone();
+            let signed_proposals = self.signed_proposals.read().clone();
             let latest_round = proposal.as_ref().map(Proposal::round).unwrap_or(*self.propose_lock.lock().await);
             ProposalCache::new(latest_round, proposal, signed_proposals)
         };

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1607,7 +1607,7 @@ impl<N: Network> Primary<N> {
         let proposal_cache = {
             let proposal = self.proposed_batch.write().take();
             let signed_proposals = self.signed_proposals.write().clone();
-            let latest_round = proposal.as_ref().map(Proposal::round).unwrap_or(self.storage.current_round());
+            let latest_round = proposal.as_ref().map(Proposal::round).unwrap_or(*self.propose_lock.lock().await);
             ProposalCache::new(latest_round, proposal, signed_proposals)
         };
         if let Err(err) = proposal_cache.store(self.gateway.dev()) {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR has three changes to address https://github.com/AleoHQ/snarkOS/issues/3171: 

1. Reverted _proposal expiration_ introduced in https://github.com/AleoHQ/snarkOS/pull/3202.
    - This approach was unsafe because it violated the non-equivocation properties of our BFT protocol.  
    - A community member @ghostant-1017 also highlighted this issue in a bug bounty finding [HackerOne-2452182].

2. The `ProposalCache` (`latest_round`, pending `Proposal`, and `SignedProposals`) will be stored to a file on shutdown, loaded on bootup, and cleared with `snarkos clean`. 
    - Ensures that honest validators do not create multiple proposals on the same round
    - Ensures that we do not sign additional validator proposals on the same round after a reboot.    
    - Ensures that the node does not create any proposals prior to it's storage round prior to the reboot.
    
3. Periodic attempts to increment the round if we met the quorum requirements in storage.
    - In our current processing of `PrimaryPing`s, we try to advance rounds in `sync_with_batch_header_from_peer`, however we perform this check PRIOR to processing the batch header, meaning it will not be included in the quorum calculation. This prevents us from advancing rounds when there are just enough certificates to meet quorum for that round (since we omit the last one we receive in the quorum calculation).
    
**Note**: An alternative to this `latest_round` approach is to store all of the certificates in `Storage` that have not made it into blocks to the `ProposalCache` file. The `latest_round` approach relies on `PrimaryPing`s to advance the storage state, but does allow the `ProposalCache` file to be relatively small.

### Implications

- If enough (a majority) of validators reboot their nodes at the same time, there could be a halting case.
    - If we signed proposals past our ledger round, but all nodes have thrown away their `Storage`, then we won't have the signatures required to reconstruct the original proposal state. 
    - This will need to be remedied by having all validators delete their `proposal_cache` file and reboot.

- Validators looking to swap machines will need to migrate their `proposal_cache` file between machines to ensure honest behavior.

## Test Plan

Unit tests have been added to for the new types and to ensure that the new checks hold.

Extensive local and burn-in testing will need to be performed.

## Related PRs

Reverts: https://github.com/AleoHQ/snarkOS/pull/3202.
An extension of: https://github.com/AleoHQ/snarkOS/pull/3200

## TODO

- [ ] Consider adding new log messages to inform validators of the importance of the storage.
