### PR TITLE
[Fix] Add checksum to `TransmissionID`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,7 +3336,7 @@ dependencies = [
  "snarkos-node-consensus",
  "snarkos-node-router",
  "snarkvm",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
+ "snarkvm-synthesizer",
  "time",
  "tokio",
  "tower",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3473,14 +3473,14 @@ dependencies = [
  "rayon",
  "self_update 0.38.0",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
  "snarkvm-ledger",
  "snarkvm-metrics",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-parameters",
+ "snarkvm-synthesizer",
+ "snarkvm-utilities",
  "thiserror",
  "ureq",
  "walkdir",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3509,519 +3509,253 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-algorithms"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "aleo-std",
- "anyhow",
- "blake2",
- "cfg-if",
- "fxhash",
- "hashbrown 0.14.5",
- "hex",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "num-traits",
- "parking_lot",
- "rand",
- "rand_chacha",
- "rand_core",
- "rayon",
- "serde",
- "sha2",
- "smallvec",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-program",
+ "snarkvm-circuit-types",
 ]
 
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-account"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-account",
 ]
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-algorithms"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-types",
+ "snarkvm-console-algorithms",
+ "snarkvm-fields",
 ]
 
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-collections"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-types",
+ "snarkvm-console-collections",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-environment"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "nom",
- "num-traits",
- "once_cell",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit-environment-witness",
+ "snarkvm-console-network",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-
-[[package]]
-name = "snarkvm-circuit-environment-witness"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-network"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-types",
+ "snarkvm-console-network",
 ]
 
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "paste",
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-program"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "paste",
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-program",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-address",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-circuit-types-string",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-address"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-address",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-boolean"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-console-types-boolean",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-field"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-console-types-field",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-group"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-group",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-integers"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-integers",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-scalar"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-circuit-types-string"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-console-types-string",
 ]
 
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-program",
+ "snarkvm-console-types",
 ]
 
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "bs58",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-account"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "bs58",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "tiny-keccak",
-]
-
-[[package]]
-name = "snarkvm-console-algorithms"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "blake2s_simd",
- "smallvec",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-types",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-collections"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "aleo-std",
- "rayon",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-types",
 ]
 
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4030,44 +3764,21 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-network"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "anyhow",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "lazy_static",
- "once_cell",
- "paste",
- "serde",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-algorithms",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4076,34 +3787,16 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-network-environment"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "anyhow",
- "bech32",
- "itertools 0.11.0",
- "nom",
- "num-traits",
- "rand",
- "serde",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4114,244 +3807,120 @@ dependencies = [
  "once_cell",
  "paste",
  "serde_json",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-program"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "enum-iterator",
- "enum_index",
- "enum_index_derive",
- "indexmap 2.2.6",
- "num-derive",
- "num-traits",
- "once_cell",
- "paste",
- "serde_json",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-types"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-address",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
+ "snarkvm-console-types-integers",
+ "snarkvm-console-types-scalar",
+ "snarkvm-console-types-string",
 ]
 
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-types-address"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
 ]
 
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-types-boolean"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-types-field"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-types-group"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-types-integers"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
 ]
 
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-types-scalar"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-console-types-string"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-integers",
 ]
 
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "rand",
  "rayon",
  "rustc_version",
  "serde",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-curves"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "rand",
- "rayon",
- "rustc_version",
- "serde",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-fields",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4360,24 +3929,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-fields"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "aleo-std",
- "anyhow",
- "itertools 0.11.0",
- "num-traits",
- "rand",
- "rayon",
- "serde",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-utilities",
  "thiserror",
  "zeroize",
 ]
@@ -4385,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4393,16 +3945,16 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-ledger-test-helpers",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-synthesizer",
  "time",
  "tracing",
 ]
@@ -4410,81 +3962,39 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "anyhow",
  "rand",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-authority"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "anyhow",
- "rand",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-subdag",
 ]
 
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-block"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
 ]
 
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-committee"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4494,8 +4004,8 @@ dependencies = [
  "rand_distr",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-metrics",
  "test-strategy",
 ]
@@ -4503,143 +4013,94 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-ledger-narwhal-data",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-ledger-narwhal-subdag",
  "snarkvm-ledger-narwhal-transmission",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-ledger-narwhal-transmission-id",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-transmission-id",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-batch-header"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-transmission-id",
  "time",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
  "tokio",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-subdag"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "indexmap 2.2.6",
- "rayon",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-transmission-id",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
  "snarkvm-ledger-narwhal-data",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-narwhal-transmission-id"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
 ]
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4652,49 +4113,14 @@ dependencies = [
  "rand_chacha",
  "rayon",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-puzzle"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "indexmap 2.2.6",
- "lru",
- "once_cell",
- "parking_lot",
- "rand",
- "rand_chacha",
- "rayon",
- "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-algorithms",
+ "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-dependencies = [
- "anyhow",
- "colored",
- "indexmap 2.2.6",
- "rand",
- "rand_chacha",
- "rayon",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-puzzle-epoch"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4705,65 +4131,30 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
  "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-synthesizer-program",
 ]
 
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-dependencies = [
- "async-trait",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "ureq",
-]
-
-[[package]]
-name = "snarkvm-ledger-query"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "async-trait",
  "reqwest",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
  "ureq",
 ]
 
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-dependencies = [
- "aleo-std-storage",
- "anyhow",
- "bincode",
- "indexmap 2.2.6",
- "parking_lot",
- "rayon",
- "serde",
- "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-ledger-store"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4776,36 +4167,36 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
  "tracing",
 ]
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "once_cell",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-synthesizer-program",
 ]
 
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4814,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4831,67 +4222,15 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "thiserror",
-]
-
-[[package]]
-name = "snarkvm-parameters"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "cfg-if",
- "colored",
- "curl",
- "hex",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "lazy_static",
- "parking_lot",
- "paste",
- "rand",
- "serde_json",
- "sha2",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-curves",
+ "snarkvm-utilities",
  "thiserror",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-dependencies = [
- "aleo-std",
- "anyhow",
- "indexmap 2.2.6",
- "itertools 0.11.0",
- "lru",
- "parking_lot",
- "rand",
- "serde",
- "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-puzzle-epoch 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "tracing",
-]
-
-[[package]]
-name = "snarkvm-synthesizer"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4901,27 +4240,29 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "serde",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-puzzle 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-puzzle-epoch 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-puzzle-epoch",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
  "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
  "tracing",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4931,74 +4272,47 @@ dependencies = [
  "rand",
  "rayon",
  "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
  "rand",
  "rand_chacha",
  "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-synthesizer-program"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "indexmap 2.2.6",
- "paste",
- "rand",
- "rand_chacha",
- "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-circuit",
+ "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "bincode",
  "once_cell",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
-]
-
-[[package]]
-name = "snarkvm-synthesizer-snark"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "bincode",
- "once_cell",
- "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-algorithms",
+ "snarkvm-circuit",
+ "snarkvm-console",
 ]
 
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5011,28 +4325,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=8a05317)",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-utilities"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "num-bigint",
- "num_cpus",
- "rand",
- "rand_xorshift",
- "rayon",
- "serde",
- "serde_json",
- "smol_str",
- "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f)",
+ "snarkvm-utilities-derives",
  "thiserror",
  "zeroize",
 ]
@@ -5040,17 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
-dependencies = [
- "proc-macro2",
- "quote 1.0.36",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "snarkvm-utilities-derives"
-version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=a6d175a#a6d175aa0b4a4f738cae4e44aa9405a028041216"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=68f4f31#68f4f31c15181c4f31aeed95426848c7feeb9bba"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4299,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=f48330b#f48330b90e06c565c8a044a8940122004e550609"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=653cc1b#653cc1ba101cf0622237a4beaa80ad79116e144c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "f48330b" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "653cc1b" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "a6d175a" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "68f4f31" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,9 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-git = "https://github.com/AleoNet/snarkVM.git"
-rev = "d170a9f" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+path = "../snarkVM"
+#git = "https://github.com/AleoNet/snarkVM.git"
+#rev = "d170a9f" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "653cc1b" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "a6d175a" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-path = "../snarkVM"
-#git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "d170a9f" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+#path = "../snarkVM"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "f48330b" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -292,10 +292,17 @@ pub mod prop_tests {
             .boxed()
     }
 
+    pub fn any_transmission_checksum() -> BoxedStrategy<<CurrentNetwork as Network>::TransmissionChecksum> {
+        Just(0)
+            .prop_perturb(|_, mut rng| <CurrentNetwork as Network>::TransmissionChecksum::from(Field::rand(&mut rng)))
+            .boxed()
+    }
+
     pub fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
         prop_oneof![
-            any_transaction_id().prop_map(TransmissionID::Transaction),
-            any_solution_id().prop_map(TransmissionID::Solution),
+            ((any_transaction_id(), any_transmission_checksum()))
+                .prop_map(|(id, cs)| TransmissionID::Transaction(id, cs)),
+            ((any_solution_id(), any_transmission_checksum())).prop_map(|(id, cs)| TransmissionID::Solution(id, cs)),
         ]
         .boxed()
     }

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -293,16 +293,14 @@ pub mod prop_tests {
     }
 
     pub fn any_transmission_checksum() -> BoxedStrategy<<CurrentNetwork as Network>::TransmissionChecksum> {
-        Just(0)
-            .prop_perturb(|_, mut rng| <CurrentNetwork as Network>::TransmissionChecksum::from(Field::rand(&mut rng)))
-            .boxed()
+        Just(0).prop_perturb(|_, mut rng| rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>()).boxed()
     }
 
     pub fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
         prop_oneof![
-            ((any_transaction_id(), any_transmission_checksum()))
+            (any_transaction_id(), any_transmission_checksum())
                 .prop_map(|(id, cs)| TransmissionID::Transaction(id, cs)),
-            ((any_solution_id(), any_transmission_checksum())).prop_map(|(id, cs)| TransmissionID::Solution(id, cs)),
+            (any_solution_id(), any_transmission_checksum()).prop_map(|(id, cs)| TransmissionID::Solution(id, cs)),
         ]
         .boxed()
     }

--- a/node/bft/events/src/transmission_request.rs
+++ b/node/bft/events/src/transmission_request.rs
@@ -58,31 +58,14 @@ impl<N: Network> FromBytes for TransmissionRequest<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{
-        prop_tests::{any_solution_id, any_transaction_id},
-        TransmissionRequest,
-    };
-    use snarkvm::{
-        console::prelude::{FromBytes, ToBytes},
-        ledger::narwhal::TransmissionID,
-    };
+    use crate::{prop_tests::any_transmission_id, TransmissionRequest};
+    use snarkvm::console::prelude::{FromBytes, ToBytes};
 
     use bytes::{Buf, BufMut, BytesMut};
-    use proptest::{
-        prelude::{BoxedStrategy, Strategy},
-        prop_oneof,
-    };
+    use proptest::prelude::{BoxedStrategy, Strategy};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
-
-    fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
-        prop_oneof![
-            any_solution_id().prop_map(TransmissionID::Solution),
-            any_transaction_id().prop_map(TransmissionID::Transaction),
-        ]
-        .boxed()
-    }
 
     pub fn any_transmission_request() -> BoxedStrategy<TransmissionRequest<CurrentNetwork>> {
         any_transmission_id().prop_map(TransmissionRequest::new).boxed()

--- a/node/bft/events/src/transmission_response.rs
+++ b/node/bft/events/src/transmission_response.rs
@@ -62,7 +62,7 @@ impl<N: Network> FromBytes for TransmissionResponse<N> {
 #[cfg(test)]
 pub mod prop_tests {
     use crate::{
-        prop_tests::{any_solution_id, any_transaction_id},
+        prop_tests::{any_solution_id, any_transaction_id, any_transmission_checksum},
         TransmissionResponse,
     };
     use snarkvm::{
@@ -82,14 +82,18 @@ pub mod prop_tests {
 
     pub fn any_transmission() -> BoxedStrategy<(TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>)> {
         prop_oneof![
-            (any_solution_id(), collection::vec(any::<u8>(), 256..=256)).prop_map(|(pc, bytes)| (
-                TransmissionID::Solution(pc),
-                Transmission::Solution(Data::Buffer(Bytes::from(bytes)))
-            )),
-            (any_transaction_id(), collection::vec(any::<u8>(), 512..=512)).prop_map(|(tid, bytes)| (
-                TransmissionID::Transaction(tid),
-                Transmission::Transaction(Data::Buffer(Bytes::from(bytes)))
-            )),
+            (any_solution_id(), any_transmission_checksum(), collection::vec(any::<u8>(), 256..=256)).prop_map(
+                |(pc, cs, bytes)| (
+                    TransmissionID::Solution(pc, cs),
+                    Transmission::Solution(Data::Buffer(Bytes::from(bytes)))
+                )
+            ),
+            (any_transaction_id(), any_transmission_checksum(), collection::vec(any::<u8>(), 512..=512)).prop_map(
+                |(tid, cs, bytes)| (
+                    TransmissionID::Transaction(tid, cs),
+                    Transmission::Transaction(Data::Buffer(Bytes::from(bytes)))
+                )
+            ),
         ]
         .boxed()
     }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -169,7 +169,11 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
 
     /// Returns `false` for all queries.
     fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool> {
-        trace!("[MockLedgerService] Contains transmission ID {} - false", fmt_id(transmission_id));
+        trace!(
+            "[MockLedgerService] Contains transmission ID {}.{} - false",
+            fmt_id(transmission_id),
+            fmt_id(transmission_id.checksum().unwrap_or_default())
+        );
         Ok(false)
     }
 
@@ -179,7 +183,11 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         transmission_id: TransmissionID<N>,
         _transmission: &mut Transmission<N>,
     ) -> Result<()> {
-        trace!("[MockLedgerService] Ensure transmission ID matches {:?} - Ok", fmt_id(transmission_id));
+        trace!(
+            "[MockLedgerService] Ensure transmission ID matches {}.{} - Ok",
+            fmt_id(transmission_id),
+            fmt_id(transmission_id.checksum().unwrap_or_default())
+        );
         Ok(())
     }
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -602,7 +602,7 @@ impl<N: Network> BFT<N> {
                     // Retrieve the transmissions.
                     for transmission_id in certificate.transmission_ids() {
                         // If the transmission already exists in the map, skip it.
-                        if transmissions.contains_key(transmission_id.0) {
+                        if transmissions.contains_key(transmission_id) {
                             continue;
                         }
                         // If the transmission already exists in the ledger, skip it.
@@ -619,7 +619,7 @@ impl<N: Network> BFT<N> {
                             );
                         };
                         // Add the transmission to the set.
-                        transmissions.insert(*transmission_id.0, transmission);
+                        transmissions.insert(*transmission_id, transmission);
                     }
                 }
                 // Trigger consensus, as this will build a new block for the ledger.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -602,7 +602,7 @@ impl<N: Network> BFT<N> {
                     // Retrieve the transmissions.
                     for transmission_id in certificate.transmission_ids() {
                         // If the transmission already exists in the map, skip it.
-                        if transmissions.contains_key(transmission_id) {
+                        if transmissions.contains_key(transmission_id.0) {
                             continue;
                         }
                         // If the transmission already exists in the ledger, skip it.
@@ -619,7 +619,7 @@ impl<N: Network> BFT<N> {
                             );
                         };
                         // Add the transmission to the set.
-                        transmissions.insert(*transmission_id, transmission);
+                        transmissions.insert(*transmission_id.0, transmission);
                     }
                 }
                 // Trigger consensus, as this will build a new block for the ledger.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -613,8 +613,9 @@ impl<N: Network> BFT<N> {
                         // Retrieve the transmission.
                         let Some(transmission) = self.storage().get_transmission(*transmission_id) else {
                             bail!(
-                                "BFT failed to retrieve transmission '{}' from round {}",
+                                "BFT failed to retrieve transmission '{}.{}' from round {}",
                                 fmt_id(transmission_id),
+                                fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed(),
                                 certificate.round()
                             );
                         };

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -226,7 +226,7 @@ mod tests {
 
     impl Input for TransmissionID<CurrentNetwork> {
         fn input() -> Self {
-            TransmissionID::Transaction(Default::default())
+            TransmissionID::Transaction(Default::default(), Default::default())
         }
     }
 

--- a/node/bft/src/helpers/partition.rs
+++ b/node/bft/src/helpers/partition.rs
@@ -93,6 +93,6 @@ mod tests {
         let transmission_id: TransmissionID<CurrentNetwork> =
             TransmissionID::Solution(SolutionID::from(123456789), 12345);
         let worker_id = assign_to_worker(transmission_id, 5).unwrap();
-        assert_eq!(worker_id, 2);
+        assert_eq!(worker_id, 4);
     }
 }

--- a/node/bft/src/helpers/partition.rs
+++ b/node/bft/src/helpers/partition.rs
@@ -90,7 +90,8 @@ mod tests {
         ]);
         let hash = sha256d_to_u128(data);
         assert_eq!(hash, 274520597840828436951879875061540363633u128);
-        let transmission_id: TransmissionID<CurrentNetwork> = TransmissionID::Solution(SolutionID::from(123456789));
+        let transmission_id: TransmissionID<CurrentNetwork> =
+            TransmissionID::Solution(SolutionID::from(123456789), 12345);
         let worker_id = assign_to_worker(transmission_id, 5).unwrap();
         assert_eq!(worker_id, 2);
     }

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -261,10 +261,22 @@ mod tests {
         assert_eq!(pending.len(), 0);
 
         // Initialize the solution IDs.
-        let solution_id_1 = TransmissionID::Solution(rng.gen::<u64>().into());
-        let solution_id_2 = TransmissionID::Solution(rng.gen::<u64>().into());
-        let solution_id_3 = TransmissionID::Solution(rng.gen::<u64>().into());
-        let solution_id_4 = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id_1 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
+        let solution_id_2 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
+        let solution_id_3 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
+        let solution_id_4 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
 
         // Initialize the SocketAddrs.
         let addr_1 = SocketAddr::from(([127, 0, 0, 1], 1234));
@@ -303,7 +315,10 @@ mod tests {
         assert!(pending.contains_peer(solution_id_4, addr_4));
         assert!(!pending.contains_peer_with_sent_request(solution_id_4, addr_4));
 
-        let unknown_id = TransmissionID::Solution(rng.gen::<u64>().into());
+        let unknown_id = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
         assert!(!pending.contains(unknown_id));
 
         // Check get.
@@ -336,7 +351,10 @@ mod tests {
         assert_eq!(pending.len(), 0);
 
         // Initialize the solution ID.
-        let solution_id_1 = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id_1 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
 
         // Initialize the SocketAddrs.
         let addr_1 = SocketAddr::from(([127, 0, 0, 1], 1234));
@@ -382,7 +400,10 @@ mod tests {
 
         for _ in 0..ITERATIONS {
             // Generate a solution ID.
-            let solution_id = TransmissionID::Solution(rng.gen::<u64>().into());
+            let solution_id = TransmissionID::Solution(
+                rng.gen::<u64>().into(),
+                rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+            );
             // Check if the number of sent requests is correct.
             let mut expected_num_sent_requests = 0;
             for i in 0..ITERATIONS {
@@ -416,8 +437,14 @@ mod tests {
         assert_eq!(pending.len(), 0);
 
         // Initialize the solution IDs.
-        let solution_id_1 = TransmissionID::Solution(rng.gen::<u64>().into());
-        let solution_id_2 = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id_1 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
+        let solution_id_2 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
 
         // Initialize the SocketAddrs.
         let addr_1 = SocketAddr::from(([127, 0, 0, 1], 1234));

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -82,7 +82,7 @@ impl<N: Network> Ready<N> {
     /// Returns the solutions in the ready queue.
     pub fn solutions(&self) -> impl '_ + Iterator<Item = (SolutionID<N>, Data<Solution<N>>)> {
         self.transmissions.read().clone().into_iter().filter_map(|(id, transmission)| match (id, transmission) {
-            (TransmissionID::Solution(id), Transmission::Solution(solution)) => Some((id, solution)),
+            (TransmissionID::Solution(id, _), Transmission::Solution(solution)) => Some((id, solution)),
             _ => None,
         })
     }
@@ -90,7 +90,7 @@ impl<N: Network> Ready<N> {
     /// Returns the transactions in the ready queue.
     pub fn transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
         self.transmissions.read().clone().into_iter().filter_map(|(id, transmission)| match (id, transmission) {
-            (TransmissionID::Transaction(id), Transmission::Transaction(tx)) => Some((id, tx)),
+            (TransmissionID::Transaction(id, _), Transmission::Transaction(tx)) => Some((id, tx)),
             _ => None,
         })
     }
@@ -156,9 +156,18 @@ mod tests {
         let ready = Ready::<CurrentNetwork>::new();
 
         // Initialize the solution IDs.
-        let solution_id_1 = TransmissionID::Solution(rng.gen::<u64>().into());
-        let solution_id_2 = TransmissionID::Solution(rng.gen::<u64>().into());
-        let solution_id_3 = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id_1 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
+        let solution_id_2 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
+        let solution_id_3 = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
 
         // Initialize the solutions.
         let solution_1 = Transmission::Solution(data(rng));
@@ -179,7 +188,10 @@ mod tests {
         transmission_ids.iter().for_each(|id| assert!(ready.contains(*id)));
 
         // Check that an unknown solution ID is not in the ready queue.
-        let solution_id_unknown = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id_unknown = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
         assert!(!ready.contains(solution_id_unknown));
 
         // Check the transmissions.
@@ -219,7 +231,10 @@ mod tests {
         let ready = Ready::<CurrentNetwork>::new();
 
         // Initialize the solution ID.
-        let solution_id = TransmissionID::Solution(rng.gen::<u64>().into());
+        let solution_id = TransmissionID::Solution(
+            rng.gen::<u64>().into(),
+            rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+        );
 
         // Initialize the solution.
         let solution = Transmission::Solution(data);

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -691,7 +691,7 @@ impl<N: Network> Storage<N> {
             // Retrieve the transmission.
             match transmission_id {
                 TransmissionID::Ratification => (),
-                TransmissionID::Solution(solution_id) => {
+                TransmissionID::Solution(solution_id, _) => {
                     // Retrieve the solution.
                     match block.get_solution(solution_id) {
                         // Insert the solution.
@@ -716,7 +716,7 @@ impl<N: Network> Storage<N> {
                         },
                     };
                 }
-                TransmissionID::Transaction(transaction_id) => {
+                TransmissionID::Transaction(transaction_id, _) => {
                     // Retrieve the transaction.
                     match unconfirmed_transactions.get(transaction_id) {
                         // Insert the transaction.
@@ -1156,8 +1156,14 @@ pub mod prop_tests {
 
     pub fn any_transmission_id() -> BoxedStrategy<TransmissionID<CurrentNetwork>> {
         prop_oneof![
-            any_transaction_id().prop_map(TransmissionID::Transaction),
-            any_solution_id().prop_map(TransmissionID::Solution),
+            any_transaction_id().prop_perturb(|id, mut rng| TransmissionID::Transaction(
+                id,
+                rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>()
+            )),
+            any_solution_id().prop_perturb(|id, mut rng| TransmissionID::Solution(
+                id,
+                rng.gen::<<CurrentNetwork as Network>::TransmissionChecksum>()
+            )),
         ]
         .boxed()
     }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -522,14 +522,39 @@ impl<N: Network> Primary<N> {
                     }
                     // Check the transmission is still valid.
                     match (id, transmission.clone()) {
-                        (TransmissionID::Solution(solution_id), Transmission::Solution(solution)) => {
+                        (TransmissionID::Solution(solution_id, checksum), Transmission::Solution(solution)) => {
+                            // Ensure the checksum matches.
+                            match solution.to_checksum::<N>() {
+                                Ok(solution_checksum) if solution_checksum == checksum => (),
+                                _ => {
+                                    trace!(
+                                        "Proposing - Skipping solution '{}' - Checksum mismatch",
+                                        fmt_id(solution_id)
+                                    );
+                                    continue 'inner;
+                                }
+                            }
                             // Check if the solution is still valid.
                             if let Err(e) = self.ledger.check_solution_basic(solution_id, solution).await {
                                 trace!("Proposing - Skipping solution '{}' - {e}", fmt_id(solution_id));
                                 continue 'inner;
                             }
                         }
-                        (TransmissionID::Transaction(transaction_id), Transmission::Transaction(transaction)) => {
+                        (
+                            TransmissionID::Transaction(transaction_id, checksum),
+                            Transmission::Transaction(transaction),
+                        ) => {
+                            // Ensure the checksum matches.
+                            match transaction.to_checksum::<N>() {
+                                Ok(transaction_checksum) if transaction_checksum == checksum => (),
+                                _ => {
+                                    trace!(
+                                        "Proposing - Skipping transaction '{}' - Checksum mismatch",
+                                        fmt_id(transaction_id)
+                                    );
+                                    continue 'inner;
+                                }
+                            }
                             // Check if the transaction is still valid.
                             if let Err(e) = self.ledger.check_transaction_basic(transaction_id, transaction).await {
                                 trace!("Proposing - Skipping transaction '{}' - {e}", fmt_id(transaction_id));
@@ -1212,8 +1237,13 @@ impl<N: Network> Primary<N> {
         let self_ = self.clone();
         self.spawn(async move {
             while let Some((solution_id, solution, callback)) = rx_unconfirmed_solution.recv().await {
+                // Compute the checksum for the solution.
+                let Ok(checksum) = solution.to_checksum::<N>() else {
+                    error!("Failed to compute the checksum for the unconfirmed solution");
+                    continue;
+                };
                 // Compute the worker ID.
-                let Ok(worker_id) = assign_to_worker(solution_id, self_.num_workers()) else {
+                let Ok(worker_id) = assign_to_worker((solution_id, checksum), self_.num_workers()) else {
                     error!("Unable to determine the worker ID for the unconfirmed solution");
                     continue;
                 };
@@ -1234,8 +1264,13 @@ impl<N: Network> Primary<N> {
         self.spawn(async move {
             while let Some((transaction_id, transaction, callback)) = rx_unconfirmed_transaction.recv().await {
                 trace!("Primary - Received an unconfirmed transaction '{}'", fmt_id(transaction_id));
+                // Compute the checksum for the transaction.
+                let Ok(checksum) = transaction.to_checksum::<N>() else {
+                    error!("Failed to compute the checksum for the unconfirmed transaction");
+                    continue;
+                };
                 // Compute the worker ID.
-                let Ok(worker_id) = assign_to_worker::<N>(&transaction_id, self_.num_workers()) else {
+                let Ok(worker_id) = assign_to_worker::<N>((&transaction_id, &checksum), self_.num_workers()) else {
                     error!("Unable to determine the worker ID for the unconfirmed transaction");
                     continue;
                 };
@@ -1798,14 +1833,19 @@ mod tests {
     ) -> Proposal<CurrentNetwork> {
         let (solution_id, solution) = sample_unconfirmed_solution(rng);
         let (transaction_id, transaction) = sample_unconfirmed_transaction(rng);
+        let solution_checksum = solution.to_checksum::<CurrentNetwork>().unwrap();
+        let transaction_checksum = transaction.to_checksum::<CurrentNetwork>().unwrap();
+
+        let solution_transmission_id = (solution_id, solution_checksum).into();
+        let transaction_transmission_id = (&transaction_id, &transaction_checksum).into();
 
         // Retrieve the private key.
         let private_key = author.private_key();
         // Prepare the transmission IDs.
-        let transmission_ids = [solution_id.into(), (&transaction_id).into()].into();
+        let transmission_ids = [solution_transmission_id, transaction_transmission_id].into();
         let transmissions = [
-            (solution_id.into(), Transmission::Solution(solution)),
-            ((&transaction_id).into(), Transmission::Transaction(transaction)),
+            (solution_transmission_id, Transmission::Solution(solution)),
+            (transaction_transmission_id, Transmission::Transaction(transaction)),
         ]
         .into();
         // Sign the batch header.
@@ -1879,10 +1919,16 @@ mod tests {
         let committee_id = Field::rand(rng);
         let (solution_id, solution) = sample_unconfirmed_solution(rng);
         let (transaction_id, transaction) = sample_unconfirmed_transaction(rng);
-        let transmission_ids = [solution_id.into(), (&transaction_id).into()].into();
+        let solution_checksum = solution.to_checksum::<CurrentNetwork>().unwrap();
+        let transaction_checksum = transaction.to_checksum::<CurrentNetwork>().unwrap();
+
+        let solution_transmission_id = (solution_id, solution_checksum).into();
+        let transaction_transmission_id = (&transaction_id, &transaction_checksum).into();
+
+        let transmission_ids = [solution_transmission_id, transaction_transmission_id].into();
         let transmissions = [
-            (solution_id.into(), Transmission::Solution(solution)),
-            ((&transaction_id).into(), Transmission::Transaction(transaction)),
+            (solution_transmission_id, Transmission::Solution(solution)),
+            (transaction_transmission_id, Transmission::Transaction(transaction)),
         ]
         .into();
 
@@ -2021,6 +2067,8 @@ mod tests {
         // Generate a solution and a transaction.
         let (solution_commitment, solution) = sample_unconfirmed_solution(&mut rng);
         let (transaction_id, transaction) = sample_unconfirmed_transaction(&mut rng);
+        let solution_checksum = solution.to_checksum::<CurrentNetwork>().unwrap();
+        let transaction_checksum = transaction.to_checksum::<CurrentNetwork>().unwrap();
 
         // Store it on one of the workers.
         primary.workers[0].process_unconfirmed_solution(solution_commitment, solution).await.unwrap();
@@ -2064,8 +2112,10 @@ mod tests {
         // Check that the proposal only contains the new transmissions that were not in previous certificates.
         let proposed_transmissions = primary.proposed_batch.read().as_ref().unwrap().transmissions().clone();
         assert_eq!(proposed_transmissions.len(), 2);
-        assert!(proposed_transmissions.contains_key(&TransmissionID::Solution(solution_commitment)));
-        assert!(proposed_transmissions.contains_key(&TransmissionID::Transaction(transaction_id)));
+        assert!(proposed_transmissions.contains_key(&TransmissionID::Solution(solution_commitment, solution_checksum)));
+        assert!(
+            proposed_transmissions.contains_key(&TransmissionID::Transaction(transaction_id, transaction_checksum))
+        );
     }
 
     #[tokio::test]

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -332,7 +332,7 @@ impl<N: Network> Worker<N> {
         self.pending.remove(transmission_id, Some(transmission.clone()));
         // Check if the solution exists.
         if self.contains_transmission(transmission_id) {
-            bail!("Solution '{}.{}' already exists.", fmt_id(solution_id), fmt_id(checksum));
+            bail!("Solution '{}.{}' already exists.", fmt_id(solution_id), fmt_id(checksum).dimmed());
         }
         // Check that the solution is well-formed and unique.
         self.ledger.check_solution_basic(solution_id, solution).await?;
@@ -374,7 +374,7 @@ impl<N: Network> Worker<N> {
                 "Worker {}.{} - Added unconfirmed transaction '{}'",
                 self.id,
                 fmt_id(transaction_id),
-                fmt_id(checksum)
+                fmt_id(checksum).dimmed()
             );
         }
         Ok(())

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -331,7 +331,7 @@ impl<N: Network> Worker<N> {
         // Remove the solution ID from the pending queue.
         self.pending.remove(transmission_id, Some(transmission.clone()));
         // Check if the solution exists.
-        if self.contains_transmission((solution_id, checksum)) {
+        if self.contains_transmission(transmission_id) {
             bail!("Solution '{}.{}' already exists.", fmt_id(solution_id), fmt_id(checksum));
         }
         // Check that the solution is well-formed and unique.

--- a/node/bft/tests/components/worker.rs
+++ b/node/bft/tests/components/worker.rs
@@ -49,7 +49,7 @@ async fn test_resend_transmission_request() {
     let initial_peer_ip = peer_ips.pop().unwrap();
 
     // Prepare a dummy transmission ID.
-    let transmission_id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::default());
+    let transmission_id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::default(), <CurrentNetwork as Network>::TransmissionChecksum::default());
 
     // Ensure the worker does not have the dummy transmission ID.
     assert!(!worker.contains_transmission(transmission_id), "Transmission should not exist");
@@ -132,7 +132,7 @@ async fn test_flood_transmission_requests() {
     let mut remaining_peer_ips = peer_ips;
 
     // Prepare a dummy transmission ID.
-    let transmission_id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::default());
+    let transmission_id = TransmissionID::Transaction(<CurrentNetwork as Network>::TransactionID::default(), <CurrentNetwork as Network>::TransmissionChecksum::default());
 
     // Ensure the worker does not have the dummy transmission ID.
     assert!(!worker.contains_transmission(transmission_id), "Transmission should not exist");

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -534,7 +534,11 @@ impl<N: Network> Consensus<N> {
         for (transmission_id, transmission) in transmissions.into_iter() {
             // Reinsert the transmission into the memory pool.
             if let Err(e) = self.reinsert_transmission(transmission_id, transmission).await {
-                warn!("Unable to reinsert transmission {} into the memory pool - {e}", fmt_id(transmission_id));
+                warn!(
+                    "Unable to reinsert transmission {}.{} into the memory pool - {e}",
+                    fmt_id(transmission_id),
+                    fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed()
+                );
             }
         }
     }

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -119,8 +119,8 @@ pub fn add_transmission_latency_metric<N: Network>(
                 Some(*key)
             } else {
                 let transmission_type = match key {
-                    TransmissionID::Solution(solution_id) if solution_ids.contains(solution_id) => Some("solution"),
-                    TransmissionID::Transaction(transaction_id) if transaction_ids.contains(transaction_id) => {
+                    TransmissionID::Solution(solution_id, _) if solution_ids.contains(solution_id) => Some("solution"),
+                    TransmissionID::Transaction(transaction_id, _) if transaction_ids.contains(transaction_id) => {
                         Some("transaction")
                     }
                     _ => None,

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "f48330b"
+rev = "653cc1b"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "653cc1b"
+rev = "a6d175a"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "a6d175a"
+rev = "68f4f31"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -65,9 +65,9 @@ path = "../router"
 version = "=2.2.7"
 
 [dependencies.snarkvm-synthesizer]
-path = "../../../snarkVM/synthesizer"
-#git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "d170a9f"
+#path = "../../../snarkVM/synthesizer"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "f48330b"
 default-features = false
 optional = true
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -65,8 +65,9 @@ path = "../router"
 version = "=2.2.7"
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/AleoNet/snarkVM.git"
-rev = "d170a9f"
+path = "../../../snarkVM/synthesizer"
+#git = "https://github.com/AleoNet/snarkVM.git"
+#rev = "d170a9f"
 default-features = false
 optional = true
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR is the sister PR of https://github.com/AleoNet/snarkVM/pull/2521, which introduces the `TransmissionChecksum` and adds additional solution guards during block creation. In the snarkOS world, additional checks are added to enforce that incoming peer transmissions have the correct `TransmissionChecksum`. This prevents malicious validators from performing a malformed solution/transaction attack.

The CI is run [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkOS?branch=fix%2Ftransmission-checksum-ci).

## Related PRs

https://github.com/AleoNet/snarkVM/pull/2521
