### PR TITLE
[Feature] Add a --version cli option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+dependencies = [
+ "git2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1245,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1735,18 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -3178,6 +3212,7 @@ name = "snarkos"
 version = "3.1.0"
 dependencies = [
  "anyhow",
+ "built",
  "clap",
  "crossterm",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,10 @@ tikv-jemallocator = "0.5"
 [dev-dependencies.rusty-hook]
 version = "0.11.2"
 
+[build-dependencies.built]
+version = "0.7"
+features = [ "git2" ]
+
 [build-dependencies.walkdir]
 version = "2"
 

--- a/build.rs
+++ b/build.rs
@@ -60,4 +60,6 @@ fn check_file_licenses<P: AsRef<Path>>(path: P) {
 fn main() {
     // Check licenses in the current folder.
     check_file_licenses(".");
+    // Register build-time information.
+    built::write_built_file().expect("Failed to acquire build-time information");
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -39,8 +39,9 @@ const STYLES: Styles = Styles::plain()
     .usage(Style::new().bold().fg_color(HEADER_COLOR))
     .literal(Style::new().bold().fg_color(LITERAL_COLOR));
 
+// Note: the basic clap-supplied version is overridden in the main module.
 #[derive(Debug, Parser)]
-#[clap(name = "snarkOS", author = "The Aleo Team <hello@aleo.org>", styles = STYLES)]
+#[clap(name = "snarkOS", author = "The Aleo Team <hello@aleo.org>", styles = STYLES, version)]
 pub struct CLI {
     /// Specify the verbosity [options: 0, 1, 2, 3]
     #[clap(default_value = "2", short, long)]

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -16,7 +16,7 @@
 use snarkos_cli::{commands::CLI, helpers::Updater};
 
 use clap::Parser;
-use std::process::exit;
+use std::{env, process::exit};
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use tikv_jemallocator::Jemalloc;
@@ -25,7 +25,13 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+// Obtain information on the build.
+include!(concat!(env!("OUT_DIR"), "/built.rs"));
+
 fn main() -> anyhow::Result<()> {
+    // A hack to avoid having to go through clap to display advanced version information.
+    check_for_version();
+
     // Parse the given arguments.
     let cli = CLI::parse();
     // Run the updater.
@@ -39,4 +45,21 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Checks whether the version information was requested and - if so - display it and exit.
+fn check_for_version() {
+    if let Some(first_arg) = env::args().nth(1) {
+        if ["--version", "-V"].contains(&&*first_arg) {
+            let version = PKG_VERSION;
+            let branch = GIT_HEAD_REF.unwrap_or("unknown_branch");
+            let commit = GIT_COMMIT_HASH.unwrap_or("unknown_commit");
+            let mut features = FEATURES_LOWERCASE_STR.to_owned();
+            features.retain(|c| c != ' ');
+
+            println!("snarkos {version} {branch} {commit} features=[{features}]");
+
+            exit(0);
+        }
+    }
 }


### PR DESCRIPTION
This PR enables a `--version` option that results in the following **build** information being printed:
```
snarkos <VERSION> <BRANCH> <COMMIT> features=[<FEATURES>]
```
example based on this PR's branch:
```
snarkos 3.1.0 refs/heads/feat/version_option2 0911d455fe0b10c5faabb9fa78452aff7662a87f features=[]
```
The features - if any - are comma-separated and w/o whitespaces; I'm not married to the square brackets, but it seemed easy to both parse, and to read by less tech-savvy users (specifically due to not ending with a "dangling" `=` in case of no features, especially if any additional details are appended in the future).

While this should be enough to cover most needs, potential additional information that I'd be happy to add if desired includes:
- whether there were any "dirty" files
- build timestamp
- build profile

Closes https://github.com/AleoNet/snarkOS/issues/3447.