### PR TITLE
[Chore] Remove deprecated rest endpoints

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -135,22 +135,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/node/address"), get(Self::get_node_address))
             .route_layer(middleware::from_fn(auth_middleware))
 
-            // ----------------- DEPRECATED ROUTES -----------------
-            // The following `GET ../latest/..` routes will be removed before mainnet.
-            // Please refer to the recommended routes for each endpoint:
-
-            // Deprecated: use `/<network>/block/height/latest` instead.
-            .route(&format!("/{network}/latest/height"), get(Self::latest_height))
-            // Deprecated: use `/<network>/block/hash/latest` instead.
-            .route(&format!("/{network}/latest/hash"), get(Self::latest_hash))
-            // Deprecated: use `/<network>/latest/block/height` instead.
-            .route(&format!("/{network}/latest/block"), get(Self::latest_block))
-            // Deprecated: use `/<network>/stateRoot/latest` instead.
-            .route(&format!("/{network}/latest/stateRoot"), get(Self::latest_state_root))
-            // Deprecated: use `/<network>/committee/latest` instead.
-            .route(&format!("/{network}/latest/committee"), get(Self::latest_committee))
-            // ------------------------------------------------------
-
             // GET ../block/..
             .route(&format!("/{network}/block/height/latest"), get(Self::get_block_height_latest))
             .route(&format!("/{network}/block/hash/latest"), get(Self::get_block_hash_latest))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -40,42 +40,6 @@ pub(crate) struct Metadata {
 }
 
 impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
-    // ----------------- DEPRECATED FUNCTIONS -----------------
-    // The functions below are associated with deprecated routes.
-    // Please use the recommended alternatives when implementing new features or refactoring.
-
-    // Deprecated: Use `get_block_height_latest` instead.
-    // GET /<network>/latest/height
-    pub(crate) async fn latest_height(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_height())
-    }
-
-    // Deprecated: Use `get_block_hash_latest` instead.
-    // GET /<network>/latest/hash
-    pub(crate) async fn latest_hash(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_hash())
-    }
-
-    // Deprecated: Use `get_block_latest` instead.
-    // GET /<network>/latest/block
-    pub(crate) async fn latest_block(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_block())
-    }
-
-    // Deprecated: Use `get_state_root_latest` instead.
-    // GET /<network>/latest/stateRoot
-    pub(crate) async fn latest_state_root(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_state_root())
-    }
-
-    // Deprecated: Use `get_committee_latest` instead.
-    // GET /<network>/latest/committee
-    pub(crate) async fn latest_committee(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.latest_committee()?))
-    }
-
-    // ---------------------------------------------------------
-
     // GET /<network>/block/height/latest
     pub(crate) async fn get_block_height_latest(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.ledger.latest_height())


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR removes the deprecated REST endpoints. The `/{network}/latest/*` format will be replaced with the already existing `/{network}/*/latest` formatting. 

These deprecated routes were left in during the testnet phase to ensure developer tooling was not broken and to give sufficient time to migrate to the new APIs.