### PR TITLE
Canary release week 24.45 - v1.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3699,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "indexmap 2.6.0",
  "itertools 0.11.0",
@@ -3737,12 +3737,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3805,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3899,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4007,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4028,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "rand",
  "rayon",
@@ -4075,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "anyhow",
  "rand",
@@ -4129,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4296,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4417,11 +4417,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "colored",
  "indexmap 2.6.0",
+ "lru",
  "once_cell",
  "parking_lot",
  "rand",
@@ -4436,12 +4437,13 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tracing",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "indexmap 2.6.0",
  "paste",
@@ -4455,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4468,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4489,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6142144#6142144d67d66c5c30beeac848ae4996d09c47d9"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=4eb83d7#4eb83d7f7276514baa9c44b920155750cfe855e7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "6142144"
+rev = "4eb83d7"
 #version = "=1.0.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.0.0"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "6142144"
+rev = "4eb83d7"
 #version = "=1.0.0"
 default-features = false
 optional = true


### PR DESCRIPTION
## Motivation
Updating snarkVM rev for Canary v1.1.3. Please see below for fixes and features added in this release.

## Release Notes

### snarkVM
- Fixed program data validation and display mechanisms to prevent potential system crashes
[AleoNet/snarkVM#2532](https://github.com/AleoNet/snarkVM/pull/2532)

- Optimized RocksDB iterator usage, reducing memory allocations by 98%, speeding up ledger loading by 14%, and decreasing memory usage by 13%
[AleoNet/snarkVM#2561](https://github.com/AleoNet/snarkVM/pull/2561)

- Implemented lazy program loading to keep only recently used programs in memory, with others loaded from storage on demand
[AleoNet/snarkVM#2553](https://github.com/AleoNet/snarkVM/pull/2553)

### snarkOS
- Added automatic peer reconnection logic to maintain network stability when connections are lost, with configurable retry intervals and backoff periods
[AleoNet/snarkOS#3407](https://github.com/AleoNet/snarkOS/pull/3407)

- Improved network connection handling by properly sequencing peer state transitions from connecting to connected status
[AleoNet/snarkOS#3424](https://github.com/AleoNet/snarkOS/pull/3424)

- Added test targets feature flag for development and testing environments
[AleoNet/snarkOS#3418](https://github.com/AleoNet/snarkOS/pull/3418)

- Enhanced developer tooling by adding private key file support for secure program execution
[AleoNet/snarkOS#3429](https://github.com/AleoNet/snarkOS/pull/3429)

## Test Plan
Mixed ISOnet with:
- v1.1.2 validator + clients (canary week 24.44)
- and this release, v1.1.3 validator + clients (canary week 24.45)