### PR TITLE
comments about quorum threshold changed from (2f + 1) to (N - f)

### DIFF
--- a/node/bft/README.md
+++ b/node/bft/README.md
@@ -18,7 +18,8 @@ Each round runs until one of two conditions is met:
 
 #### Advancing Rounds
 
-As described in the paper, the BFT advances rounds whenever n − f vertices are delivered.
+As described in the paper [Bullshark: The Partially Synchronous Version](https://arxiv.org/abs/2209.05633),
+the BFT generally advances rounds when `n − f` vertices are delivered, however:
 ```
 The problem in advancing rounds whenever n − f vertices are delivered is that parties
 might not vote for the anchor even if the party that broadcast it is just slightly slower
@@ -28,6 +29,7 @@ do not include the anchor of round r, then p sets a timer and waits for the anch
 until the timer expires. Similarly, in an odd-numbered round, parties wait for either
 f + 1 vertices that vote for the anchor, or 2f + 1 vertices that do not, or a timeout.
 ```
+Note that in this quote `2f + 1` should really be `n - f`.
 
 ## Workers
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -325,7 +325,7 @@ impl<N: Network> BFT<N> {
         self.is_even_round_ready_for_next_round(current_certificates, committee_lookback, current_round)
     }
 
-    /// Returns 'true' if the quorum threshold `(2f + 1)` is reached for this round under one of the following conditions:
+    /// Returns 'true' if the quorum threshold `(N - f)` is reached for this round under one of the following conditions:
     ///  - If the leader certificate is set for the current even round.
     ///  - The timer for the leader certificate has expired.
     fn is_even_round_ready_for_next_round(
@@ -347,7 +347,7 @@ impl<N: Network> BFT<N> {
                 return true;
             }
         }
-        // If the timer has expired, and we can achieve quorum threshold (2f + 1) without the leader, return 'true'.
+        // If the timer has expired, and we can achieve quorum threshold (N - f) without the leader, return 'true'.
         if self.is_timer_expired() {
             debug!("BFT (timer expired) - Advancing from round {current_round} to the next round (without the leader)");
             return true;
@@ -361,7 +361,7 @@ impl<N: Network> BFT<N> {
         self.leader_certificate_timer.load(Ordering::SeqCst) + MAX_LEADER_CERTIFICATE_DELAY_IN_SECS <= now()
     }
 
-    /// Returns 'true' if the quorum threshold `(2f + 1)` is reached for this round under one of the following conditions:
+    /// Returns 'true' if the quorum threshold `(N - f)` is reached for this round under one of the following conditions:
     ///  - The leader certificate is `None`.
     ///  - The leader certificate is not included up to availability threshold `(f + 1)` (in the previous certificates of the current round).
     ///  - The leader certificate timer has expired.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -363,7 +363,7 @@ impl<N: Network> Storage<N> {
     /// - All previous certificates declared in the certificate exist in storage (up to GC).
     /// - All previous certificates are for the previous round (i.e. round - 1).
     /// - All previous certificates contain a unique author.
-    /// - The previous certificates reached the quorum threshold (2f+1).
+    /// - The previous certificates reached the quorum threshold (N - f).
     pub fn check_batch_header(
         &self,
         batch_header: &BatchHeader<N>,
@@ -458,9 +458,9 @@ impl<N: Network> Storage<N> {
     /// - All transmissions declared in the batch header are provided or exist in storage (up to GC).
     /// - All previous certificates declared in the certificate exist in storage (up to GC).
     /// - All previous certificates are for the previous round (i.e. round - 1).
-    /// - The previous certificates reached the quorum threshold (2f+1).
+    /// - The previous certificates reached the quorum threshold (N - f).
     /// - The timestamps from the signers are all within the allowed time range.
-    /// - The signers have reached the quorum threshold (2f+1).
+    /// - The signers have reached the quorum threshold (N - f).
     pub fn check_certificate(
         &self,
         certificate: &BatchCertificate<N>,
@@ -530,7 +530,7 @@ impl<N: Network> Storage<N> {
     /// - All transmissions declared in the certificate are provided or exist in storage (up to GC).
     /// - All previous certificates declared in the certificate exist in storage (up to GC).
     /// - All previous certificates are for the previous round (i.e. round - 1).
-    /// - The previous certificates reached the quorum threshold (2f+1).
+    /// - The previous certificates reached the quorum threshold (N - f).
     pub fn insert_certificate(
         &self,
         certificate: BatchCertificate<N>,

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1549,8 +1549,8 @@ impl<N: Network> Primary<N> {
 
         // Check if our primary should move to the next round.
         // Note: Checking that quorum threshold is reached is important for mitigating a race condition,
-        // whereby Narwhal requires 2f+1, however the BFT only requires f+1. Without this check, the primary
-        // will advance to the next round assuming f+1, not 2f+1, which can lead to a network stall.
+        // whereby Narwhal requires N-f, however the BFT only requires f+1. Without this check, the primary
+        // will advance to the next round assuming f+1, not N-f, which can lead to a network stall.
         let is_behind_schedule = is_quorum_threshold_reached && batch_round > self.current_round();
         // Check if our primary is far behind the peer.
         let is_peer_far_in_future = batch_round > self.current_round() + self.storage.max_gc_rounds();


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

In `snarkvm_ledger_committee`, `quorum_threshold` is correctly calculated as `N - f`.
Since `N` is not always `3f + 1` (it could be `3f + 2` or `3f + 3`),
the quorum threshold is not always `2f + 1`.

NOTE: no need for CI to pass since only comments were changed.

