### PR TITLE
[Fix] Clear cached validator requests on disconnect

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1085,6 +1085,10 @@ impl<N: Network> Disconnect for Gateway<N> {
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
         if let Some(peer_ip) = self.resolver.get_listener(peer_addr) {
             self.remove_connected_peer(peer_ip);
+
+            // We don't clear this map based on time but only on peer disconnect.
+            // This is sufficient to avoid infinite growth as the committee has a fixed number
+            // of members.
             self.cache.clear_outbound_validators_requests(peer_ip);
         }
     }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1085,6 +1085,7 @@ impl<N: Network> Disconnect for Gateway<N> {
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
         if let Some(peer_ip) = self.resolver.get_listener(peer_addr) {
             self.remove_connected_peer(peer_ip);
+            self.cache.clear_outbound_validators_requests(peer_ip);
         }
     }
 }

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -39,7 +39,6 @@ pub struct Cache<N: Network> {
     /// The ordered timestamp map of peer IPs and their cache hits on transmission requests.
     seen_outbound_transmissions: RwLock<BTreeMap<i64, HashMap<SocketAddr, u32>>>,
     /// The map of IPs to the number of validators requests.
-    ///
     seen_outbound_validators_requests: RwLock<HashMap<SocketAddr, u32>>,
 }
 

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -40,9 +40,6 @@ pub struct Cache<N: Network> {
     seen_outbound_transmissions: RwLock<BTreeMap<i64, HashMap<SocketAddr, u32>>>,
     /// The map of IPs to the number of validators requests.
     ///
-    /// Note: we don't clear this map based on time but only on peer disconnect.
-    /// This is sufficient to avoid infinite growth as the committee has a fixed number
-    /// of members.
     seen_outbound_validators_requests: RwLock<HashMap<SocketAddr, u32>>,
 }
 


### PR DESCRIPTION
This PR clears the validator requests cache map for a particular peer on disconnect. This ensures the collection is periodically cleaned up despite not having a time-based expiry and is sufficient to avoid infinite growth as the committee size is bounded (but the IP may change).

A small aside for future discussion: when time permits, we may want to revisit our approach to cache invalidation both in the gateway and the router. One option would be to use an LRU with a fixed size that we clear on specific state transitions (e.g. on round increment). 
