### PR TITLE
[CDN] Enable CDN for Individual Networks

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -266,8 +266,11 @@ impl Start {
         else {
             // Determine the CDN URL.
             match &self.cdn {
-                // Use the provided CDN URL.
-                Some(cdn) => Some(cdn.clone()),
+                // Use the provided CDN URL if it is not empty.
+                Some(cdn) => match cdn.is_empty() {
+                    true => None,
+                    false => Some(cdn.clone()),
+                },
                 // If no CDN URL is provided, determine the CDN URL based on the network ID.
                 None => match N::ID {
                     MainnetV0::ID => Some(format!("{CDN_BASE_URL}/mainnet.blocks/v0")),

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -47,8 +47,6 @@ const CONCURRENT_REQUESTS: u32 = 16;
 const MAXIMUM_PENDING_BLOCKS: u32 = BLOCKS_PER_FILE * CONCURRENT_REQUESTS * 2;
 /// Maximum number of attempts for a request to the CDN.
 const MAXIMUM_REQUEST_ATTEMPTS: u8 = 10;
-/// The supported network.
-const NETWORK_ID: u16 = 0;
 
 /// Loads blocks from a CDN into the ledger.
 ///
@@ -107,11 +105,6 @@ pub async fn load_blocks<N: Network>(
     shutdown: Arc<AtomicBool>,
     process: impl FnMut(Block<N>) -> Result<()> + Clone + Send + Sync + 'static,
 ) -> Result<u32, (u32, anyhow::Error)> {
-    // If the network is not supported, return.
-    if N::ID != NETWORK_ID {
-        return Err((start_height, anyhow!("The network ({}) is not supported", N::ID)));
-    }
-
     // Create a Client to maintain a connection pool throughout the sync.
     let client = match Client::builder().build() {
         Ok(client) => client,


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds CDN support for the different networks (`MainnetV0`, `TestnetV0`, and `CanaryV0`). 

Currently the CDN is only working for `Testnet Beta` because only the `Testnet Beta` blocks have been uploaded to the CDN.

Once `mainnet` is up and running, blocks can be uploaded to the CDN, and nodes will be able to start fetching blocks from it.


Full CI is being run [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkOS/13448/workflows/a2cc4166-5345-4e29-9d38-c7f7faaec7bc).