### PR TITLE
Change block delay to 5 seconds

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -19,7 +19,7 @@ use crate::{
     spawn_blocking,
     Worker,
     CONTEXT,
-    MAX_BATCH_DELAY_IN_MS,
+    BATCH_DELAY_IN_MS,
     MEMORY_POOL_PORT,
 };
 use snarkos_account::Account;
@@ -75,14 +75,14 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
 /// The maximum interval of events to cache.
-const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
+const CACHE_EVENTS_INTERVAL: i64 = (BATCH_DELAY_IN_MS / 1000) as i64; // seconds
 /// The maximum interval of requests to cache.
-const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
+const CACHE_REQUESTS_INTERVAL: i64 = (BATCH_DELAY_IN_MS / 1000) as i64; // seconds
 
 /// The maximum number of connection attempts in an interval.
 const MAX_CONNECTION_ATTEMPTS: usize = 10;
 /// The maximum interval to restrict a peer.
-const RESTRICTED_INTERVAL: i64 = (MAX_CONNECTION_ATTEMPTS as u64 * MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
+const RESTRICTED_INTERVAL: i64 = (MAX_CONNECTION_ATTEMPTS as u64 * BATCH_DELAY_IN_MS / 1000) as i64; // seconds
 
 /// The minimum number of validators to maintain a connection to.
 const MIN_CONNECTED_VALIDATORS: usize = 175;

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -49,9 +49,9 @@ pub const CONTEXT: &str = "[MemoryPool]";
 pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
 /// The maximum number of milliseconds to wait before proposing a batch.
-pub const MAX_BATCH_DELAY_IN_MS: u64 = 2500; // ms
+pub const MAX_BATCH_DELAY_IN_MS: u64 = 5500; // ms
 /// The minimum number of seconds to wait before proposing a batch.
-pub const MIN_BATCH_DELAY_IN_SECS: u64 = 1; // seconds
+pub const MIN_BATCH_DELAY_IN_SECS: u64 = 5; // seconds
 /// The maximum number of milliseconds to wait before timing out on a fetch.
 pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
 /// The maximum number of seconds allowed for the leader to send their certificate.

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -49,13 +49,13 @@ pub const CONTEXT: &str = "[MemoryPool]";
 pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
 /// The maximum number of milliseconds to wait before proposing a batch.
-pub const MAX_BATCH_DELAY_IN_MS: u64 = 5500; // ms
+pub const BATCH_DELAY_IN_MS: u64 = 2500; // ms
 /// The minimum number of seconds to wait before proposing a batch.
-pub const MIN_BATCH_DELAY_IN_SECS: u64 = 5; // seconds
+pub const MIN_BATCH_DELAY_IN_SECS: u64 = 1; // seconds
 /// The maximum number of milliseconds to wait before timing out on a fetch.
-pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
+pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * BATCH_DELAY_IN_MS; // ms
 /// The maximum number of seconds allowed for the leader to send their certificate.
-pub const MAX_LEADER_CERTIFICATE_DELAY_IN_SECS: i64 = 2 * MAX_BATCH_DELAY_IN_MS as i64 / 1000; // seconds
+pub const MAX_LEADER_CERTIFICATE_DELAY_IN_SECS: i64 = 2 * BATCH_DELAY_IN_MS as i64 / 1000; // seconds
 /// The maximum number of seconds before the timestamp is considered expired.
 pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds
 /// The maximum number of workers that can be spawned.
@@ -63,9 +63,9 @@ pub const MAX_WORKERS: u8 = 1; // worker(s)
 
 /// The frequency at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.
-pub const PRIMARY_PING_IN_MS: u64 = 2 * MAX_BATCH_DELAY_IN_MS; // ms
+pub const PRIMARY_PING_IN_MS: u64 = 2 * BATCH_DELAY_IN_MS; // ms
 /// The frequency at which each worker broadcasts a ping to every other node.
-pub const WORKER_PING_IN_MS: u64 = 4 * MAX_BATCH_DELAY_IN_MS; // ms
+pub const WORKER_PING_IN_MS: u64 = 4 * BATCH_DELAY_IN_MS; // ms
 
 /// A helper macro to spawn a blocking task.
 #[macro_export]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1387,10 +1387,10 @@ impl<N: Network> Primary<N> {
     fn check_proposal_timestamp(&self, previous_round: u64, author: Address<N>, timestamp: i64) -> Result<()> {
         // Retrieve the timestamp of the previous timestamp to check against.
         let previous_timestamp = match self.storage.get_certificate_for_round_with_author(previous_round, author) {
-            // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_MS` seconds ago.
+            // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
             Some(certificate) => certificate.timestamp(),
             None => match self.gateway.account().address() == author {
-                // If we are the author, then ensure the previous proposal was created at least `MIN_BATCH_DELAY_IN_MS` seconds ago.
+                // If we are the author, then ensure the previous proposal was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
                 true => *self.latest_proposed_batch_timestamp.read(),
                 // If we do not see a previous certificate for the author, then proceed optimistically.
                 false => return Ok(()),
@@ -1401,7 +1401,7 @@ impl<N: Network> Primary<N> {
         let elapsed = timestamp
             .checked_sub(previous_timestamp)
             .ok_or_else(|| anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}"))?;
-        // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_MS` seconds ago.
+        // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
         match elapsed < MIN_BATCH_DELAY_IN_SECS as i64 {
             true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
             false => Ok(()),

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -23,7 +23,7 @@ use snarkos_node_bft::{
     helpers::{init_primary_channels, PrimarySender, Storage},
     Primary,
     BFT,
-    MAX_BATCH_DELAY_IN_MS,
+    BATCH_DELAY_IN_MS,
 };
 use snarkos_node_bft_storage_service::BFTMemoryService;
 use snarkvm::{
@@ -288,7 +288,7 @@ impl TestNetwork {
     // Checks if all the nodes have stopped progressing.
     pub async fn is_halted(&self) -> bool {
         let halt_round = self.validators.values().map(|v| v.primary.current_round()).max().unwrap();
-        sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS * 2)).await;
+        sleep(Duration::from_millis(BATCH_DELAY_IN_MS * 2)).await;
         self.validators.values().all(|v| v.primary.current_round() <= halt_round)
     }
 


### PR DESCRIPTION
## Motivation
The motivation behind this change is to stabilise the network's inflation rate as it is currently higher than planned since block times are 3 seconds but the economics were modelled over 10 seconds. 

This is a short term fix by adding a constant. The longer term fix would be dynamically calculating the block reward ( or block delay ) based on an average block time taken from past x amount of block (TBD).

## Test Plan
Tested on an isolated network. Empty block times are 8 seconds to allow for a buffer to 10 seconds because the block time increases with more transaction load.

Changed two constant:

```
/// The maximum number of milliseconds to wait before proposing a batch.
pub const MAX_BATCH_DELAY_IN_MS: u64 = 5500; // ms
/// The minimum number of seconds to wait before proposing a batch.
pub const MIN_BATCH_DELAY_IN_SECS: u64 = 5; // seconds
```

