### PR TITLE
[Fix] Add grace period before starting block sync

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -102,6 +102,11 @@ impl<N: Network> Sync<N> {
         // Start the block sync loop.
         let self_ = self.clone();
         self.handles.lock().push(tokio::spawn(async move {
+            // Sleep briefly to allow an initial primary ping to come in prior to entering the loop.
+            // Ideally, a node does not consider itself synced when it has not received
+            // any block locators from peer. However, in the initial bootup of validators,
+            // this needs to happen, so we use this additional sleep as a grace period.
+            tokio::time::sleep(Duration::from_millis(PRIMARY_PING_IN_MS)).await;
             loop {
                 // Sleep briefly to avoid triggering spam detection.
                 tokio::time::sleep(Duration::from_millis(PRIMARY_PING_IN_MS)).await;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR simply adds an additional grace period for the nodes to wait before attempting to call `try_block_sync`. 

Ideally, `try_block_sync` isn't called until the first `PrimaryPing` message is received, however in the initial bootup of validators, the nodes need to consider themselves synced to send the `PrimaryPing` in the first place. Hence, the heuristic wait approach.

This is needed because we've observed that during bootup, nodes were (occasionally) incorrectly setting themselves as synced and when they were in fact much further behind than the other validators. This caused them to incorrectly start processing proposals and certificates from the other validators instead of actually syncing. 

Here is an example of an observed sequence of logs that should not happen:

```
DEBUG Skipping batch proposal (node is syncing)
INFO No connected validators
DEBUG Fetched {} missing previous certificates for round {} from '{}'
DEBUG Primary is not ready to propose the next round
DEBUG Primary is safely skipping a batch proposal (please connect to more validators)
```

Upon further debugging, this seems to happen when the validator node call `try_block_sync` before receiving block locators from peers via a `Event::PrimaryPing`. The call to `try_block_sync` makes the node think it's synced since there are no block locators to sync from, and thus starts processing proposals/certificates from peers.

