### PR TITLE
Testnet Beta v0.4.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "83795c1" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "be171ce" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "83795c1"
+rev = "be171ce"
 default-features = false
 optional = true
 


### PR DESCRIPTION
## Motivation

Testnet Beta v0.4.0 release.

## Test Plan

Isonet and Canary runs prior to merge.

## Related PRs
Sister PR in snarkVM:
https://github.com/AleoNet/snarkVM/pull/2528
