### PR TITLE
Canary v0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "6d64025"
+rev = "8a05317"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
## Motivation

Please see below for improvements included in this release:
[Fix check for bond_validator increasing number of validators beyond MAX_COMMITTEE_SIZE](https://github.com/AleoNet/snarkVM/pull/2498)
[fix(tcp): fix outbound tcp requests not respecting --node bind port](https://github.com/AleoNet/snarkOS/pull/3318)
[fix(sync): Fix client sync RwLock deadlock and client block request stall](https://github.com/AleoNet/snarkOS/pull/3321)
[Turn off error log for prebonds](https://github.com/AleoNet/snarkVM/pull/2495)

## Related PRs
https://github.com/AleoNet/snarkVM/pull/2495
https://github.com/AleoNet/snarkVM/pull/2498
https://github.com/AleoNet/snarkOS/pull/3318
https://github.com/AleoNet/snarkOS/pull/3321