### PR TITLE
add committee endpoint for specific block

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -191,6 +191,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/stateRoot/latest"), get(Self::get_state_root_latest))
             .route(&format!("/{network}/stateRoot/:height"), get(Self::get_state_root))
             .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
+            .route(&format!("/{network}/committee/:height"), get(Self::get_committee))
 
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -264,6 +264,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
     }
 
+    // GET /<network>/committee/{height}
+    pub(crate) async fn get_committee(
+        State(rest): State<Self>,
+        Path(height): Path<u32>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.get_committee(height)?))
+    }
+
     // GET /<network>/peers/count
     pub(crate) async fn get_peers_count(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().number_of_connected_peers())


### PR DESCRIPTION
## Motivation
This PR just exposes the [get_committee](https://github.com/AleoHQ/snarkVM/blob/mainnet-staging/ledger/src/get.rs#L19) function to enable REST endpoint querying of a committee at any block height, not just the latest height
## Test Plan
Ran a dev network testing that this endpoint works as expected