### PR TITLE
Revert revert canary network trait

### DIFF
--- a/.devnet/analytics.sh
+++ b/.devnet/analytics.sh
@@ -14,6 +14,17 @@ else
   echo "Node.js dependencies already installed."
 fi
 
+# Prompt the user to specify a network ID
+while true; do
+  echo "Please specify a network ID (0 for mainnet, 1 for testnet, 2 for canary):"
+  read networkID
+  if [[ $networkID == 0 || $networkID == 1 || $networkID == 2 ]]; then
+    break
+  else
+    echo "Invalid network ID. Please enter 0 or 1."
+  fi
+done
+
 # Prompt the user to select a metric type
 PS3="Select a metric type: "
 options=("Average Block Time" "Rounds in Blocks" "Check Block Hash" "Quit")
@@ -22,12 +33,12 @@ do
   case $opt in
     "Average Block Time")
       echo ""
-      node analytics.js --metric-type averageBlockTime
+      node analytics.js --metric-type averageBlockTime --network-id $networkID
       break
       ;;
     "Rounds in Blocks")
       echo ""
-      node analytics.js --metric-type roundsInBlocks
+      node analytics.js --metric-type roundsInBlocks --network-id $networkID
       break
       ;;
     "Check Block Hash")
@@ -39,7 +50,7 @@ do
         echo "Error: Block height must be a positive integer."
         exit 1
       fi
-      node analytics.js --metric-type checkBlockHash --block-height "$blockHeight"
+      node analytics.js --metric-type checkBlockHash --block-height "$blockHeight" --network-id $networkID
       break
       ;;
     "Quit")

--- a/.devnet/clean.sh
+++ b/.devnet/clean.sh
@@ -12,6 +12,12 @@ NUM_INSTANCES="${NUM_INSTANCES:-$NODE_ID}"
 
 echo "Using $NUM_INSTANCES AWS EC2 instances for querying."
 
+# Read the network ID from user or use a default value of 1
+read -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " NETWORK_ID
+NETWORK_ID=${NETWORK_ID:-1}
+
+echo "Using network ID $NETWORK_ID."
+
 # Define a function to terminate the tmux session on a node
 terminate_tmux_session() {
   local NODE_ID=$1
@@ -24,7 +30,7 @@ terminate_tmux_session() {
     cd \$WORKSPACE
 
     tmux kill-session -t snarkos-session
-    snarkos clean --dev $NODE_ID
+    snarkos clean --dev $NODE_ID --network $NETWORK_ID
 
     exit  # Exit root user
 EOF

--- a/.devnet/start.sh
+++ b/.devnet/start.sh
@@ -12,6 +12,12 @@ NUM_INSTANCES="${NUM_INSTANCES:-$NODE_ID}"
 
 echo "Using $NUM_INSTANCES AWS EC2 instances for querying."
 
+# Read the network ID from user or use a default value of 1
+read -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " NETWORK_ID
+NETWORK_ID=${NETWORK_ID:-1}
+
+echo "Using network ID $NETWORK_ID."
+
 # Read the verbosity level from the user (default: 1)
 read -p "Enter the verbosity level (default: 1): " VERBOSITY
 VERBOSITY="${VERBOSITY:-1}"
@@ -37,7 +43,7 @@ start_snarkos_in_tmux() {
     tmux new-session -d -s snarkos-session
 
     # Send the snarkOS start command to the tmux session with the NODE_ID
-    tmux send-keys -t "snarkos-session" "snarkos start --nodisplay --bft 0.0.0.0:5000 --rest 0.0.0.0:3030 --allow-external-peers --peers $NODE_IP:4130 --validators $NODE_IP:5000 --rest-rps 1000 --verbosity $VERBOSITY --dev $NODE_ID --dev-num-validators $NUM_INSTANCES --validator --metrics" C-m
+    tmux send-keys -t "snarkos-session" "snarkos start --nodisplay --bft 0.0.0.0:5000 --rest 0.0.0.0:3030 --allow-external-peers --peers $NODE_IP:4130 --validators $NODE_IP:5000 --rest-rps 1000 --verbosity $VERBOSITY --network $NETWORK_ID --dev $NODE_ID --dev-num-validators $NUM_INSTANCES --validator --metrics" C-m
 
     exit  # Exit root user
 EOF

--- a/.devnet/start_sync_test.sh
+++ b/.devnet/start_sync_test.sh
@@ -12,6 +12,12 @@ NUM_INSTANCES="${NUM_INSTANCES:-$NODE_ID}"
 
 echo "Using $NUM_INSTANCES AWS EC2 instances for querying."
 
+# Read the network ID from user or use a default value of 1
+read -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " NETWORK_ID
+NETWORK_ID=${NETWORK_ID:-1}
+
+echo "Using network ID $NETWORK_ID."
+
 # Read the verbosity level from the user (default: 1)
 read -p "Enter the verbosity level (default: 1): " VERBOSITY
 VERBOSITY="${VERBOSITY:-1}"
@@ -37,7 +43,7 @@ start_snarkos_in_tmux() {
     tmux new-session -d -s snarkos-session
 
     # Send the snarkOS start command to the tmux session with the NODE_ID
-    tmux send-keys -t "snarkos-session" "snarkos start --client --nocdn --nodisplay --rest 0.0.0.0:3030 --node 0.0.0.0:4130 --verbosity 4 --metrics --logfile "/tmp/snarkos-syncing-range-3.log" --peers 167.71.249.65:4130,157.245.218.195:4130,167.71.249.55:4130" C-m
+    tmux send-keys -t "snarkos-session" "snarkos start --client --nocdn --nodisplay --rest 0.0.0.0:3030 --node 0.0.0.0:4130 --verbosity 4 --network $NETWORK_ID --metrics --logfile "/tmp/snarkos-syncing-range-3.log" --peers 167.71.249.65:4130,157.245.218.195:4130,167.71.249.55:4130" C-m
 
     exit  # Exit root user
 EOF

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 wasm/Cargo.lock
 **/build
 **.ledger-*
+**.current-proposal-cache-*
 **.logs-*
 validator-*
 **.bft-storage-*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "enum_index"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3325,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3355,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3369,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3380,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3390,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3400,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3418,12 +3438,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3434,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3449,7 +3469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3464,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3477,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3486,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3496,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3508,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3520,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3531,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3543,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3556,7 +3576,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3567,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3580,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3591,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3614,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3632,8 +3652,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
+ "enum-iterator",
  "enum_index",
  "enum_index_derive",
  "indexmap 2.2.6",
@@ -3653,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3668,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3679,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3687,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3697,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3708,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3719,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3730,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3741,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "rand",
  "rayon",
@@ -3755,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3772,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3797,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "rand",
@@ -3809,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3828,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3847,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3860,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3873,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3886,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3897,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3912,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3925,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3934,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3954,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "colored",
@@ -3969,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3982,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4009,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4024,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4033,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4058,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4087,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4110,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4124,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4137,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4158,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "393b8fb"
+rev = "49fa086ed"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/src/commands/account.rs
+++ b/cli/src/commands/account.rs
@@ -15,7 +15,7 @@
 use snarkvm::{
     console::{
         account::{Address, PrivateKey, Signature},
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
         prelude::{Environment, Uniform},
         program::{ToFields, Value},
         types::Field,
@@ -113,12 +113,14 @@ impl Account {
                     Some(vanity) => match network {
                         MainnetV0::ID => Self::new_vanity::<MainnetV0>(vanity.as_str(), discreet),
                         TestnetV0::ID => Self::new_vanity::<TestnetV0>(vanity.as_str(), discreet),
+                        CanaryV0::ID => Self::new_vanity::<CanaryV0>(vanity.as_str(), discreet),
                         unknown_id => bail!("Unknown network ID ({unknown_id})"),
                     },
                     // Generate a seeded account for the specified network.
                     None => match network {
                         MainnetV0::ID => Self::new_seeded::<MainnetV0>(seed, discreet),
                         TestnetV0::ID => Self::new_seeded::<TestnetV0>(seed, discreet),
+                        CanaryV0::ID => Self::new_seeded::<CanaryV0>(seed, discreet),
                         unknown_id => bail!("Unknown network ID ({unknown_id})"),
                     },
                 }
@@ -140,6 +142,7 @@ impl Account {
                 match network {
                     MainnetV0::ID => Self::sign::<MainnetV0>(key, message, seed, raw),
                     TestnetV0::ID => Self::sign::<TestnetV0>(key, message, seed, raw),
+                    CanaryV0::ID => Self::sign::<CanaryV0>(key, message, seed, raw),
                     unknown_id => bail!("Unknown network ID ({unknown_id})"),
                 }
             }
@@ -148,6 +151,7 @@ impl Account {
                 match network {
                     MainnetV0::ID => Self::verify::<MainnetV0>(address, signature, message, raw),
                     TestnetV0::ID => Self::verify::<TestnetV0>(address, signature, message, raw),
+                    CanaryV0::ID => Self::verify::<CanaryV0>(address, signature, message, raw),
                     unknown_id => bail!("Unknown network ID ({unknown_id})"),
                 }
             }

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -14,7 +14,7 @@
 
 use snarkvm::{
     console::{
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
         program::Ciphertext,
     },
     prelude::{Record, ViewKey},
@@ -45,6 +45,7 @@ impl Decrypt {
         match self.network {
             MainnetV0::ID => Self::decrypt_ciphertext::<MainnetV0>(&self.ciphertext, &self.view_key),
             TestnetV0::ID => Self::decrypt_ciphertext::<TestnetV0>(&self.ciphertext, &self.view_key),
+            CanaryV0::ID => Self::decrypt_ciphertext::<CanaryV0>(&self.ciphertext, &self.view_key),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -14,9 +14,9 @@
 
 use super::Developer;
 use snarkvm::{
-    circuit::{Aleo, AleoTestnetV0, AleoV0},
+    circuit::{Aleo, AleoCanaryV0, AleoTestnetV0, AleoV0},
     console::{
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
         program::ProgramOwner,
     },
     prelude::{
@@ -93,6 +93,7 @@ impl Deploy {
         match self.network {
             MainnetV0::ID => self.construct_deployment::<MainnetV0, AleoV0>(),
             TestnetV0::ID => self.construct_deployment::<TestnetV0, AleoTestnetV0>(),
+            CanaryV0::ID => self.construct_deployment::<CanaryV0, AleoCanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -14,7 +14,7 @@
 
 use super::Developer;
 use snarkvm::{
-    console::network::{MainnetV0, Network, TestnetV0},
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{
         query::Query,
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
@@ -94,6 +94,7 @@ impl Execute {
         match self.network {
             MainnetV0::ID => self.construct_execution::<MainnetV0>(),
             TestnetV0::ID => self.construct_execution::<TestnetV0>(),
+            CanaryV0::ID => self.construct_execution::<CanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -119,6 +119,7 @@ impl Developer {
         let network = match N::ID {
             snarkvm::console::network::MainnetV0::ID => "mainnet",
             snarkvm::console::network::TestnetV0::ID => "testnet",
+            snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 
@@ -147,6 +148,7 @@ impl Developer {
         let network = match N::ID {
             snarkvm::console::network::MainnetV0::ID => "mainnet",
             snarkvm::console::network::TestnetV0::ID => "testnet",
+            snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::type_complexity)]
 
 use snarkvm::{
-    console::network::{MainnetV0, Network, TestnetV0},
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{block::Block, Ciphertext, Field, FromBytes, Plaintext, PrivateKey, Record, ViewKey},
 };
 
@@ -71,6 +71,7 @@ impl Scan {
         match self.network {
             MainnetV0::ID => self.scan_records::<MainnetV0>(),
             TestnetV0::ID => self.scan_records::<TestnetV0>(),
+            CanaryV0::ID => self.scan_records::<CanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }
@@ -135,6 +136,7 @@ impl Scan {
         let network = match self.network {
             MainnetV0::ID => "mainnet",
             TestnetV0::ID => "testnet",
+            CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 
@@ -186,6 +188,7 @@ impl Scan {
         let network = match N::ID {
             MainnetV0::ID => "mainnet",
             TestnetV0::ID => "testnet",
+            CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 
@@ -364,6 +367,7 @@ impl Scan {
             let network = match N::ID {
                 MainnetV0::ID => "mainnet",
                 TestnetV0::ID => "testnet",
+                CanaryV0::ID => "canary",
                 unknown_id => bail!("Unknown network ID ({unknown_id})"),
             };
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -14,7 +14,7 @@
 
 use super::Developer;
 use snarkvm::{
-    console::network::{MainnetV0, Network, TestnetV0},
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{
         query::Query,
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
@@ -93,6 +93,7 @@ impl TransferPrivate {
         match self.network {
             MainnetV0::ID => self.construct_transfer_private::<MainnetV0>(),
             TestnetV0::ID => self.construct_transfer_private::<TestnetV0>(),
+            CanaryV0::ID => self.construct_transfer_private::<CanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -19,7 +19,7 @@ use snarkvm::{
     console::{
         account::{Address, PrivateKey},
         algorithms::Hash,
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
     },
     ledger::{
         block::Block,
@@ -183,6 +183,15 @@ impl Start {
                 TestnetV0::ID => {
                     // Parse the node from the configurations.
                     let node = cli.parse_node::<TestnetV0>(shutdown.clone()).await.expect("Failed to parse the node");
+                    // If the display is enabled, render the display.
+                    if !cli.nodisplay {
+                        // Initialize the display.
+                        Display::start(node, log_receiver).expect("Failed to initialize the display");
+                    }
+                }
+                CanaryV0::ID => {
+                    // Parse the node from the configurations.
+                    let node = cli.parse_node::<CanaryV0>(shutdown.clone()).await.expect("Failed to parse the node");
                     // If the display is enabled, render the display.
                     if !cli.nodisplay {
                         // Initialize the display.

--- a/devnet.sh
+++ b/devnet.sh
@@ -9,7 +9,7 @@ read -p "Enter the total number of clients (default: 2): " total_clients
 total_clients=${total_clients:-2}
 
 # Read the network ID from user or use a default value of 1
-read -p "Enter the network ID (mainnet = 0, testnet = 1) (default: 1): " network_id
+read -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " network_id
 network_id=${network_id:-1}
 
 # Ask the user if they want to run 'cargo install --locked --path .' or use a pre-installed binary

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1085,6 +1085,11 @@ impl<N: Network> Disconnect for Gateway<N> {
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
         if let Some(peer_ip) = self.resolver.get_listener(peer_addr) {
             self.remove_connected_peer(peer_ip);
+
+            // We don't clear this map based on time but only on peer disconnect.
+            // This is sufficient to avoid infinite growth as the committee has a fixed number
+            // of members.
+            self.cache.clear_outbound_validators_requests(peer_ip);
         }
     }
 }

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -119,6 +119,11 @@ impl<N: Network> Cache<N> {
     pub fn decrement_outbound_validators_requests(&self, peer_ip: SocketAddr) -> u32 {
         Self::decrement_counter(&self.seen_outbound_validators_requests, peer_ip)
     }
+
+    /// Clears the the IP's number of validator requests.
+    pub fn clear_outbound_validators_requests(&self, peer_ip: SocketAddr) {
+        self.seen_outbound_validators_requests.write().remove(&peer_ip);
+    }
 }
 
 impl<N: Network> Cache<N> {
@@ -292,5 +297,28 @@ mod tests {
        outbound_event,
        outbound_certificate,
        outbound_transmission
+    }
+
+    #[test]
+    fn test_seen_outbound_validators_requests() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let input = Input::input();
+
+        // Check the map is empty.
+        assert!(!cache.contains_outbound_validators_request(input));
+
+        // Insert some requests.
+        for _ in 0..3 {
+            cache.increment_outbound_validators_requests(input);
+            assert!(cache.contains_outbound_validators_request(input));
+        }
+
+        // Remove a request.
+        cache.decrement_outbound_validators_requests(input);
+        assert!(cache.contains_outbound_validators_request(input));
+
+        // Clear all requests.
+        cache.clear_outbound_validators_requests(input);
+        assert!(!cache.contains_outbound_validators_request(input));
     }
 }

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -85,6 +85,16 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
         self.pending.read().get(&item.into()).map_or(false, |peer_ips| peer_ips.contains_key(&peer_ip))
     }
 
+    /// Returns `true` if the pending queue contains the specified `item` for the specified `peer IP` with a sent request.
+    pub fn contains_peer_with_sent_request(&self, item: impl Into<T>, peer_ip: SocketAddr) -> bool {
+        self.pending.read().get(&item.into()).map_or(false, |peer_ips| {
+            peer_ips
+                .get(&peer_ip)
+                .map(|callbacks| callbacks.iter().any(|(_, _, request_sent)| *request_sent))
+                .unwrap_or(false)
+        })
+    }
+
     /// Returns the peer IPs for the specified `item`.
     pub fn get_peers(&self, item: impl Into<T>) -> Option<HashSet<SocketAddr>> {
         self.pending.read().get(&item.into()).map(|map| map.keys().cloned().collect())
@@ -254,24 +264,29 @@ mod tests {
         let solution_id_1 = TransmissionID::Solution(rng.gen::<u64>().into());
         let solution_id_2 = TransmissionID::Solution(rng.gen::<u64>().into());
         let solution_id_3 = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id_4 = TransmissionID::Solution(rng.gen::<u64>().into());
 
         // Initialize the SocketAddrs.
         let addr_1 = SocketAddr::from(([127, 0, 0, 1], 1234));
         let addr_2 = SocketAddr::from(([127, 0, 0, 1], 2345));
         let addr_3 = SocketAddr::from(([127, 0, 0, 1], 3456));
+        let addr_4 = SocketAddr::from(([127, 0, 0, 1], 4567));
 
         // Initialize the callbacks.
         let (callback_sender_1, _) = oneshot::channel();
         let (callback_sender_2, _) = oneshot::channel();
         let (callback_sender_3, _) = oneshot::channel();
+        let (callback_sender_4, _) = oneshot::channel();
 
         // Insert the solution IDs.
         assert!(pending.insert(solution_id_1, addr_1, Some((callback_sender_1, true))));
         assert!(pending.insert(solution_id_2, addr_2, Some((callback_sender_2, true))));
         assert!(pending.insert(solution_id_3, addr_3, Some((callback_sender_3, true))));
+        // Add a callback without a sent request.
+        assert!(pending.insert(solution_id_4, addr_4, Some((callback_sender_4, false))));
 
         // Check the number of SocketAddrs.
-        assert_eq!(pending.len(), 3);
+        assert_eq!(pending.len(), 4);
         assert!(!pending.is_empty());
 
         // Check the items.
@@ -282,7 +297,12 @@ mod tests {
             let id = ids[i];
             assert!(pending.contains(id));
             assert!(pending.contains_peer(id, peers[i]));
+            assert!(pending.contains_peer_with_sent_request(id, peers[i]));
         }
+        // Ensure the last item does not have a sent request.
+        assert!(pending.contains_peer(solution_id_4, addr_4));
+        assert!(!pending.contains_peer_with_sent_request(solution_id_4, addr_4));
+
         let unknown_id = TransmissionID::Solution(rng.gen::<u64>().into());
         assert!(!pending.contains(unknown_id));
 
@@ -290,12 +310,14 @@ mod tests {
         assert_eq!(pending.get_peers(solution_id_1), Some(HashSet::from([addr_1])));
         assert_eq!(pending.get_peers(solution_id_2), Some(HashSet::from([addr_2])));
         assert_eq!(pending.get_peers(solution_id_3), Some(HashSet::from([addr_3])));
+        assert_eq!(pending.get_peers(solution_id_4), Some(HashSet::from([addr_4])));
         assert_eq!(pending.get_peers(unknown_id), None);
 
         // Check remove.
         assert!(pending.remove(solution_id_1, None).is_some());
         assert!(pending.remove(solution_id_2, None).is_some());
         assert!(pending.remove(solution_id_3, None).is_some());
+        assert!(pending.remove(solution_id_4, None).is_some());
         assert!(pending.remove(unknown_id, None).is_none());
 
         // Check empty again.

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -126,6 +126,14 @@ impl<N: Network> Ready<N> {
         // Drain the transmission IDs.
         transmissions.drain(range).collect::<IndexMap<_, _>>()
     }
+
+    /// Clears all solutions from the ready queue.
+    pub(crate) fn clear_solutions(&self) {
+        // Acquire the write lock.
+        let mut transmissions = self.transmissions.write();
+        // Remove all solutions.
+        transmissions.retain(|id, _| !matches!(id, TransmissionID::Solution(..)));
+    }
 }
 
 #[cfg(test)]

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -788,6 +788,7 @@ impl<N: Network> Storage<N> {
     /// Inserts the given `certificate` into storage.
     ///
     /// Note: Do NOT use this in production. This is for **testing only**.
+    #[cfg(test)]
     #[doc(hidden)]
     pub(crate) fn testing_only_insert_certificate_testing_only(&self, certificate: BatchCertificate<N>) {
         // Retrieve the round.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -321,6 +321,13 @@ impl<N: Network> Primary<N> {
 }
 
 impl<N: Network> Primary<N> {
+    /// Clears the worker solutions.
+    pub fn clear_worker_solutions(&self) {
+        self.workers.iter().for_each(Worker::clear_solutions);
+    }
+}
+
+impl<N: Network> Primary<N> {
     /// Proposes the batch for the current round.
     ///
     /// This method performs the following steps:

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -161,7 +161,8 @@ impl<N: Network> Primary<N> {
                         // We use a dummy IP because the node should not need to request from any peers.
                         // The storage should have stored all the transmissions. If not, we simply
                         // skip the certificate.
-                        if let Err(err) = self.sync_with_certificate_from_peer(DUMMY_SELF_IP, certificate).await {
+                        if let Err(err) = self.sync_with_certificate_from_peer::<true>(DUMMY_SELF_IP, certificate).await
+                        {
                             warn!("Failed to load stored certificate {} from proposal cache - {err}", fmt_id(batch_id));
                         }
                     }
@@ -695,7 +696,7 @@ impl<N: Network> Primary<N> {
         }
 
         // If the peer is ahead, use the batch header to sync up to the peer.
-        let mut transmissions = self.sync_with_batch_header_from_peer(peer_ip, &batch_header).await?;
+        let mut transmissions = self.sync_with_batch_header_from_peer::<false>(peer_ip, &batch_header).await?;
 
         // Check that the transmission ids match and are not fee transactions.
         if let Err(err) = cfg_iter_mut!(transmissions).try_for_each(|(transmission_id, transmission)| {
@@ -907,7 +908,7 @@ impl<N: Network> Primary<N> {
         }
 
         // Store the certificate, after ensuring it is valid.
-        self.sync_with_certificate_from_peer(peer_ip, certificate).await?;
+        self.sync_with_certificate_from_peer::<false>(peer_ip, certificate).await?;
 
         // If there are enough certificates to reach quorum threshold for the certificate round,
         // then proceed to advance to the next round.
@@ -1426,7 +1427,7 @@ impl<N: Network> Primary<N> {
     ///   - Ensure the previous certificates have reached the quorum threshold.
     ///   - Ensure we have not already signed the batch ID.
     #[async_recursion::async_recursion]
-    async fn sync_with_certificate_from_peer(
+    async fn sync_with_certificate_from_peer<const IS_SYNCING: bool>(
         &self,
         peer_ip: SocketAddr,
         certificate: BatchCertificate<N>,
@@ -1445,8 +1446,16 @@ impl<N: Network> Primary<N> {
             return Ok(());
         }
 
+        // If node is not in sync mode and the node is not synced. Then return an error.
+        if !IS_SYNCING && !self.is_synced() {
+            bail!(
+                "Failed to process certificate `{}` at round {batch_round} from '{peer_ip}' (node is syncing)",
+                fmt_id(certificate.id())
+            );
+        }
+
         // If the peer is ahead, use the batch header to sync up to the peer.
-        let missing_transmissions = self.sync_with_batch_header_from_peer(peer_ip, batch_header).await?;
+        let missing_transmissions = self.sync_with_batch_header_from_peer::<IS_SYNCING>(peer_ip, batch_header).await?;
 
         // Check if the certificate needs to be stored.
         if !self.storage.contains_certificate(certificate.id()) {
@@ -1467,7 +1476,7 @@ impl<N: Network> Primary<N> {
     }
 
     /// Recursively syncs using the given batch header.
-    async fn sync_with_batch_header_from_peer(
+    async fn sync_with_batch_header_from_peer<const IS_SYNCING: bool>(
         &self,
         peer_ip: SocketAddr,
         batch_header: &BatchHeader<N>,
@@ -1478,6 +1487,14 @@ impl<N: Network> Primary<N> {
         // If the certificate round is outdated, do not store it.
         if batch_round <= self.storage.gc_round() {
             bail!("Round {batch_round} is too far in the past")
+        }
+
+        // If node is not in sync mode and the node is not synced. Then return an error.
+        if !IS_SYNCING && !self.is_synced() {
+            bail!(
+                "Failed to process batch header `{}` at round {batch_round} from '{peer_ip}' (node is syncing)",
+                fmt_id(batch_header.batch_id())
+            );
         }
 
         // Determine if quorum threshold is reached on the batch round.
@@ -1515,7 +1532,7 @@ impl<N: Network> Primary<N> {
         // Iterate through the missing previous certificates.
         for batch_certificate in missing_previous_certificates {
             // Store the batch certificate (recursively fetching any missing previous certificates).
-            self.sync_with_certificate_from_peer(peer_ip, batch_certificate).await?;
+            self.sync_with_certificate_from_peer::<IS_SYNCING>(peer_ip, batch_certificate).await?;
         }
         Ok(missing_transmissions)
     }
@@ -2070,10 +2087,45 @@ mod tests {
 
         // The author must be known to resolver to pass propose checks.
         primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary.sync.block_sync().try_block_sync(&primary.gateway.clone()).await;
 
         // Try to process the batch proposal from the peer, should succeed.
         assert!(
             primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_propose_from_peer_when_not_synced() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng).await;
+
+        // Create a valid proposal with an author that isn't the primary.
+        let round = 1;
+        let peer_account = &accounts[1];
+        let peer_ip = peer_account.0;
+        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let proposal = create_test_proposal(
+            &peer_account.1,
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            &mut rng,
+        );
+
+        // Make sure the primary is aware of the transmissions in the proposal.
+        for (transmission_id, transmission) in proposal.transmissions() {
+            primary.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
+        }
+
+        // The author must be known to resolver to pass propose checks.
+        primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+
+        // Try to process the batch proposal from the peer, should fail.
+        assert!(
+            primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.is_err()
         );
     }
 
@@ -2106,6 +2158,8 @@ mod tests {
 
         // The author must be known to resolver to pass propose checks.
         primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary.sync.block_sync().try_block_sync(&primary.gateway.clone()).await;
 
         // Try to process the batch proposal from the peer, should succeed.
         primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.unwrap();
@@ -2137,6 +2191,8 @@ mod tests {
 
         // The author must be known to resolver to pass propose checks.
         primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary.sync.block_sync().try_block_sync(&primary.gateway.clone()).await;
 
         // Try to process the batch proposal from the peer, should error.
         assert!(
@@ -2179,6 +2235,8 @@ mod tests {
 
         // The author must be known to resolver to pass propose checks.
         primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary.sync.block_sync().try_block_sync(&primary.gateway.clone()).await;
 
         // Try to process the batch proposal from the peer, should error.
         assert!(
@@ -2221,6 +2279,8 @@ mod tests {
 
         // The author must be known to resolver to pass propose checks.
         primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary.sync.block_sync().try_block_sync(&primary.gateway.clone()).await;
 
         // Try to process the batch proposal from the peer, should error.
         assert!(
@@ -2257,6 +2317,8 @@ mod tests {
 
         // The author must be known to resolver to pass propose checks.
         primary.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary.sync.block_sync().try_block_sync(&primary.gateway.clone()).await;
 
         // Try to process the batch proposal from the peer, should error.
         assert!(

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -557,6 +557,13 @@ impl<N: Network> Sync<N> {
     pub fn get_block_locators(&self) -> Result<BlockLocators<N>> {
         self.block_sync.get_block_locators()
     }
+
+    /// Returns the block sync module.
+    #[cfg(test)]
+    #[doc(hidden)]
+    pub(super) fn block_sync(&self) -> &BlockSync<N> {
+        &self.block_sync
+    }
 }
 
 // Methods to assist with fetching batch certificates from peers.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -578,10 +578,13 @@ impl<N: Network> Sync<N> {
         let (callback_sender, callback_receiver) = oneshot::channel();
         // Determine how many sent requests are pending.
         let num_sent_requests = self.pending.num_sent_requests(certificate_id);
+        // Determine if we've already sent a request to the peer.
+        let contains_peer_with_sent_request = self.pending.contains_peer_with_sent_request(certificate_id, peer_ip);
         // Determine the maximum number of redundant requests.
         let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round());
         // Determine if we should send a certificate request to the peer.
-        let should_send_request = num_sent_requests < num_redundant_requests;
+        // We send at most `num_redundant_requests` requests and each peer can only receive one request at a time.
+        let should_send_request = num_sent_requests < num_redundant_requests && !contains_peer_with_sent_request;
 
         // Insert the certificate ID into the pending queue.
         self.pending.insert(certificate_id, peer_ip, Some((callback_sender, should_send_request)));

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -152,6 +152,13 @@ impl<N: Network> Worker<N> {
 }
 
 impl<N: Network> Worker<N> {
+    /// Clears the solutions from the ready queue.
+    pub(super) fn clear_solutions(&self) {
+        self.ready.clear_solutions()
+    }
+}
+
+impl<N: Network> Worker<N> {
     /// Returns `true` if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
     pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         let transmission_id = transmission_id.into();

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -410,10 +410,13 @@ impl<N: Network> Worker<N> {
         let (callback_sender, callback_receiver) = oneshot::channel();
         // Determine how many sent requests are pending.
         let num_sent_requests = self.pending.num_sent_requests(transmission_id);
+        // Determine if we've already sent a request to the peer.
+        let contains_peer_with_sent_request = self.pending.contains_peer_with_sent_request(transmission_id, peer_ip);
         // Determine the maximum number of redundant requests.
         let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round());
         // Determine if we should send a transmission request to the peer.
-        let should_send_request = num_sent_requests < num_redundant_requests;
+        // We send at most `num_redundant_requests` requests and each peer can only receive one request at a time.
+        let should_send_request = num_sent_requests < num_redundant_requests && !contains_peer_with_sent_request;
 
         // Insert the transmission ID into the pending queue.
         self.pending.insert(transmission_id, peer_ip, Some((callback_sender, should_send_request)));

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -120,7 +120,9 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                 Entry::Vacant(vacant_entry) => {
                     // Retrieve the missing transmission.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
-                        if !aborted_transmission_ids.contains(&transmission_id) {
+                        if !aborted_transmission_ids.contains(&transmission_id)
+                            && !self.contains_transmission(transmission_id)
+                        {
                             error!("Failed to provide a missing transmission {transmission_id}");
                         }
                         continue 'outer;

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -171,7 +171,9 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                 Ok(None) => {
                     // Retrieve the missing transmission.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
-                        if !aborted_transmission_ids.contains(&transmission_id) {
+                        if !aborted_transmission_ids.contains(&transmission_id)
+                            && !self.contains_transmission(transmission_id)
+                        {
                             error!("Failed to provide a missing transmission {transmission_id}");
                         }
                         continue 'outer;

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -484,6 +484,14 @@ impl<N: Network> Consensus<N> {
         // Advance to the next block.
         self.ledger.advance_to_next_block(&next_block)?;
 
+        // If the next block starts a new epoch, clear the existing solutions.
+        if next_block.height() % N::NUM_BLOCKS_PER_EPOCH == 0 {
+            // Clear the solutions queue.
+            self.solutions_queue.lock().clear();
+            // Clear the worker solutions.
+            self.bft.primary().clear_worker_solutions();
+        }
+
         #[cfg(feature = "metrics")]
         {
             let elapsed = std::time::Duration::from_secs((snarkos_node_bft::helpers::now() - start) as u64);

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -121,6 +121,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let network = match N::ID {
             snarkvm::console::network::MainnetV0::ID => "mainnet",
             snarkvm::console::network::TestnetV0::ID => "testnet",
+            snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => {
                 eprintln!("Unknown network ID ({unknown_id})");
                 return;

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -401,12 +401,17 @@ impl<N: Network> Router<N> {
                 // TODO: Populate me with Mainnet Beta IP addresses.
             ]
         } else if N::ID == snarkvm::console::network::TestnetV0::ID {
-            // Testnet contains the following bootstrap peers.
+            // TestnetV0 contains the following bootstrap peers.
             vec![
                 SocketAddr::from_str("34.168.118.156:4130").unwrap(),
                 SocketAddr::from_str("35.231.152.213:4130").unwrap(),
                 SocketAddr::from_str("34.17.53.129:4130").unwrap(),
                 SocketAddr::from_str("35.200.149.162:4130").unwrap(),
+            ]
+        } else if N::ID == snarkvm::console::network::CanaryV0::ID {
+            // CanaryV0 contains the following bootstrap peers.
+            vec![
+                // TODO: Populate me with CanaryV0 IP addresses.
             ]
         } else {
             // Unrecognized networks contain no bootstrap peers.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -453,8 +453,11 @@ impl<N: Network> BlockSync<N> {
             // Return the list of block requests.
             (self.construct_requests(&sync_peers, min_common_ancestor), sync_peers)
         } else {
-            // Update the state of `is_block_synced` for the sync module.
-            self.update_is_block_synced(0, MAX_BLOCKS_BEHIND);
+            // Update `is_block_synced` if there are no pending requests or responses.
+            if self.requests.read().is_empty() && self.responses.read().is_empty() {
+                // Update the state of `is_block_synced` for the sync module.
+                self.update_is_block_synced(0, MAX_BLOCKS_BEHIND);
+            }
             // Return an empty list of block requests.
             (Default::default(), Default::default())
         }


### PR DESCRIPTION
## Motivation

Reverts https://github.com/AleoNet/snarkOS/pull/3272

Previously https://github.com/AleoNet/snarkOS/pull/3272 reverted a number of PRs to ensure they can be tested properly. That time has come to test all the PRs, so we're doing a revert revert.

With https://github.com/AleoNet/snarkOS/pull/3269 back in place they can all be tested on Canary.

Note that an automatically-generated revert by Github was no longer possible, so created this branch manually.

## Test Plan

Before merging, the sister PR in snarkVM (https://github.com/AleoNet/snarkVM/pull/2467) should be merged, and we should update the ref.
