### PR TITLE
Extend the IP-level ban to Router-bound connections

### DIFF
--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [features]
 default = [ ]
 metrics = [ "dep:metrics", "snarkos-node-bft-events/metrics", "snarkos-node-bft-ledger-service/metrics" ]
+test = [ ]
 
 [dependencies.aleo-std]
 workspace = true
@@ -151,6 +152,10 @@ version = "0.4"
 
 [dev-dependencies.rayon]
 version = "1"
+
+[dev-dependencies.snarkos-node-bft]
+path = "."
+features = [ "test" ]
 
 [dev-dependencies.snarkos-node-bft-ledger-service]
 path = "./ledger-service"

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -100,6 +100,26 @@ impl<N: Network> Router<N> {
             Some(peer_addr)
         };
 
+        // Check (or impose) IP-level bans.
+        #[cfg(not(any(test, feature = "test")))]
+        if !self.is_dev() && peer_side == ConnectionSide::Initiator {
+            // If the IP is already banned, update the ban timestamp and reject the connection.
+            if self.is_ip_banned(peer_addr.ip()) {
+                self.update_ip_ban(peer_addr.ip());
+                trace!("Rejected a connection request from banned IP '{}'", peer_addr.ip());
+                return Err(error(format!("'{}' is a banned IP address", peer_addr.ip())));
+            }
+
+            // Check the previous low-level connection timestamp.
+            if let Some(peer_stats) = self.tcp.known_peers().get(peer_addr.ip()) {
+                if peer_stats.timestamp().elapsed().as_secs() <= Router::<N>::MIN_CONNECTION_INTERVAL_IN_SECS {
+                    self.update_ip_ban(peer_addr.ip());
+                    trace!("Rejected a consecutive connection request from IP '{}'", peer_addr.ip());
+                    return Err(error(format!("'{}' appears to be spamming connections", peer_addr.ip())));
+                }
+            }
+        }
+
         // Perform the handshake; we pass on a mutable reference to peer_ip in case the process is broken at any point in time.
         let handshake_result = if peer_side == ConnectionSide::Responder {
             self.handshake_inner_initiator(peer_addr, &mut peer_ip, stream, genesis_header, restrictions_id).await

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -42,6 +42,8 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     const MAXIMUM_NUMBER_OF_PEERS: usize = 21;
     /// The maximum number of provers to maintain connections with.
     const MAXIMUM_NUMBER_OF_PROVERS: usize = Self::MAXIMUM_NUMBER_OF_PEERS / 4;
+    /// The amount of time an IP address is prohibited from connecting.
+    const IP_BAN_TIME_IN_SECS: u64 = 30;
 
     /// Handles the heartbeat request.
     fn heartbeat(&self) {
@@ -60,6 +62,8 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         self.handle_trusted_peers();
         // Keep the puzzle request up to date.
         self.handle_puzzle_request();
+        // Unban any addresses whose ban time has expired.
+        self.handle_banned_ips();
     }
 
     /// TODO (howardwu): Consider checking minimum number of validators, to exclude clients and provers.
@@ -282,5 +286,10 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     /// This function updates the puzzle if network has updated.
     fn handle_puzzle_request(&self) {
         // No-op
+    }
+
+    // Remove addresses whose ban time has expired.
+    fn handle_banned_ips(&self) {
+        self.tcp().banned_peers().remove_old_bans(Self::IP_BAN_TIME_IN_SECS);
     }
 }

--- a/node/tcp/src/helpers/banned_peers.rs
+++ b/node/tcp/src/helpers/banned_peers.rs
@@ -1,0 +1,39 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, net::IpAddr, time::Instant};
+
+use parking_lot::RwLock;
+
+/// Contains the set of peers currently banned by IP.
+#[derive(Default)]
+pub struct BannedPeers(RwLock<HashMap<IpAddr, Instant>>);
+
+impl BannedPeers {
+    /// Check whether the given IP address is currently banned.
+    pub fn is_ip_banned(&self, ip: IpAddr) -> bool {
+        self.0.read().contains_key(&ip)
+    }
+
+    /// Insert or update a banned IP.
+    pub fn update_ip_ban(&self, ip: IpAddr) {
+        let timestamp = Instant::now();
+        self.0.write().insert(ip, timestamp);
+    }
+
+    /// Remove the expired entries.
+    pub fn remove_old_bans(&self, ban_time_in_secs: u64) {
+        self.0.write().retain(|_, timestamp| timestamp.elapsed().as_secs() < ban_time_in_secs);
+    }
+}

--- a/node/tcp/src/helpers/known_peers.rs
+++ b/node/tcp/src/helpers/known_peers.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::IpAddr,
+    sync::Arc,
+    time::Instant,
+};
 
 use parking_lot::RwLock;
 
@@ -20,45 +25,53 @@ use crate::Stats;
 
 /// Contains statistics related to Tcp's peers, currently connected or not.
 #[derive(Default)]
-pub struct KnownPeers(RwLock<HashMap<SocketAddr, Arc<Stats>>>);
+pub struct KnownPeers(RwLock<HashMap<IpAddr, Arc<Stats>>>);
 
 impl KnownPeers {
     /// Adds an address to the list of known peers.
-    pub fn add(&self, addr: SocketAddr) {
-        self.0.write().entry(addr).or_default();
+    pub fn add(&self, addr: IpAddr) {
+        let timestamp = Instant::now();
+        match self.0.write().entry(addr) {
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(Stats::new(timestamp)));
+            }
+            Entry::Occupied(entry) => {
+                *entry.get().timestamp.write() = timestamp;
+            }
+        }
     }
 
     /// Returns the stats for the given peer.
-    pub fn get(&self, addr: SocketAddr) -> Option<Arc<Stats>> {
+    pub fn get(&self, addr: IpAddr) -> Option<Arc<Stats>> {
         self.0.read().get(&addr).map(Arc::clone)
     }
 
     /// Removes an address from the list of known peers.
-    pub fn remove(&self, addr: SocketAddr) -> Option<Arc<Stats>> {
+    pub fn remove(&self, addr: IpAddr) -> Option<Arc<Stats>> {
         self.0.write().remove(&addr)
     }
 
     /// Returns the list of all known peers and their stats.
-    pub fn snapshot(&self) -> HashMap<SocketAddr, Arc<Stats>> {
+    pub fn snapshot(&self) -> HashMap<IpAddr, Arc<Stats>> {
         self.0.read().clone()
     }
 
     /// Registers a submission of a message to the given address.
-    pub fn register_sent_message(&self, to: SocketAddr, size: usize) {
+    pub fn register_sent_message(&self, to: IpAddr, size: usize) {
         if let Some(stats) = self.0.read().get(&to) {
             stats.register_sent_message(size);
         }
     }
 
     /// Registers a receipt of a message to the given address.
-    pub fn register_received_message(&self, from: SocketAddr, size: usize) {
+    pub fn register_received_message(&self, from: IpAddr, size: usize) {
         if let Some(stats) = self.0.read().get(&from) {
             stats.register_received_message(size);
         }
     }
 
     /// Registers a failure associated with the given address.
-    pub fn register_failure(&self, addr: SocketAddr) {
+    pub fn register_failure(&self, addr: IpAddr) {
         if let Some(stats) = self.0.read().get(&addr) {
             stats.register_failure();
         }

--- a/node/tcp/src/helpers/mod.rs
+++ b/node/tcp/src/helpers/mod.rs
@@ -15,6 +15,9 @@
 mod config;
 pub use config::Config;
 
+mod banned_peers;
+pub use banned_peers::BannedPeers;
+
 pub mod connections;
 pub use connections::{Connection, ConnectionSide};
 

--- a/node/tcp/src/helpers/stats.rs
+++ b/node/tcp/src/helpers/stats.rs
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use parking_lot::RwLock;
+use std::{
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+    time::Instant,
+};
 
 /// Contains statistics related to Tcp.
-#[derive(Default)]
 pub struct Stats {
+    /// The timestamp of the creation (for the node) or connection (to a peer).
+    pub(crate) timestamp: RwLock<Instant>,
     /// The number of all messages sent.
     msgs_sent: AtomicU64,
     /// The number of all messages received.
@@ -30,6 +35,23 @@ pub struct Stats {
 }
 
 impl Stats {
+    /// Creates a new instance of the object.
+    pub fn new(timestamp: Instant) -> Self {
+        Self {
+            timestamp: RwLock::new(timestamp),
+            msgs_sent: Default::default(),
+            msgs_received: Default::default(),
+            bytes_sent: Default::default(),
+            bytes_received: Default::default(),
+            failures: Default::default(),
+        }
+    }
+
+    /// Returns the creation or connection timestamp.
+    pub fn timestamp(&self) -> Instant {
+        *self.timestamp.read()
+    }
+
     /// Returns the number of sent messages and their collective size in bytes.
     pub fn sent(&self) -> (u64, u64) {
         let msgs = self.msgs_sent.load(Relaxed);

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -143,7 +143,7 @@ impl<R: Reading> ReadingInternal for R {
             while let Some(msg) = inbound_message_receiver.recv().await {
                 if let Err(e) = self_clone.process_message(addr, msg).await {
                     error!(parent: node.span(), "can't process a message from {addr}: {e}");
-                    node.known_peers().register_failure(addr);
+                    node.known_peers().register_failure(addr.ip());
                 }
                 #[cfg(feature = "metrics")]
                 metrics::decrement_gauge(metrics::tcp::TCP_TASKS, 1f64);
@@ -178,7 +178,7 @@ impl<R: Reading> ReadingInternal for R {
                     }
                     Err(e) => {
                         error!(parent: node.span(), "can't read from {addr}: {e}");
-                        node.known_peers().register_failure(addr);
+                        node.known_peers().register_failure(addr.ip());
                         if node.config().fatal_io_errors.contains(&e.kind()) {
                             break;
                         }
@@ -229,7 +229,7 @@ impl<D: Decoder> Decoder for CountingCodec<D> {
 
             if ret.is_some() {
                 self.acc = 0;
-                self.node.known_peers().register_received_message(self.addr, read_len);
+                self.node.known_peers().register_received_message(self.addr.ip(), read_len);
                 self.node.stats().register_received_message(read_len);
             } else {
                 self.acc = read_len;

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -219,12 +219,12 @@ impl<W: Writing> WritingInternal for W {
                 match self_clone.write_to_stream(*msg, &mut framed).await {
                     Ok(len) => {
                         let _ = wrapped_msg.delivery_notification.send(Ok(()));
-                        node.known_peers().register_sent_message(addr, len);
+                        node.known_peers().register_sent_message(addr.ip(), len);
                         node.stats().register_sent_message(len);
                         trace!(parent: node.span(), "sent {}B to {}", len, addr);
                     }
                     Err(e) => {
-                        node.known_peers().register_failure(addr);
+                        node.known_peers().register_failure(addr.ip());
                         error!(parent: node.span(), "couldn't send a message to {}: {}", addr, e);
                         let is_fatal = node.config().fatal_io_errors.contains(&e.kind());
                         let _ = wrapped_msg.delivery_notification.send(Err(e));

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -39,6 +39,7 @@ use tracing::*;
 use crate::{
     connections::{Connection, ConnectionSide, Connections},
     protocols::{Protocol, Protocols},
+    BannedPeers,
     Config,
     KnownPeers,
     Stats,
@@ -75,6 +76,8 @@ pub struct InnerTcp {
     connections: Connections,
     /// Collects statistics related to the node's peers.
     known_peers: KnownPeers,
+    /// Contains the set of currently banned peers.
+    banned_peers: BannedPeers,
     /// Collects statistics related to the node itself.
     stats: Stats,
     /// The node's tasks.
@@ -101,6 +104,7 @@ impl Tcp {
             connecting: Default::default(),
             connections: Default::default(),
             known_peers: Default::default(),
+            banned_peers: Default::default(),
             stats: Stats::new(Instant::now()),
             tasks: Default::default(),
         }));
@@ -163,6 +167,12 @@ impl Tcp {
     #[inline]
     pub fn known_peers(&self) -> &KnownPeers {
         &self.known_peers
+    }
+
+    /// Returns a reference to the set of currently banned peers.
+    #[inline]
+    pub fn banned_peers(&self) -> &BannedPeers {
+        &self.banned_peers
     }
 
     /// Returns a reference to the statistics.

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -22,7 +22,7 @@ use std::{
         atomic::{AtomicUsize, Ordering::*},
         Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use once_cell::sync::OnceCell;
@@ -101,7 +101,7 @@ impl Tcp {
             connecting: Default::default(),
             connections: Default::default(),
             known_peers: Default::default(),
-            stats: Default::default(),
+            stats: Stats::new(Instant::now()),
             tasks: Default::default(),
         }));
 
@@ -255,7 +255,7 @@ impl Tcp {
 
         if let Err(ref e) = ret {
             self.connecting.lock().remove(&addr);
-            self.known_peers().register_failure(addr);
+            self.known_peers().register_failure(addr.ip());
             error!(parent: self.span(), "Unable to initiate a connection with {addr}: {e}");
         }
 
@@ -280,13 +280,6 @@ impl Tcp {
             // Shut down the associated tasks of the peer.
             for task in conn.tasks.iter().rev() {
                 task.abort();
-            }
-
-            // If the (owning) Tcp was not the initiator of the connection, it doesn't know the listening address
-            // of the associated peer, so the related stats are unreliable; the next connection initiated by the
-            // peer could be bound to an entirely different port number
-            if conn.side() == ConnectionSide::Initiator {
-                self.known_peers().remove(conn.addr());
             }
 
             debug!(parent: self.span(), "Disconnected from {}", conn.addr());
@@ -386,7 +379,7 @@ impl Tcp {
         tokio::spawn(async move {
             if let Err(e) = tcp.adapt_stream(stream, addr, ConnectionSide::Responder).await {
                 tcp.connecting.lock().remove(&addr);
-                tcp.known_peers().register_failure(addr);
+                tcp.known_peers().register_failure(addr.ip());
                 error!(parent: tcp.span(), "Failed to connect with {addr}: {e}");
             }
         });
@@ -426,7 +419,7 @@ impl Tcp {
 
     /// Prepares the freshly acquired connection to handle the protocols the Tcp implements.
     async fn adapt_stream(&self, stream: TcpStream, peer_addr: SocketAddr, own_side: ConnectionSide) -> io::Result<()> {
-        self.known_peers.add(peer_addr);
+        self.known_peers.add(peer_addr.ip());
 
         // Register the port seen by the peer.
         if own_side == ConnectionSide::Initiator {


### PR DESCRIPTION
Based on https://github.com/AleoNet/snarkOS/pull/3366, only the last 2 commits are new.

This PR moves the IP-level ban piping down to the `Tcp` object level, making it available to both `Gateway` and `Router`, and applies it to the latter.

Filing as a draft, as it depends on the aforementioned base PR.

Cc @vicsn 