### PR TITLE
[Fix] Coupling block sync to DAG state  

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -821,12 +821,12 @@ impl<N: Network> BFT<N> {
             }
         });
 
-        // Process the request to check if the batch certificate was recently committed. 
+        // Process the request to check if the batch certificate was recently committed.
         let self_ = self.clone();
         self.spawn(async move {
             while let Some((certificate, callback)) = rx_is_recently_committed.recv().await {
-                // Check if the certificate was recently committed. 
-                let is_committed = self_.dag.read().is_recently_committed(certificate.round(), certificate.id()); 
+                // Check if the certificate was recently committed.
+                let is_committed = self_.dag.read().is_recently_committed(certificate.round(), certificate.id());
                 // Send the callback **after** updating the DAG.
                 // Note: We must await the DAG update before proceeding.
                 callback.send(is_committed).ok();

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -99,11 +99,11 @@ impl<N: Network> BFTSender<N> {
         callback_receiver.await?
     }
 
-    /// Sends the batch certificate to the BFT to receive a callback on whether the certificate was recently committed. 
+    /// Sends the batch certificate to the BFT to receive a callback on whether the certificate was recently committed.
     pub async fn send_sync_certificate_to_check_commit_bft(&self, certificate: BatchCertificate<N>) -> Result<bool> {
         // Initialize a callback sender and receiver.
         let (callback_sender, callback_receiver) = oneshot::channel();
-        // Send the certificate to the BFT. 
+        // Send the certificate to the BFT.
         self.tx_is_recently_committed.send((certificate, callback_sender)).await?;
         // Await the callback to continue.
         Ok(callback_receiver.await?)
@@ -125,10 +125,22 @@ pub fn init_bft_channels<N: Network>() -> (BFTSender<N>, BFTReceiver<N>) {
     let (tx_primary_certificate, rx_primary_certificate) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_sync_bft_dag_at_bootup, rx_sync_bft_dag_at_bootup) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_sync_bft, rx_sync_bft) = mpsc::channel(MAX_CHANNEL_SIZE);
-    let (tx_is_recently_committed, rx_is_recently_committed) = mpsc::channel(MAX_CHANNEL_SIZE); 
+    let (tx_is_recently_committed, rx_is_recently_committed) = mpsc::channel(MAX_CHANNEL_SIZE);
 
-    let sender = BFTSender { tx_primary_round, tx_primary_certificate, tx_sync_bft_dag_at_bootup, tx_sync_bft, tx_is_recently_committed };
-    let receiver = BFTReceiver { rx_primary_round, rx_primary_certificate, rx_sync_bft_dag_at_bootup, rx_sync_bft, rx_is_recently_committed };
+    let sender = BFTSender {
+        tx_primary_round,
+        tx_primary_certificate,
+        tx_sync_bft_dag_at_bootup,
+        tx_sync_bft,
+        tx_is_recently_committed,
+    };
+    let receiver = BFTReceiver {
+        rx_primary_round,
+        rx_primary_certificate,
+        rx_sync_bft_dag_at_bootup,
+        rx_sync_bft,
+        rx_is_recently_committed,
+    };
 
     (sender, receiver)
 }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -375,23 +375,12 @@ impl<N: Network> Sync<N> {
                 })
                 .collect::<HashMap<_, _>>();
 
-            // Iterate over the certificates.
+            // Sync the storage with the certificates.
             for certificates in subdag.values().cloned() {
                 cfg_into_iter!(certificates.clone()).for_each(|certificate| {
                     // Sync the batch certificate with the block.
                     self.storage.sync_certificate_with_block(&block, certificate.clone(), &unconfirmed_transactions);
                 });
-
-                // Sync the BFT DAG with the certificates.
-                for certificate in certificates {
-                    // If a BFT sender was provided, send the certificate to the BFT.
-                    if let Some(bft_sender) = self.bft_sender.get() {
-                        // Await the callback to continue.
-                        if let Err(e) = bft_sender.send_sync_bft(certificate).await {
-                            bail!("Sync - {e}");
-                        };
-                    }
-                }
             }
         }
 
@@ -469,15 +458,56 @@ impl<N: Network> Sync<N> {
                     }
                 }
 
-                // Add the blocks to the ledger.
-                for block in blocks_to_add {
+                // Sync the BFT DAG with the blocks.
+                for block in blocks_to_add.clone(){
                     // Check that the blocks are sequential and can be added to the ledger.
                     let block_height = block.height();
                     if block_height != self.ledger.latest_block_height().saturating_add(1) {
                         warn!("Skipping block {block_height} from the latest block responses - not sequential.");
                         continue;
                     }
+                    if let Authority::Quorum(subdag) = block.authority() {
+                        // Iterate over the certificates.
+                        for certificates in subdag.values().cloned() {
+                            // Sync the BFT DAG with the certificates.
+                            for certificate in certificates {
+                                // If a BFT sender was provided, send the certificate to the BFT.
+                                if let Some(bft_sender) = self.bft_sender.get() {
+                                    // Await the callback to continue.
+                                    if let Err(e) = bft_sender.send_sync_bft(certificate).await {
+                                        bail!("Sync - {e}");
+                                    };
+                                }
+                            }
+                        }
+                    }
+                }
 
+                // Check if the leader certificate of the block has recently been committed in the replicated DAG state above. 
+                // This ensures consistency between block sync and the BFT DAG state. 
+                for block in blocks_to_add {
+                    // Retrieve the block height.
+                    let block_height = block.height();
+                    if let Authority::Quorum(subdag) = block.authority() {
+                        // Retrieve the leader certificate of the subdag. 
+                        let leader_certificate = subdag.leader_certificate(); 
+                        if let Some(bft_sender) = self.bft_sender.get() {
+                            // Await the callback to continue.
+                            match bft_sender.send_sync_certificate_to_check_commit_bft(leader_certificate.clone()).await {
+                                Ok(is_recently_committed) => {
+                                    if !is_recently_committed{
+                                        bail!("Sync - Failed to advance blocks - leader certificate with author {} from round {} was not recently committed.", leader_certificate.author(), leader_certificate.round());
+                                    }
+                                    info!("Sync - leader certificate with author {} from round {} was recently committed.", leader_certificate.author(), leader_certificate.round());
+                                },
+                                Err(e) => {
+                                    bail!("Sync - Failed to check if leader certificate was recently committed - {e}");
+                                }
+                            }; 
+                        }
+                    }
+                    // Add the block to the ledger. 
+                    info!("Proceeding to advance to sync block at height {}. ", block_height); 
                     let self_ = self.clone();
                     tokio::task::spawn_blocking(move || {
                         // Check the next block.
@@ -496,6 +526,7 @@ impl<N: Network> Sync<N> {
                     // Remove the block height from the latest block responses.
                     latest_block_responses.remove(&block_height);
                 }
+
             } else {
                 debug!(
                     "Availability threshold was not reached for block {next_block_height} at round {commit_round}. Checking next block..."

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -458,8 +458,10 @@ impl<N: Network> Sync<N> {
                     }
                 }
 
-                // Sync the BFT DAG with the blocks.
-                for block in blocks_to_add.clone(){
+                // Sync the BFT DAG with the blocks. Adding the certificates for the sync blocks must occur before checking if the leader certificates have been committed.
+                // Note subdags can be committed by the linking rule and so checking recent commits should only occur after the root subdag, that reached availability 
+                // threshold, was committed in the BFT. 
+                for block in blocks_to_add.clone() {
                     // Check that the blocks are sequential and can be added to the ledger.
                     let block_height = block.height();
                     if block_height != self.ledger.latest_block_height().saturating_add(1) {


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation
This PR focuses on coupling block sync to DAG state replication. When a node is syncing via block responses, it will sync its storage and DAG with the certificates contained in the block and attempt to update its ledger. Previously, there were scenarios where a node would commit certificates in its DAG without advancing blocks. Instead, the committal of certificates and advancement of blocks during sync should be coupled. This PR commits certificates in the DAG only when blocks are advanced to in the sync module and creates a channel to the BFT to ensure that the leader certificate of the block being added was recently committed in the BFT. 

