### PR TITLE
Revert "Revert "Merge pull request #3269 from AleoHQ/feat/testnetv1""

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "enum_index"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3325,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3355,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3369,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3380,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3390,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3400,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3418,12 +3438,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3434,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3449,7 +3469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3464,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3477,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3486,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3496,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3508,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3520,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3531,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3543,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3556,7 +3576,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3567,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3580,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3591,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3614,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3632,8 +3652,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
+ "enum-iterator",
  "enum_index",
  "enum_index_derive",
  "indexmap 2.2.6",
@@ -3653,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3668,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3679,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3687,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3697,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3708,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3719,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3730,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3741,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "rand",
  "rayon",
@@ -3755,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3772,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3797,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "rand",
@@ -3809,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3828,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3847,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3860,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3873,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3886,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3897,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3912,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3925,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3934,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3954,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "anyhow",
  "colored",
@@ -3969,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3982,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4009,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4024,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4033,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4058,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4087,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4110,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4124,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4137,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4158,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=0bd71b5#0bd71b5835f0721b5c22e2ce144da0e19256606d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "49fa086ed"
+rev = "a7ff5dec9"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "393b8fb"
+rev = "49fa086ed"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/src/commands/account.rs
+++ b/cli/src/commands/account.rs
@@ -15,7 +15,7 @@
 use snarkvm::{
     console::{
         account::{Address, PrivateKey, Signature},
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
         prelude::{Environment, Uniform},
         program::{ToFields, Value},
         types::Field,
@@ -113,12 +113,14 @@ impl Account {
                     Some(vanity) => match network {
                         MainnetV0::ID => Self::new_vanity::<MainnetV0>(vanity.as_str(), discreet),
                         TestnetV0::ID => Self::new_vanity::<TestnetV0>(vanity.as_str(), discreet),
+                        CanaryV0::ID => Self::new_vanity::<CanaryV0>(vanity.as_str(), discreet),
                         unknown_id => bail!("Unknown network ID ({unknown_id})"),
                     },
                     // Generate a seeded account for the specified network.
                     None => match network {
                         MainnetV0::ID => Self::new_seeded::<MainnetV0>(seed, discreet),
                         TestnetV0::ID => Self::new_seeded::<TestnetV0>(seed, discreet),
+                        CanaryV0::ID => Self::new_seeded::<CanaryV0>(seed, discreet),
                         unknown_id => bail!("Unknown network ID ({unknown_id})"),
                     },
                 }
@@ -140,6 +142,7 @@ impl Account {
                 match network {
                     MainnetV0::ID => Self::sign::<MainnetV0>(key, message, seed, raw),
                     TestnetV0::ID => Self::sign::<TestnetV0>(key, message, seed, raw),
+                    CanaryV0::ID => Self::sign::<CanaryV0>(key, message, seed, raw),
                     unknown_id => bail!("Unknown network ID ({unknown_id})"),
                 }
             }
@@ -148,6 +151,7 @@ impl Account {
                 match network {
                     MainnetV0::ID => Self::verify::<MainnetV0>(address, signature, message, raw),
                     TestnetV0::ID => Self::verify::<TestnetV0>(address, signature, message, raw),
+                    CanaryV0::ID => Self::verify::<CanaryV0>(address, signature, message, raw),
                     unknown_id => bail!("Unknown network ID ({unknown_id})"),
                 }
             }

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -14,7 +14,7 @@
 
 use snarkvm::{
     console::{
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
         program::Ciphertext,
     },
     prelude::{Record, ViewKey},
@@ -45,6 +45,7 @@ impl Decrypt {
         match self.network {
             MainnetV0::ID => Self::decrypt_ciphertext::<MainnetV0>(&self.ciphertext, &self.view_key),
             TestnetV0::ID => Self::decrypt_ciphertext::<TestnetV0>(&self.ciphertext, &self.view_key),
+            CanaryV0::ID => Self::decrypt_ciphertext::<CanaryV0>(&self.ciphertext, &self.view_key),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -14,9 +14,9 @@
 
 use super::Developer;
 use snarkvm::{
-    circuit::{Aleo, AleoTestnetV0, AleoV0},
+    circuit::{Aleo, AleoCanaryV0, AleoTestnetV0, AleoV0},
     console::{
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
         program::ProgramOwner,
     },
     prelude::{
@@ -93,6 +93,7 @@ impl Deploy {
         match self.network {
             MainnetV0::ID => self.construct_deployment::<MainnetV0, AleoV0>(),
             TestnetV0::ID => self.construct_deployment::<TestnetV0, AleoTestnetV0>(),
+            CanaryV0::ID => self.construct_deployment::<CanaryV0, AleoCanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -14,7 +14,7 @@
 
 use super::Developer;
 use snarkvm::{
-    console::network::{MainnetV0, Network, TestnetV0},
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{
         query::Query,
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
@@ -94,6 +94,7 @@ impl Execute {
         match self.network {
             MainnetV0::ID => self.construct_execution::<MainnetV0>(),
             TestnetV0::ID => self.construct_execution::<TestnetV0>(),
+            CanaryV0::ID => self.construct_execution::<CanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -119,6 +119,7 @@ impl Developer {
         let network = match N::ID {
             snarkvm::console::network::MainnetV0::ID => "mainnet",
             snarkvm::console::network::TestnetV0::ID => "testnet",
+            snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 
@@ -147,6 +148,7 @@ impl Developer {
         let network = match N::ID {
             snarkvm::console::network::MainnetV0::ID => "mainnet",
             snarkvm::console::network::TestnetV0::ID => "testnet",
+            snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::type_complexity)]
 
 use snarkvm::{
-    console::network::{MainnetV0, Network, TestnetV0},
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{block::Block, Ciphertext, Field, FromBytes, Plaintext, PrivateKey, Record, ViewKey},
 };
 
@@ -71,6 +71,7 @@ impl Scan {
         match self.network {
             MainnetV0::ID => self.scan_records::<MainnetV0>(),
             TestnetV0::ID => self.scan_records::<TestnetV0>(),
+            CanaryV0::ID => self.scan_records::<CanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }
@@ -135,6 +136,7 @@ impl Scan {
         let network = match self.network {
             MainnetV0::ID => "mainnet",
             TestnetV0::ID => "testnet",
+            CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 
@@ -186,6 +188,7 @@ impl Scan {
         let network = match N::ID {
             MainnetV0::ID => "mainnet",
             TestnetV0::ID => "testnet",
+            CanaryV0::ID => "canary",
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         };
 
@@ -364,6 +367,7 @@ impl Scan {
             let network = match N::ID {
                 MainnetV0::ID => "mainnet",
                 TestnetV0::ID => "testnet",
+                CanaryV0::ID => "canary",
                 unknown_id => bail!("Unknown network ID ({unknown_id})"),
             };
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -14,7 +14,7 @@
 
 use super::Developer;
 use snarkvm::{
-    console::network::{MainnetV0, Network, TestnetV0},
+    console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{
         query::Query,
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
@@ -93,6 +93,7 @@ impl TransferPrivate {
         match self.network {
             MainnetV0::ID => self.construct_transfer_private::<MainnetV0>(),
             TestnetV0::ID => self.construct_transfer_private::<TestnetV0>(),
+            CanaryV0::ID => self.construct_transfer_private::<CanaryV0>(),
             unknown_id => bail!("Unknown network ID ({unknown_id})"),
         }
     }

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -19,7 +19,7 @@ use snarkvm::{
     console::{
         account::{Address, PrivateKey},
         algorithms::Hash,
-        network::{MainnetV0, Network, TestnetV0},
+        network::{CanaryV0, MainnetV0, Network, TestnetV0},
     },
     ledger::{
         block::Block,
@@ -183,6 +183,15 @@ impl Start {
                 TestnetV0::ID => {
                     // Parse the node from the configurations.
                     let node = cli.parse_node::<TestnetV0>(shutdown.clone()).await.expect("Failed to parse the node");
+                    // If the display is enabled, render the display.
+                    if !cli.nodisplay {
+                        // Initialize the display.
+                        Display::start(node, log_receiver).expect("Failed to initialize the display");
+                    }
+                }
+                CanaryV0::ID => {
+                    // Parse the node from the configurations.
+                    let node = cli.parse_node::<CanaryV0>(shutdown.clone()).await.expect("Failed to parse the node");
                     // If the display is enabled, render the display.
                     if !cli.nodisplay {
                         // Initialize the display.

--- a/devnet.sh
+++ b/devnet.sh
@@ -9,7 +9,7 @@ read -p "Enter the total number of clients (default: 2): " total_clients
 total_clients=${total_clients:-2}
 
 # Read the network ID from user or use a default value of 1
-read -p "Enter the network ID (mainnet = 0, testnet = 1) (default: 1): " network_id
+read -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " network_id
 network_id=${network_id:-1}
 
 # Ask the user if they want to run 'cargo install --locked --path .' or use a pre-installed binary

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -121,6 +121,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let network = match N::ID {
             snarkvm::console::network::MainnetV0::ID => "mainnet",
             snarkvm::console::network::TestnetV0::ID => "testnet",
+            snarkvm::console::network::CanaryV0::ID => "canary",
             unknown_id => {
                 eprintln!("Unknown network ID ({unknown_id})");
                 return;

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -401,12 +401,17 @@ impl<N: Network> Router<N> {
                 // TODO: Populate me with Mainnet Beta IP addresses.
             ]
         } else if N::ID == snarkvm::console::network::TestnetV0::ID {
-            // Testnet contains the following bootstrap peers.
+            // TestnetV0 contains the following bootstrap peers.
             vec![
                 SocketAddr::from_str("34.168.118.156:4130").unwrap(),
                 SocketAddr::from_str("35.231.152.213:4130").unwrap(),
                 SocketAddr::from_str("34.17.53.129:4130").unwrap(),
                 SocketAddr::from_str("35.200.149.162:4130").unwrap(),
+            ]
+        } else if N::ID == snarkvm::console::network::CanaryV0::ID {
+            // CanaryV0 contains the following bootstrap peers.
+            vec![
+                // TODO: Populate me with CanaryV0 IP addresses.
             ]
         } else {
             // Unrecognized networks contain no bootstrap peers.


### PR DESCRIPTION
Re-introduces https://github.com/AleoNet/snarkOS/pull/3269

Previously https://github.com/AleoNet/snarkOS/pull/3272 reverted a number of PRs to ensure they can be tested properly. The time has come to test the PRs, so we're doing a partial revert revert.

With https://github.com/AleoNet/snarkOS/pull/3269 back in place they can all be tested on Canary.

After the sister PR https://github.com/AleoNet/snarkVM/pull/2468 is merged, we should update the ref again.