### PR TITLE
Updating Canary genesis block with TransmissionID checksum - v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "68f4f31" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "3d8b912" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -117,7 +117,7 @@ impl<N: Network> From<DisconnectReason> for Event<N> {
 
 impl<N: Network> Event<N> {
     /// The version of the event protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 6;
+    pub const VERSION: u32 = 7;
 
     /// Returns the event name.
     #[inline]

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "68f4f31"
+rev = "3d8b912"
 default-features = false
 optional = true
 

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -111,7 +111,7 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 15;
+    pub const VERSION: u32 = 16;
 
     /// Returns the message name.
     #[inline]


### PR DESCRIPTION
## Motivation

Please see below for improvements included in this release:
[[Fix] Add checksum to TransmissionID](https://github.com/AleoNet/snarkOS/pull/3367)

## Related PRs
The sister PR is https://github.com/AleoNet/snarkVM/pull/2522
https://github.com/AleoNet/snarkVM/pull/2521
[AleoNet/snarkOS#3367](https://github.com/AleoNet/snarkOS/pull/3367)
