### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,19 @@ This will output a new Aleo account in the terminal.
 
 Next, to start a proving node, from the `snarkOS` directory, run:
 ```
-./run-prover.sh
+./run-prover.sh --network <0 - Mainnet, 1 - Testnet>
 ```
 When prompted, enter your Aleo private key:
 ```
 Enter the Aleo Prover account private key:
 APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
+
+You can also start a prover with `snarkos start` without rebuilding:
+```
+snarkos start --prover --private-key APrivateKey1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx --nodisplay --network <0 - Mainnet, 1 - Testnet>
+```
+**`This method is NOT advised unless you update snarkOS yourself & rebuild it manually.`**
 
 ## 4. FAQs
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Since the build guide does not mention an ability to use snarkOS flags with `.sh`-files (specifically `--network`), it has been added to the guide with appropriate network values.

Also, if anyone wants to NOT rebuild `snarkOS` binary at startup, I've added a straightforward description with **`snarkos`**. A disclaimer is also added if anyone decides to run the node this way.

## Test Plan

No changes to the code were applied. 

## Related PRs

No related PRs.
