### PR TITLE
[Feature] Introduce IP-level bans for connection spam targeting validators

### DIFF
--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ ]
 metrics = [ "dep:metrics", "snarkos-node-bft-events/metrics", "snarkos-node-bft-ledger-service/metrics" ]
+test = [ ]
 
 [dependencies.aleo-std]
 workspace = true
@@ -151,6 +152,10 @@ version = "0.4"
 
 [dev-dependencies.rayon]
 version = "1"
+
+[dev-dependencies.snarkos-node-bft]
+path = "."
+features = [ "test" ]
 
 [dev-dependencies.snarkos-node-bft-ledger-service]
 path = "./ledger-service"

--- a/node/tcp/src/helpers/known_peers.rs
+++ b/node/tcp/src/helpers/known_peers.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::IpAddr,
+    sync::Arc,
+    time::Instant,
+};
 
 use parking_lot::RwLock;
 
@@ -20,45 +25,53 @@ use crate::Stats;
 
 /// Contains statistics related to Tcp's peers, currently connected or not.
 #[derive(Default)]
-pub struct KnownPeers(RwLock<HashMap<SocketAddr, Arc<Stats>>>);
+pub struct KnownPeers(RwLock<HashMap<IpAddr, Arc<Stats>>>);
 
 impl KnownPeers {
     /// Adds an address to the list of known peers.
-    pub fn add(&self, addr: SocketAddr) {
-        self.0.write().entry(addr).or_default();
+    pub fn add(&self, addr: IpAddr) {
+        let timestamp = Instant::now();
+        match self.0.write().entry(addr) {
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(Stats::new(timestamp)));
+            }
+            Entry::Occupied(entry) => {
+                *entry.get().timestamp.write() = timestamp;
+            }
+        }
     }
 
     /// Returns the stats for the given peer.
-    pub fn get(&self, addr: SocketAddr) -> Option<Arc<Stats>> {
+    pub fn get(&self, addr: IpAddr) -> Option<Arc<Stats>> {
         self.0.read().get(&addr).map(Arc::clone)
     }
 
     /// Removes an address from the list of known peers.
-    pub fn remove(&self, addr: SocketAddr) -> Option<Arc<Stats>> {
+    pub fn remove(&self, addr: IpAddr) -> Option<Arc<Stats>> {
         self.0.write().remove(&addr)
     }
 
     /// Returns the list of all known peers and their stats.
-    pub fn snapshot(&self) -> HashMap<SocketAddr, Arc<Stats>> {
+    pub fn snapshot(&self) -> HashMap<IpAddr, Arc<Stats>> {
         self.0.read().clone()
     }
 
     /// Registers a submission of a message to the given address.
-    pub fn register_sent_message(&self, to: SocketAddr, size: usize) {
+    pub fn register_sent_message(&self, to: IpAddr, size: usize) {
         if let Some(stats) = self.0.read().get(&to) {
             stats.register_sent_message(size);
         }
     }
 
     /// Registers a receipt of a message to the given address.
-    pub fn register_received_message(&self, from: SocketAddr, size: usize) {
+    pub fn register_received_message(&self, from: IpAddr, size: usize) {
         if let Some(stats) = self.0.read().get(&from) {
             stats.register_received_message(size);
         }
     }
 
     /// Registers a failure associated with the given address.
-    pub fn register_failure(&self, addr: SocketAddr) {
+    pub fn register_failure(&self, addr: IpAddr) {
         if let Some(stats) = self.0.read().get(&addr) {
             stats.register_failure();
         }

--- a/node/tcp/src/helpers/stats.rs
+++ b/node/tcp/src/helpers/stats.rs
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use parking_lot::RwLock;
+use std::{
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+    time::Instant,
+};
 
 /// Contains statistics related to Tcp.
-#[derive(Default)]
 pub struct Stats {
+    /// The timestamp of the creation (for the node) or connection (to a peer).
+    pub(crate) timestamp: RwLock<Instant>,
     /// The number of all messages sent.
     msgs_sent: AtomicU64,
     /// The number of all messages received.
@@ -30,6 +35,23 @@ pub struct Stats {
 }
 
 impl Stats {
+    /// Creates a new instance of the object.
+    pub fn new(timestamp: Instant) -> Self {
+        Self {
+            timestamp: RwLock::new(timestamp),
+            msgs_sent: Default::default(),
+            msgs_received: Default::default(),
+            bytes_sent: Default::default(),
+            bytes_received: Default::default(),
+            failures: Default::default(),
+        }
+    }
+
+    /// Returns the creation or connection timestamp.
+    pub fn timestamp(&self) -> Instant {
+        *self.timestamp.read()
+    }
+
     /// Returns the number of sent messages and their collective size in bytes.
     pub fn sent(&self) -> (u64, u64) {
         let msgs = self.msgs_sent.load(Relaxed);

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -143,7 +143,7 @@ impl<R: Reading> ReadingInternal for R {
             while let Some(msg) = inbound_message_receiver.recv().await {
                 if let Err(e) = self_clone.process_message(addr, msg).await {
                     error!(parent: node.span(), "can't process a message from {addr}: {e}");
-                    node.known_peers().register_failure(addr);
+                    node.known_peers().register_failure(addr.ip());
                 }
                 #[cfg(feature = "metrics")]
                 metrics::decrement_gauge(metrics::tcp::TCP_TASKS, 1f64);
@@ -178,7 +178,7 @@ impl<R: Reading> ReadingInternal for R {
                     }
                     Err(e) => {
                         error!(parent: node.span(), "can't read from {addr}: {e}");
-                        node.known_peers().register_failure(addr);
+                        node.known_peers().register_failure(addr.ip());
                         if node.config().fatal_io_errors.contains(&e.kind()) {
                             break;
                         }
@@ -229,7 +229,7 @@ impl<D: Decoder> Decoder for CountingCodec<D> {
 
             if ret.is_some() {
                 self.acc = 0;
-                self.node.known_peers().register_received_message(self.addr, read_len);
+                self.node.known_peers().register_received_message(self.addr.ip(), read_len);
                 self.node.stats().register_received_message(read_len);
             } else {
                 self.acc = read_len;

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -219,12 +219,12 @@ impl<W: Writing> WritingInternal for W {
                 match self_clone.write_to_stream(*msg, &mut framed).await {
                     Ok(len) => {
                         let _ = wrapped_msg.delivery_notification.send(Ok(()));
-                        node.known_peers().register_sent_message(addr, len);
+                        node.known_peers().register_sent_message(addr.ip(), len);
                         node.stats().register_sent_message(len);
                         trace!(parent: node.span(), "sent {}B to {}", len, addr);
                     }
                     Err(e) => {
-                        node.known_peers().register_failure(addr);
+                        node.known_peers().register_failure(addr.ip());
                         error!(parent: node.span(), "couldn't send a message to {}: {}", addr, e);
                         let is_fatal = node.config().fatal_io_errors.contains(&e.kind());
                         let _ = wrapped_msg.delivery_notification.send(Err(e));

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -22,7 +22,7 @@ use std::{
         atomic::{AtomicUsize, Ordering::*},
         Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use once_cell::sync::OnceCell;
@@ -101,7 +101,7 @@ impl Tcp {
             connecting: Default::default(),
             connections: Default::default(),
             known_peers: Default::default(),
-            stats: Default::default(),
+            stats: Stats::new(Instant::now()),
             tasks: Default::default(),
         }));
 
@@ -255,7 +255,7 @@ impl Tcp {
 
         if let Err(ref e) = ret {
             self.connecting.lock().remove(&addr);
-            self.known_peers().register_failure(addr);
+            self.known_peers().register_failure(addr.ip());
             error!(parent: self.span(), "Unable to initiate a connection with {addr}: {e}");
         }
 
@@ -280,13 +280,6 @@ impl Tcp {
             // Shut down the associated tasks of the peer.
             for task in conn.tasks.iter().rev() {
                 task.abort();
-            }
-
-            // If the (owning) Tcp was not the initiator of the connection, it doesn't know the listening address
-            // of the associated peer, so the related stats are unreliable; the next connection initiated by the
-            // peer could be bound to an entirely different port number
-            if conn.side() == ConnectionSide::Initiator {
-                self.known_peers().remove(conn.addr());
             }
 
             debug!(parent: self.span(), "Disconnected from {}", conn.addr());
@@ -386,7 +379,7 @@ impl Tcp {
         tokio::spawn(async move {
             if let Err(e) = tcp.adapt_stream(stream, addr, ConnectionSide::Responder).await {
                 tcp.connecting.lock().remove(&addr);
-                tcp.known_peers().register_failure(addr);
+                tcp.known_peers().register_failure(addr.ip());
                 error!(parent: tcp.span(), "Failed to connect with {addr}: {e}");
             }
         });
@@ -426,7 +419,7 @@ impl Tcp {
 
     /// Prepares the freshly acquired connection to handle the protocols the Tcp implements.
     async fn adapt_stream(&self, stream: TcpStream, peer_addr: SocketAddr, own_side: ConnectionSide) -> io::Result<()> {
-        self.known_peers.add(peer_addr);
+        self.known_peers.add(peer_addr.ip());
 
         // Register the port seen by the peer.
         if own_side == ConnectionSide::Initiator {


### PR DESCRIPTION
This PR primarily targets https://github.com/AleoNet/snarkOS/issues/3311, but my intention is for the new setup to be extensible based on potential future needs (e.g. detecting and banning for message spam).

The 1st commit alters the (currently mostly unused) low-level `KnownPeers` collection to work on IPs only (instead of IP+port pairs) and extends the related `Stats` object with a `timestamp` field which is updated whenever a (low-level) connection is established.

The new IP-level bans are introduced only at the (higher-level) handshake level for the following reasons:
- the BFT setup can use and configure them separately from the `Router` setup
- the `Heartbeat` can be used to clean up expired bans
- the overall setup is simpler that way (e.g. the `Tcp` doesn't need to do any housekeeping)

The downside is that several concurrent low-level connection attempts may still be accepted even post-IP-ban. However, this would also (though to a lesser extent) be the case if the ban check was moved "to the lower level", as we would still have to accept an inbound connection before being able to check its IP. That being said, these are relatively lightweight and still subject to peer limits.

The ban-related `const`s were picked arbitrarily and we may choose any other values instead. Also, this new feature is disabled for tests and `--dev` runs (since they almost exclusively involve a single localhost IP).

CI run is [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkOS?branch=feat%2Fper_ip_bans_ci)