### PR TITLE
Update issue template link to correct repository URL

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
-## 👉 [Please follow one of these issue templates](https://github.com/AleoHQ/snarkOS/issues/new/choose) 👈
+## 👉 [Please follow one of these issue templates](https://github.com/AleoNet/snarkOS/issues/new/choose) 👈
 
 Note: to keep the backlog clean and actionable, issues may be immediately closed if they do not follow one of the above issue templates.


### PR DESCRIPTION
## Motivation

This PR updates the defaulting issue template link in [ISSUE_TEMPLATE.md](https://github.com/AleoNet/snarkOS/blob/mainnet-staging/.github/ISSUE_TEMPLATE.md) to point correctly to the `AleoNet` repository. Previously, the link incorrectly pointed to the `AleoHQ` repository.

## Test Plan

To verify this change:
1. Navigate to the [.github/ISSUE_TEMPLATE.md](https://github.com/paulallensuxs/snarkOS/blob/patch-1/.github/ISSUE_TEMPLATE.md).
2. Click on the updated link to ensure it correctly redirects to the `https://github.com/AleoNet/snarkOS/issues/new/choose` page.
3. Confirm that the page loads the correct repository's issue templates.

No code changes were made, so no additional testing is necessary beyond link verification.

## Related PRs

None.
