### PR TITLE
Remove redundant code

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -822,10 +822,6 @@ impl<N: Network> Primary<N> {
                     }
                     // Retrieve the committee lookback for the round.
                     let committee_lookback = self_.ledger.get_committee_lookback_for_round(proposal.round())?;
-                    // Retrieve the address of the validator.
-                    let Some(signer) = self_.gateway.resolver().get_address(peer_ip) else {
-                        bail!("Signature is from a disconnected validator");
-                    };
                     // Add the signature to the batch.
                     proposal.add_signature(signer, signature, &committee_lookback)?;
                     info!("Received a batch signature for round {} from '{peer_ip}'", proposal.round());


### PR DESCRIPTION
The logic is redundant, because we already get the signer at 
https://github.com/AleoNet/snarkOS/pull/3288/files#diff-730a4dec91b426c3e3cb97824dba5b96097304cf2568e9376f3a6ed793080284R784-R787
