### PR TITLE
[Optimize] Clear solutions queue and worker solutions on new epoch

### DIFF
--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -126,6 +126,14 @@ impl<N: Network> Ready<N> {
         // Drain the transmission IDs.
         transmissions.drain(range).collect::<IndexMap<_, _>>()
     }
+
+    /// Clears all solutions from the ready queue.
+    pub(crate) fn clear_solutions(&self) {
+        // Acquire the write lock.
+        let mut transmissions = self.transmissions.write();
+        // Remove all solutions.
+        transmissions.retain(|id, _| !matches!(id, TransmissionID::Solution(..)));
+    }
 }
 
 #[cfg(test)]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -320,6 +320,13 @@ impl<N: Network> Primary<N> {
 }
 
 impl<N: Network> Primary<N> {
+    /// Clears the worker solutions.
+    pub fn clear_worker_solutions(&self) {
+        self.workers.iter().for_each(Worker::clear_solutions);
+    }
+}
+
+impl<N: Network> Primary<N> {
     /// Proposes the batch for the current round.
     ///
     /// This method performs the following steps:

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -152,6 +152,13 @@ impl<N: Network> Worker<N> {
 }
 
 impl<N: Network> Worker<N> {
+    /// Clears the solutions from the ready queue.
+    pub(super) fn clear_solutions(&self) {
+        self.ready.clear_solutions()
+    }
+}
+
+impl<N: Network> Worker<N> {
     /// Returns `true` if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
     pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         let transmission_id = transmission_id.into();

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -484,6 +484,14 @@ impl<N: Network> Consensus<N> {
         // Advance to the next block.
         self.ledger.advance_to_next_block(&next_block)?;
 
+        // If the next block starts a new epoch, clear the existing solutions.
+        if next_block.height() % N::NUM_BLOCKS_PER_EPOCH == 0 {
+            // Clear the solutions queue.
+            self.solutions_queue.lock().clear();
+            // Clear the worker solutions.
+            self.bft.primary().clear_worker_solutions();
+        }
+
         #[cfg(feature = "metrics")]
         {
             let elapsed = std::time::Duration::from_secs((snarkos_node_bft::helpers::now() - start) as u64);


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR clears all the solutions from the solutions queue and worker ready queue when a new epoch starts. This prevents the node from being stuck on iteratively processing old solutions that are no longer relevant but is still held in memory.

Note: This is only done for validator nodes who are advancing via consensus. Syncing validators will not run this cleanup because they should not be processing incoming solutions in the first place.

An alternative approachs:
1. Pass in a particular epoch hash to retain (so we don't erroneously clear the solutions that are actually valid).
2. Clear the solutions on a timeout system.