### PR TITLE
Spam connections and forged block locators fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,6 +3504,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync-communication-service",
  "snarkos-node-sync-locators",
+ "snarkos-node-tcp",
  "snarkvm",
  "tokio",
  "tracing",

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1142,7 +1142,6 @@ impl<N: Network> Handshake for Gateway<N> {
         if self.dev().is_none() && peer_side == ConnectionSide::Initiator {
             // If the IP is already banned, update the ban timestamp and reject the connection.
             if self.is_ip_banned(peer_addr.ip()) {
-                self.update_ip_ban(peer_addr.ip());
                 trace!("{CONTEXT} Gateway rejected a connection request from banned IP '{}'", peer_addr.ip());
                 return Err(error(format!("'{}' is a banned IP address", peer_addr.ip())));
             }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1165,13 +1165,11 @@ impl<N: Network> Handshake for Gateway<N> {
             let num_attempts = self.cache.insert_inbound_connection(peer_addr.ip(), CONNECTION_ATTEMPTS_SINCE_SECS);
 
             debug!("Number of connection attempts from '{}': {}", peer_addr.ip(), num_attempts);
-            if num_attempts >= MAX_CONNECTION_ATTEMPTS
-            {
+            if num_attempts > MAX_CONNECTION_ATTEMPTS {
                 self.update_ip_ban(peer_addr.ip());
                 trace!("{CONTEXT} Gateway rejected a consecutive connection request from IP '{}'", peer_addr.ip());
                 return Err(error(format!("'{}' appears to be spamming connections", peer_addr.ip())));
             }
-
         }
 
         let stream = self.borrow_stream(&mut connection);

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -24,6 +24,7 @@ use crate::{
 use snarkos_node_bft_events::{CertificateRequest, CertificateResponse, Event};
 use snarkos_node_bft_ledger_service::LedgerService;
 use snarkos_node_sync::{locators::BlockLocators, BlockSync, BlockSyncMode};
+use snarkos_node_tcp::P2P;
 use snarkvm::{
     console::{network::Network, types::Field},
     ledger::{authority::Authority, block::Block, narwhal::BatchCertificate},
@@ -67,7 +68,7 @@ impl<N: Network> Sync<N> {
     /// Initializes a new sync instance.
     pub fn new(gateway: Gateway<N>, storage: Storage<N>, ledger: Arc<dyn LedgerService<N>>) -> Self {
         // Initialize the block sync module.
-        let block_sync = BlockSync::new(BlockSyncMode::Gateway, ledger.clone());
+        let block_sync = BlockSync::new(BlockSyncMode::Gateway, ledger.clone(), gateway.tcp().clone());
         // Return the sync instance.
         Self {
             gateway,

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use snarkos_node_bft_events::{CertificateRequest, CertificateResponse, Event};
 use snarkos_node_bft_ledger_service::LedgerService;
-use snarkos_node_sync::{locators::BlockLocators, BlockSync, BlockSyncMode};
+use snarkos_node_sync::{BlockSync, BlockSyncMode, locators::BlockLocators};
 use snarkos_node_tcp::P2P;
 use snarkvm::{
     console::{network::Network, types::Field},

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -101,6 +101,32 @@ impl<N: Network> Router<N> {
             Some(peer_addr)
         };
 
+        // Check (or impose) IP-level bans.
+        #[cfg(not(any(test, feature = "test")))]
+        if !self.is_dev() && peer_side == ConnectionSide::Initiator {
+            // If the IP is already banned, update the ban timestamp and reject the connection.
+            if self.is_ip_banned(peer_addr.ip()) {
+                self.update_ip_ban(peer_addr.ip());
+                trace!("Rejected a connection request from banned IP '{}'", peer_addr.ip());
+                return Err(error(format!("'{}' is a banned IP address", peer_addr.ip())));
+            }
+
+            // Check the previous low-level connection timestamp.
+            if let Some(peer_stats) = self.tcp.known_peers().get(peer_addr.ip()) {
+                let num_attempts = self.cache.insert_inbound_connection(peer_addr.ip(), 10);
+
+                debug!("Number of connection attempts from '{}': {}", peer_addr.ip(), num_attempts);
+                debug!("Seconds since connection attempt: {}", peer_stats.timestamp().elapsed().as_secs());
+                if peer_stats.timestamp().elapsed().as_secs() <= Router::<N>::MIN_CONNECTION_INTERVAL_IN_SECS
+                    && num_attempts >= Router::<N>::MAX_CONNECTION_ATTEMPTS
+                {
+                    self.update_ip_ban(peer_addr.ip());
+                    trace!("Rejected a consecutive connection request from IP '{}'", peer_addr.ip());
+                    return Err(error(format!("'{}' appears to be spamming connections", peer_addr.ip())));
+                }
+            }
+        }
+
         // Perform the handshake; we pass on a mutable reference to peer_ip in case the process is broken at any point in time.
         let handshake_result = if peer_side == ConnectionSide::Responder {
             self.handshake_inner_initiator(peer_addr, &mut peer_ip, stream, genesis_header, restrictions_id).await

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -106,7 +106,6 @@ impl<N: Network> Router<N> {
         if !self.is_dev() && peer_side == ConnectionSide::Initiator {
             // If the IP is already banned, update the ban timestamp and reject the connection.
             if self.is_ip_banned(peer_addr.ip()) {
-                self.update_ip_ban(peer_addr.ip());
                 trace!("Rejected a connection request from banned IP '{}'", peer_addr.ip());
                 return Err(error(format!("'{}' is a banned IP address", peer_addr.ip())));
             }

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -110,11 +110,11 @@ impl<N: Network> Router<N> {
                 return Err(error(format!("'{}' is a banned IP address", peer_addr.ip())));
             }
 
-            let num_attempts = self.cache.insert_inbound_connection(peer_addr.ip(),  Router::<N>::CONNECTION_ATTEMPTS_SINCE_SECS);
+            let num_attempts =
+                self.cache.insert_inbound_connection(peer_addr.ip(), Router::<N>::CONNECTION_ATTEMPTS_SINCE_SECS);
 
             debug!("Number of connection attempts from '{}': {}", peer_addr.ip(), num_attempts);
-            if num_attempts >= Router::<N>::MAX_CONNECTION_ATTEMPTS
-            {
+            if num_attempts > Router::<N>::MAX_CONNECTION_ATTEMPTS {
                 self.update_ip_ban(peer_addr.ip());
                 trace!("Rejected a consecutive connection request from IP '{}'", peer_addr.ip());
                 return Err(error(format!("'{}' appears to be spamming connections", peer_addr.ip())));

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -43,6 +43,8 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     const MAXIMUM_NUMBER_OF_PEERS: usize = 21;
     /// The maximum number of provers to maintain connections with.
     const MAXIMUM_NUMBER_OF_PROVERS: usize = Self::MAXIMUM_NUMBER_OF_PEERS / 4;
+    /// The amount of time an IP address is prohibited from connecting.
+    const IP_BAN_TIME_IN_SECS: u64 = 300;
 
     /// Handles the heartbeat request.
     fn heartbeat(&self) {
@@ -61,6 +63,8 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         self.handle_trusted_peers();
         // Keep the puzzle request up to date.
         self.handle_puzzle_request();
+        // Unban any addresses whose ban time has expired.
+        self.handle_banned_ips();
     }
 
     /// TODO (howardwu): Consider checking minimum number of validators, to exclude clients and provers.
@@ -219,11 +223,19 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         if num_deficient > 0 {
             // Initialize an RNG.
             let rng = &mut OsRng;
+            let banned_ips = self.tcp().banned_peers().get_banned_ips();
 
             // Attempt to connect to more peers.
-            for peer_ip in self.router().candidate_peers().into_iter().choose_multiple(rng, num_deficient) {
+            for peer_ip in self
+                .router()
+                .candidate_peers()
+                .into_iter()
+                .filter(|peer| !banned_ips.contains(&peer.ip()))
+                .choose_multiple(rng, num_deficient)
+            {
                 self.router().connect(peer_ip);
             }
+
             if self.router().allow_external_peers() {
                 // Request more peers from the connected peers.
                 for peer_ip in self.router().connected_peers().into_iter().choose_multiple(rng, 3) {
@@ -283,5 +295,10 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     /// This function updates the puzzle if network has updated.
     fn handle_puzzle_request(&self) {
         // No-op
+    }
+
+    // Remove addresses whose ban time has expired.
+    fn handle_banned_ips(&self) {
+        self.tcp().banned_peers().remove_old_bans(Self::IP_BAN_TIME_IN_SECS);
     }
 }

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -21,7 +21,7 @@ use crate::{
 use snarkvm::prelude::Network;
 
 use colored::Colorize;
-use rand::{prelude::IteratorRandom, rngs::OsRng, Rng};
+use rand::{Rng, prelude::IteratorRandom, rngs::OsRng};
 
 /// A helper function to compute the maximum of two numbers.
 /// See Rust issue 92391: https://github.com/rust-lang/rust/issues/92391.
@@ -237,16 +237,9 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         if num_deficient > 0 {
             // Initialize an RNG.
             let rng = &mut OsRng;
-            let banned_ips = self.tcp().banned_peers().get_banned_ips();
 
             // Attempt to connect to more peers.
-            for peer_ip in self
-                .router()
-                .candidate_peers()
-                .into_iter()
-                .filter(|peer| !banned_ips.contains(&peer.ip()))
-                .choose_multiple(rng, num_deficient)
-            {
+            for peer_ip in self.router().candidate_peers().into_iter().choose_multiple(rng, num_deficient) {
                 self.router().connect(peer_ip);
             }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -112,7 +112,7 @@ impl<N: Network> Router<N> {
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
     #[cfg(not(any(test, feature = "test")))]
-    const MIN_CONNECTION_INTERVAL_IN_SECS: u64 = 10;
+    const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
     const RADIO_SILENCE_IN_SECS: u64 = 150; // 2.5 minutes

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -46,6 +46,8 @@ use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 
 use anyhow::{bail, Result};
 use parking_lot::{Mutex, RwLock};
+#[cfg(not(any(test, feature = "test")))]
+use std::net::IpAddr;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
@@ -105,6 +107,12 @@ impl<N: Network> Router<N> {
     const MAXIMUM_CANDIDATE_PEERS: usize = 10_000;
     /// The maximum number of connection failures permitted by an inbound connecting peer.
     const MAXIMUM_CONNECTION_FAILURES: usize = 5;
+    /// The maximum amount of connection attempts withing a 10 second threshold
+    #[cfg(not(any(test, feature = "test")))]
+    const MAX_CONNECTION_ATTEMPTS: usize = 10;
+    /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
+    #[cfg(not(any(test, feature = "test")))]
+    const MIN_CONNECTION_INTERVAL_IN_SECS: u64 = 10;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
     const RADIO_SILENCE_IN_SECS: u64 = 150; // 2.5 minutes
@@ -424,6 +432,18 @@ impl<N: Network> Router<N> {
             // Unrecognized networks contain no bootstrap peers.
             vec![]
         }
+    }
+
+    /// Check whether the given IP address is currently banned.
+    #[cfg(not(any(test, feature = "test")))]
+    fn is_ip_banned(&self, ip: IpAddr) -> bool {
+        self.tcp.banned_peers().is_ip_banned(&ip)
+    }
+
+    /// Insert or update a banned IP.
+    #[cfg(not(any(test, feature = "test")))]
+    fn update_ip_ban(&self, ip: IpAddr) {
+        self.tcp.banned_peers().update_ip_ban(ip);
     }
 
     /// Returns the list of metrics for the connected peers.

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -105,8 +105,6 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone(), shutdown.clone()));
-        // Initialize the sync module.
-        let sync = BlockSync::new(BlockSyncMode::Router, ledger_service.clone());
         // Determine if the client should allow external peers.
         let allow_external_peers = true;
 
@@ -121,6 +119,10 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             matches!(storage_mode, StorageMode::Development(_)),
         )
         .await?;
+
+        // Initialize the sync module.
+        let sync = BlockSync::new(BlockSyncMode::Router, ledger_service.clone(), router.tcp().clone());
+
         // Initialize the node.
         let mut node = Self {
             ledger: ledger.clone(),

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -100,8 +100,6 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(ProverLedgerService::new());
-        // Initialize the sync module.
-        let sync = BlockSync::new(BlockSyncMode::Router, ledger_service.clone());
         // Determine if the prover should allow external peers.
         let allow_external_peers = true;
 
@@ -116,6 +114,10 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
             matches!(storage_mode, StorageMode::Development(_)),
         )
         .await?;
+
+        // Initialize the sync module.
+        let sync = BlockSync::new(BlockSyncMode::Router, ledger_service.clone(), router.tcp().clone());
+
         // Compute the maximum number of puzzle instances.
         let max_puzzle_instances = num_cpus::get().saturating_sub(2).clamp(1, 6);
         // Initialize the node.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -107,12 +107,10 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), shutdown.clone()));
-        // Initialize the sync module.
-        let sync = BlockSync::new(BlockSyncMode::Gateway, ledger_service.clone());
 
         // Initialize the consensus.
         let mut consensus =
-            Consensus::new(account.clone(), ledger_service, bft_ip, trusted_validators, storage_mode.clone())?;
+            Consensus::new(account.clone(), ledger_service.clone(), bft_ip, trusted_validators, storage_mode.clone())?;
         // Initialize the primary channels.
         let (primary_sender, primary_receiver) = init_primary_channels::<N>();
         // Start the consensus.
@@ -129,6 +127,9 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             matches!(storage_mode, StorageMode::Development(_)),
         )
         .await?;
+
+        // Initialize the sync module.
+        let sync = BlockSync::new(BlockSyncMode::Gateway, ledger_service, router.tcp().clone());
 
         // Initialize the node.
         let mut node = Self {

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -66,6 +66,10 @@ version = "=2.2.7"
 path = "locators"
 version = "=2.2.7"
 
+[dependencies.snarkos-node-tcp]
+path = "../tcp"
+version = "=2.2.7"
+
 [dependencies.snarkvm]
 workspace = true
 

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.0.0"
 
 [dependencies.snarkos-node-tcp]
 path = "../tcp"
-version = "=2.2.7"
+version = "=3.0.0"
 
 [dependencies.snarkvm]
 workspace = true

--- a/node/tcp/src/helpers/banned_peers.rs
+++ b/node/tcp/src/helpers/banned_peers.rs
@@ -1,0 +1,66 @@
+// Copyright 2024 Aleo Network Foundation
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, net::IpAddr, time::Instant};
+
+use parking_lot::RwLock;
+use tracing::trace;
+
+/// Contains the ban details for a banned peer.
+pub struct BanConfig {
+    /// The time when the ban was created.
+    banned_at: Instant,
+    /// Amount of times the peer has been banned.
+    banned_count: u8,
+}
+
+impl BanConfig {
+    /// Creates a new ban config.
+    pub fn new(count: u8) -> Self {
+        Self { banned_at: Instant::now(), banned_count: count }
+    }
+}
+
+/// Contains the set of peers currently banned by IP.
+#[derive(Default)]
+pub struct BannedPeers(RwLock<HashMap<IpAddr, BanConfig>>);
+
+impl BannedPeers {
+    /// Check whether the given IP address is currently banned.
+    pub fn is_ip_banned(&self, ip: &IpAddr) -> bool {
+        self.0.read().contains_key(ip)
+    }
+
+    /// Get ban count for the given IP address.
+    pub fn get_ban_count(&self, ip: IpAddr) -> Option<u8> {
+        self.0.read().get(&ip).map(|delay| delay.banned_count)
+    }
+
+    /// Insert or update a banned IP.
+    pub fn update_ip_ban(&self, ip: IpAddr) {
+        let count = self.get_ban_count(ip).unwrap_or(0).saturating_add(1u8);
+
+        trace!("Banning IP: {:?} with count: {}", ip, count);
+        let ban_config = BanConfig::new(count);
+        self.0.write().insert(ip, ban_config);
+    }
+
+    /// Remove the expired entries
+    pub fn remove_old_bans(&self, ban_time_in_secs: u64) {
+        self.0.write().retain(|_, ban_config| {
+            ban_config.banned_at.elapsed().as_secs() < (ban_time_in_secs << ban_config.banned_count.max(32))
+        });
+    }
+}

--- a/node/tcp/src/helpers/banned_peers.rs
+++ b/node/tcp/src/helpers/banned_peers.rs
@@ -22,19 +22,14 @@ use parking_lot::RwLock;
 pub struct BanConfig {
     /// The time when the ban was created.
     banned_at: Instant,
-    /// Amount of times the peer has been banned.
-    count: u8,
 }
 
 impl BanConfig {
     /// Creates a new ban config.
-    pub fn new(banned_at: Instant, count: u8) -> Self {
-        Self { banned_at, count }
+    pub fn new(banned_at: Instant) -> Self {
+        Self { banned_at }
     }
 
-    pub fn update_count(&mut self) {
-        self.count += 1;
-    }
 }
 
 /// Contains the set of peers currently banned by IP.
@@ -45,11 +40,6 @@ impl BannedPeers {
     /// Check whether the given IP address is currently banned.
     pub fn is_ip_banned(&self, ip: &IpAddr) -> bool {
         self.0.read().contains_key(ip)
-    }
-
-    /// Get ban count for the given IP address.
-    pub fn get_ban_count(&self, ip: IpAddr) -> Option<u8> {
-        self.0.read().get(&ip).map(|delay| delay.count)
     }
 
     /// Get all banned IPs.
@@ -64,21 +54,13 @@ impl BannedPeers {
 
     /// Insert or update a banned IP.
     pub fn update_ip_ban(&self, ip: IpAddr) {
-        if let Some(config) = self.get_ban_config(ip) {
-            let mut config = config;
-            config.update_count();
-            self.0.write().insert(ip, config);
-        } else {
-            self.0.write().insert(ip, BanConfig::new(Instant::now(), 1u8));
-        }
+        self.0.write().insert(ip, BanConfig::new(Instant::now()));
     }
 
     /// Remove the expired entries
     pub fn remove_old_bans(&self, ban_time_in_secs: u64) {
         self.0.write().retain(|_, ban_config| {
-            let shift = ban_config.count.min(32);
-            let ban_duration = ban_time_in_secs.checked_shl(shift as u32).unwrap_or(u64::MAX);
-            ban_config.banned_at.elapsed().as_secs() < ban_duration
+            ban_config.banned_at.elapsed().as_secs() < ban_time_in_secs
         });
     }
 }

--- a/node/tcp/src/helpers/known_peers.rs
+++ b/node/tcp/src/helpers/known_peers.rs
@@ -13,7 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::IpAddr,
+    sync::Arc,
+    time::Instant,
+};
 
 use parking_lot::RwLock;
 
@@ -21,45 +26,53 @@ use crate::Stats;
 
 /// Contains statistics related to Tcp's peers, currently connected or not.
 #[derive(Default)]
-pub struct KnownPeers(RwLock<HashMap<SocketAddr, Arc<Stats>>>);
+pub struct KnownPeers(RwLock<HashMap<IpAddr, Arc<Stats>>>);
 
 impl KnownPeers {
     /// Adds an address to the list of known peers.
-    pub fn add(&self, addr: SocketAddr) {
-        self.0.write().entry(addr).or_default();
+    pub fn add(&self, addr: IpAddr) {
+        let timestamp = Instant::now();
+        match self.0.write().entry(addr) {
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(Stats::new(timestamp)));
+            }
+            Entry::Occupied(entry) => {
+                *entry.get().timestamp.write() = timestamp;
+            }
+        }
     }
 
     /// Returns the stats for the given peer.
-    pub fn get(&self, addr: SocketAddr) -> Option<Arc<Stats>> {
+    pub fn get(&self, addr: IpAddr) -> Option<Arc<Stats>> {
         self.0.read().get(&addr).map(Arc::clone)
     }
 
     /// Removes an address from the list of known peers.
-    pub fn remove(&self, addr: SocketAddr) -> Option<Arc<Stats>> {
+    pub fn remove(&self, addr: IpAddr) -> Option<Arc<Stats>> {
         self.0.write().remove(&addr)
     }
 
     /// Returns the list of all known peers and their stats.
-    pub fn snapshot(&self) -> HashMap<SocketAddr, Arc<Stats>> {
+    pub fn snapshot(&self) -> HashMap<IpAddr, Arc<Stats>> {
         self.0.read().clone()
     }
 
     /// Registers a submission of a message to the given address.
-    pub fn register_sent_message(&self, to: SocketAddr, size: usize) {
+    pub fn register_sent_message(&self, to: IpAddr, size: usize) {
         if let Some(stats) = self.0.read().get(&to) {
             stats.register_sent_message(size);
         }
     }
 
     /// Registers a receipt of a message to the given address.
-    pub fn register_received_message(&self, from: SocketAddr, size: usize) {
+    pub fn register_received_message(&self, from: IpAddr, size: usize) {
         if let Some(stats) = self.0.read().get(&from) {
             stats.register_received_message(size);
         }
     }
 
     /// Registers a failure associated with the given address.
-    pub fn register_failure(&self, addr: SocketAddr) {
+    pub fn register_failure(&self, addr: IpAddr) {
         if let Some(stats) = self.0.read().get(&addr) {
             stats.register_failure();
         }

--- a/node/tcp/src/helpers/known_peers.rs
+++ b/node/tcp/src/helpers/known_peers.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     net::IpAddr,
     sync::Arc,
     time::Instant,

--- a/node/tcp/src/helpers/mod.rs
+++ b/node/tcp/src/helpers/mod.rs
@@ -16,6 +16,9 @@
 mod config;
 pub use config::Config;
 
+mod banned_peers;
+pub use banned_peers::BannedPeers;
+
 pub mod connections;
 pub use connections::{Connection, ConnectionSide};
 

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -220,12 +220,12 @@ impl<W: Writing> WritingInternal for W {
                 match self_clone.write_to_stream(*msg, &mut framed).await {
                     Ok(len) => {
                         let _ = wrapped_msg.delivery_notification.send(Ok(()));
-                        node.known_peers().register_sent_message(addr, len);
+                        node.known_peers().register_sent_message(addr.ip(), len);
                         node.stats().register_sent_message(len);
                         trace!(parent: node.span(), "sent {}B to {}", len, addr);
                     }
                     Err(e) => {
-                        node.known_peers().register_failure(addr);
+                        node.known_peers().register_failure(addr.ip());
                         error!(parent: node.span(), "couldn't send a message to {}: {}", addr, e);
                         let is_fatal = node.config().fatal_io_errors.contains(&e.kind());
                         let _ = wrapped_msg.delivery_notification.send(Err(e));

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -38,8 +38,6 @@ use tokio::{
 use tracing::*;
 
 use crate::{
-    connections::{Connection, ConnectionSide, Connections},
-    protocols::{Protocol, Protocols},
     BannedPeers,
     Config,
     KnownPeers,


### PR DESCRIPTION
## Motivation

The motivation behind this PR is to have a mechanism of banning peer IPs as outlined [here](https://github.com/AleoNet/snarkOS/pull/3388) to mitigate cases that might stall client/validators.

## Approach
A banned peers list was implemented to store peers acting maliciously that are banned for 300 seconds. If a peer sends more than 10 connection requests in under 10 seconds they get banned and if a peer does not respond to block requests within 600 seconds ( can be changed ) they get banned.

## Test Plan

This was tested on an isolated network with a different ip/machine per peer. Plan is to test this out on the Canary network with the relevant attacks.

## Related PRs

https://github.com/AleoNet/snarkOS/pull/3366
https://github.com/AleoNet/snarkOS/pull/3388
