### PR TITLE
[Perf] Fetch transmissions and certificates simultaneously

### DIFF
--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -21,7 +21,7 @@ use crate::{
 use snarkvm::prelude::Network;
 
 use colored::Colorize;
-use rand::{prelude::IteratorRandom, rngs::OsRng, Rng};
+use rand::{Rng, prelude::IteratorRandom, rngs::OsRng};
 
 /// A helper function to compute the maximum of two numbers.
 /// See Rust issue 92391: https://github.com/rust-lang/rust/issues/92391.


### PR DESCRIPTION
## Motivation

Fetching transmissions poses a significant bottleneck in consensus. This simple change can avoid waiting for a synchronous roundtrip of certificate fetching, which happens almost every round.

## Test Plan

Tested on a local devnet with traffic.