### PR TITLE
[Logs] Update log levels for safe behavior

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -199,7 +199,9 @@ impl<N: Network> BFT<N> {
         // Ensure the current round is at least the storage round (this is a sanity check).
         let storage_round = self.storage().current_round();
         if current_round < storage_round {
-            warn!("BFT is safely skipping an update for round {current_round}, as storage is at round {storage_round}");
+            debug!(
+                "BFT is safely skipping an update for round {current_round}, as storage is at round {storage_round}"
+            );
             return false;
         }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the log messages, primary to de-escalate `WARN` logs that should realistically be safe and be on the `DEBUG` level.

Examples of such logs are:
- `WARN Cannot store a signature from '{peer_ip}' - This batch was already certified`
- `WARN Cannot sign a batch from '{peer_ip}' - Batch for round {round} already exists in storage (gc = {gc_round})`
- `WARN Primary is safely skipping (round {round} was already certified)`

These do not need to be at a `WARN` level as are alarming to node operators, but they demonstrate safe behavior.