### PR TITLE
Fix flaky test_storage_coherence

### DIFF
--- a/node/bft/tests/narwhal_e2e.rs
+++ b/node/bft/tests/narwhal_e2e.rs
@@ -158,8 +158,7 @@ async fn test_storage_coherence() {
     assert!(network.is_committee_coherent(1..TARGET_ROUND));
 
     // Check the round certificates are coherent across the network. We skip the genesis round and
-    // check up to 2 rounds before the the target round as the round preceding the target round
-    // might still be incomplete since the network advances when quorum is reached, not when all
-    // the nodes have completed the round.
-    assert!(network.is_certificate_round_coherent(1..TARGET_ROUND - 1));
+    // check only up to 3 rounds before the the target round, because the network advances when
+    // quorum is reached, not when all the nodes have completed the round and received certificates.
+    assert!(network.is_certificate_round_coherent(1..TARGET_ROUND - 2));
 }


### PR DESCRIPTION
## Motivation

This test failed in [recent CI](https://github.com/ProvableHQ/snarkOS/runs/35793859049) and sometimes locally too on macbook M2 Max. Let's make it a bit more lenient.

A more complete refactor would entail only checking if at least a quorum's worth of certificates is the same in a quorum's worth of nodes, but the current heuristic approach should be sufficient as a test case.