### PR TITLE
[hotfix] Update the genesis targets for TestnetV0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "140ff26"
+rev = "393b8fb"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
## Motivation

Update to point to hotfix commit in snarkVM PR 2464.

## Related PRs

https://github.com/AleoNet/snarkVM/pull/2464
