### PR TITLE
Testnet Beta v0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "8a05317"
+rev = "d170a9f"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 


### PR DESCRIPTION
## Motivation

Testnet Beta v0.3.0 release which is also the Canary v0.3.1 release due to the updates to the genesis block.

## Test Plan

Isonet and Canary runs prior to merge.

## Related PRs
https://github.com/AleoNet/snarkVM/pull/2502
https://github.com/AleoNet/snarkVM/pull/2503
