### PR TITLE
fix: Improve error message for invalid node type

### DIFF
--- a/node/router/messages/src/helpers/node_type.rs
+++ b/node/router/messages/src/helpers/node_type.rs
@@ -77,7 +77,7 @@ impl FromBytes for NodeType {
             0 => Ok(Self::Client),
             1 => Ok(Self::Prover),
             2 => Ok(Self::Validator),
-            _ => Err(error("Invalid node type")),
+            x => Err(error(format!("Invalid node type: expected 0, 1, or 2, got {x}."))),
         }
     }
 }


### PR DESCRIPTION
## Motivation

Add more information in the error message about an invalid node type. It can be helpful when troubleshooting a broken/misconfigured node.

## Test Plan

No specific tests.

## Related PRs

None.
