### PR TITLE
Canary release week 24.43 - v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,8 +3546,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1061bdbbe9f6b7eff608380fc2bc27c511f180915c1b6bd9ab3c43f848392a52"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3578,8 +3577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4c2cb2fb5fe072253de93ff27a27d02d9f6fa8aef15b8399d9aae03fa106f"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3609,8 +3607,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67c386f93ffbb7fbeba46a630bb837d5aa091173cc6ea46600cf7d4bf201b8e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3624,8 +3621,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69da527dfb8a06b363fd9acae69d6365aa85073256bb15ef5ad339cb034bd5d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3636,8 +3632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8627c5f44cc7f4c4678600695f3f47ec2f8eb9f4f8393bb17f4c852fd314bb"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3647,8 +3642,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362fcfa5fe6b4d33390789d29f3319911c84defd1dea2743c4519b293f58fecc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3658,8 +3652,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cddfa1c833dc94ce9b7535b85ed81cc5a34cf2561f1af4c2f6f5c528b26432e6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "indexmap 2.5.0",
  "itertools 0.11.0",
@@ -3677,14 +3670,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4065b220b837d3f4bd96f35936c6a2933e19a2f699e636b0df3d8181f51a4c67"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d254a30e2845428af200f95158884faf72728aa6b1de46ac2d53af74dfa884"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3695,8 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3691543e4c0baa34ed530b12e0f301fa230992f612e1fc063cb43a3c7852f2cf"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3711,8 +3701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cea90b7bc5e098dcbd1bd9d728501edc85a87cbd739c2bc635562529cb1cd03"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3727,8 +3716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5715abd9e1fb0a56e79f6ff6db1e9b8e87729478f7598958b122ef1b3ce88249"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3741,8 +3729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a324ea89623793473a14358ca1fa141264f74462c950a29465f104415bff677"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3751,8 +3738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234e943a1ee4add148e6cbff71c10e01fd455f38a96f447c4477385d3eb87747"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3762,8 +3748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b5bf2e2feb77d7397a298776e18d03cf8dadb466bdc277fb74ff99b7957de6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3775,8 +3760,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97574f286199b541a10534786e50c35ac2fe0f253e8bfc77b7845ddece4793a9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3788,8 +3772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a510f4c84e8008ad4428a57b59655c4039c65ee8078e486c144d30ab1e610c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3800,8 +3783,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bc5a0408577eb7f189aa046f5ac8ee4b8aa7bb966dfa81c68d8cea026c5a25"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3813,8 +3795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed74b1e7be553d4fdd80927c6d12d30b61ad28314effc365e1ba91949926c655"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3827,8 +3808,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfcfc296f0400d2625c0ef610e1eb48a12867c56d632650a62ae2e26fde5a9a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3839,8 +3819,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa04a8fe25fbc2158d4f3abaff90b1ed2448eae85a5fa97725b6d2ff9ce712e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3853,8 +3832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca93893f6d697f0f1938b114f0d4538c5fab2b131ba508fe543ecae4097042a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3865,8 +3843,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90917fbec1e94134eb73c318672fa13e13e7dbd9813408bfdf142040cd054deb"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -3889,8 +3866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a0ad6b84cec66a885a88552178767b1a781309f3a4fe8d2f4fa840fb151091"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3908,8 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a655d52f38795d6f037a1f76d3f0dbd3f835cb34fbb6918cdea6362aa6a9e020"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3931,8 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3128d85a6fbd3970f9d4f5877007c2b9a80ed8eea647f5079733f6b4ba93c6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3947,8 +3921,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28905bc383be6c2e0ae8c0f0a02f40b0fa6642fa2e166bac8a32c7d75dd8163"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3959,8 +3932,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d8ac49336d82e4ed1d7d90f0403a917feea00d84951963c4799f8d961acd63"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3968,8 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9267b908876d5d29f011db164398765cc66a8d086e5de6fcd5ddc5f120752e2"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3979,8 +3950,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d667d3f4afe1e6692dac476f6ead3d2739ed60c9ef0f70db7767fa010e99928"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3991,8 +3961,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5832e7aecd318968406deffc0cea4e794f6902465c69771a997fe733124920"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4003,8 +3972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89d7d37cdc1efb57dc0baaeb950a01532761d42d645c986202206d4493d2fa6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4015,8 +3983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dec34afefe1cb78a77d11f494cd654701b2b0b169c6aef8131a156b2b9db96d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4027,8 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c7963b24dc45ec0663ded89bdf05986bf61c339b104c64d37622143c4cc13"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "rand",
  "rayon",
@@ -4042,8 +4008,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e8966ab9ec5300b20285d9054521785b63a95b501323bad8216066a90015ae"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4060,8 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151c38941f583a0ac28cf99e0af446fc7e6e39ea1e3895d722b91365091e3bf5"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4086,8 +4050,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df0d3b6bd6b853916c956e46746c33d470ca5bb5f5404d98b9c3f1fd6390cc3"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "anyhow",
  "rand",
@@ -4099,8 +4062,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100f73fcc90866ed7c7e14af4afd1b66a87b3bc4325aab8455e9120f6bd0dcb8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4120,8 +4082,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c002b3ab30383901bc0a684b8c1fdfb6b9f4aaa71e7a59e323e5558ccd1df4b"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -4140,8 +4101,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abd5008b0837ac2fe1d33dc2be4ea38af778c3a8cfcab0f1839a70cf85eb54e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4154,8 +4114,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d096cf0c0cc0b205797a811f7cd8694cb487bb945f17058a5fc8710703c793a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4168,8 +4127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3770f99778463ce8be6fb10f29a5737f889882ba358ea948d6c8e8a9021bd6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4182,8 +4140,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f5641442b912623075331c51154fb447ba3b1990a28554417f55f1139a8667"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4194,8 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7747990ad94acb969cda70976b478ed40a0beb22583774434114e5419e5ea5d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4210,8 +4166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbc85999cce7f6c3cfff47db8bae834cb5eee374c5a06d9be959bb5bc5ce5f2"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4224,8 +4179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25614b92aed358b842cd3d0993afca1c4c41b5901f3f8b4fc806d0a97bda797d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4234,8 +4188,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710122e2513287c1e992fb4dd11d74f1cfbdb49f15c0f50a3bf8bab82caedb49"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4255,8 +4208,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aae558db942169cafcfa83544562155d870f1770c473a8f800f3cea92886882"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4277,8 +4229,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49609967badb249a3600f20d3f5a6600f727394f344800d30b1f89e0f278fe55"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4291,8 +4242,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0496ffd4e01b9a2a7914d6afa04d3b6a8ff8fa85edb37c0b25108d0a8b636a52"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4319,8 +4269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d0a96a24dfeb15bd9aae4f2e49559428cb9a1862c0ce801e030baab3b478c7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4335,8 +4284,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24160c0da9b79304568c854a5d53ce0e6fe815ed25f9ade0c6f5df31e60df79"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4345,8 +4293,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f76c9e570372079d5705e45233aee5d18e72f77f19232b4c910146c8cef023"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4371,8 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123712831bcb405db1eac34db195b07da96ab7787833750cbc52b03e966a2820"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4404,8 +4350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39539619196b61e499db123e0e499c5a6ec61346ec1784d6350c9325146881d2"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4429,8 +4374,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5520850ffbfe8fd074608fded31f1a4fbc62100f83de1bb0f6b083b8b6e381"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "indexmap 2.5.0",
  "paste",
@@ -4444,8 +4388,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48155b6411c0735196e95668a7d8347b15a36ebae7dc91a824d292897f10bd8a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4458,8 +4401,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fcbfa865d7b4a30922bcdb18adc15c5bf8ce2ea42250184d7d95655b493f7c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4480,8 +4422,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b78577ade70f11743b6f76f6cf4b5fc16905b41caa499d691e0ae822d0340ab"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
-#git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "3d42aa0"
-version = "=1.0.0"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "dea322b"
+#version = "=1.0.0"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -66,8 +66,8 @@ version = "=3.0.0"
 
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
-#git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "3d42aa0"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "dea322b"
 version = "=1.0.0"
 default-features = false
 optional = true


### PR DESCRIPTION
## Motivation
Updating snarkVM rev for Canary v1.1.1. Please see below for fixes and features added in this release.

## Test Plan
Mixed ISOnet over the weekend with v1.0.0 validator + clients and this version.

## Related PRs

### snarkVM

https://github.com/AleoNet/snarkVM/pull/2482
https://github.com/AleoNet/snarkVM/pull/2499
https://github.com/AleoNet/snarkVM/pull/2507
https://github.com/AleoNet/snarkVM/pull/2513
https://github.com/AleoNet/snarkVM/pull/2514
https://github.com/AleoNet/snarkVM/pull/2515
https://github.com/AleoNet/snarkVM/pull/2526
https://github.com/AleoNet/snarkVM/pull/2531
https://github.com/AleoNet/snarkVM/pull/2538
https://github.com/AleoNet/snarkVM/pull/2546
https://github.com/AleoNet/snarkVM/pull/2557
https://github.com/AleoNet/snarkVM/pull/2558

### snarkOS

[AleoNet/snarkOS#3307](https://github.com/AleoNet/snarkOS/pull/3307)
[AleoNet/snarkOS#3330](https://github.com/AleoNet/snarkOS/pull/3330)
[AleoNet/snarkOS#3345](https://github.com/AleoNet/snarkOS/pull/3345)
[AleoNet/snarkOS#3347](https://github.com/AleoNet/snarkOS/pull/3347)
[AleoNet/snarkOS#3360](https://github.com/AleoNet/snarkOS/pull/3360)
[AleoNet/snarkOS#3365](https://github.com/AleoNet/snarkOS/pull/3365)
[AleoNet/snarkOS#3369](https://github.com/AleoNet/snarkOS/pull/3369)
