### PR TITLE
[Fix] Cache block requests on the gateway

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -546,35 +546,35 @@ impl<N: Network> Gateway<N> {
             bail!("Dropping '{peer_ip}' for spamming events (num_events = {num_events})")
         }
         // Rate limit for duplicate requests.
-        if matches!(&event, &Event::CertificateRequest(_) | &Event::CertificateResponse(_)) {
-            // Retrieve the certificate ID.
-            let certificate_id = match &event {
-                Event::CertificateRequest(CertificateRequest { certificate_id }) => *certificate_id,
-                Event::CertificateResponse(CertificateResponse { certificate }) => certificate.id(),
-                _ => unreachable!(),
-            };
-            // Skip processing this certificate if the rate limit was exceed (i.e. someone is spamming a specific certificate).
-            let num_events = self.cache.insert_inbound_certificate(certificate_id, CACHE_REQUESTS_INTERVAL);
-            if num_events >= self.max_cache_duplicates() {
-                return Ok(());
+        match event {
+            Event::CertificateRequest(_) | Event::CertificateResponse(_) => {
+                // Retrieve the certificate ID.
+                let certificate_id = match &event {
+                    Event::CertificateRequest(CertificateRequest { certificate_id }) => *certificate_id,
+                    Event::CertificateResponse(CertificateResponse { certificate }) => certificate.id(),
+                    _ => unreachable!(),
+                };
+                // Skip processing this certificate if the rate limit was exceed (i.e. someone is spamming a specific certificate).
+                let num_events = self.cache.insert_inbound_certificate(certificate_id, CACHE_REQUESTS_INTERVAL);
+                if num_events >= self.max_cache_duplicates() {
+                    return Ok(());
+                }
             }
-        } else if matches!(&event, &Event::TransmissionRequest(_) | Event::TransmissionResponse(_)) {
-            // Retrieve the transmission ID.
-            let transmission_id = match &event {
-                Event::TransmissionRequest(TransmissionRequest { transmission_id }) => *transmission_id,
-                Event::TransmissionResponse(TransmissionResponse { transmission_id, .. }) => *transmission_id,
-                _ => unreachable!(),
-            };
-            // Skip processing this certificate if the rate limit was exceeded (i.e. someone is spamming a specific certificate).
-            let num_events = self.cache.insert_inbound_transmission(transmission_id, CACHE_REQUESTS_INTERVAL);
-            if num_events >= self.max_cache_duplicates() {
-                return Ok(());
+            Event::TransmissionRequest(TransmissionRequest { transmission_id })
+            | Event::TransmissionResponse(TransmissionResponse { transmission_id, .. }) => {
+                // Skip processing this certificate if the rate limit was exceeded (i.e. someone is spamming a specific certificate).
+                let num_events = self.cache.insert_inbound_transmission(transmission_id, CACHE_REQUESTS_INTERVAL);
+                if num_events >= self.max_cache_duplicates() {
+                    return Ok(());
+                }
             }
-        } else if matches!(&event, &Event::BlockRequest(_)) {
-            let num_events = self.cache.insert_inbound_block_request(peer_ip, CACHE_REQUESTS_INTERVAL);
-            if num_events >= self.max_cache_duplicates() {
-                return Ok(());
+            Event::BlockRequest(_) => {
+                let num_events = self.cache.insert_inbound_block_request(peer_ip, CACHE_REQUESTS_INTERVAL);
+                if num_events >= self.max_cache_duplicates() {
+                    return Ok(());
+                }
             }
+            _ => {}
         }
         trace!("{CONTEXT} Received '{}' from '{peer_ip}'", event.name());
 
@@ -988,29 +988,30 @@ impl<N: Network> Transport<N> for Gateway<N> {
             }};
         }
 
-        // If the event type is a certificate request, increment the cache.
-        if matches!(event, Event::CertificateRequest(_)) | matches!(event, Event::CertificateResponse(_)) {
-            // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
-            self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-            // Send the event to the peer.
-            send!(self, insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
-        }
-        // If the event type is a transmission request, increment the cache.
-        else if matches!(event, Event::TransmissionRequest(_)) | matches!(event, Event::TransmissionResponse(_)) {
-            // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
-            self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-            // Send the event to the peer.
-            send!(self, insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
-        } else if let Event::BlockRequest(request) = event {
-            // Insert the outbound request so we can match it to responses.
-            self.cache.insert_outbound_block_request(peer_ip, request);
-            // Send the event to the peer and updatet the outbound event cache, use the general rate limit.
-            send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
-        }
-        // Otherwise, employ a general rate limit.
-        else {
-            // Send the event to the peer.
-            send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
+        // Increment the cache for certificate, transmission and block events.
+        match event {
+            Event::CertificateRequest(_) | Event::CertificateResponse(_) => {
+                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
+                // Send the event to the peer.
+                send!(self, insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
+            }
+            Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => {
+                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
+                // Send the event to the peer.
+                send!(self, insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
+            }
+            Event::BlockRequest(request) => {
+                // Insert the outbound request so we can match it to responses.
+                self.cache.insert_outbound_block_request(peer_ip, request);
+                // Send the event to the peer and updatet the outbound event cache, use the general rate limit.
+                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
+            }
+            _ => {
+                // Send the event to the peer, use the general rate limit.
+                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
+            }
         }
     }
 

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::events::BlockRequest;
 use snarkvm::{console::types::Field, ledger::narwhal::TransmissionID, prelude::Network};
 
 use core::hash::Hash;
 use parking_lot::RwLock;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     net::{IpAddr, SocketAddr},
 };
 use time::OffsetDateTime;
@@ -32,6 +33,8 @@ pub struct Cache<N: Network> {
     seen_inbound_certificates: RwLock<BTreeMap<i64, HashMap<Field<N>, u32>>>,
     /// The ordered timestamp map of transmission IDs and cache hits.
     seen_inbound_transmissions: RwLock<BTreeMap<i64, HashMap<TransmissionID<N>, u32>>>,
+    /// The ordered timestamp map of inbound block requests and cache hits.
+    seen_inbound_block_requests: RwLock<BTreeMap<i64, HashMap<SocketAddr, u32>>>,
     /// The ordered timestamp map of peer IPs and their cache hits on outbound events.
     seen_outbound_events: RwLock<BTreeMap<i64, HashMap<SocketAddr, u32>>>,
     /// The ordered timestamp map of peer IPs and their cache hits on certificate requests.
@@ -40,6 +43,8 @@ pub struct Cache<N: Network> {
     seen_outbound_transmissions: RwLock<BTreeMap<i64, HashMap<SocketAddr, u32>>>,
     /// The map of IPs to the number of validators requests.
     seen_outbound_validators_requests: RwLock<HashMap<SocketAddr, u32>>,
+    /// The ordered timestamp map of outbound block requests and cache hits.
+    seen_outbound_block_requests: RwLock<HashMap<SocketAddr, HashSet<BlockRequest>>>,
 }
 
 impl<N: Network> Default for Cache<N> {
@@ -57,10 +62,12 @@ impl<N: Network> Cache<N> {
             seen_inbound_events: Default::default(),
             seen_inbound_certificates: Default::default(),
             seen_inbound_transmissions: Default::default(),
+            seen_inbound_block_requests: Default::default(),
             seen_outbound_events: Default::default(),
             seen_outbound_certificates: Default::default(),
             seen_outbound_transmissions: Default::default(),
             seen_outbound_validators_requests: Default::default(),
+            seen_outbound_block_requests: Default::default(),
         }
     }
 }
@@ -84,6 +91,11 @@ impl<N: Network> Cache<N> {
     /// Inserts a transmission ID into the cache, returning the number of recent events.
     pub fn insert_inbound_transmission(&self, key: TransmissionID<N>, interval_in_secs: i64) -> usize {
         Self::retain_and_insert(&self.seen_inbound_transmissions, key, interval_in_secs)
+    }
+
+    /// Inserts a block request into the cache, returning the number of recent events.
+    pub fn insert_inbound_block_request(&self, key: SocketAddr, interval_in_secs: i64) -> usize {
+        Self::retain_and_insert(&self.seen_inbound_block_requests, key, interval_in_secs)
     }
 }
 
@@ -123,6 +135,25 @@ impl<N: Network> Cache<N> {
     /// Clears the the IP's number of validator requests.
     pub fn clear_outbound_validators_requests(&self, peer_ip: SocketAddr) {
         self.seen_outbound_validators_requests.write().remove(&peer_ip);
+    }
+
+    /// Inserts the block request for the given peer.
+    pub fn insert_outbound_block_request(&self, peer_ip: SocketAddr, request: BlockRequest) {
+        self.seen_outbound_block_requests.write().entry(peer_ip).or_default().insert(request);
+    }
+
+    /// Removes the block request for the given peer. Returns whether the request was present.
+    pub fn remove_outbound_block_request(&self, peer_ip: SocketAddr, request: &BlockRequest) -> bool {
+        self.seen_outbound_block_requests
+            .write()
+            .get_mut(&peer_ip)
+            .map(|requests| requests.remove(request))
+            .unwrap_or(false)
+    }
+
+    /// Clears the peer's number of outbound block requests.
+    pub fn clear_outbound_block_requests(&self, peer_ip: SocketAddr) {
+        self.seen_outbound_block_requests.write().remove(&peer_ip);
     }
 }
 


### PR DESCRIPTION
This PR implements caching for block requests so they can be rate limited and matched to inbound block responses. I have also refactored some verbose branching logic to use `match` statements in the second commit. It can be dropped, if a smaller diff is preferred. 

I've opted to clear the outbound block request cache in the same way as the validator requests (https://github.com/AleoNet/snarkOS/pull/3254). Time-based expiry isn't necessary as the committee is bounded and the collection is cleared on peer disconnect. Inbound requests use a time-based expiry.

Fixes #3324.
