### PR TITLE
Remove test feature from cfg

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -65,7 +65,7 @@ use futures::SinkExt;
 use indexmap::{IndexMap, IndexSet};
 use parking_lot::{Mutex, RwLock};
 use rand::seq::{IteratorRandom, SliceRandom};
-#[cfg(not(any(test, feature = "test")))]
+#[cfg(not(any(test)))]
 use std::net::IpAddr;
 use std::{collections::HashSet, future::Future, io, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::{
@@ -92,7 +92,7 @@ const MIN_CONNECTED_VALIDATORS: usize = 175;
 const MAX_VALIDATORS_TO_SEND: usize = 200;
 
 /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
-#[cfg(not(any(test, feature = "test")))]
+#[cfg(not(any(test)))]
 const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
 /// The amount of time an IP address is prohibited from connecting.
 const IP_BAN_TIME_IN_SECS: u64 = 300;
@@ -469,13 +469,13 @@ impl<N: Network> Gateway<N> {
     }
 
     /// Check whether the given IP address is currently banned.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test)))]
     fn is_ip_banned(&self, ip: IpAddr) -> bool {
         self.tcp.banned_peers().is_ip_banned(&ip)
     }
 
     /// Insert or update a banned IP.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test)))]
     fn update_ip_ban(&self, ip: IpAddr) {
         self.tcp.banned_peers().update_ip_ban(ip);
     }
@@ -1154,7 +1154,7 @@ impl<N: Network> Handshake for Gateway<N> {
         let peer_side = connection.side();
 
         // Check (or impose) IP-level bans.
-        #[cfg(not(any(test, feature = "test")))]
+        #[cfg(not(any(test)))]
         if self.dev().is_none() && peer_side == ConnectionSide::Initiator {
             // If the IP is already banned reject the connection.
             if self.is_ip_banned(peer_addr.ip()) {

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -102,7 +102,7 @@ impl<N: Network> Router<N> {
         };
 
         // Check (or impose) IP-level bans.
-        #[cfg(not(any(test, feature = "test")))]
+        #[cfg(not(any(test)))]
         if !self.is_dev() && peer_side == ConnectionSide::Initiator {
             // If the IP is already banned reject the connection.
             if self.is_ip_banned(peer_addr.ip()) {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -47,7 +47,7 @@ use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 
 use anyhow::{Result, bail};
 use parking_lot::{Mutex, RwLock};
-#[cfg(not(any(test, feature = "test")))]
+#[cfg(not(any(test)))]
 use std::net::IpAddr;
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
@@ -107,14 +107,14 @@ pub struct InnerRouter<N: Network> {
 
 impl<N: Network> Router<N> {
     /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test)))]
     const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
     /// The maximum number of candidate peers permitted to be stored in the node.
     const MAXIMUM_CANDIDATE_PEERS: usize = 10_000;
     /// The maximum number of connection failures permitted by an inbound connecting peer.
     const MAXIMUM_CONNECTION_FAILURES: usize = 5;
     /// The maximum amount of connection attempts withing a 10 second threshold
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test)))]
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
@@ -450,13 +450,13 @@ impl<N: Network> Router<N> {
     }
 
     /// Check whether the given IP address is currently banned.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test)))]
     fn is_ip_banned(&self, ip: IpAddr) -> bool {
         self.tcp.banned_peers().is_ip_banned(&ip)
     }
 
     /// Insert or update a banned IP.
-    #[cfg(not(any(test, feature = "test")))]
+    #[cfg(not(any(test)))]
     fn update_ip_ban(&self, ip: IpAddr) {
         self.tcp.banned_peers().update_ip_ban(ip);
     }


### PR DESCRIPTION
## Motivation

Clippy was having issues with `#[cfg(not(any(test, feature = "test")))]` as the `test` feature does not exist. So this PR changes it to `#[cfg(not(any(test)))]`.

