### PR TITLE
Add support for GET /{network}/block/{height}/header

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -153,6 +153,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/block/:height_or_hash"), get(Self::get_block))
             // The path param here is actually only the height, but the name must match the route
             // above, otherwise there'll be a conflict at runtime.
+            .route(&format!("/{network}/block/:height_or_hash/header"), get(Self::get_block_header))
             .route(&format!("/{network}/block/:height_or_hash/transactions"), get(Self::get_block_transactions))
 
             // GET and POST ../transaction/..

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -125,6 +125,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_height(&hash)?))
     }
 
+    // GET /<network>/block/{height}/header
+    pub(crate) async fn get_block_header(
+        State(rest): State<Self>,
+        Path(height): Path<u32>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.get_header(height)?))
+    }
+
     // GET /<network>/block/{height}/transactions
     pub(crate) async fn get_block_transactions(
         State(rest): State<Self>,


### PR DESCRIPTION
## Motivation

Currently one must query the whole block in order to get the information in the header. This commit mimics the existing endpoint to only get the transactions for a block.

With this commit it is possible to query only the headers for blocks. This will reduce both bandwidth and payload sizes for the one parsing the result.

## Test Plan

Start a local validator node and query the header of the first block. 

```
curl http://127.0.0.1:3030/canary/block/0/header
```

Second, query a non existing block

```
curl http://127.0.0.1:3030/canary/block/999999999/header
```

## Related PRs

None.