### PR TITLE
Optimize BlockLocators Iterator with Parallel Processing

### DIFF
--- a/node/sync/locators/Cargo.toml
+++ b/node/sync/locators/Cargo.toml
@@ -21,6 +21,9 @@ default = [ ]
 test = [ ]
 test_targets = [ "snarkvm/test_targets" ]
 
+[dependencies]
+rayon = "1.10"
+
 [dependencies.anyhow]
 version = "1.0"
 

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -15,10 +15,13 @@
 
 use snarkvm::prelude::{FromBytes, IoResult, Network, Read, ToBytes, Write, error, has_duplicates};
 
+use rayon::prelude::*;
+use rayon::iter::IntoParallelIterator;
 use anyhow::{Result, bail, ensure};
 use indexmap::{IndexMap, indexmap};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, btree_map::IntoIter};
+use std::iter::FromIterator;
 
 /// The number of recent blocks (near tip).
 pub const NUM_RECENT_BLOCKS: usize = 100; // 100 blocks
@@ -61,11 +64,14 @@ impl<N: Network> IntoIterator for BlockLocators<N> {
     type IntoIter = IntoIter<u32, N::BlockHash>;
     type Item = (u32, N::BlockHash);
 
-    // TODO (howardwu): Consider using `BTreeMap::from_par_iter` if it is more performant.
-    //  Check by sorting 300-1000 items and comparing the performance.
-    //  (https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.from_par_iter)
     fn into_iter(self) -> Self::IntoIter {
-        BTreeMap::from_iter(self.checkpoints.into_iter().chain(self.recents)).into_iter()
+        BTreeMap::from_iter(
+            self.checkpoints
+            .into_par_iter()
+            .chain(self.recents.into_par_iter())
+            .collect::<Vec<_>>(),
+        )
+            .into_iter()
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR aims to optimize the BlockLocators into_iter method by introducing parallel processing. The existing sequential processing approach can be time-consuming when handling large datasets of block data. By leveraging rayon for parallel processing, this change seeks to improve performance in merging checkpoints and recents maps, providing a more efficient solution for large-scale data handling.

## Test Plan

Generate a dataset of 1000 items to compare processing speeds.

## Related PRs

(Link any related PRs here)
