### PR TITLE
fix incorrect usage of Ordering::Relaxed

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -334,7 +334,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     #[cfg(feature = "ledger-write")]
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
         // If the Ctrl-C handler registered the signal, then skip advancing to the next block.
-        if self.shutdown.load(Ordering::Relaxed) {
+        if self.shutdown.load(Ordering::Acquire) {
             bail!("Skipping advancing to block {} - The node is shutting down", block.height());
         }
         // Advance to the next block.

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -19,11 +19,7 @@
 use snarkvm::prelude::{
     block::Block,
     store::{cow_to_copied, ConsensusStorage},
-    Deserialize,
-    DeserializeOwned,
-    Ledger,
-    Network,
-    Serialize,
+    Deserialize, DeserializeOwned, Ledger, Network, Serialize,
 };
 
 use anyhow::{anyhow, bail, Result};
@@ -171,7 +167,7 @@ pub async fn load_blocks<N: Network>(
     let mut current_height = start_height.saturating_sub(1);
     while current_height < end_height - 1 {
         // If we are instructed to shut down, abort.
-        if shutdown.load(Ordering::Relaxed) {
+        if shutdown.load(Ordering::Acquire) {
             info!("Stopping block sync at {} - shutting down", current_height);
             // We can shut down cleanly from here, as the node hasn't been started yet.
             std::process::exit(0);
@@ -250,7 +246,7 @@ async fn download_block_bundles<N: Network>(
     let mut start = cdn_start;
     while start < cdn_end - 1 {
         // If we are instructed to shut down, stop downloading.
-        if shutdown.load(Ordering::Relaxed) {
+        if shutdown.load(Ordering::Acquire) {
             break;
         }
 

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -19,7 +19,11 @@
 use snarkvm::prelude::{
     block::Block,
     store::{cow_to_copied, ConsensusStorage},
-    Deserialize, DeserializeOwned, Ledger, Network, Serialize,
+    Deserialize,
+    DeserializeOwned,
+    Ledger,
+    Network,
+    Serialize,
 };
 
 use anyhow::{anyhow, bail, Result};

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -20,7 +20,11 @@ use snarkos_node_bft::ledger_service::CoreLedgerService;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
     messages::{Message, NodeType, UnconfirmedSolution},
-    Heartbeat, Inbound, Outbound, Router, Routing,
+    Heartbeat,
+    Inbound,
+    Outbound,
+    Router,
+    Routing,
 };
 use snarkos_node_sync::{BlockSync, BlockSyncMode};
 use snarkos_node_tcp::{

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -20,11 +20,7 @@ use snarkos_node_bft::ledger_service::CoreLedgerService;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
     messages::{Message, NodeType, UnconfirmedSolution},
-    Heartbeat,
-    Inbound,
-    Outbound,
-    Router,
-    Routing,
+    Heartbeat, Inbound, Outbound, Router, Routing,
 };
 use snarkos_node_sync::{BlockSync, BlockSyncMode};
 use snarkos_node_tcp::{
@@ -167,7 +163,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         self.handles.lock().push(tokio::spawn(async move {
             loop {
                 // If the Ctrl-C handler registered the signal, stop the node.
-                if node.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+                if node.shutdown.load(std::sync::atomic::Ordering::Acquire) {
                     info!("Shutting down block production");
                     break;
                 }
@@ -194,7 +190,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
 
         // Shut down the node.
         trace!("Shutting down the node...");
-        self.shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.shutdown.store(true, std::sync::atomic::Ordering::Release);
 
         // Abort the tasks.
         trace!("Shutting down the validator...");

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -19,11 +19,7 @@ use snarkos_account::Account;
 use snarkos_node_bft::ledger_service::ProverLedgerService;
 use snarkos_node_router::{
     messages::{Message, NodeType, UnconfirmedSolution},
-    Heartbeat,
-    Inbound,
-    Outbound,
-    Router,
-    Routing,
+    Heartbeat, Inbound, Outbound, Router, Routing,
 };
 use snarkos_node_sync::{BlockSync, BlockSyncMode};
 use snarkos_node_tcp::{
@@ -152,7 +148,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Prover<N, C> {
 
         // Shut down the puzzle.
         debug!("Shutting down the puzzle...");
-        self.shutdown.store(true, Ordering::Relaxed);
+        self.shutdown.store(true, Ordering::Release);
 
         // Abort the tasks.
         debug!("Shutting down the prover...");
@@ -223,7 +219,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
             }
 
             // If the Ctrl-C handler registered the signal, stop the prover.
-            if self.shutdown.load(Ordering::Relaxed) {
+            if self.shutdown.load(Ordering::Acquire) {
                 debug!("Shutting down the puzzle...");
                 break;
             }

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -19,7 +19,11 @@ use snarkos_account::Account;
 use snarkos_node_bft::ledger_service::ProverLedgerService;
 use snarkos_node_router::{
     messages::{Message, NodeType, UnconfirmedSolution},
-    Heartbeat, Inbound, Outbound, Router, Routing,
+    Heartbeat,
+    Inbound,
+    Outbound,
+    Router,
+    Routing,
 };
 use snarkos_node_sync::{BlockSync, BlockSyncMode};
 use snarkos_node_tcp::{

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -21,11 +21,7 @@ use snarkos_node_consensus::Consensus;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
     messages::{NodeType, PuzzleResponse, UnconfirmedSolution, UnconfirmedTransaction},
-    Heartbeat,
-    Inbound,
-    Outbound,
-    Router,
-    Routing,
+    Heartbeat, Inbound, Outbound, Router, Routing,
 };
 use snarkos_node_sync::{BlockSync, BlockSyncMode};
 use snarkos_node_tcp::{
@@ -36,8 +32,7 @@ use snarkvm::prelude::{
     block::{Block, Header},
     puzzle::Solution,
     store::ConsensusStorage,
-    Ledger,
-    Network,
+    Ledger, Network,
 };
 
 use aleo_std::StorageMode;
@@ -421,7 +416,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
 
         // Shut down the node.
         trace!("Shutting down the node...");
-        self.shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.shutdown.store(true, std::sync::atomic::Ordering::Release);
 
         // Abort the tasks.
         trace!("Shutting down the validator...");
@@ -443,8 +438,7 @@ mod tests {
     use super::*;
     use snarkvm::prelude::{
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
-        MainnetV0,
-        VM,
+        MainnetV0, VM,
     };
 
     use anyhow::bail;

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -21,7 +21,11 @@ use snarkos_node_consensus::Consensus;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
     messages::{NodeType, PuzzleResponse, UnconfirmedSolution, UnconfirmedTransaction},
-    Heartbeat, Inbound, Outbound, Router, Routing,
+    Heartbeat,
+    Inbound,
+    Outbound,
+    Router,
+    Routing,
 };
 use snarkos_node_sync::{BlockSync, BlockSyncMode};
 use snarkos_node_tcp::{
@@ -32,7 +36,8 @@ use snarkvm::prelude::{
     block::{Block, Header},
     puzzle::Solution,
     store::ConsensusStorage,
-    Ledger, Network,
+    Ledger,
+    Network,
 };
 
 use aleo_std::StorageMode;
@@ -438,7 +443,8 @@ mod tests {
     use super::*;
     use snarkvm::prelude::{
         store::{helpers::memory::ConsensusMemory, ConsensusStore},
-        MainnetV0, VM,
+        MainnetV0,
+        VM,
     };
 
     use anyhow::bail;


### PR DESCRIPTION
## Motivation
Ordering is important. While Relaxed is atomic on its own, it can't sync cache between threads.

This PR fixes such incorrect usage