### PR TITLE
Canary release week 24.47 - v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3600,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "indexmap 2.5.0",
  "itertools 0.11.0",
@@ -3724,12 +3724,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3770,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3986,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4026,7 +4026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "rand",
  "rayon",
@@ -4062,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4104,7 +4104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "anyhow",
  "rand",
@@ -4116,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4220,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4242,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4296,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4430,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "indexmap 2.5.0",
  "paste",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4457,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.0.0"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=0b391d2#0b391d2a0fad8c1ee49b3fc64e6a64d4b801ad2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=d432417#d432417d78924837b4003bce1a51049b52ce79bd"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "0b391d2"
+rev = "d432417"
 #version = "=1.0.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.0.0"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "0b391d2"
+rev = "d432417"
 #version = "=1.0.0"
 default-features = false
 optional = true


### PR DESCRIPTION
## Motivation

Updating snarkVM rev for Canary v1.2.1. Please see below for fixes and features added in this release.

## Test Plan

Mixed ISOnet with:

mainnet stable validator + clients
v1.1.4 validator + clients (canary week 24.46)
and this release, v1.2.1 validator + clients (canary week 24.47)

## Related PRs
[AleoNet/snarkVM#2472](https://github.com/AleoNet/snarkVM/pull/2472)
[AleoNet/snarkOS#2500](https://github.com/AleoNet/snarkVM/pull/2500)
[AleoNet/snarkOS#3409](https://github.com/AleoNet/snarkOS/pull/3409)