### PR TITLE
[Perf] Avoid deserialization of previously added blocks

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -661,6 +661,10 @@ impl<N: Network> Gateway<N> {
                     if !self.cache.remove_outbound_block_request(peer_ip, &request) {
                         bail!("Unsolicited block response from '{peer_ip}'")
                     }
+                    // Return early if we already advanced past the block request.
+                    if self.ledger.latest_block_height() >= request.end_height {
+                        return Ok(());
+                    }
                     // Perform the deferred non-blocking deserialization of the blocks.
                     let blocks = blocks.deserialize().await.map_err(|error| anyhow!("[BlockResponse] {error}"))?;
                     // Ensure the block response is well-formed.


### PR DESCRIPTION
## Motivation

Validators often optimistically request blocks (given that `MAX_BLOCKS_BEHIND` is only 1). As a result, validators often receive a block which is incredibly expensive to deserialize, even though they already advanced.

This PR avoids deserialization if we already advanced to `request.end_height`.

As a future optimization, we can also meddle with the deserialization of `DataBlocks` so we can deserialize only *some* blocks if we already advanced.

## Test Plan

- [ ] Local network failed, seemingly at the point where we switch from Block syncing to Consensus syncing
- [ ] Ran deployed network