### PR TITLE
Avoid unnecessary calculations in propose_batch

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -351,12 +351,6 @@ impl<N: Network> Primary<N> {
             return Ok(());
         }
 
-        // Determine if the current proposal is expired.
-        if round == *lock_guard {
-            warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
-            return Ok(());
-        }
-
         // If there is a batch being proposed already,
         // rebroadcast the batch header to the non-signers, and return early.
         if let Some(proposal) = self.proposed_batch.read().as_ref() {
@@ -425,6 +419,12 @@ impl<N: Network> Primary<N> {
                 }
             }
             debug!("Primary is safely skipping {}", format!("(round {round} was already certified)").dimmed());
+            return Ok(());
+        }
+
+        // Determine if the current round has been proposed.
+        if round == *lock_guard {
+            warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
             return Ok(());
         }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -342,6 +342,9 @@ impl<N: Network> Primary<N> {
         // Compute the previous round.
         let previous_round = round.saturating_sub(1);
 
+        // If the current round is 0, return early.
+        ensure!(round > 0, "Round 0 cannot have transaction batches");
+
         // If the current storage round is below the latest proposal round, then return early.
         if round < *lock_guard {
             warn!("Cannot propose a batch for round {round} - the latest proposal cache round is {}", *lock_guard);
@@ -533,8 +536,7 @@ impl<N: Network> Primary<N> {
                 }
             }
         }
-        // Ditto if the batch had already been proposed and not expired.
-        ensure!(round > 0, "Round 0 cannot have transaction batches");
+
         // Determine the current timestamp.
         let current_timestamp = now();
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -423,6 +423,10 @@ impl<N: Network> Primary<N> {
         }
 
         // Determine if the current round has been proposed.
+        // Note: Do NOT make this judgment in advance before rebroadcast and round update. Rebroadcasting is
+        // good for network reliability and should not be prevented for the already existing proposed_batch.
+        // If a certificate already exists for the current round, an attempt should be made to advance the
+        // round as early as possible.
         if round == *lock_guard {
             warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
             return Ok(());


### PR DESCRIPTION
Determine in advance whether the proposal has expired.
If it expires, return directly and skip the subsequent process.