### PR TITLE
[Optimize] Disable transaction loop for production environments

### DIFF
--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -361,20 +361,8 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
                     return Ok(());
                 }
             }
-            _ => {
-                // Retrieve the genesis committee.
-                let Ok(Some(committee)) = self.ledger.get_committee_for_round(0) else {
-                    // If the genesis committee is not available, do not start the loop.
-                    return Ok(());
-                };
-                // Retrieve the first member.
-                // Note: It is guaranteed that the committee has at least one member.
-                let first_member = committee.members().first().unwrap().0;
-                // If the node is not the first member, do not start the loop.
-                if self.address() != *first_member {
-                    return Ok(());
-                }
-            }
+            // If the node is not running in development mode, do not generate dev traffic.
+            _ => return Ok(()),
         }
 
         let self_ = self.clone();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR removes the transaction pool generation loop for production environments. This was necessary previously because we required transactions to advance consensus. Now that we allow empty blocks (no transactions or solutions), these "filler" transactions are no longer necessary to drive the chain.

Note: We keep the transaction pool in development environments for testing purposes.