### PR TITLE
perf: Change link-time optimization in dev and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ debug-assertions = false
 
 [profile.dev]
 opt-level = 2
-lto = "thin"
+lto = "off"
 incremental = true
 
 [profile.test]


### PR DESCRIPTION
## Motivation

This change improves the development cycle in both dev and test, when running the same command multiple times in a row.

On my machine I can see improvements from minutes to seconds. For example when running `cargo run` and `cargo test`.

## Test Plan

Compare running this commands 3 times in a row with or without this patch

```
cargo test
```

```
cargo run accounts new
```

## Related PRs

None