### PR TITLE
[Perf] Rate-limit unique Certificates from unique peers

### DIFF
--- a/node/bft/events/src/batch_certified.rs
+++ b/node/bft/events/src/batch_certified.rs
@@ -17,20 +17,23 @@ use super::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BatchCertified<N: Network> {
+    /// The certificate id.
+    pub certificate_id: Field<N>,
+    /// The batch certificate.
     pub certificate: Data<BatchCertificate<N>>,
 }
 
 impl<N: Network> BatchCertified<N> {
     /// Initializes a new batch certified event.
-    pub fn new(certificate: Data<BatchCertificate<N>>) -> Self {
-        Self { certificate }
+    pub fn new(certificate_id: Field<N>, certificate: Data<BatchCertificate<N>>) -> Self {
+        Self { certificate_id, certificate }
     }
 }
 
 impl<N: Network> From<BatchCertificate<N>> for BatchCertified<N> {
     /// Initializes a new batch certified event.
     fn from(certificate: BatchCertificate<N>) -> Self {
-        Self::new(Data::Object(certificate))
+        Self::new(certificate.id(), Data::Object(certificate))
     }
 }
 
@@ -44,16 +47,18 @@ impl<N: Network> EventTrait for BatchCertified<N> {
 
 impl<N: Network> ToBytes for BatchCertified<N> {
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
+        self.certificate_id.write_le(&mut writer)?;
         self.certificate.write_le(&mut writer)?;
         Ok(())
     }
 }
 
 impl<N: Network> FromBytes for BatchCertified<N> {
-    fn read_le<R: Read>(reader: R) -> IoResult<Self> {
-        let certificate = Data::read_le(reader)?;
+    fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
+        let certificate_id = Field::<N>::read_le(&mut reader)?;
+        let certificate = Data::read_le(&mut reader)?;
 
-        Ok(Self { certificate })
+        Ok(Self { certificate_id, certificate })
     }
 }
 

--- a/node/bft/events/src/primary_ping.rs
+++ b/node/bft/events/src/primary_ping.rs
@@ -19,6 +19,7 @@ use super::*;
 pub struct PrimaryPing<N: Network> {
     pub version: u32,
     pub block_locators: BlockLocators<N>,
+    pub certificate_id: Field<N>,
     pub primary_certificate: Data<BatchCertificate<N>>,
 }
 
@@ -27,16 +28,17 @@ impl<N: Network> PrimaryPing<N> {
     pub const fn new(
         version: u32,
         block_locators: BlockLocators<N>,
+        certificate_id: Field<N>,
         primary_certificate: Data<BatchCertificate<N>>,
     ) -> Self {
-        Self { version, block_locators, primary_certificate }
+        Self { version, block_locators, certificate_id, primary_certificate }
     }
 }
 
 impl<N: Network> From<(u32, BlockLocators<N>, BatchCertificate<N>)> for PrimaryPing<N> {
     /// Initializes a new ping event.
     fn from((version, block_locators, primary_certificate): (u32, BlockLocators<N>, BatchCertificate<N>)) -> Self {
-        Self::new(version, block_locators, Data::Object(primary_certificate))
+        Self::new(version, block_locators, primary_certificate.id(), Data::Object(primary_certificate))
     }
 }
 
@@ -54,6 +56,8 @@ impl<N: Network> ToBytes for PrimaryPing<N> {
         self.version.write_le(&mut writer)?;
         // Write the block locators.
         self.block_locators.write_le(&mut writer)?;
+        // Write the certificate id.
+        self.certificate_id.write_le(&mut writer)?;
         // Write the primary certificate.
         self.primary_certificate.write_le(&mut writer)?;
 
@@ -67,11 +71,13 @@ impl<N: Network> FromBytes for PrimaryPing<N> {
         let version = u32::read_le(&mut reader)?;
         // Read the block locators.
         let block_locators = BlockLocators::read_le(&mut reader)?;
+        // Read the certificate id.
+        let certificate_id = Field::read_le(&mut reader)?;
         // Read the primary certificate.
         let primary_certificate = Data::read_le(&mut reader)?;
 
         // Return the ping event.
-        Ok(Self::new(version, block_locators, primary_certificate))
+        Ok(Self::new(version, block_locators, certificate_id, primary_certificate))
     }
 }
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -17,13 +17,14 @@ use crate::{
     CONTEXT,
     MAX_BATCH_DELAY_IN_MS,
     MEMORY_POOL_PORT,
+    PRIMARY_PING_IN_MS,
     Worker,
-    events::{EventCodec, PrimaryPing},
     helpers::{Cache, PrimarySender, Resolver, Storage, SyncSender, WorkerSender, assign_to_worker},
     spawn_blocking,
 };
 use snarkos_account::Account;
 use snarkos_node_bft_events::{
+    BatchCertified,
     BlockRequest,
     BlockResponse,
     CertificateRequest,
@@ -33,7 +34,9 @@ use snarkos_node_bft_events::{
     DataBlocks,
     DisconnectReason,
     Event,
+    EventCodec,
     EventTrait,
+    PrimaryPing,
     TransmissionRequest,
     TransmissionResponse,
     ValidatorsRequest,
@@ -78,6 +81,8 @@ use tokio_util::codec::Framed;
 const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
 /// The maximum interval of requests to cache.
 const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
+/// The maximum interval of events to cache.
+const CACHE_PRIMARY_CERTIFICATES_INTERVAL: i64 = 3 * (PRIMARY_PING_IN_MS / 1000) as i64; // seconds
 
 /// The maximum number of connection attempts in an interval.
 const MAX_CONNECTION_ATTEMPTS: usize = 10;
@@ -561,6 +566,21 @@ impl<N: Network> Gateway<N> {
                     return Ok(());
                 }
             }
+            Event::PrimaryPing(_) | Event::BatchCertified(_) => {
+                // Retrieve the certificate ID.
+                let certificate_id = match &event {
+                    Event::PrimaryPing(PrimaryPing { certificate_id, .. }) => *certificate_id,
+                    Event::BatchCertified(BatchCertified { certificate_id, .. }) => *certificate_id,
+                    _ => unreachable!(),
+                };
+                // Skip processing duplicate primary certificates received from the same peer.
+                let num_events = self
+                    .cache
+                    .insert_inbound_primary_certificate((peer_ip, certificate_id), CACHE_PRIMARY_CERTIFICATES_INTERVAL);
+                if num_events >= 2 {
+                    return Ok(());
+                }
+            }
             Event::TransmissionRequest(TransmissionRequest { transmission_id })
             | Event::TransmissionResponse(TransmissionResponse { transmission_id, .. }) => {
                 // Skip processing this certificate if the rate limit was exceeded (i.e. someone is spamming a specific certificate).
@@ -594,7 +614,8 @@ impl<N: Network> Gateway<N> {
             }
             Event::BatchCertified(batch_certified) => {
                 // Send the batch certificate to the primary.
-                let _ = self.primary_sender().tx_batch_certified.send((peer_ip, batch_certified.certificate)).await;
+                let BatchCertified { certificate_id, certificate } = batch_certified;
+                let _ = self.primary_sender().tx_batch_certified.send((peer_ip, certificate_id, certificate)).await;
                 Ok(())
             }
             Event::BlockRequest(block_request) => {
@@ -676,7 +697,7 @@ impl<N: Network> Gateway<N> {
                 bail!("{CONTEXT} {:?}", disconnect.reason)
             }
             Event::PrimaryPing(ping) => {
-                let PrimaryPing { version, block_locators, primary_certificate } = ping;
+                let PrimaryPing { version, block_locators, certificate_id, primary_certificate } = ping;
 
                 // Ensure the event version is not outdated.
                 if version < Event::<N>::VERSION {
@@ -691,8 +712,9 @@ impl<N: Network> Gateway<N> {
                     }
                 }
 
-                // Send the batch certificates to the primary.
-                let _ = self.primary_sender().tx_primary_ping.send((peer_ip, primary_certificate)).await;
+                // Send the batch certificate to the primary.
+                let _ =
+                    self.primary_sender().tx_primary_ping.send((peer_ip, certificate_id, primary_certificate)).await;
                 Ok(())
             }
             Event::TransmissionRequest(request) => {

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -82,7 +82,7 @@ const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // sec
 /// The maximum interval of requests to cache.
 const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
 /// The maximum interval of events to cache.
-const CACHE_PRIMARY_CERTIFICATES_INTERVAL: i64 = 3 * (PRIMARY_PING_IN_MS / 1000) as i64; // seconds
+const CACHE_PRIMARY_CERTIFICATES_INTERVAL: i64 = ((2 * PRIMARY_PING_IN_MS) / 1000) as i64; // seconds
 
 /// The maximum number of connection attempts in an interval.
 const MAX_CONNECTION_ATTEMPTS: usize = 10;

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -32,6 +32,8 @@ pub struct Cache<N: Network> {
     seen_inbound_events: RwLock<BTreeMap<i64, HashMap<SocketAddr, u32>>>,
     /// The ordered timestamp map of certificate IDs and cache hits.
     seen_inbound_certificates: RwLock<BTreeMap<i64, HashMap<Field<N>, u32>>>,
+    /// The ordered timestamp map of (peer IPs, primary certificate IDs) and cache hits.
+    seen_inbound_primary_certificates: RwLock<BTreeMap<i64, HashMap<(SocketAddr, Field<N>), u32>>>,
     /// The ordered timestamp map of transmission IDs and cache hits.
     seen_inbound_transmissions: RwLock<BTreeMap<i64, HashMap<TransmissionID<N>, u32>>>,
     /// The ordered timestamp map of inbound block requests and cache hits.
@@ -62,6 +64,7 @@ impl<N: Network> Cache<N> {
             seen_inbound_connections: Default::default(),
             seen_inbound_events: Default::default(),
             seen_inbound_certificates: Default::default(),
+            seen_inbound_primary_certificates: Default::default(),
             seen_inbound_transmissions: Default::default(),
             seen_inbound_block_requests: Default::default(),
             seen_outbound_events: Default::default(),
@@ -87,6 +90,11 @@ impl<N: Network> Cache<N> {
     /// Inserts a certificate ID into the cache, returning the number of recent events.
     pub fn insert_inbound_certificate(&self, key: Field<N>, interval_in_secs: i64) -> usize {
         Self::retain_and_insert(&self.seen_inbound_certificates, key, interval_in_secs)
+    }
+
+    /// Inserts a (peer_ip, primary certificate ID) into the cache, returning the number of recent events.
+    pub fn insert_inbound_primary_certificate(&self, key: (SocketAddr, Field<N>), interval_in_secs: i64) -> usize {
+        Self::retain_and_insert(&self.seen_inbound_primary_certificates, key, interval_in_secs)
     }
 
     /// Inserts a transmission ID into the cache, returning the number of recent events.

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -29,7 +29,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::Result,
+    prelude::{Field, Result},
 };
 
 use indexmap::IndexMap;
@@ -125,8 +125,8 @@ pub fn init_bft_channels<N: Network>() -> (BFTSender<N>, BFTReceiver<N>) {
 pub struct PrimarySender<N: Network> {
     pub tx_batch_propose: mpsc::Sender<(SocketAddr, BatchPropose<N>)>,
     pub tx_batch_signature: mpsc::Sender<(SocketAddr, BatchSignature<N>)>,
-    pub tx_batch_certified: mpsc::Sender<(SocketAddr, Data<BatchCertificate<N>>)>,
-    pub tx_primary_ping: mpsc::Sender<(SocketAddr, Data<BatchCertificate<N>>)>,
+    pub tx_batch_certified: mpsc::Sender<(SocketAddr, Field<N>, Data<BatchCertificate<N>>)>,
+    pub tx_primary_ping: mpsc::Sender<(SocketAddr, Field<N>, Data<BatchCertificate<N>>)>,
     pub tx_unconfirmed_solution: mpsc::Sender<(SolutionID<N>, Data<Solution<N>>, oneshot::Sender<Result<()>>)>,
     pub tx_unconfirmed_transaction: mpsc::Sender<(N::TransactionID, Data<Transaction<N>>, oneshot::Sender<Result<()>>)>,
 }
@@ -165,8 +165,8 @@ impl<N: Network> PrimarySender<N> {
 pub struct PrimaryReceiver<N: Network> {
     pub rx_batch_propose: mpsc::Receiver<(SocketAddr, BatchPropose<N>)>,
     pub rx_batch_signature: mpsc::Receiver<(SocketAddr, BatchSignature<N>)>,
-    pub rx_batch_certified: mpsc::Receiver<(SocketAddr, Data<BatchCertificate<N>>)>,
-    pub rx_primary_ping: mpsc::Receiver<(SocketAddr, Data<BatchCertificate<N>>)>,
+    pub rx_batch_certified: mpsc::Receiver<(SocketAddr, Field<N>, Data<BatchCertificate<N>>)>,
+    pub rx_primary_ping: mpsc::Receiver<(SocketAddr, Field<N>, Data<BatchCertificate<N>>)>,
     pub rx_unconfirmed_solution: mpsc::Receiver<(SolutionID<N>, Data<Solution<N>>, oneshot::Sender<Result<()>>)>,
     pub rx_unconfirmed_transaction:
         mpsc::Receiver<(N::TransactionID, Data<Transaction<N>>, oneshot::Sender<Result<()>>)>,

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -914,11 +914,22 @@ impl<N: Network> Primary<N> {
     async fn process_batch_certificate_from_peer(
         &self,
         peer_ip: SocketAddr,
-        certificate: BatchCertificate<N>,
+        certificate_id: Field<N>,
+        certificate: Data<BatchCertificate<N>>,
     ) -> Result<()> {
         // Ensure storage does not already contain the certificate.
-        if self.storage.contains_certificate(certificate.id()) {
+        if self.storage.contains_certificate(certificate_id) {
             return Ok(());
+        }
+        // Deserialize the primary certificate in the primary ping.
+        let Ok(certificate) = spawn_blocking!(certificate.deserialize_blocking()) else {
+            bail!("Failed to deserialize certificate from '{peer_ip}'");
+        };
+        // Ensure the certificate id matches the given id.
+        if certificate.id() != certificate_id {
+            // Proceed to disconnect the validator.
+            self.gateway.disconnect(peer_ip);
+            bail!("Malicious peer - Received a batch certificate with mismatching id from ({peer_ip})");
         }
 
         // Retrieve the batch certificate author.
@@ -1057,25 +1068,21 @@ impl<N: Network> Primary<N> {
         // Start the primary ping handler.
         let self_ = self.clone();
         self.spawn(async move {
-            while let Some((peer_ip, primary_certificate)) = rx_primary_ping.recv().await {
+            while let Some((peer_ip, certificate_id, primary_certificate)) = rx_primary_ping.recv().await {
                 // If the primary is not synced, then do not process the primary ping.
                 if !self_.sync.is_synced() {
                     trace!("Skipping a primary ping from '{peer_ip}' {}", "(node is syncing)".dimmed());
                     continue;
                 }
-
                 // Spawn a task to process the primary certificate.
                 {
                     let self_ = self_.clone();
                     tokio::spawn(async move {
-                        // Deserialize the primary certificate in the primary ping.
-                        let Ok(primary_certificate) = spawn_blocking!(primary_certificate.deserialize_blocking())
-                        else {
-                            warn!("Failed to deserialize primary certificate in 'PrimaryPing' from '{peer_ip}'");
-                            return;
-                        };
                         // Process the primary certificate.
-                        if let Err(e) = self_.process_batch_certificate_from_peer(peer_ip, primary_certificate).await {
+                        if let Err(e) = self_
+                            .process_batch_certificate_from_peer(peer_ip, certificate_id, primary_certificate)
+                            .await
+                        {
                             warn!("Cannot process a primary certificate in a 'PrimaryPing' from '{peer_ip}' - {e}");
                         }
                     });
@@ -1171,7 +1178,7 @@ impl<N: Network> Primary<N> {
         // Process the certified batch.
         let self_ = self.clone();
         self.spawn(async move {
-            while let Some((peer_ip, batch_certificate)) = rx_batch_certified.recv().await {
+            while let Some((peer_ip, certificate_id, batch_certificate)) = rx_batch_certified.recv().await {
                 // If the primary is not synced, then do not store the certificate.
                 if !self_.sync.is_synced() {
                     trace!("Skipping a certified batch from '{peer_ip}' {}", "(node is syncing)".dimmed());
@@ -1180,13 +1187,10 @@ impl<N: Network> Primary<N> {
                 // Spawn a task to process the batch certificate.
                 let self_ = self_.clone();
                 tokio::spawn(async move {
-                    // Deserialize the batch certificate.
-                    let Ok(batch_certificate) = spawn_blocking!(batch_certificate.deserialize_blocking()) else {
-                        warn!("Failed to deserialize the batch certificate from '{peer_ip}'");
-                        return;
-                    };
                     // Process the batch certificate.
-                    if let Err(e) = self_.process_batch_certificate_from_peer(peer_ip, batch_certificate).await {
+                    if let Err(e) =
+                        self_.process_batch_certificate_from_peer(peer_ip, certificate_id, batch_certificate).await
+                    {
                         warn!("Cannot store a certificate from '{peer_ip}' - {e}");
                     }
                 });

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -682,12 +682,12 @@ impl<N: Network> Primary<N> {
         if let Some((signed_round, signed_batch_id, signature)) =
             self.signed_proposals.read().get(&batch_author).copied()
         {
-            // If the signed round is ahead of the peer's batch round, then the validator is malicious.
+            // If the signed round is ahead of the peer's batch round.
             if signed_round > batch_header.round() {
                 bail!("Peer ({batch_author}) proposed a batch for a previous round ({})", batch_header.round());
             }
 
-            // If the round matches and the batch ID differs, then the validator is malicious.
+            // If the round matches and the batch ID differs.
             if signed_round == batch_header.round() && signed_batch_id != batch_header.batch_id() {
                 bail!("Peer ({batch_author}) proposed another batch for the same round ({signed_round})");
             }


### PR DESCRIPTION
## Motivation

Certificates take a long time to process (up to `MAX_CERTIFICATES` signatures). Moreover, primary certificates are rebroadcasted every 5 seconds. Under heavy load, when rounds take longer, this means a lot of work is spent processing duplicate certificates. This PR implements some simple rate limiting checks.

Perhaps, in the future the id check can be encapsulated within the `Data` object.

## Test Plan

- [x] Local test
- [ ] Remote test