### PR TITLE
add configurable metrics listening cli option

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -128,9 +128,13 @@ pub struct Start {
     /// Specify the path to the file where logs will be stored
     #[clap(default_value_os_t = std::env::temp_dir().join("snarkos.log"), long = "logfile")]
     pub logfile: PathBuf,
+
     /// Enables the metrics exporter
     #[clap(default_value = "false", long = "metrics")]
     pub metrics: bool,
+    /// Specify the IP address and port for the metrics exporter
+    #[clap(long = "metrics-ip")]
+    pub metrics_ip: Option<SocketAddr>,
 
     /// Specify the path to a directory containing the storage database for the ledger
     #[clap(long = "storage")]
@@ -558,7 +562,7 @@ impl Start {
 
         // Initialize the metrics.
         if self.metrics {
-            metrics::initialize_metrics();
+            metrics::initialize_metrics(self.metrics_ip);
         }
 
         // Initialize the storage mode.

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -602,7 +602,7 @@ async fn main() -> Result<()> {
     #[cfg(feature = "metrics")]
     if args.metrics {
         info!("Initializing metrics...");
-        metrics::initialize_metrics();
+        metrics::initialize_metrics(SocketAddr::from_str(&format!("0.0.0.0:{}", 9000 + args.id)).ok());
     }
 
     // Start the monitoring server.

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -30,6 +30,7 @@ use snarkvm::{
 };
 use std::{
     collections::HashMap,
+    net::SocketAddr,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -38,9 +39,12 @@ use std::{
 use time::OffsetDateTime;
 
 /// Initializes the metrics and returns a handle to the task running the metrics exporter.
-pub fn initialize_metrics() {
+pub fn initialize_metrics(ip: Option<SocketAddr>) {
     // Build the Prometheus exporter.
-    metrics_exporter_prometheus::PrometheusBuilder::new().install().expect("can't build the prometheus exporter");
+    let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
+    if let Some(ip) = ip { builder.with_http_listener(ip) } else { builder }
+        .install()
+        .expect("can't build the prometheus exporter");
 
     // Register the snarkVM metrics.
     snarkvm::metrics::register_metrics();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Add an snarkOS cli option to configure the listening host and port of the metrics exporter.

Although I think listening to 127.0.0.1 by default should be a better default value, I kept 0.0.0.0 to not break existing users (the previous default was hardcoded `0.0.0.0:9000`). Same for the cli option name, although it's different from rest and cdn options. Lemme know if breaking backwards compatibility is acceptable there.

## Test Plan

Tested locally

## Related PRs

(Link any related PRs here)
