### PR TITLE
[Fix] change get_blocks range to closed interval

### DIFF
--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -137,7 +137,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
         // Prepare a closure for the blocking work.
         let get_json_blocks = move || -> Result<ErasedJson, RestError> {
-            let blocks = cfg_into_iter!((start_height..end_height))
+            let blocks = cfg_into_iter!((start_height..=end_height))
                 .map(|height| rest.ledger.get_block(height))
                 .collect::<Result<Vec<_>, _>>()?;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation
Close issue: #3387

We say `GET /testnet/blocks?start={start_height}&end={end_height}` Returns the blocks for **the given block range** ( [api doc](https://developer.aleo.org/testnet/public_endpoints/get_blocks) )

**the given block range**  was not described clearly enough.

`/testnet/blocks` returns the blocks of `from start_height to end_height - 1`. But I think it should return `from start_height to end_height` with closed interval which is more friendly with human intuition, cuz we always use current block height as end_height, easily misunderstood if we need give it **current block height + 1**.

## Test Plan
change
https://github.com/AleoNet/snarkOS/blob/0cc6fe3d9ad1f8c43c2037dac670a1fd417b2c99/node/rest/src/routes.rs#L140
to
```rust
let blocks = cfg_into_iter!((start_height..=end_height)) 
```
