### PR TITLE
[Optimize] Store pending certificates to proposal cache file

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -32,7 +32,7 @@ if [[ $clear_ledger == "y" ]]; then
 
   for ((index = 0; index < $((total_validators + total_clients)); index++)); do
     # Run 'snarkos clean' for each node in the background
-    snarkos clean --dev $index &
+    snarkos clean --network $network_id --dev $index &
 
     # Store the process ID of the background task
     clean_processes+=($!)

--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -16,13 +16,15 @@ use crate::helpers::{Proposal, SignedProposals};
 
 use snarkvm::{
     console::{account::Address, network::Network},
-    prelude::{anyhow, bail, FromBytes, IoResult, Read, Result, ToBytes, Write},
+    ledger::narwhal::BatchCertificate,
+    prelude::{anyhow, bail, error, FromBytes, IoResult, Read, Result, ToBytes, Write},
 };
 
 use aleo_std::{aleo_ledger_dir, StorageMode};
+use indexmap::IndexSet;
 use std::{fs, path::PathBuf};
 
-// Returns the path where a proposal cache file may be stored.
+/// Returns the path where a proposal cache file may be stored.
 pub fn proposal_cache_path(network: u16, dev: Option<u16>) -> PathBuf {
     const PROPOSAL_CACHE_FILE_NAME: &str = "current-proposal-cache";
 
@@ -48,12 +50,19 @@ pub struct ProposalCache<N: Network> {
     proposal: Option<Proposal<N>>,
     /// The signed proposals this node has received.
     signed_proposals: SignedProposals<N>,
+    /// The pending certificates in storage that have not been included in the ledger.
+    pending_certificates: IndexSet<BatchCertificate<N>>,
 }
 
 impl<N: Network> ProposalCache<N> {
     /// Initializes a new instance of the proposal cache.
-    pub fn new(latest_round: u64, proposal: Option<Proposal<N>>, signed_proposals: SignedProposals<N>) -> Self {
-        Self { latest_round, proposal, signed_proposals }
+    pub fn new(
+        latest_round: u64,
+        proposal: Option<Proposal<N>>,
+        signed_proposals: SignedProposals<N>,
+        pending_certificates: IndexSet<BatchCertificate<N>>,
+    ) -> Self {
+        Self { latest_round, proposal, signed_proposals, pending_certificates }
     }
 
     /// Ensure that the proposal and every signed proposal is associated with the `expected_signer`.
@@ -110,9 +119,9 @@ impl<N: Network> ProposalCache<N> {
         Ok(())
     }
 
-    /// Returns the latest round, proposal and signed proposals.
-    pub fn into(self) -> (u64, Option<Proposal<N>>, SignedProposals<N>) {
-        (self.latest_round, self.proposal, self.signed_proposals)
+    /// Returns the latest round, proposal, signed proposals, and pending certificates.
+    pub fn into(self) -> (u64, Option<Proposal<N>>, SignedProposals<N>, IndexSet<BatchCertificate<N>>) {
+        (self.latest_round, self.proposal, self.signed_proposals, self.pending_certificates)
     }
 }
 
@@ -127,6 +136,12 @@ impl<N: Network> ToBytes for ProposalCache<N> {
         }
         // Serialize the `signed_proposals`.
         self.signed_proposals.write_le(&mut writer)?;
+        // Write the number of pending certificates.
+        u32::try_from(self.pending_certificates.len()).map_err(error)?.write_le(&mut writer)?;
+        // Serialize the pending certificates.
+        for certificate in &self.pending_certificates {
+            certificate.write_le(&mut writer)?;
+        }
 
         Ok(())
     }
@@ -144,15 +159,20 @@ impl<N: Network> FromBytes for ProposalCache<N> {
         };
         // Deserialize `signed_proposals`.
         let signed_proposals = SignedProposals::read_le(&mut reader)?;
+        // Read the number of pending certificates.
+        let num_certificates = u32::read_le(&mut reader)?;
+        // Deserialize the pending certificates.
+        let pending_certificates =
+            (0..num_certificates).map(|_| BatchCertificate::read_le(&mut reader)).collect::<IoResult<IndexSet<_>>>()?;
 
-        Ok(Self::new(latest_round, proposal, signed_proposals))
+        Ok(Self::new(latest_round, proposal, signed_proposals, pending_certificates))
     }
 }
 
 impl<N: Network> Default for ProposalCache<N> {
     /// Initializes a new instance of the proposal cache.
     fn default() -> Self {
-        Self::new(0, None, Default::default())
+        Self::new(0, None, Default::default(), Default::default())
     }
 }
 
@@ -162,6 +182,7 @@ mod tests {
     use crate::helpers::{proposal::tests::sample_proposal, signed_proposals::tests::sample_signed_proposals};
     use snarkvm::{
         console::{account::PrivateKey, network::MainnetV0},
+        ledger::narwhal::batch_certificate::test_helpers::sample_batch_certificates,
         utilities::TestRng,
     };
 
@@ -176,8 +197,9 @@ mod tests {
         let proposal = sample_proposal(rng);
         let signed_proposals = sample_signed_proposals(signer, rng);
         let round = proposal.round();
+        let pending_certificates = sample_batch_certificates(rng);
 
-        ProposalCache::new(round, Some(proposal), signed_proposals)
+        ProposalCache::new(round, Some(proposal), signed_proposals, pending_certificates)
     }
 
     #[test]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -43,6 +43,7 @@ use crate::{
 use snarkos_account::Account;
 use snarkos_node_bft_events::PrimaryPing;
 use snarkos_node_bft_ledger_service::LedgerService;
+use snarkos_node_sync::DUMMY_SELF_IP;
 use snarkvm::{
     console::{
         prelude::*,
@@ -120,19 +121,6 @@ impl<N: Network> Primary<N> {
         // Initialize the sync module.
         let sync = Sync::new(gateway.clone(), storage.clone(), ledger.clone());
 
-        // Fetch the signed proposals from the file system if it exists.
-        let proposal_cache = match ProposalCache::<N>::exists(dev) {
-            true => match ProposalCache::<N>::load(gateway.account().address(), dev) {
-                Ok(proposal) => proposal,
-                Err(err) => {
-                    bail!("Failed to read the signed proposals from the file system - {err}.");
-                }
-            },
-            false => ProposalCache::default(),
-        };
-        // Extract the proposal and signed proposals.
-        let (latest_certificate_round, proposed_batch, signed_proposals) = proposal_cache.into();
-
         // Initialize the primary instance.
         Ok(Self {
             sync,
@@ -141,12 +129,53 @@ impl<N: Network> Primary<N> {
             ledger,
             workers: Arc::from(vec![]),
             bft_sender: Default::default(),
-            proposed_batch: Arc::new(RwLock::new(proposed_batch)),
+            proposed_batch: Default::default(),
             latest_proposed_batch_timestamp: Default::default(),
-            signed_proposals: Arc::new(RwLock::new(signed_proposals)),
+            signed_proposals: Default::default(),
             handles: Default::default(),
-            propose_lock: Arc::new(TMutex::new(latest_certificate_round)),
+            propose_lock: Default::default(),
         })
+    }
+
+    /// Load the proposal cache file and update the Primary state with the stored data.
+    async fn load_proposal_cache(&self) -> Result<()> {
+        // Fetch the signed proposals from the file system if it exists.
+        let proposal_cache = match ProposalCache::<N>::exists(self.gateway.dev()) {
+            true => match ProposalCache::<N>::load(self.gateway.account().address(), self.gateway.dev()) {
+                Ok(proposal) => proposal,
+                Err(err) => {
+                    bail!("Failed to read the signed proposals from the file system - {err}.");
+                }
+            },
+            false => return Ok(()),
+        };
+        // Extract the proposal and signed proposals.
+        let (latest_certificate_round, proposed_batch, signed_proposals) = proposal_cache.into();
+
+        // Update the storage with the pending certificates.
+        // The Storage should have been initialized with the latest certificate round.
+
+        // Write the proposed batch.
+        *self.proposed_batch.write() = proposed_batch;
+        // Write the signed proposals.
+        *self.signed_proposals.write() = signed_proposals;
+        // Writ the propose lock.
+        *self.propose_lock.lock().await = latest_certificate_round;
+
+        // Update the storage with the pending certificates.
+        // The Storage should have been initialized with the latest certificate round.
+        // TODO (raychu86): Uncomment this section.
+        // for certificate in pending_certificates {
+        //     let batch_id = certificate.batch_id();
+        //     // We use a dummy IP because the node should not need to request from any peers.
+        //     // The storage should have stored all the transmissions in the BFT persistent storage. Otherwise, we
+        //     // skip the certificate.
+        //     if let Err(err) = self.sync_with_certificate_from_peer(DUMMY_SELF_IP, certificate) {
+        //         warn!("Failed to load stored certificate {} - {err}", fmt_id(batch_id));
+        //     }
+        // }
+
+        Ok(())
     }
 
     /// Run the primary instance.
@@ -194,6 +223,8 @@ impl<N: Network> Primary<N> {
         let (sync_sender, sync_receiver) = init_sync_channels();
         // Next, initialize the sync module.
         self.sync.run(bft_sender, sync_receiver).await?;
+        // Load the proposal cache.
+        self.load_proposal_cache().await?;
         // Next, initialize the gateway.
         self.gateway.run(primary_sender, worker_senders, Some(sync_sender)).await;
         // Lastly, start the primary handlers.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -82,8 +82,8 @@ impl<N: Network> Sync<N> {
         }
     }
 
-    /// Starts the sync module.
-    pub async fn run(&self, bft_sender: Option<BFTSender<N>>, sync_receiver: SyncReceiver<N>) -> Result<()> {
+    /// Initializes the sync module and sync the storage with the ledger at bootup.
+    pub async fn initialize(&self, bft_sender: Option<BFTSender<N>>) -> Result<()> {
         // If a BFT sender was provided, set it.
         if let Some(bft_sender) = bft_sender {
             self.bft_sender.set(bft_sender).expect("BFT sender already set in gateway");
@@ -92,8 +92,11 @@ impl<N: Network> Sync<N> {
         info!("Syncing storage with the ledger...");
 
         // Sync the storage with the ledger.
-        self.sync_storage_with_ledger_at_bootup().await?;
+        self.sync_storage_with_ledger_at_bootup().await
+    }
 
+    /// Starts the sync module.
+    pub async fn run(&self, sync_receiver: SyncReceiver<N>) -> Result<()> {
         info!("Starting the sync module...");
 
         // Start the block sync loop.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -906,7 +906,7 @@ mod tests {
         let core_ledger = Arc::new(CoreLedgerService::new(ledger.clone(), Default::default()));
         // Sample rounds of batch certificates starting at the genesis round from a static set of 4 authors.
         let (round_to_certificates_map, committee) = {
-            // Initialize the committee. 
+            // Initialize the committee.
             let committee = ledger.latest_committee().unwrap();
             // Initialize a mapping from the round number to the set of batch certificates in the round.
             let mut round_to_certificates_map: HashMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> =
@@ -946,7 +946,6 @@ mod tests {
                 // Update the map of certificates.
                 round_to_certificates_map.insert(round, current_certificates.clone());
                 previous_certificates = current_certificates.clone();
-
             }
             (round_to_certificates_map, committee)
         };
@@ -1024,16 +1023,16 @@ mod tests {
 
         /*
             Check that the pending certificates are computed correctly.
-        */  
-        
-        // Retrieve the pending certificates. 
-        let pending_certificates = storage.get_pending_certificates(); 
-        // Check that all of the pending certificates are not contained in the ledger. 
+        */
+
+        // Retrieve the pending certificates.
+        let pending_certificates = storage.get_pending_certificates();
+        // Check that all of the pending certificates are not contained in the ledger.
         for certificate in pending_certificates.clone() {
-            assert!(!core_ledger.contains_certificate(&certificate.id()).unwrap_or(false)); 
+            assert!(!core_ledger.contains_certificate(&certificate.id()).unwrap_or(false));
         }
-        // Initialize an empty set to be populated with the committed certificates in the block subdags. 
-        let mut committed_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::new(); 
+        // Initialize an empty set to be populated with the committed certificates in the block subdags.
+        let mut committed_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::new();
         {
             let subdag_maps = [&subdag_map, &subdag_map_2, &subdag_map_3];
             for subdag in subdag_maps.iter() {
@@ -1041,15 +1040,15 @@ mod tests {
                     committed_certificates.extend(subdag_certificates.iter().cloned());
                 }
             }
-        }; 
-        // Create the set of candidate pending certificates as the set of all certificates minus the set of the committed certificates. 
-        let mut candidate_pending_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::new(); 
-        for certificate in certificates.clone(){
-            if !committed_certificates.contains(&certificate){
-                candidate_pending_certificates.insert(certificate); 
+        };
+        // Create the set of candidate pending certificates as the set of all certificates minus the set of the committed certificates.
+        let mut candidate_pending_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::new();
+        for certificate in certificates.clone() {
+            if !committed_certificates.contains(&certificate) {
+                candidate_pending_certificates.insert(certificate);
             }
         }
-        // Check that the set of pending certificates is equal to the set of candidate pending certificates. 
+        // Check that the set of pending certificates is equal to the set of candidate pending certificates.
         assert_eq!(pending_certificates, candidate_pending_certificates);
         Ok(())
     }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -874,4 +874,183 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_pending_certificates() -> anyhow::Result<()> {
+        let rng = &mut TestRng::default();
+        // Initialize the round parameters.
+        let max_gc_rounds = BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64;
+        let commit_round = 2;
+
+        // Initialize the store.
+        let store = CurrentConsensusStore::open(None).unwrap();
+        let account: Account<CurrentNetwork> = Account::new(rng)?;
+
+        // Create a genesis block with a seeded RNG to reproduce the same genesis private keys.
+        let seed: u64 = rng.gen();
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let genesis = VM::from(store).unwrap().genesis_beacon(account.private_key(), genesis_rng).unwrap();
+
+        // Extract the private keys from the genesis committee by using the same RNG to sample private keys.
+        let genesis_rng = &mut TestRng::from_seed(seed);
+        let private_keys = [
+            *account.private_key(),
+            PrivateKey::new(genesis_rng)?,
+            PrivateKey::new(genesis_rng)?,
+            PrivateKey::new(genesis_rng)?,
+        ];
+        // Initialize the ledger with the genesis block.
+        let ledger = CurrentLedger::load(genesis.clone(), StorageMode::Production).unwrap();
+        // Initialize the ledger.
+        let core_ledger = Arc::new(CoreLedgerService::new(ledger.clone(), Default::default()));
+        // Sample rounds of batch certificates starting at the genesis round from a static set of 4 authors.
+        let (round_to_certificates_map, committee) = {
+            // Initialize the committee. 
+            let committee = ledger.latest_committee().unwrap();
+            // Initialize a mapping from the round number to the set of batch certificates in the round.
+            let mut round_to_certificates_map: HashMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> =
+                HashMap::new();
+            let mut previous_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::with_capacity(4);
+
+            for round in 0..=commit_round + 8 {
+                let mut current_certificates = IndexSet::new();
+                let previous_certificate_ids: IndexSet<_> = if round == 0 || round == 1 {
+                    IndexSet::new()
+                } else {
+                    previous_certificates.iter().map(|c| c.id()).collect()
+                };
+                let committee_id = committee.id();
+                // Create a certificate for each validator.
+                for (i, private_key_1) in private_keys.iter().enumerate() {
+                    let batch_header = BatchHeader::new(
+                        private_key_1,
+                        round,
+                        now(),
+                        committee_id,
+                        Default::default(),
+                        previous_certificate_ids.clone(),
+                        rng,
+                    )
+                    .unwrap();
+                    // Sign the batch header.
+                    let mut signatures = IndexSet::with_capacity(4);
+                    for (j, private_key_2) in private_keys.iter().enumerate() {
+                        if i != j {
+                            signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
+                        }
+                    }
+                    current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
+                }
+
+                // Update the map of certificates.
+                round_to_certificates_map.insert(round, current_certificates.clone());
+                previous_certificates = current_certificates.clone();
+
+            }
+            (round_to_certificates_map, committee)
+        };
+
+        // Initialize the storage.
+        let storage = Storage::new(core_ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        // Insert certificates into storage.
+        let mut certificates: Vec<BatchCertificate<CurrentNetwork>> = Vec::new();
+        for i in 1..=commit_round + 8 {
+            let c = (*round_to_certificates_map.get(&i).unwrap()).clone();
+            certificates.extend(c);
+        }
+        for certificate in certificates.clone().iter() {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+        }
+        // Create block 1.
+        let leader_round_1 = commit_round;
+        let leader_1 = committee.get_leader(leader_round_1).unwrap();
+        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader_1).unwrap();
+        let mut subdag_map: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
+        let block_1 = {
+            let mut leader_cert_map = IndexSet::new();
+            leader_cert_map.insert(leader_certificate.clone());
+            let mut previous_cert_map = IndexSet::new();
+            for cert in storage.get_certificates_for_round(commit_round - 1) {
+                previous_cert_map.insert(cert);
+            }
+            subdag_map.insert(commit_round, leader_cert_map.clone());
+            subdag_map.insert(commit_round - 1, previous_cert_map.clone());
+            let subdag = Subdag::from(subdag_map.clone())?;
+            core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?
+        };
+        // Insert block 1.
+        core_ledger.advance_to_next_block(&block_1)?;
+
+        // Create block 2.
+        let leader_round_2 = commit_round + 2;
+        let leader_2 = committee.get_leader(leader_round_2).unwrap();
+        let leader_certificate_2 = storage.get_certificate_for_round_with_author(leader_round_2, leader_2).unwrap();
+        let mut subdag_map_2: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
+        let block_2 = {
+            let mut leader_cert_map_2 = IndexSet::new();
+            leader_cert_map_2.insert(leader_certificate_2.clone());
+            let mut previous_cert_map_2 = IndexSet::new();
+            for cert in storage.get_certificates_for_round(leader_round_2 - 1) {
+                previous_cert_map_2.insert(cert);
+            }
+            subdag_map_2.insert(leader_round_2, leader_cert_map_2.clone());
+            subdag_map_2.insert(leader_round_2 - 1, previous_cert_map_2.clone());
+            let subdag_2 = Subdag::from(subdag_map_2.clone())?;
+            core_ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default())?
+        };
+        // Insert block 2.
+        core_ledger.advance_to_next_block(&block_2)?;
+
+        // Create block 3
+        let leader_round_3 = commit_round + 4;
+        let leader_3 = committee.get_leader(leader_round_3).unwrap();
+        let leader_certificate_3 = storage.get_certificate_for_round_with_author(leader_round_3, leader_3).unwrap();
+        let mut subdag_map_3: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
+        let block_3 = {
+            let mut leader_cert_map_3 = IndexSet::new();
+            leader_cert_map_3.insert(leader_certificate_3.clone());
+            let mut previous_cert_map_3 = IndexSet::new();
+            for cert in storage.get_certificates_for_round(leader_round_3 - 1) {
+                previous_cert_map_3.insert(cert);
+            }
+            subdag_map_3.insert(leader_round_3, leader_cert_map_3.clone());
+            subdag_map_3.insert(leader_round_3 - 1, previous_cert_map_3.clone());
+            let subdag_3 = Subdag::from(subdag_map_3.clone())?;
+            core_ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default())?
+        };
+        // Insert block 3.
+        core_ledger.advance_to_next_block(&block_3)?;
+
+        /*
+            Check that the pending certificates are computed correctly.
+        */  
+        
+        // Retrieve the pending certificates. 
+        let pending_certificates = storage.get_pending_certificates(); 
+        // Check that all of the pending certificates are not contained in the ledger. 
+        for certificate in pending_certificates.clone() {
+            assert!(!core_ledger.contains_certificate(&certificate.id()).unwrap_or(false)); 
+        }
+        // Initialize an empty set to be populated with the committed certificates in the block subdags. 
+        let mut committed_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::new(); 
+        {
+            let subdag_maps = [&subdag_map, &subdag_map_2, &subdag_map_3];
+            for subdag in subdag_maps.iter() {
+                for subdag_certificates in subdag.values() {
+                    committed_certificates.extend(subdag_certificates.iter().cloned());
+                }
+            }
+        }; 
+        // Create the set of candidate pending certificates as the set of all certificates minus the set of the committed certificates. 
+        let mut candidate_pending_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::new(); 
+        for certificate in certificates.clone(){
+            if !committed_certificates.contains(&certificate){
+                candidate_pending_certificates.insert(certificate); 
+            }
+        }
+        // Check that the set of pending certificates is equal to the set of candidate pending certificates. 
+        assert_eq!(pending_certificates, candidate_pending_certificates);
+        Ok(())
+    }
 }

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -52,7 +52,7 @@ pub const MAX_BLOCKS_BEHIND: u32 = 1; // blocks
 
 /// This is a dummy IP address that is used to represent the local node.
 /// Note: This here does not need to be a real IP address, but it must be unique/distinct from all other connections.
-const DUMMY_SELF_IP: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+pub const DUMMY_SELF_IP: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BlockSyncMode {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR is an extension of https://github.com/AleoHQ/snarkOS/pull/3239 that addresses https://github.com/AleoHQ/snarkOS/issues/3171.

This PR adds to the functionality of the `ProposalCache` by adding pending certificates (that have not yet been included in ledger) to the list of attributes to store to file. 

This should increase the robustness of reboots because nodes should now not need to rely on `PrimaryPings` to catch up to other peers in a reboot scenario. Initial testing has observed successful restarts (in the honest case) for any number of validators (including scenarios of more than `f+1` validators rebooting).


## Test Plan

Burn-in tests and additional reboot testing needs to be done to ensure robustness of this change.

## Related PRs

Extension of https://github.com/AleoHQ/snarkOS/pull/3239
