### PR TITLE
Canary release week 24.50 - v1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,8 +3636,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2afaf734585b42090147ce2aae7ce90a3e5f10b452d4efbcd47d2e4ca26969"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3668,8 +3667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d91040c5a51a3c335741aa4fbb8176a612d44760f040c7d9d5833653c6691e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3699,8 +3697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8208642e213e2e20a07d7ceb7facb2e080be99714d55d2ebc67dcdbd6b4aef8b"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3714,8 +3711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4758873037211d81f1d40bfdd6ae1904aabb7298a4217ff83baaddca7f70b7"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3726,8 +3722,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec8ca5e7f6b08e6854e31be1c1207cf6ca26da64f91912d264b0752b14f51cf"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3737,8 +3732,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a709a676a90ce395b811d138698995b515ecc39186772ff7f3c3bb1e1654fbc"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3748,8 +3742,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789c270e95ca1707e3f7d7bd0cc6e90a144cc3a502fe08afde553d6ac0bba9b1"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "indexmap 2.5.0",
  "itertools 0.11.0",
@@ -3767,14 +3760,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ad62fa4ac3a96440d5ebbda604d9cadaf89d518ecd9b062538213820f37c45"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb397309d0c2ddae4fa21fe28b676801e1b4ac352c51c19d7f5fb5f71d968b2d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3785,8 +3776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c32c9e1d5f97212a8f78083b73141d38ee65b120fbd30494fbb76829cb41414"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3801,8 +3791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aff3706d5b770254d967c4771e684424f2440d774945c671fa45883eb5d59e0"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3817,8 +3806,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0973cefa284be203c7b6e8f408d8115a8520fc10fa0e717c2560fca2ee1f07af"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3831,8 +3819,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7137bc6814f983597d6f50d2f88e7dce90237f34586526fbc8d77f841b5455b"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3841,8 +3828,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee531ed89f191a5714684e65c7c271eb1af87bec71abbbc9928e325c0e80674"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3852,8 +3838,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2696c6891bf303cfe71ead8378d98f7faea98c76311ef3d15c85191598ddd481"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3865,8 +3850,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f70807c61d48cabe62b59e5e93fcbb107b62835176c2fe10dcd7a98d02ce15"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3878,8 +3862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba07230428833ac7eecd478f18baa6370b1eb68fe1f1ef93fc3e6c37312e8b6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3890,8 +3873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fb5a0a45eb4982902325912636a82e601b002fadff3d8415e489129c6a846c"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3903,8 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157d8026f2ad796f03a4d41753a9cf2496625d829bb785020e83c2d5554e246a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3917,8 +3898,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909aeac3e1fd4e0f4e56b0ed74d590b9c1a4ff9ab6144fb9b6b81483f0705b99"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3929,8 +3909,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7271e3a4e79b8e23a2461695b84e7d22e329b2089b9b05365627f9e6f3e17cb8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3943,8 +3922,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b330afcf51263442b406b260b18d04b91ce395133390290c637ca79c38973b8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3955,8 +3933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d8154a1456f6e4d0ff458a1107d98c596e095a5ef1fd019cbcfa4ea2e6bf6f"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -3979,8 +3956,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20fd9b2abd65743d04f45533941af710fece03d6ab6adf577000cfbaeb845f32"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3998,8 +3974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7340c6fb347209fe846765b1b2911c63f72c788615f6150c3c588c0b8195a410"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4021,8 +3996,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d66f03c46d92eaf59d18451fad067728e0a5e17618c2447cd82969294c0221"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4037,8 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9cd4cd1f8c2f9129a25d51922a5b1ce6a79719202435c24579998b0e2794ee"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4049,8 +4022,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909a71996dd113a07e748d818145223af9893d4c2c45a9fc165b8426f97a0571"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4058,8 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf76e7ef6c508d01a8a1b2a1340262127eb48253984ac1aca98bdb4f43c662f"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4069,8 +4040,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223bcd81ed18834c042dcf077f71805f28fcb976549b35f8ca47b52f39fe317f"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4081,8 +4051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a392d380a382749b75225552ec27c86b5f33adea11dd7a1774c8927781aeca"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4093,8 +4062,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b7d745b3c27eee7dd4d3a8278341617c9aa10783c7919e3eb3efe7084e0853"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4105,8 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f1048223dc7839e19a2fb60666801fd0fefdcb5a5987394ffe7603f928bc45"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4117,8 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bbd49b827182dd51c3054ec04528ab4eebb61883f0e7d8efeeb53800f684e5"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "rand",
  "rayon",
@@ -4132,8 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b47d900853fbebdb22cf609b7f2cef3e352032c07d11759ee22027d07e758"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4150,8 +4115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fb0a9ba2b0373f3c242cc13140039f66b82167c31e578172e048da2c375033"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4176,8 +4140,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b24b9e54725e0eb3d3dea16159a0e5871fc5a48a7a93ad30c45914a87509d1"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "anyhow",
  "rand",
@@ -4189,8 +4152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec668a611a2e15e927943914253bfd3b9a6f709fd56a8f40bc75046cd07d77e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4210,8 +4172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a6cb54ae8d7dc233164123c0be74786c746ed07a525d3c5b3ad1df368560f8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -4230,8 +4191,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74c3b84031541e865bc972aa773154f429c1350a848cac1fe42d5bf1e326b57"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4244,8 +4204,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550fbc76ff67e050f480751fc52930015e6ccaeea852ad8eddb5ec595e804375"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4258,8 +4217,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0451c6227e6cb15688129fa24cf0f5a49120e0e26c89e61fbfcd8a9c0ba4ad40"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4272,8 +4230,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5a38e42c52112d9ceb2331ded74d4e68040979471a5a1d9041165e83e43291"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4284,8 +4241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbcd2d0dbc7dbe837dfb30de786ac341dd88afdb973b3a2a4c076a39d414e2e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "indexmap 2.5.0",
  "rayon",
@@ -4300,8 +4256,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d5f001471a0a4f72d06bc9140c8fc3f52f23512956b657903b12a04c3504cf"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4314,8 +4269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e348c47cb47148043240680a89839210d6bdfbcd8fcffe4df7b7b99e25411d"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4324,8 +4278,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251252c6b6d48ccdfeee38f63127f01bcd1da1edcc8e73f71de5f33719cb059"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4345,8 +4298,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e0de23eabafe1380f54556a694c1a9a3574767fb4dd49c9c15975641a30e66"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4367,8 +4319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d0a7c91e30017cf69a2f8d1636ea682b54a674c555d3d23b9f74d0cf376482"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4381,8 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184854df19e419bc4f363713f1c5ba73248fa98e184edec881aba77b397b77cd"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4409,8 +4359,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe102cdd6a1720907253b63f0a6e42272644573f0d1610c5e721d4a3dd4c92c6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4425,8 +4374,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d69b61a5c2f5583893841ea1db02f4e937b7e6c22fed7b60773d071f097e7e6"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4435,8 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c31bcc6cc152a8a9fc6992e32edba8f885b736d9ed67c4d9eead979e51d009"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4461,8 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01171b6362e9b10f0a1b19364e86758c79f5469227d25ad677a37d675c31f172"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4494,8 +4440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6576f8a4e376780da7a047a8424ddcc3d991192802fc4e333af275aa90c9bf37"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4519,8 +4464,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baea91c7ea8d8584bbe632340dd90cc56b4cc2127025981c298113d227bb587a"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "indexmap 2.5.0",
  "paste",
@@ -4534,8 +4478,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe2b943d82c5361917cbac96fbf8060f030ae0555efc9cfe0bd13e1e45680cb"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4548,8 +4491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c395af67af40e35bb22a1996acbc01119ba129199f6e2b498bf91706754c98"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4570,8 +4512,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857e98d8e92501c0c6a8102e3f2714a550bf2455977d05c25a10a45b5f8ce047"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=be48f30#be48f30bfeb78f327a57d08f23f7a0aff4e65a95"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
-#git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "6322baf"
-version = "=1.1.0"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "be48f30"
+#version = "=1.1.0"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -67,9 +67,9 @@ version = "=3.1.0"
 
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
-#git = "https://github.com/AleoNet/snarkVM.git"
-#rev = "6322baf"
-version = "=1.1.0"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "be48f30"
+# version = "=1.1.0"
 default-features = false
 optional = true
 


### PR DESCRIPTION
## Motivation

Updating snarkVM rev for Canary v1.2.4. 

Changelog
- Compute optimization [PR](https://github.com/ProvableHQ/snarkVM/pull/2579)
- Minor cleanup proof system [PR](https://github.com/ProvableHQ/snarkVM/pull/2581)

## Test Plan

Mixed ISOnet with:

mainnet stable validator + clients
v1.2.3 validator + clients (canary week 24.49)
and this release, v1.2.4 validator + clients (canary week 24.50)
