### PR TITLE
Add support for account new --save-to-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "snarkos-node-rest",
  "snarkvm",
  "sys-info",
+ "tempfile",
  "thiserror",
  "time",
  "tokio",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -104,6 +104,9 @@ workspace = true
 [dependencies.sys-info]
 version = "0.9"
 
+[dependencies.tempfile]
+version = "3"
+
 [dependencies.time]
 version = "0.3"
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -646,15 +646,7 @@ fn check_permissions(path: &PathBuf) -> Result<(), snarkvm::prelude::Error> {
     {
         use std::os::unix::fs::PermissionsExt;
         ensure!(path.exists(), "The file '{:?}' does not exist", path);
-        let parent = path.parent();
-        if let Some(parent) = parent {
-            let parent_permissions = parent.metadata()?.permissions().mode();
-            ensure!(
-                parent_permissions & 0o777 == 0o700,
-                "The folder {:?} must be readable only by the owner (0700)",
-                parent
-            );
-        }
+        crate::check_parent_permissions(path)?;
         let permissions = path.metadata()?.permissions().mode();
         ensure!(permissions & 0o777 == 0o600, "The file {:?} must be readable only by the owner (0600)", path);
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -21,3 +21,47 @@ extern crate thiserror;
 
 pub mod commands;
 pub mod helpers;
+
+use anyhow::Result;
+use std::{
+    fs::{File, Permissions},
+    path::Path,
+};
+
+#[cfg(unix)]
+pub fn check_parent_permissions<T: AsRef<Path>>(path: T) -> Result<()> {
+    use anyhow::{bail, ensure};
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Some(parent) = path.as_ref().parent() {
+        let permissions = parent.metadata()?.permissions().mode();
+        ensure!(permissions & 0o777 == 0o700, "The folder {:?} must be readable only by the owner (0700)", parent);
+    } else {
+        let path = path.as_ref();
+        bail!("Parent does not exist for path={}", path.display());
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn check_parent_permissions<T: AsRef<Path>>(_path: T) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_user_read_only(file: &File) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = Permissions::from_mode(0o400);
+    file.set_permissions(permissions)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn set_user_read_only(file: &File) -> Result<()> {
+    let mut permissions = file.metadata()?.permissions();
+    permissions.set_readonly(true);
+    file.set_permissions(permissions)?;
+    Ok(())
+}

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -21,7 +21,7 @@ use crate::{
 use snarkvm::prelude::Network;
 
 use colored::Colorize;
-use rand::{prelude::IteratorRandom, rngs::OsRng, Rng};
+use rand::{Rng, prelude::IteratorRandom, rngs::OsRng};
 
 /// A helper function to compute the maximum of two numbers.
 /// See Rust issue 92391: https://github.com/rust-lang/rust/issues/92391.


### PR DESCRIPTION
## Motivation
When creating ephemeral networks for integration testing, it is convenient to be able to generate accounts programmatically and save the account information into files, especially the private-key-file for a new account.

Therefore, we introduce the command line switch `--save-to-file`.

```
snarkos account new --save-to-file /path/to/test-account-1
```

This feature, will create good synergy with the existing feature to use the command-line switch `--private-key-file`.

The PR is split into two commits

1. Add the feature to use --save-to-file for account new
1. Add tempfile as a dependency

## Test Plan

Make sure that you can use the switches `--save-to-file` and `--private-key-file` together when using the command-line interface (cli).

## Related PRs

