### PR TITLE
[Fix] Clear seen_outbound_block_requests on peer disconnect

### DIFF
--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -196,6 +196,11 @@ impl<N: Network> Cache<N> {
     pub fn decrement_outbound_peer_requests(&self, peer_ip: SocketAddr) -> u32 {
         Self::decrement_counter(&self.seen_outbound_peer_requests, peer_ip)
     }
+
+    /// Removes all cache entries applicable to the given key.
+    pub fn clear_peer_entries(&self, peer_ip: SocketAddr) {
+        self.seen_outbound_block_requests.write().remove(&peer_ip);
+    }
 }
 
 impl<N: Network> Cache<N> {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -514,6 +514,8 @@ impl<N: Network> Router<N> {
         self.connected_peers.write().remove(&peer_ip);
         // Add the peer to the candidate peers.
         self.candidate_peers.write().insert(peer_ip);
+        // Clear cached entries applicable to the peer.
+        self.cache.clear_peer_entries(peer_ip);
         #[cfg(feature = "metrics")]
         self.update_metrics();
     }


### PR DESCRIPTION
This PR clears a peer's `seen_outbound_block_requests` when it gets disconnected.

There may be other cache collections (in `Router`) that require this sort of adjustment, and this depends on whether they too need to be invalidated once the peer is disconnected. Once this PR is merged, this will only require additional lines to be added to `Cache::clear_peer_entries`.

Fixes https://github.com/AleoNet/snarkOS/issues/3326.