### PR TITLE
Canary v0.4.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4270,6 +4270,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "rand_chacha",
  "rayon",
  "serde_json",
  "snarkvm-circuit",
@@ -4285,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4299,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4312,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4333,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=be171ce#be171ce0720544c2bc51e27e1674a62fff585adc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "be171ce" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "5bb50a8" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -117,7 +117,7 @@ impl<N: Network> From<DisconnectReason> for Event<N> {
 
 impl<N: Network> Event<N> {
     /// The version of the event protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 7;
+    pub const VERSION: u32 = 8;
 
     /// Returns the event name.
     #[inline]

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -741,25 +741,28 @@ mod tests {
                 // Create a certificate for the leader.
                 if round <= 5 {
                     let leader = committee.get_leader(round).unwrap();
-                    let i = addresses.iter().position(|&address| address == leader).unwrap();
-                    let batch_header = BatchHeader::new(
-                        &private_keys[i],
-                        round,
-                        now(),
-                        committee_id,
-                        Default::default(),
-                        previous_certificate_ids.clone(),
-                        rng,
-                    )
-                    .unwrap();
-                    // Sign the batch header.
-                    let mut signatures = IndexSet::with_capacity(4);
-                    for (j, private_key_2) in private_keys.iter().enumerate() {
-                        if i != j {
-                            signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
+                    let leader_index = addresses.iter().position(|&address| address == leader).unwrap();
+                    let non_leader_index = addresses.iter().position(|&address| address != leader).unwrap();
+                    for i in [leader_index, non_leader_index].into_iter() {
+                        let batch_header = BatchHeader::new(
+                            &private_keys[i],
+                            round,
+                            now(),
+                            committee_id,
+                            Default::default(),
+                            previous_certificate_ids.clone(),
+                            rng,
+                        )
+                        .unwrap();
+                        // Sign the batch header.
+                        let mut signatures = IndexSet::with_capacity(4);
+                        for (j, private_key_2) in private_keys.iter().enumerate() {
+                            if i != j {
+                                signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
+                            }
                         }
+                        current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
                     }
-                    current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
                 }
 
                 // Create a certificate for each validator.
@@ -836,8 +839,15 @@ mod tests {
             for cert in storage.get_certificates_for_round(leader_round_2 - 1) {
                 previous_cert_map_2.insert(cert);
             }
+            let mut prev_commit_cert_map_2 = IndexSet::new();
+            for cert in storage.get_certificates_for_round(leader_round_2 - 2) {
+                if cert != leader_certificate {
+                    prev_commit_cert_map_2.insert(cert);
+                }
+            }
             subdag_map_2.insert(leader_round_2, leader_cert_map_2.clone());
             subdag_map_2.insert(leader_round_2 - 1, previous_cert_map_2.clone());
+            subdag_map_2.insert(leader_round_2 - 2, prev_commit_cert_map_2.clone());
             let subdag_2 = Subdag::from(subdag_map_2.clone())?;
             core_ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default())?
         };
@@ -856,8 +866,15 @@ mod tests {
             for cert in storage.get_certificates_for_round(leader_round_3 - 1) {
                 previous_cert_map_3.insert(cert);
             }
+            let mut prev_commit_cert_map_3 = IndexSet::new();
+            for cert in storage.get_certificates_for_round(leader_round_3 - 2) {
+                if cert != leader_certificate_2 {
+                    prev_commit_cert_map_3.insert(cert);
+                }
+            }
             subdag_map_3.insert(leader_round_3, leader_cert_map_3.clone());
             subdag_map_3.insert(leader_round_3 - 1, previous_cert_map_3.clone());
+            subdag_map_3.insert(leader_round_3 - 2, prev_commit_cert_map_3.clone());
             let subdag_3 = Subdag::from(subdag_map_3.clone())?;
             core_ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default())?
         };
@@ -875,14 +892,13 @@ mod tests {
         let sync = Sync::new(gateway.clone(), storage.clone(), syncing_ledger.clone());
         // Try to sync block 1.
         sync.sync_storage_with_block(block_1).await?;
-        // Ensure that the sync ledger has not advanced.
-        assert_eq!(syncing_ledger.latest_block_height(), 0);
+        assert_eq!(syncing_ledger.latest_block_height(), 1);
         // Try to sync block 2.
         sync.sync_storage_with_block(block_2).await?;
-        // Ensure that the sync ledger has not advanced.
-        assert_eq!(syncing_ledger.latest_block_height(), 0);
+        assert_eq!(syncing_ledger.latest_block_height(), 2);
         // Try to sync block 3.
         sync.sync_storage_with_block(block_3).await?;
+        assert_eq!(syncing_ledger.latest_block_height(), 3);
         // Ensure blocks 1 and 2 were added to the ledger.
         assert!(syncing_ledger.contains_block_height(1));
         assert!(syncing_ledger.contains_block_height(2));

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "be171ce"
+rev = "5bb50a8"
 default-features = false
 optional = true
 

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -111,7 +111,7 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 16;
+    pub const VERSION: u32 = 17;
 
     /// Returns the message name.
     #[inline]


### PR DESCRIPTION
## Motivation

Please see below for improvements included in this release:
[Fix] Add subdag verification checks
[Fix] Make deployment verification consistent by deterministically seeding the RNG.

## Related PRs
https://github.com/AleoNet/snarkVM/pull/2537
https://github.com/AleoNet/snarkVM/pull/2535
