### PR TITLE
adds open file limit recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ cargo install --locked --path .
 
 Please ensure ports `4130/tcp` and `3030/tcp` are open on your router and OS firewall.
 
+**Note:** Ensure that your open file limit is set to 16,384 or above.
+For the recommended setting run:
+```
+# Increase the open file limit for the current user (replace <username> with your username)
+echo "<username> - nofile 65536" | sudo tee -a /etc/security/limits.conf
+# Increase the default system open file limit
+sudo bash -c 'echo "DefaultLimitNOFILE=65536" >> /etc/systemd/system.conf'
+```
+
 ## 3. Run an Aleo Node
 
 ## 3.1 Run an Aleo Client


### PR DESCRIPTION
## Motivation

The motivation to add a recommended open file limit to the Readme is to prevent any potential issues when running a node on Aleo as seen in practice and testing.

