### PR TITLE
[Fix] Update Github Action permissions for `release.yaml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   ubuntu:
     name: Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -51,6 +53,8 @@ jobs:
   macos:
     name: macOS
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -91,6 +95,8 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    permissions:
+      contents: write
     continue-on-error: true
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the job permissions for the Jobs in `release.yaml` to allow for automated version releases when specific tags are created. 

The current repo permissions are intended to be restrictive, so this change allows **only** this job to have updated permissions.
