### PR TITLE
[Feature] Support endpoints for querying historical data for the `delegated`, `bonded`, and `unbonding` mappings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **.DS_Store
 wasm/Cargo.lock
 **/build
+**.history-*
 **.ledger-*
 **.logs-*
 validator-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
  "addr2line",
  "cc",
@@ -495,9 +495,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -1298,9 +1298,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1346,7 +1346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8d52be92d09acc2e01dddb7fde3ad983fc6489c7db4837e605bc3fca4cb63e"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1712,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-tls",
  "indexmap 2.2.6",
  "ipnet",
@@ -1811,11 +1811,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1958,9 +1957,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
 ]
@@ -1976,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.1.3"
+version = "5.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
+checksum = "b5ca541f22b1c46d4bb9801014f234758ab4297e7870b904b6a8415b980a7388"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2206,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -2227,7 +2226,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2397,14 +2396,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2418,13 +2417,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2435,9 +2434,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -2453,7 +2452,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2678,7 +2677,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b3c585a1ced6b97ac13bd5e56f66559e5a75f477da5913f70df98e114518446"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "indicatif",
  "log",
  "quick-xml",
@@ -2697,7 +2696,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a34ad8e4a86884ab42e9b8690e9343abdcfe5fa38a0318cfe1565ba9ad437b4"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "indicatif",
  "log",
  "quick-xml",
@@ -2900,6 +2899,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
+ "snarkvm-synthesizer",
  "tikv-jemallocator",
  "walkdir",
 ]
@@ -3146,7 +3146,7 @@ dependencies = [
  "snarkvm",
  "tokio",
  "tracing",
- "tracing-test 0.2.4",
+ "tracing-test 0.2.5",
 ]
 
 [[package]]
@@ -4020,6 +4020,8 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "serde",
+ "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4426,9 +4428,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4445,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",
@@ -4698,14 +4700,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
- "lazy_static",
  "tracing-core",
  "tracing-subscriber 0.3.18",
- "tracing-test-macro 0.2.4",
+ "tracing-test-macro 0.2.5",
 ]
 
 [[package]]
@@ -4721,13 +4722,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "lazy_static",
  "quote 1.0.36",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4786,9 +4786,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -4840,9 +4840,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -4974,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -2114,9 +2114,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "anyhow",
  "colored",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4254,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "6d0d8b92cd8358e8d229c11df9358decae64d137c5be540952c5ca7b25aea768"
 
 [[package]]
 name = "memoffset"
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "anyhow",
  "colored",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4254,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=38666d0#38666d01a9b8f9511dc3098d506e8b0231e33cd3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,7 +3056,6 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
- "snarkvm-synthesizer 0.16.19",
  "tikv-jemallocator",
  "walkdir",
 ]
@@ -3337,6 +3336,7 @@ dependencies = [
  "snarkos-node-consensus",
  "snarkos-node-router",
  "snarkvm",
+ "snarkvm-synthesizer",
  "time",
  "tokio",
  "tower",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3473,14 +3473,14 @@ dependencies = [
  "rayon",
  "self_update 0.38.0",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
  "snarkvm-ledger",
  "snarkvm-metrics",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-parameters",
+ "snarkvm-synthesizer",
+ "snarkvm-utilities",
  "thiserror",
  "ureq",
  "walkdir",
@@ -3489,6 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3508,498 +3509,253 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves 0.16.19",
- "snarkvm-fields 0.16.19",
- "snarkvm-parameters 0.16.19",
- "snarkvm-utilities 0.16.19",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-algorithms"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "aleo-std",
- "anyhow",
- "blake2",
- "cfg-if",
- "fxhash",
- "hashbrown 0.14.5",
- "hex",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "num-traits",
- "parking_lot",
- "rand",
- "rand_chacha",
- "rand_core",
- "rayon",
- "serde",
- "sha2",
- "smallvec",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-account 0.16.19",
- "snarkvm-circuit-algorithms 0.16.19",
- "snarkvm-circuit-collections 0.16.19",
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-network 0.16.19",
- "snarkvm-circuit-program 0.16.19",
- "snarkvm-circuit-types 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-program",
+ "snarkvm-circuit-types",
 ]
 
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19",
- "snarkvm-circuit-network 0.16.19",
- "snarkvm-circuit-types 0.16.19",
- "snarkvm-console-account 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-account"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-account",
 ]
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-types 0.16.19",
- "snarkvm-console-algorithms 0.16.19",
- "snarkvm-fields 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-algorithms"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-types",
+ "snarkvm-console-algorithms",
+ "snarkvm-fields",
 ]
 
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19",
- "snarkvm-circuit-types 0.16.19",
- "snarkvm-console-collections 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-collections"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-types",
+ "snarkvm-console-collections",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-algorithms 0.16.19",
- "snarkvm-circuit-environment-witness 0.16.19",
- "snarkvm-console-network 0.16.19",
- "snarkvm-curves 0.16.19",
- "snarkvm-fields 0.16.19",
- "snarkvm-utilities 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-environment"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "nom",
- "num-traits",
- "once_cell",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit-environment-witness",
+ "snarkvm-console-network",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-
-[[package]]
-name = "snarkvm-circuit-environment-witness"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19",
- "snarkvm-circuit-collections 0.16.19",
- "snarkvm-circuit-types 0.16.19",
- "snarkvm-console-network 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-network"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-types",
+ "snarkvm-console-network",
 ]
 
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "paste",
- "snarkvm-circuit-account 0.16.19",
- "snarkvm-circuit-algorithms 0.16.19",
- "snarkvm-circuit-collections 0.16.19",
- "snarkvm-circuit-network 0.16.19",
- "snarkvm-circuit-types 0.16.19",
- "snarkvm-console-program 0.16.19",
- "snarkvm-utilities 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-program"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "paste",
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-program",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-address 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-circuit-types-field 0.16.19",
- "snarkvm-circuit-types-group 0.16.19",
- "snarkvm-circuit-types-integers 0.16.19",
- "snarkvm-circuit-types-scalar 0.16.19",
- "snarkvm-circuit-types-string 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-address",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-circuit-types-string",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-circuit-types-field 0.16.19",
- "snarkvm-circuit-types-group 0.16.19",
- "snarkvm-circuit-types-scalar 0.16.19",
- "snarkvm-console-types-address 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-address"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-address",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-boolean"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-console-types-boolean",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-field"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-console-types-field",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-circuit-types-field 0.16.19",
- "snarkvm-circuit-types-scalar 0.16.19",
- "snarkvm-console-types-group 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-group"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-group",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-circuit-types-field 0.16.19",
- "snarkvm-circuit-types-scalar 0.16.19",
- "snarkvm-console-types-integers 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-integers"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-integers",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-circuit-types-field 0.16.19",
- "snarkvm-console-types-scalar 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-scalar"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19",
- "snarkvm-circuit-types-boolean 0.16.19",
- "snarkvm-circuit-types-field 0.16.19",
- "snarkvm-circuit-types-integers 0.16.19",
- "snarkvm-console-types-string 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-string"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-console-types-string",
 ]
 
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-account 0.16.19",
- "snarkvm-console-algorithms 0.16.19",
- "snarkvm-console-collections 0.16.19",
- "snarkvm-console-network 0.16.19",
- "snarkvm-console-program 0.16.19",
- "snarkvm-console-types 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-program",
+ "snarkvm-console-types",
 ]
 
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "bs58",
- "snarkvm-console-network 0.16.19",
- "snarkvm-console-types 0.16.19",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-account"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "bs58",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types 0.16.19",
- "snarkvm-fields 0.16.19",
- "snarkvm-utilities 0.16.19",
- "tiny-keccak",
-]
-
-[[package]]
-name = "snarkvm-console-algorithms"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "blake2s_simd",
- "smallvec",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-types",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms 0.16.19",
- "snarkvm-console-types 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-collections"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "aleo-std",
- "rayon",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-types",
 ]
 
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4008,43 +3764,21 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "snarkvm-algorithms 0.16.19",
- "snarkvm-console-algorithms 0.16.19",
- "snarkvm-console-collections 0.16.19",
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types 0.16.19",
- "snarkvm-curves 0.16.19",
- "snarkvm-fields 0.16.19",
- "snarkvm-parameters 0.16.19",
- "snarkvm-utilities 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-network"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "anyhow",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "lazy_static",
- "once_cell",
- "paste",
- "serde",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-algorithms",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4053,33 +3787,16 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "snarkvm-curves 0.16.19",
- "snarkvm-fields 0.16.19",
- "snarkvm-utilities 0.16.19",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-network-environment"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "anyhow",
- "bech32",
- "itertools 0.11.0",
- "nom",
- "num-traits",
- "rand",
- "serde",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4090,233 +3807,120 @@ dependencies = [
  "once_cell",
  "paste",
  "serde_json",
- "snarkvm-console-account 0.16.19",
- "snarkvm-console-algorithms 0.16.19",
- "snarkvm-console-collections 0.16.19",
- "snarkvm-console-network 0.16.19",
- "snarkvm-console-types 0.16.19",
- "snarkvm-utilities 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-program"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "enum_index",
- "enum_index_derive",
- "indexmap 2.2.6",
- "num-derive",
- "num-traits",
- "once_cell",
- "paste",
- "serde_json",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-address 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
- "snarkvm-console-types-group 0.16.19",
- "snarkvm-console-types-integers 0.16.19",
- "snarkvm-console-types-scalar 0.16.19",
- "snarkvm-console-types-string 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-types"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-address",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
+ "snarkvm-console-types-integers",
+ "snarkvm-console-types-scalar",
+ "snarkvm-console-types-string",
 ]
 
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
- "snarkvm-console-types-group 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-types-address"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
 ]
 
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-types-boolean"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-types-field"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
- "snarkvm-console-types-scalar 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-types-group"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
- "snarkvm-console-types-scalar 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-types-integers"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-types-scalar"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19",
- "snarkvm-console-types-boolean 0.16.19",
- "snarkvm-console-types-field 0.16.19",
- "snarkvm-console-types-integers 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-console-types-string"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-integers",
 ]
 
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "rand",
  "rayon",
  "rustc_version",
  "serde",
- "snarkvm-fields 0.16.19",
- "snarkvm-utilities 0.16.19",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-curves"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "rand",
- "rayon",
- "rustc_version",
- "serde",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4325,24 +3929,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.16.19",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-fields"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "aleo-std",
- "anyhow",
- "itertools 0.11.0",
- "num-traits",
- "rand",
- "rayon",
- "serde",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-utilities",
  "thiserror",
  "zeroize",
 ]
@@ -4350,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4358,16 +3945,16 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-ledger-test-helpers",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-synthesizer",
  "time",
  "tracing",
 ]
@@ -4375,78 +3962,38 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "anyhow",
  "rand",
  "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-narwhal-subdag 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-authority"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "anyhow",
- "rand",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-subdag",
 ]
 
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-authority 0.16.19",
- "snarkvm-ledger-committee 0.16.19",
- "snarkvm-ledger-narwhal-batch-header 0.16.19",
- "snarkvm-ledger-narwhal-subdag 0.16.19",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19",
- "snarkvm-ledger-puzzle 0.16.19",
- "snarkvm-synthesizer-program 0.16.19",
- "snarkvm-synthesizer-snark 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-block"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
 ]
 
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-narwhal-batch-header 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-committee"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4456,8 +4003,8 @@ dependencies = [
  "rand_distr",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-metrics",
  "test-strategy",
 ]
@@ -4465,138 +4012,94 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-data",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-ledger-narwhal-transmission-id",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-narwhal-batch-header 0.16.19",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-transmission-id",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-transmission-id",
  "time",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
  "tokio",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-committee 0.16.19",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19",
- "snarkvm-ledger-narwhal-batch-header 0.16.19",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-subdag"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-transmission-id",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
  "snarkvm-ledger-narwhal-data",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-puzzle 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4609,33 +4112,14 @@ dependencies = [
  "rand_chacha",
  "rayon",
  "serde_json",
- "snarkvm-algorithms 0.16.19",
- "snarkvm-console 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-puzzle"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "indexmap 2.2.6",
- "lru",
- "once_cell",
- "parking_lot",
- "rand",
- "rand_chacha",
- "rayon",
- "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-algorithms",
+ "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "anyhow",
  "colored",
@@ -4643,75 +4127,27 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-puzzle 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-puzzle-epoch"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "anyhow",
- "colored",
- "indexmap 2.2.6",
- "rand",
- "rand_chacha",
- "rayon",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-dependencies = [
- "async-trait",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-store 0.16.19",
- "snarkvm-synthesizer-program 0.16.19",
- "ureq",
-]
-
-[[package]]
-name = "snarkvm-ledger-query"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "async-trait",
  "reqwest",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
  "ureq",
 ]
 
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-dependencies = [
- "aleo-std-storage",
- "anyhow",
- "bincode",
- "indexmap 2.2.6",
- "parking_lot",
- "rayon",
- "serde",
- "serde_json",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-authority 0.16.19",
- "snarkvm-ledger-block 0.16.19",
- "snarkvm-ledger-committee 0.16.19",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19",
- "snarkvm-ledger-puzzle 0.16.19",
- "snarkvm-synthesizer-program 0.16.19",
- "snarkvm-synthesizer-snark 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-ledger-store"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4724,36 +4160,36 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
  "tracing",
 ]
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "once_cell",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-synthesizer-program",
 ]
 
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4762,6 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4778,66 +4215,15 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves 0.16.19",
- "snarkvm-utilities 0.16.19",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-parameters"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "cfg-if",
- "colored",
- "curl",
- "hex",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "lazy_static",
- "parking_lot",
- "paste",
- "rand",
- "serde_json",
- "sha2",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-curves",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-dependencies = [
- "aleo-std",
- "anyhow",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "lru",
- "parking_lot",
- "rand",
- "serde",
- "serde_json",
- "snarkvm-algorithms 0.16.19",
- "snarkvm-circuit 0.16.19",
- "snarkvm-console 0.16.19",
- "snarkvm-ledger-block 0.16.19",
- "snarkvm-ledger-committee 0.16.19",
- "snarkvm-ledger-puzzle 0.16.19",
- "snarkvm-ledger-puzzle-epoch 0.16.19",
- "snarkvm-ledger-query 0.16.19",
- "snarkvm-ledger-store 0.16.19",
- "snarkvm-utilities 0.16.19",
- "tracing",
-]
-
-[[package]]
-name = "snarkvm-synthesizer"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4847,27 +4233,28 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "serde",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-puzzle-epoch 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-puzzle-epoch",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
  "tracing",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4877,71 +4264,47 @@ dependencies = [
  "rand",
  "rayon",
  "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
  "rand",
  "rand_chacha",
  "serde_json",
- "snarkvm-circuit 0.16.19",
- "snarkvm-console 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-synthesizer-program"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "indexmap 2.2.6",
- "paste",
- "rand",
- "rand_chacha",
- "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-circuit",
+ "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "bincode",
  "once_cell",
  "serde_json",
- "snarkvm-algorithms 0.16.19",
- "snarkvm-circuit 0.16.19",
- "snarkvm-console 0.16.19",
-]
-
-[[package]]
-name = "snarkvm-synthesizer-snark"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "bincode",
- "once_cell",
- "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4954,28 +4317,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "snarkvm-utilities-derives 0.16.19",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-utilities"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "num-bigint",
- "num_cpus",
- "rand",
- "rand_xorshift",
- "rayon",
- "serde",
- "serde_json",
- "smol_str",
- "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=06bba06)",
+ "snarkvm-utilities-derives",
  "thiserror",
  "zeroize",
 ]
@@ -4983,16 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-dependencies = [
- "proc-macro2",
- "quote 1.0.36",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "snarkvm-utilities-derives"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e9b351e#e9b351ef8e008d2277b60890c897162a2ac22f21"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d8b92cd8358e8d229c11df9358decae64d137c5be540952c5ca7b25aea768"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -2533,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4012,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "colored",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4254,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7e31e10#7e31e109b2d918337eac9d46224f4f22c3c72e44"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,6 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3331,7 +3330,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3361,7 +3359,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3375,7 +3372,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3386,7 +3382,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3396,7 +3391,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3406,7 +3400,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3424,12 +3417,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3440,7 +3431,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3455,7 +3445,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3470,7 +3459,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3483,7 +3471,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3492,7 +3479,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3488,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3499,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3526,7 +3510,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3520,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3549,7 +3531,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3562,7 +3543,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3573,7 +3553,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3586,7 +3565,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3597,7 +3575,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3620,7 +3597,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3638,7 +3614,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3659,7 +3634,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3674,7 +3648,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3685,7 +3658,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3693,7 +3665,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3703,7 +3674,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3714,7 +3684,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3725,7 +3694,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3736,7 +3704,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3747,7 +3714,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "rand",
  "rayon",
@@ -3761,7 +3727,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3778,7 +3743,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3803,7 +3767,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "rand",
@@ -3815,7 +3778,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3834,7 +3796,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3853,7 +3814,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3866,7 +3826,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3879,7 +3838,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3892,7 +3850,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3903,7 +3860,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3918,7 +3874,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3931,7 +3886,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3940,7 +3894,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3960,7 +3913,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "anyhow",
  "colored",
@@ -3975,7 +3927,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3988,7 +3939,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +3965,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +3979,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +3987,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4011,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4093,7 +4039,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4061,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4130,7 +4074,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4086,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4106,6 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ path = "snarkos/main.rs"
 
 [features]
 metrics = [ "snarkos-node-metrics", "snarkos-node/metrics" ]
-history = [ "snarkos-node/history", "snarkvm-synthesizer/history" ]
+history = [ "snarkos-node/history" ]
 
 [dependencies.anyhow]
 version = "1.0.79"
@@ -119,11 +119,6 @@ version = "=2.2.7"
 [dependencies.snarkos-node-tcp]
 path = "./node/tcp"
 version = "=2.2.7"
-
-[dependencies.snarkvm-synthesizer]
-path = "../snarkVM/synthesizer"
-default-features = false
-optional = true
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "38666d0"
+rev = "7e31e10"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "e9b351e"
+rev = "38666d0"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ path = "snarkos/main.rs"
 
 [features]
 metrics = [ "snarkos-node-metrics", "snarkos-node/metrics" ]
-history = [ "snarkos-node/history" ]
+history = [ "snarkos-node/history", "snarkvm-synthesizer/history" ]
 
 [dependencies.anyhow]
 version = "1.0.79"
@@ -120,6 +120,11 @@ version = "=2.2.7"
 [dependencies.snarkos-node-tcp]
 path = "./node/tcp"
 version = "=2.2.7"
+
+[dependencies.snarkvm-synthesizer]
+path = "../snarkVM/synthesizer"
+default-features = false
+optional = true
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "7e31e10"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "6d64025"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,10 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/AleoNet/snarkVM.git"
-rev = "74a437897"
+#git = "https://github.com/AleoNet/snarkVM.git"
+#rev = "74a437897"
 #version = "=0.16.18"
+path = "../snarkVM"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]
@@ -56,6 +57,7 @@ path = "snarkos/main.rs"
 
 [features]
 metrics = [ "snarkos-node-metrics", "snarkos-node/metrics" ]
+history = [ "snarkos-node/history" ]
 
 [dependencies.anyhow]
 version = "1.0.79"

--- a/devnet.sh
+++ b/devnet.sh
@@ -22,7 +22,7 @@ clear_ledger=${clear_ledger:-n}
 
 if [[ $build_binary == "y" ]]; then
   # Build the binary using 'cargo install --path .'
-  cargo install --features history --locked --path . || exit 1
+  cargo install --locked --path . || exit 1
 fi
 
 # Clear the ledger logs for each validator if the user chooses to clear ledger

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,6 +27,7 @@ metrics = [
   "snarkos-node-router/metrics",
   "snarkos-node-tcp/metrics"
 ]
+history = [ "snarkos-node-rest/history" ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -65,8 +65,8 @@ path = "../router"
 version = "=2.2.7"
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "7e31e10"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "6d64025"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -66,7 +66,7 @@ version = "=2.2.7"
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "e9b351e"
+rev = "38666d0"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -66,7 +66,7 @@ version = "=2.2.7"
 
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "38666d0"
+rev = "7e31e10"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "rayon" ]
+history = [ ]
 
 [dependencies.anyhow]
 version = "1.0.79"

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "rayon" ]
-history = [ ]
+history = [ "snarkvm-synthesizer/history" ]
 
 [dependencies.anyhow]
 version = "1.0.79"
@@ -63,6 +63,12 @@ version = "=2.2.7"
 [dependencies.snarkos-node-router]
 path = "../router"
 version = "=2.2.7"
+
+[dependencies.snarkvm-synthesizer]
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "e9b351e"
+default-features = false
+optional = true
 
 [dependencies.rand]
 version = "0.8"

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -129,7 +129,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         };
 
         let router = {
-            let mut routes = axum::Router::new()
+            let routes = axum::Router::new()
 
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
             .route(&format!("/{network}/node/address"), get(Self::get_node_address))
@@ -200,10 +200,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
             // If the `history` feature is enabled, enable the additional endpoint.
             #[cfg(feature = "history")]
-            {
-                routes =
-                    routes.route(&format!("/{network}/block/:blockHeight/history/:mapping"), get(Self::get_history));
-            }
+            let routes =
+                routes.route(&format!("/{network}/block/:blockHeight/history/:mapping"), get(Self::get_history));
 
             routes
             // Pass in `Rest` to make things convenient.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -198,10 +198,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/committee/:height"), get(Self::get_committee))
             .route(&format!("/{network}/delegators/:validator"), get(Self::get_delegators_for_validator));
 
-            // TODO: Cleanup
+            // If the `history` feature is enabled, enable the additional endpoint.
             #[cfg(feature = "history")]
             {
-                routes = routes.route(&format!("/{network}/block/:blockHeight/history/:mapping"), get(Self::get_history))
+                routes =
+                    routes.route(&format!("/{network}/block/:blockHeight/history/:mapping"), get(Self::get_history));
             }
 
             routes

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -129,7 +129,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         };
 
         let router = {
-            axum::Router::new()
+            let mut routes = axum::Router::new()
 
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
             .route(&format!("/{network}/node/address"), get(Self::get_node_address))
@@ -196,8 +196,15 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/stateRoot/:height"), get(Self::get_state_root))
             .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
             .route(&format!("/{network}/committee/:height"), get(Self::get_committee))
-            .route(&format!("/{network}/delegators/:validator"), get(Self::get_delegators_for_validator))
+            .route(&format!("/{network}/delegators/:validator"), get(Self::get_delegators_for_validator));
 
+            // TODO: Cleanup
+            #[cfg(feature = "history")]
+            {
+                routes = routes.route(&format!("/{network}/block/:blockHeight/history/:mapping"), get(Self::get_history))
+            }
+
+            routes
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())
             // Enable tower-http tracing.

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -454,8 +454,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Path((height, mapping)): Path<(u32, snarkvm::synthesizer::MappingName)>,
     ) -> Result<impl axum::response::IntoResponse, RestError> {
         // Retrieve the history for the given block height and variant.
-        let history =
-            snarkvm::synthesizer::History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode().clone());
+        let history = snarkvm::synthesizer::History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode());
         let result = history
             .load_mapping(height, mapping)
             .map_err(|_| RestError(format!("Could not load mapping '{mapping}' from block '{height}'")))?;

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -19,11 +19,12 @@ use snarkvm::{
     prelude::{block::Transaction, Address, Identifier, LimitedWriter, Plaintext, ToBytes},
 };
 
+use axum::response::IntoResponse;
 use indexmap::IndexMap;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use snarkvm::prelude::{History, HistoryVariant};
+use snarkvm::prelude::{History, MappingName};
 
 /// The `get_blocks` query object.
 #[derive(Deserialize, Serialize)]
@@ -447,15 +448,15 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     // GET /{network}/block/{blockHeight}/history/{mapping}
-    // TODO: Clean up
     #[cfg(feature = "history")]
     pub(crate) async fn get_history(
         State(rest): State<Self>,
-        Path((height, variant)): Path<(u32, HistoryVariant)>,
-    ) -> Result<ErasedJson, RestError> {
+        Path((height, variant)): Path<(u32, MappingName)>,
+    ) -> Result<impl IntoResponse, RestError> {
         // Retrieve the history for the given block height and variant.
         let history = History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode().clone());
         let result = history.load_entry(height, variant)?;
-        Ok(ErasedJson::pretty(result))
+
+        Ok((StatusCode::OK, [(CONTENT_TYPE, "application/json")], result))
     }
 }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -451,10 +451,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     #[cfg(feature = "history")]
     pub(crate) async fn get_history(
         State(rest): State<Self>,
-        Path((height, mapping)): Path<(u32, snarkvm::prelude::MappingName)>,
+        Path((height, mapping)): Path<(u32, snarkvm::synthesizer::MappingName)>,
     ) -> Result<impl axum::response::IntoResponse, RestError> {
         // Retrieve the history for the given block height and variant.
-        let history = snarkvm::prelude::History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode().clone());
+        let history =
+            snarkvm::synthesizer::History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode().clone());
         let result = history
             .load_mapping(height, mapping)
             .map_err(|_| RestError(format!("Could not load mapping '{mapping}' from block '{height}'")))?;

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -455,7 +455,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let history = snarkvm::prelude::History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode().clone());
         let result = history
             .load_mapping(height, mapping)
-            .map_err(|err| RestError(format!("Could not load mapping '{mapping}' from block '{height}'")))?;
+            .map_err(|_| RestError(format!("Could not load mapping '{mapping}' from block '{height}'")))?;
 
         Ok((StatusCode::OK, [(CONTENT_TYPE, "application/json")], result))
     }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -23,6 +23,7 @@ use indexmap::IndexMap;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use snarkvm::prelude::{History, HistoryVariant};
 
 /// The `get_blocks` query object.
 #[derive(Deserialize, Serialize)]
@@ -443,5 +444,18 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         rest.routing.propagate(message, &[]);
 
         Ok(ErasedJson::pretty(solution_id))
+    }
+
+    // GET /{network}/block/{blockHeight}/history/{mapping}
+    // TODO: Clean up
+    #[cfg(feature = "history")]
+    pub(crate) async fn get_history(
+        State(rest): State<Self>,
+        Path((height, variant)): Path<(u32, HistoryVariant)>,
+    ) -> Result<ErasedJson, RestError> {
+        // Retrieve the history for the given block height and variant.
+        let history = History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode().clone());
+        let result = history.load_entry(height, variant)?;
+        Ok(ErasedJson::pretty(result))
     }
 }


### PR DESCRIPTION
This PR exposes endpoints for querying previous states of the `delegated`, `bonded`, and `unbonding` mappings in credits.aleo.

If the history feature is enabled, the node will log data (via a feature-enabled snarkVM) and expose the `// GET /{network}/block/{blockHeight}/history/{mapping}` endpoint for users to query.

Note. The entirety of this PR is gated under the history feature.

[CI ran succesfully here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkOS/13349/workflows/91ed0034-7233-4094-88cc-027e7e33bfff)