### PR TITLE
[Fix] Fix `Scan` and update CDN TLS version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2642,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
+ "hyper-rustls",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -2637,6 +2652,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -2645,11 +2661,13 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -2754,6 +2772,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
@@ -2762,7 +2792,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -2791,6 +2821,16 @@ name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2862,6 +2902,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -4795,6 +4845,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5140,12 +5200,12 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.5",
 ]
 
 [[package]]
@@ -5299,6 +5359,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -15,6 +15,7 @@
 
 #![allow(clippy::type_complexity)]
 
+use crate::commands::CDN_BASE_URL;
 use snarkvm::{
     console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{block::Block, Ciphertext, Field, FromBytes, Plaintext, PrivateKey, Record, ViewKey},
@@ -31,8 +32,6 @@ use std::{
 use zeroize::Zeroize;
 
 const MAX_BLOCK_RANGE: u32 = 50;
-// TODO (raychu86): This should be configurable based on network.
-const CDN_ENDPOINT: &str = "https://s3.us-west-1.amazonaws.com/testnet3.blocks/phase3";
 
 /// Scan the snarkOS node for records.
 #[derive(Debug, Parser, Zeroize)]
@@ -172,6 +171,16 @@ impl Scan {
         }
     }
 
+    /// Returns the CDN to prefetch initial blocks from, from the given configurations.
+    fn parse_cdn<N: Network>() -> Result<String> {
+        match N::ID {
+            MainnetV0::ID => Ok(format!("{CDN_BASE_URL}/mainnet/v0")),
+            TestnetV0::ID => Ok(format!("{CDN_BASE_URL}/testnet/v0")),
+            CanaryV0::ID => Ok(format!("{CDN_BASE_URL}/canary/v0")),
+            _ => bail!("Unknown network ID ({})", N::ID),
+        }
+    }
+
     /// Fetch owned ciphertext records from the endpoint.
     fn fetch_records<N: Network>(
         private_key: Option<PrivateKey<N>>,
@@ -215,11 +224,13 @@ impl Scan {
         let mut request_start = match is_development_network {
             true => start_height,
             false => {
+                // Parse the CDN endpoint.
+                let cdn_endpoint = Self::parse_cdn::<N>()?;
                 // Scan the CDN first for records.
                 Self::scan_from_cdn(
                     start_height,
                     end_height,
-                    CDN_ENDPOINT.to_string(),
+                    cdn_endpoint,
                     endpoint.to_string(),
                     private_key,
                     *view_key,

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -59,7 +59,7 @@ const DEVELOPMENT_MODE_RNG_SEED: u64 = 1234567890u64;
 const DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS: u16 = 4;
 
 /// The CDN base url.
-const CDN_BASE_URL: &str = "https://blocks.aleo.org";
+pub(crate) const CDN_BASE_URL: &str = "https://blocks.aleo.org";
 
 /// A mapping of `staker_address` to `(validator_address, withdrawal_address, amount)`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -41,6 +41,7 @@ optional = true
 
 [dependencies.reqwest]
 version = "0.11"
+features = [ "rustls-tls" ]
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `Scan` CLI command to support the correct network. In addition, this PR updates the CDN TLS version to use `Reqwest::rust_tls` instead of `Reqwest::native_tls`. `native_tls` does not support the configuration of the new endpoint `https://blocks.aleo.org/v0/...`, so the change is necessary.


CI is run [here](https://app.circleci.com/pipelines/github/ProvableHQ/snarkOS?branch=fix%2Fcdn-CI).