### PR TITLE
Updated canary genesis block - bump snarkVM rev - 9c3bd7f

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "57b16db1e"
+rev = "9c3bd7f"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
## Motivation

Update snarkOS to point to new canary genesis block.
[9c3bd7f](https://github.com/AleoNet/snarkVM/commit/9c3bd7f87bc13795f366d5f8dd96a14bfc82d375)

## Related PRs

https://github.com/AleoNet/snarkVM/pull/2471 - sister PR
