### PR TITLE
Canary release week 24.44 - v1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3629,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "indexmap 2.5.0",
  "itertools 0.11.0",
@@ -3722,12 +3722,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3738,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3790,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3992,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "rand",
  "rayon",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4102,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "anyhow",
  "rand",
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4203,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "indexmap 2.5.0",
  "paste",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4474,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=dea322b#dea322b3d374ac0fa7dae26cf006bf67acd52e9e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "dea322b"
+rev = "6142144"
 #version = "=1.0.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,8 +67,8 @@ version = "=3.0.0"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "dea322b"
-version = "=1.0.0"
+rev = "6142144"
+#version = "=1.0.0"
 default-features = false
 optional = true
 


### PR DESCRIPTION
## Motivation
Updating snarkVM rev for Canary v1.1.2. Please see below for fixes and features added in this release.

## Release Notes
- Fixes fetching data from CDN for certain platforms
- Fixes the `--rest-rps` flag to parse the given rate limit as you would expect it to

## Test Plan
Mixed ISOnet over the weekend with:
- mainnet stable validator + clients 
- v1.1.1 validator + clients (canary week 24.43)
- and this release, v1.1.2 validator + clients (canary week 24.44)

## Related PRs

### snarkVM

https://github.com/AleoNet/snarkVM/pull/2554
https://github.com/AleoNet/snarkVM/pull/2562
https://github.com/AleoNet/snarkVM/pull/2567

### snarkOS

[AleoNet/snarkOS#3395](https://github.com/AleoNet/snarkOS/pull/3395)
[AleoNet/snarkOS#3405](https://github.com/AleoNet/snarkOS/pull/3405)
[AleoNet/snarkOS#3408](https://github.com/AleoNet/snarkOS/pull/3408)
[AleoNet/snarkOS#3414](https://github.com/AleoNet/snarkOS/pull/3414)
