### PR TITLE
[Fix] Remove usage of current committee if the round is in the future

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -148,7 +148,6 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     }
 
     /// Returns the committee for the given round.
-    /// If the given round is in the future, then the current committee is returned.
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
         // Check if the committee is already in the cache.
         if let Some(committee) = self.committee_cache.lock().get(&round) {
@@ -163,12 +162,12 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
                 // Return the committee.
                 Ok(committee)
             }
-            // Return the current committee if the round is in the future.
+            // Return the current committee if the round is equivalent.
             None => {
                 // Retrieve the current committee.
                 let current_committee = self.current_committee()?;
-                // Return the current committee if the round is in the future.
-                match current_committee.starting_round() <= round {
+                // Return the current committee if the round is equivalent.
+                match current_committee.starting_round() == round {
                     true => Ok(current_committee),
                     false => bail!("No committee found for round {round} in the ledger"),
                 }
@@ -177,7 +176,6 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     }
 
     /// Returns the committee lookback for the given round.
-    /// If the committee lookback round is in the future, then the current committee is returned.
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>> {
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -147,7 +147,6 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     }
 
     /// Returns the committee for the given round.
-    /// If the given round is in the future, then the current committee is returned.
     fn get_committee_for_round(&self, _round: u64) -> Result<Committee<N>> {
         Ok(self.committee.clone())
     }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -118,13 +118,11 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     }
 
     /// Returns the committee for the given round.
-    /// If the given round is in the future, then the current committee is returned.
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
         bail!("Committee for round {round} does not exist in prover")
     }
 
     /// Returns the committee lookback for the given round.
-    /// If the committee lookback round is in the future, then the current committee is returned.
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>> {
         bail!("Previous committee for round {round} does not exist in prover")
     }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -74,11 +74,9 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn current_committee(&self) -> Result<Committee<N>>;
 
     /// Returns the committee for the given round.
-    /// If the given round is in the future, then the current committee is returned.
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns the committee lookback for the given round.
-    /// If the committee lookback round is in the future, then the current committee is returned.
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns `true` if the ledger contains the given certificate ID.

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -129,7 +129,6 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     }
 
     /// Returns the committee for the given round.
-    /// If the given round is in the future, then the current committee is returned.
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
         self.inner.get_committee_for_round(round)
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates `get_committee_for_round` by  removing the condition to use the `current_committee` if the given round number is in the future. I believe this was a necessity when we did not employ the use of committee lookbacks, and needed to rely on the latest committee.

This is useful because in the scenario observed by https://github.com/AleoHQ/snarkOS/pull/3249, where nodes are processing certificates far in the future. They would erroneously disconnect from the peer due to a difference in committee ID instead of simply ignoring the certificate/proposal that was too far in the future to process.


Below is an example of the disconnect log:
```
WARN Cannot sign a batch from '{}' - Malicious peer - proposed batch has a different committee ID ({expected_committee_id} != {batch_header.committee_id()})
```

This is **SAFE** because we only ever call `get_committee_for_round` via `get_committee_lookback_for_round` and this edge case is never hit in the normal/honest operations of nodes. 