### PR TITLE
Fix tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
  "addr2line",
  "cc",
@@ -495,9 +495,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -819,6 +819,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +860,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1109,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -1267,12 +1298,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -1286,9 +1317,9 @@ checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "9f3935c160d00ac752e09787e6e6bfc26494c2183cc922f1bc678a60d4733bc2"
 
 [[package]]
 name = "httpdate"
@@ -1298,9 +1329,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1346,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1354,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1391,13 +1422,133 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -1622,6 +1773,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
  "libc",
@@ -1712,7 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-tls",
  "indexmap 2.2.6",
  "ipnet",
@@ -1811,11 +1968,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1958,9 +2114,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
 ]
@@ -1976,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.1.3"
+version = "5.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
+checksum = "b5ca541f22b1c46d4bb9801014f234758ab4297e7870b904b6a8415b980a7388"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2206,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2227,7 +2383,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2397,14 +2553,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2418,13 +2574,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2435,9 +2591,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -2453,7 +2609,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2678,7 +2834,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b3c585a1ced6b97ac13bd5e56f66559e5a75f477da5913f70df98e114518446"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "indicatif",
  "log",
  "quick-xml",
@@ -2697,7 +2853,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a34ad8e4a86884ab42e9b8690e9343abdcfe5fa38a0318cfe1565ba9ad437b4"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "indicatif",
  "log",
  "quick-xml",
@@ -3146,7 +3302,7 @@ dependencies = [
  "snarkvm",
  "tokio",
  "tracing",
- "tracing-test 0.2.4",
+ "tracing-test 0.2.5",
 ]
 
 [[package]]
@@ -3301,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3332,7 +3488,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3362,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3376,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3387,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3397,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3407,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3425,12 +3581,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3441,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3456,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3471,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3484,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3493,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3503,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3515,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3527,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3538,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3550,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3563,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3574,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3587,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3598,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3621,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3639,8 +3795,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
+ "enum-iterator",
  "enum_index",
  "enum_index_derive",
  "indexmap 2.2.6",
@@ -3660,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3675,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3686,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3694,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3704,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3715,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3726,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3737,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3748,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "rand",
  "rayon",
@@ -3762,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3779,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3804,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "anyhow",
  "rand",
@@ -3816,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3835,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3854,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3867,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3880,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3893,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3904,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3919,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3932,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3941,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3961,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "anyhow",
  "colored",
@@ -3976,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3989,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4016,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4031,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4040,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4065,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4075,7 +4232,6 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4095,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4118,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4132,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4145,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4166,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
@@ -4207,6 +4363,12 @@ dependencies = [
  "quote 1.0.36",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
@@ -4317,6 +4479,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4471,6 +4644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,9 +4670,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4506,9 +4689,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
@@ -4759,14 +4942,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
- "lazy_static",
  "tracing-core",
  "tracing-subscriber 0.3.18",
- "tracing-test-macro 0.2.4",
+ "tracing-test-macro 0.2.5",
 ]
 
 [[package]]
@@ -4782,13 +4964,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "lazy_static",
  "quote 1.0.36",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4819,25 +5000,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4847,9 +5013,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -4884,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4900,10 +5066,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -5035,9 +5213,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5232,6 +5410,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,6 +5466,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5265,6 +5500,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3488,7 +3488,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3563,7 +3563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3581,12 +3581,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3671,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3795,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3843,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3861,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3894,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "rand",
  "rayon",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3961,7 +3961,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "anyhow",
  "rand",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3992,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4118,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "anyhow",
  "colored",
@@ -4133,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4232,6 +4232,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4251,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4274,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4288,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4301,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4322,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=43e681f45#43e681f4588129a4564debc1af526855787b11a8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=454d555#454d555a0ee1478dce5fa1822b64525a361b6b27"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "06bba06"
+rev = "43e681f45"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "43e681f45"
+rev = "454d555"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -885,35 +885,6 @@ mod tests {
         assert!(config.parse_cdn().is_none());
     }
 
-    #[tokio::test]
-    async fn test_rest_ip_behavior_in_production() {
-        // Test default REST IP when REST flag is not passed in prod mode
-        let mut config = Start::try_parse_from(["snarkos", "--private-key", "aleo1xx"].iter()).unwrap();
-        let _ = config
-            .parse_node::<CurrentNetwork>(Default::default())
-            .await
-            .expect("Failed to parse the node with default settings");
-        assert_eq!(config.rest, Some(SocketAddr::from_str("0.0.0.0:3030").unwrap()));
-
-        // Test specified REST IP when passed in prod mode
-        let mut config =
-            Start::try_parse_from(["snarkos", "--rest", "192.168.1.1:8080", "--private-key", "aleo1xx"].iter())
-                .unwrap();
-        let _ = config
-            .parse_node::<CurrentNetwork>(Default::default())
-            .await
-            .expect("Failed to parse the node with specified REST IP");
-        assert_eq!(config.rest, Some(SocketAddr::from_str("192.168.1.1:8080").unwrap()));
-
-        // Test behavior when REST flag is not passed and REST is disabled in prod mode
-        let mut config = Start::try_parse_from(["snarkos", "--norest", "--private-key", "aleo1xx"].iter()).unwrap();
-        let _ = config
-            .parse_node::<CurrentNetwork>(Default::default())
-            .await
-            .expect("Failed to parse the node with REST disabled");
-        assert!(config.rest.is_none());
-    }
-
     #[test]
     fn test_parse_development_and_genesis() {
         let prod_genesis = Block::from_bytes_le(CurrentNetwork::genesis_bytes()).unwrap();


### PR DESCRIPTION
## Motivation

Fixes tests on current AleoNet/snarkOS:mainnet-staging:
- updates snarkVM rev to make sure https://github.com/AleoNet/snarkVM/pull/2485 was included
- removes an incomplete test which should have never been committed - this is my oversight

Additionally, https://github.com/AleoNet/snarkVM/pull/2487 needs to be merged because its snarkOS cousin was already merged.

## Related PRs
snarkVM sister PR for release of Canary v0.2.1
https://github.com/AleoNet/snarkVM/pull/2492