### PR TITLE
Delay the promotion of the peer from connecting to connected

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -114,11 +114,6 @@ impl<N: Network> Router<N> {
             }
         }
 
-        // If the handshake succeeded, announce it.
-        if let Ok((ref peer_ip, _)) = handshake_result {
-            info!("Connected to '{peer_ip}'");
-        }
-
         handshake_result
     }
 

--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -22,6 +22,8 @@ use std::{net::SocketAddr, time::Instant};
 pub struct Peer<N: Network> {
     /// The IP address of the peer, with the port set to the listener port.
     peer_ip: SocketAddr,
+    /// The connected address of the peer.
+    peer_addr: SocketAddr,
     /// The Aleo address of the peer.
     address: Address<N>,
     /// The node type of the peer.
@@ -36,9 +38,10 @@ pub struct Peer<N: Network> {
 
 impl<N: Network> Peer<N> {
     /// Initializes a new instance of `Peer`.
-    pub fn new(listening_ip: SocketAddr, challenge_request: &ChallengeRequest<N>) -> Self {
+    pub fn new(listening_ip: SocketAddr, connected_ip: SocketAddr, challenge_request: &ChallengeRequest<N>) -> Self {
         Self {
             peer_ip: listening_ip,
+            peer_addr: connected_ip,
             address: challenge_request.address,
             node_type: challenge_request.node_type,
             version: challenge_request.version,
@@ -50,6 +53,11 @@ impl<N: Network> Peer<N> {
     /// Returns the IP address of the peer, with the port set to the listener port.
     pub const fn ip(&self) -> SocketAddr {
         self.peer_ip
+    }
+
+    /// Returns the connected address of the peer.
+    pub const fn addr(&self) -> SocketAddr {
+        self.peer_addr
     }
 
     /// Returns the Aleo address of the peer.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -46,7 +46,7 @@ use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 use anyhow::{bail, Result};
 use parking_lot::{Mutex, RwLock};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap, HashSet},
     future::Future,
     net::SocketAddr,
     ops::Deref,
@@ -86,7 +86,7 @@ pub struct InnerRouter<N: Network> {
     /// and prevents duplicate outbound connection attempts to the same IP address, it is unable to
     /// prevent simultaneous "two-way" connections between two peers (i.e. both nodes simultaneously
     /// attempt to connect to each other). This set is used to prevent this from happening.
-    connecting_peers: Mutex<HashSet<SocketAddr>>,
+    connecting_peers: Mutex<HashMap<SocketAddr, Option<Peer<N>>>>,
     /// The set of candidate peer IPs.
     candidate_peers: RwLock<HashSet<SocketAddr>>,
     /// The set of restricted peer IPs.
@@ -188,9 +188,12 @@ impl<N: Network> Router<N> {
             bail!("Dropping connection attempt to '{peer_ip}' (restricted)")
         }
         // Ensure the node is not already connecting to this peer.
-        if !self.connecting_peers.lock().insert(peer_ip) {
-            bail!("Dropping connection attempt to '{peer_ip}' (already shaking hands as the initiator)")
-        }
+        match self.connecting_peers.lock().entry(peer_ip) {
+            Entry::Vacant(entry) => entry.insert(None),
+            Entry::Occupied(_) => {
+                bail!("Dropping connection attempt to '{peer_ip}' (already shaking hands as the initiator)")
+            }
+        };
         Ok(())
     }
 
@@ -292,7 +295,7 @@ impl<N: Network> Router<N> {
 
     /// Returns `true` if the node is currently connecting to the given peer IP.
     pub fn is_connecting(&self, ip: &SocketAddr) -> bool {
-        self.connecting_peers.lock().contains(ip)
+        self.connecting_peers.lock().contains_key(ip)
     }
 
     /// Returns `true` if the given IP is restricted.
@@ -435,10 +438,14 @@ impl<N: Network> Router<N> {
     }
 
     /// Inserts the given peer into the connected peers.
-    pub fn insert_connected_peer(&self, peer: Peer<N>, peer_addr: SocketAddr) {
-        let peer_ip = peer.ip();
-        // Adds a bidirectional map between the listener address and (ambiguous) peer address.
-        self.resolver.insert_peer(peer_ip, peer_addr);
+    pub fn insert_connected_peer(&self, peer_ip: SocketAddr) {
+        // Move the peer from "connecting" to "connected".
+        let peer = if let Some(Some(peer)) = self.connecting_peers.lock().remove(&peer_ip) {
+            peer
+        } else {
+            warn!("Couldn't promote {peer_ip} from \"connecting\" to \"connected\"");
+            return;
+        };
         // Add an entry for this `Peer` in the connected peers.
         self.connected_peers.write().insert(peer_ip, peer);
         // Remove this peer from the candidate peers, if it exists.
@@ -447,6 +454,7 @@ impl<N: Network> Router<N> {
         self.restricted_peers.write().remove(&peer_ip);
         #[cfg(feature = "metrics")]
         self.update_metrics();
+        info!("Connected to '{peer_ip}'");
     }
 
     /// Inserts the given peer IPs to the set of candidate peers.

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -17,11 +17,8 @@ use common::*;
 
 use deadline::deadline;
 use peak_alloc::PeakAlloc;
-use snarkos_node_router::Routing;
-use snarkos_node_tcp::{
-    protocols::{Disconnect, Handshake},
-    P2P,
-};
+use snarkos_node_router::{Outbound, Routing};
+use snarkos_node_tcp::protocols::{Disconnect, Handshake, OnConnect};
 use snarkvm::{prelude::Rng, utilities::TestRng};
 
 use core::time::Duration;
@@ -57,6 +54,9 @@ async fn test_connection_cleanups() {
     nodes[0].enable_disconnect().await;
     nodes[1].enable_disconnect().await;
 
+    nodes[0].enable_on_connect().await;
+    nodes[1].enable_on_connect().await;
+
     nodes[0].enable_listener().await;
     nodes[1].enable_listener().await;
 
@@ -69,9 +69,10 @@ async fn test_connection_cleanups() {
         nodes[1].connect(nodes[0].local_ip());
 
         // Wait until the connection is complete.
-        let tcp0 = nodes[0].tcp().clone();
-        let tcp1 = nodes[1].tcp().clone();
-        deadline!(Duration::from_secs(3), move || tcp0.num_connected() == 1 && tcp1.num_connected() == 1);
+        let node0 = nodes[0].clone();
+        let node1 = nodes[1].clone();
+        deadline!(Duration::from_secs(3), move || node0.router().number_of_connected_peers() == 1
+            && node1.router().number_of_connected_peers() == 1);
 
         // Since the connectee doesn't read from the connector, it can't tell that the connector disconnected
         // from it, so it needs to disconnect from it manually.
@@ -79,9 +80,10 @@ async fn test_connection_cleanups() {
         nodes[1].disconnect(nodes[0].local_ip());
 
         // Wait until the disconnect is complete.
-        let tcp0 = nodes[0].tcp().clone();
-        let tcp1 = nodes[1].tcp().clone();
-        deadline!(Duration::from_secs(3), move || tcp0.num_connected() == 0 && tcp1.num_connected() == 0);
+        let node0 = nodes[0].clone();
+        let node1 = nodes[1].clone();
+        deadline!(Duration::from_secs(3), move || node0.router().number_of_connected_peers() == 0
+            && node1.router().number_of_connected_peers() == 0);
 
         // Register heap use after a single connection.
         if i == 0 {

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -92,8 +92,15 @@ impl<N: Network> Handshake for TestRouter<N> {
 
 #[async_trait]
 impl<N: Network> OnConnect for TestRouter<N> {
-    async fn on_connect(&self, _peer_addr: SocketAddr) {
-        // This behavior is currently not tested.
+    async fn on_connect(&self, peer_addr: SocketAddr) {
+        let peer_ip = if let Some(ip) = self.router().resolve_to_listener(&peer_addr) {
+            ip
+        } else {
+            panic!("The peer IP should be known by the time OnConnect is triggered!");
+        };
+
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
     }
 }
 

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -15,7 +15,10 @@
 mod common;
 use common::*;
 
-use snarkos_node_tcp::{protocols::Handshake, P2P};
+use snarkos_node_tcp::{
+    protocols::{Handshake, OnConnect},
+    P2P,
+};
 
 use core::time::Duration;
 use deadline::deadline;
@@ -87,6 +90,10 @@ async fn test_connect_with_handshake() {
     // Enable handshake protocol.
     node0.enable_handshake().await;
     node1.enable_handshake().await;
+
+    // Enable on_connect protocol.
+    node0.enable_on_connect().await;
+    node1.enable_on_connect().await;
 
     // Start listening.
     node0.tcp().enable_listener().await.unwrap();
@@ -163,6 +170,7 @@ async fn test_validator_connection() {
     let node0 = validator(0, 2, &[], false).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     node0.enable_handshake().await;
+    node0.enable_on_connect().await;
     node0.tcp().enable_listener().await.unwrap();
 
     // Get the local IP address from the first router.
@@ -172,6 +180,7 @@ async fn test_validator_connection() {
     let node1 = validator(0, 2, &[addr0], false).await;
     assert_eq!(node1.number_of_connected_peers(), 0);
     node1.enable_handshake().await;
+    node1.enable_on_connect().await;
     node1.tcp().enable_listener().await.unwrap();
 
     {

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -15,7 +15,10 @@
 mod common;
 use common::*;
 
-use snarkos_node_tcp::{protocols::Handshake, P2P};
+use snarkos_node_tcp::{
+    protocols::{Handshake, OnConnect},
+    P2P,
+};
 
 use core::time::Duration;
 
@@ -72,6 +75,10 @@ async fn test_disconnect_with_handshake() {
     // Enable handshake protocol.
     node0.enable_handshake().await;
     node1.enable_handshake().await;
+
+    // Enable on_connect protocol.
+    node0.enable_on_connect().await;
+    node1.enable_on_connect().await;
 
     // Start listening.
     node0.tcp().enable_listener().await.unwrap();

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -67,6 +67,8 @@ where
     async fn on_connect(&self, peer_addr: SocketAddr) {
         // Resolve the peer address to the listener address.
         let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) else { return };
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
         // Retrieve the block locators.
         let block_locators = match self.sync.get_block_locators() {
             Ok(block_locators) => Some(block_locators),

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -60,6 +60,8 @@ where
     async fn on_connect(&self, peer_addr: SocketAddr) {
         // Resolve the peer address to the listener address.
         let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) else { return };
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
         // Send the first `Ping` message to the peer.
         self.send_ping(peer_ip, None);
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -63,6 +63,8 @@ where
     async fn on_connect(&self, peer_addr: SocketAddr) {
         // Resolve the peer address to the listener address.
         let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) else { return };
+        // Promote the peer's status from "connecting" to "connected".
+        self.router().insert_connected_peer(peer_ip);
         // Retrieve the block locators.
         let block_locators = match self.sync.get_block_locators() {
             Ok(block_locators) => Some(block_locators),


### PR DESCRIPTION
A re-opening of https://github.com/AleoNet/snarkOS/pull/2690; there is also https://github.com/AleoNet/snarkOS/pull/2729 which I had considered to be a simpler alternative, but I believe that both changes are desirable (with this one going in first) for a more foolproof setup.

The Aleo network stack is two-tiered, and both the lower- and higher-level layers recognize that connections may have been started but not fully finalized yet, which corresponds to the "connecting" and "connected" states of connections and peers respectively.

This PR ensures that the lower networking layer is the first one to conclude its connection setup, which is done by marking the (higher-level) peers as "connected" only via `OnConnect`, which is triggered only after the lower-level layer has concluded all its work. To do this, the `Peer` object (instead of just the address) is persisted in the `connecting_peers` collection past the handshake, and moved to `connected_peers` only during `OnConnect::on_connect`.

The existing tests are adjusted to account for this; I've also tested it locally in a `--dev` network.

Fixes https://github.com/AleoNet/snarkOS/issues/3331 and all other potential issues of its kind (i.e. attempting to treat a connection as fully established before the lower-level TCP stack recognizes it as such).