### PR TITLE
[fix] CLI error handling message

### DIFF
--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -131,8 +131,7 @@ impl Developer {
             Ok(response) => response.into_json().map_err(|err| err.into()),
             Err(err) => match err {
                 ureq::Error::Status(_status, response) => {
-                    // Response::into_string() returns the response BODY, but there is none
-                    // better to format using debug this at least gives some useful info
+                    // Debug formatting displays more useful info, especially if the response body is empty.
                     bail!("Failed to fetch program {program_id}: {response:?}")
                 }
                 err => bail!(err),

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -131,7 +131,9 @@ impl Developer {
             Ok(response) => response.into_json().map_err(|err| err.into()),
             Err(err) => match err {
                 ureq::Error::Status(_status, response) => {
-                    bail!(response.into_string().unwrap_or("Response too large!".to_owned()))
+                    // Response::into_string() returns the response BODY, but there is none
+                    // better to format using debug this at least gives some useful info
+                    bail!("Failed to fetch program {program_id}: {response:?}")
                 }
                 err => bail!(err),
             },


### PR DESCRIPTION
Fixes https://github.com/AleoNet/snarkOS/issues/3286

Now prints the following:
```
cargo run -- developer execute  --private-key APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH --query "http://0.0.0.0:3030" --broadcast "http://0.0.0.0:3030/mainnet/transaction/broadcast" credits.aleo transfer_public
   Compiling snarkos-cli v2.2.7 (/home/jos/Projects/snarkOS/cli)
   Compiling snarkos v2.2.7 (/home/jos/Projects/snarkOS)
    Finished dev [optimized] target(s) in 11.03s
     Running `target/debug/snarkos developer execute --private-key APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH --query 'http://0.0.0.0:3030' --broadcast 'http://0.0.0.0:3030/mainnet/transaction/broadcast' credits.aleo transfer_public`

📦 Creating execution transaction for 'credits.aleo/transfer_public'...

⚠️  Failed to fetch program credits.aleo: Response[status: 404, status_text: Not Found, url: http://0.0.0.0:3030/mainnet/program/credits.aleo]
```