### PR TITLE
Enclose check_next_block Call with Debug Assertions for Validators

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -479,7 +479,8 @@ impl<N: Network> Consensus<N> {
 
         // Create the candidate next block.
         let next_block = self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions)?;
-        // Check that the block is well-formed.
+        // Check that the block is well-formed. Run only in debug mode to catch issues during development; redundant for validators.
+        #[cfg(debug_assertions)]
         self.ledger.check_next_block(&next_block)?;
         // Advance to the next block.
         self.ledger.advance_to_next_block(&next_block)?;


### PR DESCRIPTION
## Motivation

The `check_next_block` function incurs significant processing time, which contributes to increased block times. For validators participating in consensus, the checks performed by this function are redundant, as they are already handled elsewhere in the codebase. This PR encloses the `check_next_block` call within debug assertions (`#[cfg(debug_assertions)]`) to optimize performance and reduce block times in production environments.

## Test Plan

Ran it locally. Todo: Further stress tests (load, syncing).

To verify that all checks remain adequately covered, you can find useful notes in this diff:

[check_next_block.patch](https://github.com/user-attachments/files/16731624/check_next_block.patch)