### PR TITLE
Mainnet Beta release v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3582,12 +3582,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3744,7 +3744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "rand",
  "rayon",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "anyhow",
  "rand",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4286,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=5bb50a8#5bb50a845c774f10247657947b9f1c9ec7f21d81"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=02994a1#02994a1e34e7db8da6c27587537b165aa488868c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "5bb50a8" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+rev = "02994a1" # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,7 +67,7 @@ version = "=2.2.7"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "5bb50a8"
+rev = "02994a1"
 default-features = false
 optional = true
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -398,7 +398,10 @@ impl<N: Network> Router<N> {
         } else if N::ID == snarkvm::console::network::MainnetV0::ID {
             // Mainnet contains the following bootstrap peers.
             vec![
-                // TODO: Populate me with Mainnet Beta IP addresses.
+                SocketAddr::from_str("34.105.20.52:4130").unwrap(),
+                SocketAddr::from_str("35.231.118.193:4130").unwrap(),
+                SocketAddr::from_str("35.204.253.77:4130").unwrap(),
+                SocketAddr::from_str("34.87.188.140:4130").unwrap(),
             ]
         } else if N::ID == snarkvm::console::network::TestnetV0::ID {
             // TestnetV0 contains the following bootstrap peers.

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -80,7 +80,7 @@ async fn test_disconnect_with_handshake() {
     // Connect node0 to node1.
     node0.connect(node1.local_ip());
     // Sleep briefly.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    tokio::time::sleep(Duration::from_millis(1000)).await;
 
     print_tcp!(node0);
     print_tcp!(node1);


### PR DESCRIPTION
## Motivation
Updating Mainnet Beta genesis block for release `v0.1.0` and adding Mainnet bootstrap peers.

## Related PRs
https://github.com/AleoNet/snarkVM/pull/2542
