### PR TITLE
Update for ARC-41: handle credits.aleo changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,47 +136,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -184,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arrayref"
@@ -202,13 +203,13 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-recursion"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -230,7 +231,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -241,14 +242,14 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -263,7 +264,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -352,9 +353,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -389,7 +390,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -494,12 +495,13 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -519,9 +521,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -540,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
 dependencies = [
  "glob",
  "libc",
@@ -580,7 +582,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -591,9 +593,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -651,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -679,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -761,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -830,9 +832,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encode_unicode"
@@ -883,9 +885,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -902,15 +904,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1025,7 +1027,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1094,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1164,9 +1166,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1278,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
@@ -1320,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1352,17 +1354,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
 dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "pin-project-lite",
- "socket2",
  "tokio",
 ]
 
@@ -1416,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "rayon",
  "serde",
 ]
@@ -1442,9 +1443,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1475,6 +1476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,9 +1507,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1545,9 +1552,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -1592,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -1610,15 +1617,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1636,7 +1643,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1725,7 +1732,7 @@ checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "metrics",
  "num_cpus",
  "quanta",
@@ -1756,9 +1763,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
 ]
@@ -1799,7 +1806,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1879,11 +1886,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1902,7 +1908,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1926,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -1970,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32"
+checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2002,7 +2008,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2031,9 +2037,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2041,22 +2047,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -2096,7 +2102,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -2123,7 +2129,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2190,19 +2196,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2342,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.1"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -2371,11 +2377,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -2500,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -2521,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -2534,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
@@ -2557,15 +2563,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2574,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rusty-fork"
@@ -2604,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -2634,11 +2640,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2647,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2706,35 +2712,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -2824,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2866,9 +2872,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol_str"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
@@ -3294,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3325,14 +3331,14 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
  "blake2",
  "cfg-if",
  "fxhash",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3355,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3369,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3380,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3390,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3400,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3418,12 +3424,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3434,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3449,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3464,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3477,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3486,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3496,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3508,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3520,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3531,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3543,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3556,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3567,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3580,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3591,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3614,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3632,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3653,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3668,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3679,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3687,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3697,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3708,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3719,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3730,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3741,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "rand",
  "rayon",
@@ -3755,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3772,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3797,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "anyhow",
  "rand",
@@ -3809,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3828,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3847,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3860,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3873,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3886,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3897,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3912,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3925,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3934,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3954,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "anyhow",
  "colored",
@@ -3969,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3982,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4009,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4024,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4033,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4058,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4087,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4110,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4124,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4137,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4158,18 +4164,18 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=393b8fb#393b8fb12fa046c4288a7ba880ca8d4341a259bd"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4215,7 +4221,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.36",
  "structmeta-derive",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4226,7 +4232,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4248,7 +4254,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.36",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4281,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
@@ -4349,7 +4355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -4369,27 +4375,27 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.36",
  "structmeta",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4504,7 +4510,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4543,16 +4549,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4653,7 +4658,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4840,9 +4845,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
@@ -4858,11 +4863,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.6"
+version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -4971,7 +4976,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -5005,7 +5010,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5053,11 +5058,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5226,29 +5231,29 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -5261,5 +5266,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3424,12 +3424,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "rand",
  "rayon",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "anyhow",
  "rand",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "anyhow",
  "colored",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=57b16db1e#57b16db1e03e28f634fdf97d996dcb6caa78ff25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3424,12 +3424,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "rand",
  "rayon",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "anyhow",
  "rand",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "anyhow",
  "colored",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=e52e9db02#e52e9db025492824e386d668b099d84655140a0d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3424,12 +3424,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "rand",
  "rayon",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "rand",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "colored",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=55474105c#55474105cab66ec0b69e2280aedbe88c06cd94c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
 rev = "393b8fb"
-#version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "9c3bd7f"
+rev = "e52e9db02"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "55474105c"
+rev = "74a437897"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "e52e9db02"
+rev = "55474105c"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -393,10 +393,11 @@ impl Start {
                         );
 
                         // Add or update the validator entry in the list of members
-                        members
-                            .entry(*validator_address)
-                            .and_modify(|(stake, _, _)| *stake += amount)
-                            .or_insert((*amount, true, rng.gen_range(0..100)));
+                        members.entry(*validator_address).and_modify(|(stake, _, _)| *stake += amount).or_insert((
+                            *amount,
+                            true,
+                            rng.gen_range(0..100),
+                        ));
                     }
                     // Construct the committee.
                     let committee = Committee::<N>::new(0u64, members)?;
@@ -657,19 +658,55 @@ fn load_or_compute_genesis<N: Network>(
             .collect::<Vec<_>>()
     ]?);
 
-    // Input the parameters' metadata.
-    preimage.extend(snarkvm::parameters::mainnet::BondValidatorVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::BondPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::UnbondPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::SetValidatorStateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::TransferPrivateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::TransferPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::FeePrivateVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::FeePublicVerifier::METADATA.as_bytes());
-    preimage.extend(snarkvm::parameters::mainnet::InclusionVerifier::METADATA.as_bytes());
+    // Input the parameters' metadata based on network
+    match N::ID {
+        snarkvm::console::network::MainnetV0::ID => {
+            preimage.extend(snarkvm::parameters::mainnet::BondValidatorVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::BondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::UnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::SetValidatorStateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::FeePrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::FeePublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::mainnet::InclusionVerifier::METADATA.as_bytes());
+        }
+        snarkvm::console::network::TestnetV0::ID => {
+            preimage.extend(snarkvm::parameters::testnet::BondValidatorVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::BondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::UnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::SetValidatorStateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::FeePrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::FeePublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::testnet::InclusionVerifier::METADATA.as_bytes());
+        }
+        snarkvm::console::network::CanaryV0::ID => {
+            preimage.extend(snarkvm::parameters::canary::BondValidatorVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::BondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::UnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::ClaimUnbondPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::SetValidatorStateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPrivateToPublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::TransferPublicToPrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::FeePrivateVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::FeePublicVerifier::METADATA.as_bytes());
+            preimage.extend(snarkvm::parameters::canary::InclusionVerifier::METADATA.as_bytes());
+        }
+        _ => {
+            // Unrecognized Network ID
+            bail!("Unrecognized Network ID: {}", N::ID);
+        }
+    }
 
     // Initialize the hasher.
     let hasher = snarkvm::console::algorithms::BHP256::<N>::setup("aleo.dev.block")?;

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -223,7 +223,7 @@ fn genesis_block(
     let vm = VM::from(store).unwrap();
     // Initialize the genesis block.
     let bonded_balances: IndexMap<_, _> =
-        committee.members().iter().map(|(address, (amount, _))| (*address, (*address, *address, *amount))).collect();
+        committee.members().iter().map(|(address, (amount, _, _))| (*address, (*address, *address, *amount))).collect();
     vm.genesis_quorum(&genesis_private_key, committee, public_balances, bonded_balances, rng).unwrap()
 }
 
@@ -276,7 +276,7 @@ fn initialize_components(node_id: u16, num_nodes: u16) -> Result<(Committee<Curr
         // Sample the account.
         let account = Account::new(&mut rand_chacha::ChaChaRng::seed_from_u64(i as u64))?;
         // Add the validator.
-        members.insert(account.address(), (MIN_VALIDATOR_STAKE, false));
+        members.insert(account.address(), (MIN_VALIDATOR_STAKE, false, i as u8));
         println!("  Validator {}: {}", i, account.address());
     }
     println!();

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1703,7 +1703,7 @@ mod tests {
             for i in 0..COMMITTEE_SIZE {
                 let socket_addr = format!("127.0.0.1:{}", 5000 + i).parse().unwrap();
                 let account = Account::new(rng).unwrap();
-                members.insert(account.address(), (MIN_VALIDATOR_STAKE, true));
+                members.insert(account.address(), (MIN_VALIDATOR_STAKE, true, rng.gen_range(0..100)));
                 accounts.push((socket_addr, account));
             }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -949,7 +949,7 @@ mod prop_tests {
             let rng = &mut TestRng::fixed(i as u64);
             let address = Address::new(rng.gen());
             info!("Validator {i}: {address}");
-            members.insert(address, (MIN_VALIDATOR_STAKE, false));
+            members.insert(address, (MIN_VALIDATOR_STAKE, false, rng.gen_range(0..100)));
         }
         // Initialize the committee.
         Committee::<CurrentNetwork>::new(1u64, members).unwrap()

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -137,7 +137,7 @@ impl TestNetwork {
         let bonded_balances: IndexMap<_, _> = committee
             .members()
             .iter()
-            .map(|(address, (amount, _))| (*address, (*address, *address, *amount)))
+            .map(|(address, (amount, _, _))| (*address, (*address, *address, *amount)))
             .collect();
         let gen_key = *accounts[0].private_key();
         let public_balance_per_validator = (CurrentNetwork::STARTING_SUPPLY
@@ -338,7 +338,7 @@ pub fn new_test_committee(n: u16, rng: &mut TestRng) -> (Vec<Account<CurrentNetw
         let account = Account::new(rng).unwrap();
         info!("Validator {}: {}", i, account.address());
 
-        members.insert(account.address(), (MIN_VALIDATOR_STAKE, false));
+        members.insert(account.address(), (MIN_VALIDATOR_STAKE, false, rng.gen_range(0..100)));
         accounts.push(account);
     }
     // Initialize the committee.

--- a/node/bft/tests/common/utils.rs
+++ b/node/bft/tests/common/utils.rs
@@ -188,7 +188,7 @@ pub fn sample_ledger(
 ) -> Arc<TranslucentLedgerService<CurrentNetwork, ConsensusMemory<CurrentNetwork>>> {
     let num_nodes = committee.num_members();
     let bonded_balances: IndexMap<_, _> =
-        committee.members().iter().map(|(address, (amount, _))| (*address, (*address, *address, *amount))).collect();
+        committee.members().iter().map(|(address, (amount, _, _))| (*address, (*address, *address, *amount))).collect();
     let gen_key = *accounts[0].private_key();
     let public_balance_per_validator =
         (CurrentNetwork::STARTING_SUPPLY - (num_nodes as u64) * MIN_VALIDATOR_STAKE) / (num_nodes as u64);


### PR DESCRIPTION
This PR should be merged after the snarkVM ARC-41 changes: https://github.com/AleoNet/snarkVM/pull/2453

## Summary from snarkVM

Currently, validators will need to have 10M credits in order to self.bond as a validator. The problem is that most or all of these validators won't actually have 10M credits. To bring Aleo in line with other ecosystems, we want to relax 2 existing constraints:

Delegators can delegate to any address (with the same 10,000 credit minimum & maximum of 100,000 delegators) even if that address is not in the committee
Validators only require a self bond of 100 credits to join the committee, given the total delegation for them is >= 10M credits.
Although the changes are significant, the staking abstraction should closely follow what existed before.

## Technical changes

  - These changes only require adding support for adding the commission to the struct within the committee mapping when generating the genesis block.
  - We may also have to bump snarkVM/snarkOS versions