### PR TITLE
[Fix] Configure metrics compilation in root toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [features]
-metrics = [ "snarkos-node-metrics", "snarkos-node/metrics" ]
+default = [ "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-cli/metrics" ]
 history = [ "snarkos-node/history" ]
 test_targets = [ "snarkos-cli/test_targets" ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = [ "snarkos-node/metrics" ]
+metrics = [ "snarkos-node/metrics" ]
 test_targets = [ "snarkvm/test_targets" ]
 
 [dependencies.aleo-std]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-metrics = [ "snarkos-node/metrics" ]
+metrics = [ "dep:metrics", "snarkos-node/metrics" ]
 test_targets = [ "snarkvm/test_targets" ]
 
 [dependencies.aleo-std]
@@ -50,6 +50,7 @@ features = [ "serde", "rayon" ]
 package = "snarkos-node-metrics"
 path = "../node/metrics"
 version = "=3.2.0"
+optional = true
 
 [dependencies.num_cpus]
 version = "1"

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -137,9 +137,11 @@ pub struct Start {
     pub logfile: PathBuf,
 
     /// Enables the metrics exporter
+    #[cfg(feature = "metrics")]
     #[clap(default_value = "false", long = "metrics")]
     pub metrics: bool,
     /// Specify the IP address and port for the metrics exporter
+    #[cfg(feature = "metrics")]
     #[clap(long = "metrics-ip")]
     pub metrics_ip: Option<SocketAddr>,
 
@@ -587,6 +589,7 @@ impl Start {
         crate::helpers::check_validator_machine(node_type);
 
         // Initialize the metrics.
+        #[cfg(feature = "metrics")]
         if self.metrics {
             metrics::initialize_metrics(self.metrics_ip);
         }

--- a/node/tcp/Cargo.toml
+++ b/node/tcp/Cargo.toml
@@ -25,31 +25,31 @@ async-trait = "0.1"
 bytes = "1"
 parking_lot = "0.12"
 
-  [dependencies.futures-util]
-  version = "0.3"
-  features = [ "sink" ]
+[dependencies.futures-util]
+version = "0.3"
+features = [ "sink" ]
 
-  [dependencies.metrics]
-  package = "snarkos-node-metrics"
-  path = "../metrics"
-  version = "=3.2.0"
-  optional = true
+[dependencies.metrics]
+package = "snarkos-node-metrics"
+path = "../metrics"
+version = "=3.2.0"
+optional = true
 
-  [dependencies.once_cell]
-  version = "1"
-  features = [ "parking_lot" ]
+[dependencies.once_cell]
+version = "1"
+features = [ "parking_lot" ]
 
-  [dependencies.tokio]
-  version = "1.28"
-  features = [ "io-util", "net", "parking_lot", "rt", "sync", "time" ]
+[dependencies.tokio]
+version = "1.28"
+features = [ "io-util", "net", "parking_lot", "rt", "sync", "time" ]
 
-  [dependencies.tokio-util]
-  version = "0.7"
-  features = [ "codec" ]
+[dependencies.tokio-util]
+version = "0.7"
+features = [ "codec" ]
 
-  [dependencies.tracing]
-  version = "0.1"
-  default-features = false
+[dependencies.tracing]
+version = "0.1"
+default-features = false
 
 [dev-dependencies.tokio]
 version = "1.28"


### PR DESCRIPTION
The `cli` crate currently enables metrics as a default feature, this PR moves the feature's configuration to the root level toml, enables it by default and introduces a `metrics` feature on `cli`. In addition, `snarks-node-metrics` is made optional. 

Correct configuration can be verified with a reverse-search for the metrics crate by feature:
- `cargo tree -e features -i snarkos-node-metrics` (which should show matches, metrics being enabled by default)
- `cargo tree -e features -i snarkos-node-metrics --no-default-features` (which should show no matches)

Fixes #3379. 

The last commit realigns the dependencies in the tcp crate, lmk if I should drop it or move it someplace else. 

Edit: prometheus metric sanity check was also successful with a small devnet. 