### PR TITLE
[Feature] Batch proposal spend limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f2a841f04c2eaeb5a95312e5201a9e4b7c95b64ca99870d6bd2e2376df540a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6118baab6285accf088b31d5ea5029c37bbf9d98e62b4d8720a0a5a66bc2e427"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrary"
@@ -218,8 +218,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -240,19 +240,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -304,7 +304,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -328,7 +328,7 @@ dependencies = [
  "fastrand",
  "futures-util",
  "headers",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -371,9 +371,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bech32"
@@ -404,11 +404,11 @@ dependencies = [
  "peeking_take_while",
  "prettyplease",
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -434,9 +434,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake2"
@@ -499,18 +499,17 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -522,9 +521,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -548,14 +547,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -580,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -590,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -602,14 +601,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -636,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -724,7 +723,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -812,8 +811,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -864,8 +863,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -906,8 +905,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -949,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -984,8 +983,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1060,9 +1059,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1166,8 +1165,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1271,7 +1270,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1316,7 +1315,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1359,7 +1358,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 1.2.0",
+ "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
@@ -1371,7 +1370,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1411,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1438,18 +1437,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1462,9 +1461,9 @@ checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1505,7 +1504,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1568,7 +1567,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
@@ -1715,8 +1714,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1752,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1777,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "ipnet"
@@ -1832,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -1884,9 +1883,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libgit2-sys"
@@ -1922,7 +1921,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -1943,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "libc",
@@ -1961,15 +1960,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2070,7 +2069,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2172,8 +2171,8 @@ checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2185,7 +2184,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "memchr",
  "mime",
@@ -2290,8 +2289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2350,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 dependencies = [
  "parking_lot_core",
 ]
@@ -2374,7 +2373,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2390,8 +2389,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2497,22 +2496,22 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2539,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -2557,11 +2556,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -2592,19 +2591,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -2617,7 +2616,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -2667,9 +2666,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2729,7 +2728,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cassowary",
  "crossterm",
  "indoc",
@@ -2744,11 +2743,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2773,11 +2772,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2881,16 +2880,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -2922,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2967,11 +2966,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2992,15 +2991,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.0",
  "subtle",
  "zeroize",
 ]
@@ -3041,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3052,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty-fork"
@@ -3082,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3126,7 +3125,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3184,7 +3183,7 @@ dependencies = [
  "log",
  "quick-xml",
  "regex",
- "reqwest 0.12.12",
+ "reqwest 0.12.14",
  "self-replace",
  "semver",
  "serde_json",
@@ -3196,37 +3195,37 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3235,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -3346,7 +3345,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -3427,7 +3426,7 @@ dependencies = [
  "clap",
  "colored",
  "crossterm",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "nix",
  "num_cpus",
  "parking_lot",
@@ -3446,7 +3445,7 @@ dependencies = [
  "snarkvm",
  "sys-info",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tracing",
@@ -3489,7 +3488,7 @@ dependencies = [
  "colored",
  "deadline",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "lru",
  "num_cpus",
  "once_cell",
@@ -3532,7 +3531,7 @@ dependencies = [
  "colored",
  "deadline",
  "futures",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.12.1",
  "lru",
  "mockall",
@@ -3572,7 +3571,7 @@ version = "3.3.2"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "proptest",
  "rayon",
  "serde",
@@ -3590,7 +3589,7 @@ name = "snarkos-node-bft-ledger-service"
 version = "3.3.2"
 dependencies = [
  "async-trait",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "parking_lot",
  "rand",
  "rayon",
@@ -3606,7 +3605,7 @@ version = "3.3.2"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "lru",
  "parking_lot",
  "snarkvm",
@@ -3639,7 +3638,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.12.1",
  "lru",
  "once_cell",
@@ -3675,8 +3674,8 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-extra",
- "http 1.2.0",
- "indexmap 2.7.1",
+ "http 1.3.1",
+ "indexmap 2.8.0",
  "jsonwebtoken",
  "once_cell",
  "parking_lot",
@@ -3708,7 +3707,7 @@ dependencies = [
  "deadline",
  "futures",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "linked-hash-map",
  "parking_lot",
  "peak_alloc",
@@ -3738,7 +3737,7 @@ version = "3.3.2"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "proptest",
  "rayon",
  "serde",
@@ -3756,7 +3755,7 @@ name = "snarkos-node-sync"
 version = "3.3.2"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.12.1",
  "once_cell",
  "parking_lot",
@@ -3786,7 +3785,7 @@ name = "snarkos-node-sync-locators"
 version = "3.3.2"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "snarkvm",
  "tracing",
@@ -3810,14 +3809,14 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "anstyle",
  "anyhow",
  "clap",
  "colored",
  "dotenvy",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "num-format",
  "once_cell",
  "parking_lot",
@@ -3833,7 +3832,7 @@ dependencies = [
  "snarkvm-parameters",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ureq",
  "walkdir",
 ]
@@ -3841,7 +3840,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3850,7 +3849,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.14.5",
  "hex",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "num-traits",
  "parking_lot",
@@ -3865,13 +3864,13 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3885,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3896,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3906,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3916,9 +3915,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "nom",
  "num-traits",
@@ -3934,12 +3933,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3950,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3965,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3980,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3993,7 +3992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4002,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4012,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4024,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4036,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4047,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4059,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4072,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4083,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4096,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4107,10 +4106,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "lazy_static",
  "once_cell",
@@ -4130,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4148,12 +4147,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -4170,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4185,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4196,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4204,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4214,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4225,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4236,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4247,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4258,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "rand",
  "rayon",
@@ -4266,13 +4265,13 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4282,19 +4281,18 @@ dependencies = [
  "rayon",
  "serde",
  "snarkvm-utilities",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.7.1",
- "lru",
+ "indexmap 2.8.0",
  "parking_lot",
  "rand",
  "rayon",
@@ -4315,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "anyhow",
  "rand",
@@ -4327,9 +4325,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4347,10 +4345,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "proptest",
  "rand",
  "rand_chacha",
@@ -4366,7 +4364,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4379,9 +4377,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4392,9 +4390,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4405,7 +4403,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4416,9 +4414,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4431,7 +4429,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4444,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4453,12 +4451,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "lru",
  "once_cell",
  "parking_lot",
@@ -4473,12 +4471,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
  "colored",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "lru",
  "parking_lot",
  "rand",
@@ -4494,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4507,12 +4505,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "once_cell",
  "parking_lot",
  "rayon",
@@ -4534,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4549,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4558,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4567,7 +4565,7 @@ dependencies = [
  "colored",
  "curl",
  "hex",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "lazy_static",
  "parking_lot",
@@ -4577,17 +4575,17 @@ dependencies = [
  "sha2",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
  "lru",
  "parking_lot",
@@ -4615,11 +4613,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "colored",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "once_cell",
  "parking_lot",
  "rand",
@@ -4639,9 +4637,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "paste",
  "rand",
  "rand_chacha",
@@ -4654,7 +4652,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4667,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4681,18 +4679,18 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4736,7 +4734,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
 dependencies = [
- "quote 1.0.38",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -4759,9 +4757,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "structmeta-derive",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4771,8 +4769,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4792,9 +4790,9 @@ checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4821,18 +4819,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
@@ -4867,8 +4865,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4904,11 +4902,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
@@ -4929,9 +4926,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
+ "quote 1.0.40",
  "structmeta",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4945,11 +4942,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4959,19 +4956,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5006,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -5021,15 +5018,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5056,9 +5053,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5071,9 +5068,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5094,8 +5091,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5144,9 +5141,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5197,10 +5194,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
@@ -5237,7 +5234,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http 1.2.0",
+ "http 1.3.1",
  "pin-project",
  "thiserror 1.0.69",
  "tower 0.4.13",
@@ -5263,8 +5260,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5379,7 +5376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
 dependencies = [
  "lazy_static",
- "quote 1.0.38",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -5389,8 +5386,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5429,9 +5426,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5473,7 +5470,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.23",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5598,8 +5595,8 @@ dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -5622,7 +5619,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
- "quote 1.0.38",
+ "quote 1.0.40",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5633,8 +5630,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5724,33 +5721,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -5804,11 +5806,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5824,6 +5842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5834,6 +5858,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5848,10 +5878,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5866,6 +5908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5876,6 +5924,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5890,6 +5944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,6 +5960,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winreg"
@@ -5917,7 +5983,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5951,8 +6017,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5962,8 +6028,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -5973,28 +6047,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -6014,8 +6099,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6036,24 +6121,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.38",
- "syn 2.0.98",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+checksum = "c1d48a995652704e4d5061678c5a1d19c851ccc788cebb90aaef5cd4642b0837"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "zopfli",
 ]
@@ -6065,7 +6150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7c724c3a8e5833aad6b7028f4f0989fa3a640ce799bf8c352f417b8ef9db3e"
 dependencies = [
  "ed25519-dalek",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "blst",
  "cc",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3983,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "indexmap 2.8.0",
  "itertools 0.11.0",
@@ -4033,12 +4033,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4111,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4123,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4135,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4229,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4247,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4269,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4303,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4324,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4346,7 +4346,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4357,7 +4357,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "rand",
  "rayon",
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "anyhow",
  "rand",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4553,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4596,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4653,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4662,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4721,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "indexmap 2.8.0",
  "paste",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4774,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10bcf43#10bcf435d9308c0cfeae79ff7ebcf6418a1b7958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "blst",
  "cc",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3991,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4001,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "indexmap 2.8.0",
  "itertools 0.11.0",
@@ -4030,12 +4030,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4203,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4266,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4343,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4354,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "rand",
  "rayon",
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "anyhow",
  "rand",
@@ -4424,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4502,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4513,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4606,7 +4606,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4634,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "indexmap 2.8.0",
  "paste",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#da44e2ff41369f52df494b5bf69707b8233fb03d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0407e17#0407e17e4d101000ccdc92e5db1172ddb1b6b858"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3896,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "indexmap 2.8.0",
  "itertools 0.11.0",
@@ -3935,12 +3935,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4003,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "rand",
  "rayon",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "anyhow",
  "rand",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4380,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4474,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4508,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4550,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4640,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "indexmap 2.8.0",
  "paste",
@@ -4655,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4689,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#6f6f6a326243c6c6a2c5ad7515069e4618f16841"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,6 +3588,7 @@ dependencies = [
 name = "snarkos-node-bft-ledger-service"
 version = "3.3.2"
 dependencies = [
+ "anyhow",
  "async-trait",
  "indexmap 2.8.0",
  "parking_lot",
@@ -3809,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3840,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3870,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3884,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3895,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3905,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3915,13 +3916,14 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "indexmap 2.8.0",
  "itertools 0.11.0",
  "nom",
  "num-traits",
  "once_cell",
+ "smallvec",
  "snarkvm-algorithms",
  "snarkvm-circuit-environment-witness",
  "snarkvm-console-network",
@@ -3933,12 +3935,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3949,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3964,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3979,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3992,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4001,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4011,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4023,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4035,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4046,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4058,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4071,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4082,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4095,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4106,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4129,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4147,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4169,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4184,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4195,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4203,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4213,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4224,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4235,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4246,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4257,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "rand",
  "rayon",
@@ -4271,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4288,11 +4290,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap 2.8.0",
+ "lru",
  "parking_lot",
  "rand",
  "rayon",
@@ -4313,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "anyhow",
  "rand",
@@ -4325,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4345,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4364,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4377,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4390,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4403,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4414,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4429,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4442,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4451,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4471,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4492,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4505,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4532,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4547,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4556,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4581,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4613,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4637,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "indexmap 2.8.0",
  "paste",
@@ -4652,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4665,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4686,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#c16048176f3cfee26ff0083d00af4e92bd21000f"
+source = "git+https://github.com/niklaslong/snarkVM.git?branch=feat%2Fspend-limits#bbcb34d562d1965b95a4df50d9a8d3811746cb8f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 git = "https://github.com/niklaslong/snarkVM.git"
 branch = "feat/spend-limits"
-#path = "../snarkVM"
+# path = "../snarkVM"
 # git = "https://github.com/ProvableHQ/snarkVM.git"
 # rev = "fb93f06"
 #version = "=1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 # path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "10bcf43"
+rev = "7aaa46a"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,11 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
-# path = "../snarkVM"
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "fb93f06"
+git = "https://github.com/niklaslong/snarkVM.git"
+branch = "feat/spend-limits"
+#path = "../snarkVM"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "fb93f06"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,9 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
-git = "https://github.com/niklaslong/snarkVM.git"
-branch = "feat/spend-limits"
 # path = "../snarkVM"
-# git = "https://github.com/ProvableHQ/snarkVM.git"
-# rev = "69f97fa"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "0407e17"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -27,6 +27,9 @@ test = [ "mock", "translucent" ]
 translucent = [ "ledger" ]
 test_targets = [ "snarkvm/test_targets" ]
 
+[dependencies.anyhow]
+version = "1.0"
+
 [dependencies.async-trait]
 version = "0.1"
 

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -375,6 +375,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         Ok(())
     }
 
+    /// Computes the execution cost in microcredits for a transaction.
     fn compute_cost(&self, _transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64> {
         self.ledger.vm().compute_cost(&transaction)
     }

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -379,7 +379,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     /// Returns the storage and compute cost for a transaction in microcredits.
     /// This is used to limit the amount of compute in the block generation hot
     /// path. This does NOT represent the full costs which a user has to pay.
-    fn compute_cost(&self, _transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64> {
+    fn transaction_spent_cost_in_microcredits(
+        &self,
+        _transaction_id: N::TransactionID,
+        transaction: Transaction<N>,
+    ) -> Result<u64> {
         match &transaction {
             // Include the synthesis cost and storage cost for deployments.
             Transaction::Deploy(_, _, _, deployment, _) => {

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -393,7 +393,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         };
 
         // Collect the Optional Stack corresponding to the transaction if its an Execution.
-        let stack = if let Transaction::Execute(_, ref execution, _) = transaction {
+        let stack = if let Transaction::Execute(_, _, ref execution, _) = transaction {
             // Get the root transition from the execution.
             let root_transition = execution.peek()?;
             // Get the stack from the process.

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -376,7 +376,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         Ok(())
     }
 
-    /// Returns the storage and compute cost for a transaction in microcredits.
+    /// Returns the spent cost for a transaction in microcredits.
     /// This is used to limit the amount of compute in the block generation hot
     /// path. This does NOT represent the full costs which a user has to pay.
     fn transaction_spent_cost_in_microcredits(

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -376,21 +376,6 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     }
 
     fn compute_cost(&self, _transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64> {
-        // TODO: move to VM or ledger?
-        let process = self.ledger.vm().process();
-
-        // Collect the Optional Stack corresponding to the transaction if its an Execution.
-        let stack = if let Transaction::Execute(_, _, ref execution, _) = transaction {
-            // Get the root transition from the execution.
-            let root_transition = execution.peek()?;
-            // Get the stack from the process.
-            Some(process.read().get_stack(root_transition.program_id())?.clone())
-        } else {
-            None
-        };
-
-        use snarkvm::prelude::compute_cost;
-
-        compute_cost(&transaction, stack)
+        self.ledger.vm().compute_cost(&transaction)
     }
 }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -237,8 +237,11 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     }
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, _transaction_id: N::TransactionID, _transaction: Transaction<N>) -> Result<u64> {
-        // Return 10 credit so this function can be used to test spend limits.
-        Ok(10_000_000)
+    fn transaction_spent_cost_in_microcredits(
+        &self,
+        _transaction_id: N::TransactionID,
+        _transaction: Transaction<N>,
+    ) -> Result<u64> {
+        Ok(N::TRANSACTION_SPEND_LIMIT)
     }
 }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -236,7 +236,7 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         Ok(())
     }
 
-    /// Computes the execution cost in microcredits for a transaction.
+    /// Returns the spent cost for a transaction in microcredits.
     fn transaction_spent_cost_in_microcredits(
         &self,
         _transaction_id: N::TransactionID,

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -235,4 +235,9 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         self.height_to_round_and_hash.lock().insert(block.height(), (block.round(), block.hash()));
         Ok(())
     }
+
+    /// TODO: is this reasonable?
+    fn compute_cost(&self, _transaction_id: N::TransactionID, _transaction: Data<Transaction<N>>) -> Result<u64> {
+        Ok(0)
+    }
 }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -202,7 +202,7 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     async fn check_transaction_basic(
         &self,
         transaction_id: N::TransactionID,
-        _transaction: Data<Transaction<N>>,
+        _transaction: Transaction<N>,
     ) -> Result<()> {
         trace!("[MockLedgerService] Check transaction basic {:?} - Ok", fmt_id(transaction_id));
         Ok(())
@@ -237,8 +237,8 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     }
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, _transaction_id: N::TransactionID, _transaction: Data<Transaction<N>>) -> Result<u64> {
-        // Return 1 credit so this function can be used to test spend limits.
+    fn compute_cost(&self, _transaction_id: N::TransactionID, _transaction: Transaction<N>) -> Result<u64> {
+        // Return 10 credit so this function can be used to test spend limits.
         Ok(10_000_000)
     }
 }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -236,8 +236,9 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         Ok(())
     }
 
-    /// TODO: is this reasonable?
+    /// Computes the execution cost in microcredits for a transaction.
     fn compute_cost(&self, _transaction_id: N::TransactionID, _transaction: Data<Transaction<N>>) -> Result<u64> {
-        Ok(0)
+        // Return 1 credit so this function can be used to test spend limits.
+        Ok(10_000_000)
     }
 }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -187,6 +187,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         bail!("Cannot advance to next block in prover - {block}")
     }
 
+    /// Computes the execution cost in microcredits for a transaction.
     fn compute_cost(&self, transaction_id: N::TransactionID, _transaction: Data<Transaction<N>>) -> Result<u64> {
         bail!("Transaction '{transaction_id}' doesn't exist in prover")
     }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -187,7 +187,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         bail!("Cannot advance to next block in prover - {block}")
     }
 
-    /// Computes the execution cost in microcredits for a transaction.
+    /// Returns the spent cost for a transaction in microcredits.
     fn transaction_spent_cost_in_microcredits(
         &self,
         transaction_id: N::TransactionID,

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -186,4 +186,8 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
         bail!("Cannot advance to next block in prover - {block}")
     }
+
+    fn compute_cost(&self, transaction_id: N::TransactionID, _transaction: Data<Transaction<N>>) -> Result<u64> {
+        bail!("Transaction '{transaction_id}' doesn't exist in prover")
+    }
 }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -188,7 +188,11 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     }
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, transaction_id: N::TransactionID, _transaction: Transaction<N>) -> Result<u64> {
+    fn transaction_spent_cost_in_microcredits(
+        &self,
+        transaction_id: N::TransactionID,
+        _transaction: Transaction<N>,
+    ) -> Result<u64> {
         bail!("Transaction '{transaction_id}' doesn't exist in prover")
     }
 }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -161,7 +161,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     async fn check_transaction_basic(
         &self,
         _transaction_id: N::TransactionID,
-        _transaction: Data<Transaction<N>>,
+        _transaction: Transaction<N>,
     ) -> Result<()> {
         Ok(())
     }
@@ -188,7 +188,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     }
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, transaction_id: N::TransactionID, _transaction: Data<Transaction<N>>) -> Result<u64> {
+    fn compute_cost(&self, transaction_id: N::TransactionID, _transaction: Transaction<N>) -> Result<u64> {
         bail!("Transaction '{transaction_id}' doesn't exist in prover")
     }
 }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -121,5 +121,6 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     #[cfg(feature = "ledger-write")]
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
 
+    /// Computes the execution cost in microcredits for a transaction.
     fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64>;
 }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -122,5 +122,9 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64>;
+    fn transaction_spent_cost_in_microcredits(
+        &self,
+        transaction_id: N::TransactionID,
+        transaction: Transaction<N>,
+    ) -> Result<u64>;
 }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -121,7 +121,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     #[cfg(feature = "ledger-write")]
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
 
-    /// Computes the execution cost in microcredits for a transaction.
+    /// Returns the spent cost for a transaction in microcredits.
     fn transaction_spent_cost_in_microcredits(
         &self,
         transaction_id: N::TransactionID,

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -103,7 +103,7 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     async fn check_transaction_basic(
         &self,
         transaction_id: N::TransactionID,
-        transaction: Data<Transaction<N>>,
+        transaction: Transaction<N>,
     ) -> Result<()>;
 
     /// Checks the given block is valid next block.
@@ -122,5 +122,5 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64>;
+    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64>;
 }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -120,4 +120,6 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     /// Adds the given block as the next block in the ledger.
     #[cfg(feature = "ledger-write")]
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
+
+    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64>;
 }

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -197,7 +197,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     }
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64> {
-        self.inner.compute_cost(transaction_id, transaction)
+    fn transaction_spent_cost_in_microcredits(
+        &self,
+        transaction_id: N::TransactionID,
+        transaction: Transaction<N>,
+    ) -> Result<u64> {
+        self.inner.transaction_spent_cost_in_microcredits(transaction_id, transaction)
     }
 }

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -195,4 +195,8 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     fn advance_to_next_block(&self, block: &Block<N>) -> Result<()> {
         self.inner.advance_to_next_block(block)
     }
+
+    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64> {
+        self.inner.compute_cost(transaction_id, transaction)
+    }
 }

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -196,7 +196,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         self.inner.advance_to_next_block(block)
     }
 
-    /// Computes the execution cost in microcredits for a transaction.
+    /// Returns the spent cost for a transaction in microcredits.
     fn transaction_spent_cost_in_microcredits(
         &self,
         transaction_id: N::TransactionID,

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -172,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     async fn check_transaction_basic(
         &self,
         _transaction_id: N::TransactionID,
-        _transaction: Data<Transaction<N>>,
+        _transaction: Transaction<N>,
     ) -> Result<()> {
         Ok(())
     }
@@ -197,7 +197,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
     }
 
     /// Computes the execution cost in microcredits for a transaction.
-    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64> {
+    fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64> {
         self.inner.compute_cost(transaction_id, transaction)
     }
 }

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -196,6 +196,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         self.inner.advance_to_next_block(block)
     }
 
+    /// Computes the execution cost in microcredits for a transaction.
     fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64> {
         self.inner.compute_cost(transaction_id, transaction)
     }

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -163,7 +163,14 @@ impl<N: Network> Ready<N> {
     pub fn remove_front(&mut self) -> Option<(TransmissionID<N>, Transmission<N>)> {
         if let Some((transmission_id, transmission)) = self.transmissions.pop_front() {
             self.transmission_ids.remove(&transmission_id);
-            self.offset += 1;
+
+            if self.transmission_ids.is_empty() {
+                debug_assert!(self.transmissions.is_empty());
+                self.offset = 0;
+            } else {
+                self.offset += 1;
+            }
+
             Some((transmission_id, transmission))
         } else {
             None

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -82,7 +82,6 @@ impl<N: Network> Ready<N> {
 
     /// Returns the transmissions in the ready queue.
     pub fn transmissions(&self) -> IndexMap<TransmissionID<N>, Transmission<N>> {
-        // TODO: return iterator?
         self.transmissions.iter().cloned().collect()
     }
 

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -29,12 +29,12 @@ use std::collections::{HashMap, VecDeque, hash_map::Entry::Vacant};
 pub struct Ready<N: Network> {
     /// Maps each transmission ID to its logical index (physical index + offset)
     /// in `transmissions`.
-    transmission_ids: HashMap<TransmissionID<N>, isize>,
+    transmission_ids: HashMap<TransmissionID<N>, i64>,
     /// An ordered collection of (transmission ID, transmission).
     transmissions: VecDeque<(TransmissionID<N>, Transmission<N>)>,
     /// An offset used to adjust logical indices when elements are inserted or
     /// removed at the front.
-    offset: isize,
+    offset: i64,
 }
 
 impl<N: Network> Default for Ready<N> {
@@ -129,7 +129,7 @@ impl<N: Network> Ready<N> {
         let transmission_id = transmission_id.into();
 
         if let Vacant(entry) = self.transmission_ids.entry(transmission_id) {
-            entry.insert(physical_index as isize + self.offset);
+            entry.insert(physical_index as i64 + self.offset);
             self.transmissions.push_back((transmission_id, transmission));
             true
         } else {
@@ -184,7 +184,7 @@ impl<N: Network> Ready<N> {
         self.transmission_ids.clear();
         self.offset = 0;
         for (i, (id, _)) in self.transmissions.iter().enumerate() {
-            self.transmission_ids.insert(*id, i as isize);
+            self.transmission_ids.insert(*id, i as i64);
         }
     }
 }

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -263,9 +263,6 @@ mod tests {
         assert!(ready.is_empty());
         // Check the transmission IDs.
         assert_eq!(ready.transmission_ids(), IndexSet::new());
-
-        dbg!(ready.offset);
-
         // Check the transmissions.
         assert_eq!(transmissions, vec![
             (solution_id_1, solution_1),

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -128,6 +128,16 @@ impl<N: Network> Ready<N> {
         transmissions.drain(range).collect::<IndexMap<_, _>>()
     }
 
+    /// Inserts the transmission at the front of the queue.
+    pub fn shift_insert_front(&self, key: TransmissionID<N>, value: Transmission<N>) {
+        self.transmissions.write().shift_insert(0, key, value);
+    }
+
+    /// Removes and returns the first transmission from the queue.
+    pub fn shift_remove_front(&self) -> Option<(TransmissionID<N>, Transmission<N>)> {
+        self.transmissions.write().shift_remove_index(0)
+    }
+
     /// Clears all solutions from the ready queue.
     pub(crate) fn clear_solutions(&self) {
         // Acquire the write lock.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -506,15 +506,7 @@ impl<N: Network> Primary<N> {
 
             // Check the transactions for inclusion in the batch proposal.
             while num_transmissions_included_for_worker < num_transmissions_per_worker {
-                // Determine the number of remaining transmissions for the worker.
-                // let num_remaining_transmissions =
-                //     num_transmissions_per_worker.saturating_sub(num_transmissions_included_for_worker);
-
-                let (id, transmission) = match worker_transmissions.next() {
-                    Some(transmission) => transmission,
-                    // If the worker is empty, break early.
-                    None => break,
-                };
+                let Some((id, transmission)) = worker_transmissions.next() else { break };
 
                 // Check if the ledger already contains the transmission.
                 if self.ledger.contains_transmission(&id).unwrap_or(true) {
@@ -525,7 +517,6 @@ impl<N: Network> Primary<N> {
                 // Check if the storage already contain the transmission.
                 // Note: We do not skip if this is the first transmission in the proposal, to ensure that
                 // the primary does not propose a batch with no transmissions.
-                // if !transmissions.is_empty() && self.storage.contains_transmission(id) {
                 if num_transmissions_included != 0 && self.storage.contains_transmission(id) {
                     trace!("Proposing - Skipping transmission '{}' - Already in storage", fmt_id(id));
                     continue;

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -500,8 +500,7 @@ impl<N: Network> Primary<N> {
         'outer: for worker in self.workers().iter() {
             let mut num_worker_transmissions = 0usize;
 
-            // TODO(nkls): this is O(n), consider improving the underlying data structures.
-            while let Some((id, transmission)) = worker.shift_remove_front() {
+            while let Some((id, transmission)) = worker.remove_front() {
                 if transmissions.len() == BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH {
                     break 'outer;
                 }
@@ -564,8 +563,8 @@ impl<N: Network> Primary<N> {
                                         fmt_id(transaction_id)
                                     );
 
-                                    // Reinsert the transmission into the worker, O(n).
-                                    worker.shift_insert_front(id, transmission);
+                                    // Reinsert the transmission into the worker.
+                                    worker.insert_front(id, transmission);
                                     break 'outer;
                                 }
                             }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2209,6 +2209,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_propose_batch_over_spend_limit() {
+        let mut rng = TestRng::default();
+        // Create two primaries to test spend limit activation on V4.
+        let (accounts, committee) = sample_committee(&mut rng);
+        let primary_v3 = primary_with_committee(
+            0,
+            &accounts,
+            committee.clone(),
+            CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap(),
+        );
+        let primary_v4 = primary_with_committee(
+            1,
+            &accounts,
+            committee,
+            CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V4).unwrap(),
+        );
+
+        // Check there is no batch currently proposed.
+        assert!(primary_v3.proposed_batch.read().is_none());
+        assert!(primary_v4.proposed_batch.read().is_none());
+        // Check the workers are empty.
+        primary_v3.workers().iter().for_each(|worker| assert!(worker.transmissions().is_empty()));
+        primary_v4.workers().iter().for_each(|worker| assert!(worker.transmissions().is_empty()));
+
+        // Generate a solution and a transaction.
+        let (solution_id, solution) = sample_unconfirmed_solution(&mut rng);
+        primary_v3.workers[0].process_unconfirmed_solution(solution_id, solution.clone()).await.unwrap();
+        primary_v4.workers[0].process_unconfirmed_solution(solution_id, solution).await.unwrap();
+
+        // At 10 credits per execution, 10 transactions should max out a batch, add a few more.
+        for _i in 0..15 {
+            let (transaction_id, transaction) = sample_unconfirmed_transaction(&mut rng);
+            // Store it on one of the workers.
+            primary_v3.workers[0].process_unconfirmed_transaction(transaction_id, transaction.clone()).await.unwrap();
+            primary_v4.workers[0].process_unconfirmed_transaction(transaction_id, transaction).await.unwrap();
+        }
+
+        // Try to propose a batch again. This time, it should succeed.
+        assert!(primary_v3.propose_batch().await.is_ok());
+        assert!(primary_v4.propose_batch().await.is_ok());
+        // Expect 10/15 transactions to be included in the proposal, along with
+        // the solution, for v3 consensus all 15 should be included.
+        assert_eq!(primary_v3.proposed_batch.read().as_ref().unwrap().transmissions().len(), 16);
+        assert_eq!(primary_v4.proposed_batch.read().as_ref().unwrap().transmissions().len(), 11);
+        // Check the transactions were correctly drained from the workers (15 + 1 - 11).
+        assert_eq!(primary_v3.workers().iter().map(|worker| worker.transmissions().len()).sum::<usize>(), 0);
+        assert_eq!(primary_v4.workers().iter().map(|worker| worker.transmissions().len()).sum::<usize>(), 5);
+    }
+
+    #[tokio::test]
     async fn test_batch_propose_from_peer() {
         let mut rng = TestRng::default();
         let (primary, accounts) = primary_without_handlers(&mut rng);
@@ -2481,6 +2531,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_batch_propose_from_peer_over_spend_limit() {
+        let mut rng = TestRng::default();
+
+        // Create two primaries to test spend limit activation on V4.
+        let (accounts, committee) = sample_committee(&mut rng);
+        let primary_v3 = primary_with_committee(
+            0,
+            &accounts,
+            committee.clone(),
+            CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap(),
+        );
+        let primary_v4 = primary_with_committee(
+            1,
+            &accounts,
+            committee.clone(),
+            CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V4).unwrap(),
+        );
+
+        // Create a valid proposal with an author that isn't the primary.
+        let round = 1;
+        let peer_account = &accounts[1];
+        let peer_ip = peer_account.0;
+        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let proposal = create_test_proposal(
+            &peer_account.1,
+            committee,
+            round,
+            Default::default(),
+            timestamp,
+            // At 10 credits per execution, this should bring the batch above
+            // the spend limit.
+            11,
+            &mut rng,
+        );
+
+        // Make sure the primary is aware of the transmissions in the proposal.
+        for (transmission_id, transmission) in proposal.transmissions() {
+            primary_v3.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone());
+            primary_v4.workers[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone());
+        }
+
+        // The author must be known to resolver to pass propose checks.
+        primary_v3.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        primary_v4.gateway.resolver().insert_peer(peer_ip, peer_ip, peer_account.1.address());
+        // The primary must be considered synced.
+        primary_v3.sync.block_sync().try_block_sync(&primary_v3.gateway.clone()).await;
+        primary_v4.sync.block_sync().try_block_sync(&primary_v4.gateway.clone()).await;
+
+        // Check the spend limit is enforced from V4 onwards.
+        assert!(
+            primary_v3
+                .process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into())
+                .await
+                .is_ok()
+        );
+        assert!(
+            primary_v4
+                .process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
     async fn test_propose_batch_with_storage_round_behind_proposal_lock() {
         let round = 3;
         let mut rng = TestRng::default();
@@ -2541,47 +2655,6 @@ mod tests {
         assert!(primary.propose_batch().await.is_ok());
         assert!(primary.proposed_batch.read().is_some());
         assert!(primary.proposed_batch.read().as_ref().unwrap().round() > primary.current_round());
-    }
-
-    #[tokio::test]
-    async fn test_propose_batch_over_spend_limit() {
-        let mut rng = TestRng::default();
-        // Instantiate two primaries to test spend limit activation on V4.
-        let (primary_v3, _) =
-            primary_without_handlers(&mut rng, CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V3).unwrap()).await;
-        let (primary_v4, _) =
-            primary_without_handlers(&mut rng, CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V4).unwrap()).await;
-
-        // Check there is no batch currently proposed.
-        assert!(primary_v3.proposed_batch.read().is_none());
-        assert!(primary_v4.proposed_batch.read().is_none());
-        // Check the workers are empty.
-        primary_v3.workers().iter().for_each(|worker| assert!(worker.transmissions().is_empty()));
-        primary_v4.workers().iter().for_each(|worker| assert!(worker.transmissions().is_empty()));
-
-        // Generate a solution and a transaction.
-        let (solution_id, solution) = sample_unconfirmed_solution(&mut rng);
-        primary_v3.workers[0].process_unconfirmed_solution(solution_id, solution.clone()).await.unwrap();
-        primary_v4.workers[0].process_unconfirmed_solution(solution_id, solution).await.unwrap();
-
-        // At 10 credits per execution, 10 transactions should max out a batch, add a few more.
-        for _i in 0..15 {
-            let (transaction_id, transaction) = sample_unconfirmed_transaction(&mut rng);
-            // Store it on one of the workers.
-            primary_v3.workers[0].process_unconfirmed_transaction(transaction_id, transaction.clone()).await.unwrap();
-            primary_v4.workers[0].process_unconfirmed_transaction(transaction_id, transaction).await.unwrap();
-        }
-
-        // Try to propose a batch again. This time, it should succeed.
-        assert!(primary_v3.propose_batch().await.is_ok());
-        assert!(primary_v4.propose_batch().await.is_ok());
-        // Expect 10/15 transactions to be included in the proposal, along with
-        // the solution, for v3 consensus all 15 should be included.
-        assert_eq!(primary_v3.proposed_batch.read().as_ref().unwrap().transmissions().len(), 16);
-        assert_eq!(primary_v4.proposed_batch.read().as_ref().unwrap().transmissions().len(), 11);
-        // Check the transactions were correctly drained from the workers (15 + 1 - 11).
-        assert_eq!(primary_v3.workers().iter().map(|worker| worker.transmissions().len()).sum::<usize>(), 0);
-        assert_eq!(primary_v4.workers().iter().map(|worker| worker.transmissions().len()).sum::<usize>(), 5);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -579,7 +579,9 @@ impl<N: Network> Primary<N> {
 
                         if N::CONSENSUS_VERSION(block_height)? >= ConsensusVersion::V4 {
                             match self.ledger.compute_cost(transaction_id, transaction) {
-                                Ok(cost) if proposal_cost + cost <= N::BATCH_SPEND_LIMIT => proposal_cost += cost,
+                                Ok(cost) if proposal_cost + cost <= BatchHeader::<N>::BATCH_SPEND_LIMIT => {
+                                    proposal_cost += cost
+                                }
                                 _ => {
                                     trace!(
                                         "Proposing - Skipping transaction '{}' - Batch spend limit surpassed",
@@ -833,7 +835,7 @@ impl<N: Network> Primary<N> {
                 }
             }
 
-            if proposal_cost > N::BATCH_SPEND_LIMIT {
+            if proposal_cost > BatchHeader::<N>::BATCH_SPEND_LIMIT {
                 bail!(
                     "Malicious peer - batch proposal from '{peer_ip}' exceeds the spend limit: '{proposal_cost}' microcredits"
                 );
@@ -2544,7 +2546,7 @@ mod tests {
 
         // Create a valid proposal with an author that isn't the primary.
         let round = 1;
-        let peer_account = &accounts[1];
+        let peer_account = &accounts[2];
         let peer_ip = peer_account.0;
         let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
         let proposal = create_test_proposal(

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -604,7 +604,7 @@ impl<N: Network> Primary<N> {
 
                 // If the transmission is valid, insert it into the proposal's transmission list.
                 transmissions.insert(id, transmission);
-                num_worker_transmissions += 1;
+                num_worker_transmissions = num_worker_transmissions.saturating_add(1);
             }
         }
 
@@ -831,7 +831,9 @@ impl<N: Network> Primary<N> {
                         }
                     })?;
 
-                    proposal_cost += self.ledger.compute_cost(*transaction_id, transaction)?
+                    proposal_cost = proposal_cost.saturating_add(
+                        self.ledger.transaction_spent_cost_in_microcredits(*transaction_id, transaction)?,
+                    )
                 }
             }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -580,6 +580,7 @@ impl<N: Network> Primary<N> {
 
         *lock_guard = round;
 
+        // TODO(nkls): check spend limits?
         /* Proceeding to sign & propose the batch. */
         info!("Proposing a batch with {} transmissions for round {round}...", transmissions.len());
 
@@ -768,6 +769,7 @@ impl<N: Network> Primary<N> {
         // Inserts the missing transmissions into the workers.
         self.insert_missing_transmissions_into_workers(peer_ip, missing_transmissions.into_iter())?;
 
+        // TODO(nkls): check spend limits?
         /* Proceeding to sign the batch. */
 
         // Retrieve the batch ID.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -578,7 +578,7 @@ impl<N: Network> Primary<N> {
                             .saturating_add((BatchHeader::<N>::MAX_GC_ROUNDS as u32).saturating_div(2));
 
                         if N::CONSENSUS_VERSION(block_height)? >= ConsensusVersion::V4 {
-                            match self.ledger.compute_cost(transaction_id, transaction) {
+                            match self.ledger.transaction_spent_cost_in_microcredits(transaction_id, transaction) {
                                 Ok(cost) if proposal_cost + cost <= BatchHeader::<N>::BATCH_SPEND_LIMIT => {
                                     proposal_cost += cost
                                 }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -802,10 +802,9 @@ impl<N: Network> Primary<N> {
             }
 
             if proposal_cost > N::BATCH_SPEND_LIMIT {
-                debug!(
-                    "Batch propose from peer '{peer_ip}' exceeds the batch spend limit — cost in microcredits: '{proposal_cost}'"
+                bail!(
+                    "Malicious peer - batch proposal from '{peer_ip}' exceeds the spend limit: '{proposal_cost}' microcredits"
                 );
-                return Ok(());
             }
         }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -838,7 +838,7 @@ mod tests {
         let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
         let _ = worker_.send_transmission_request(peer_ip, transmission_id).await;
         assert!(worker.pending.contains(transmission_id));
-        let result = dbg!(worker.process_unconfirmed_transaction(transaction_id, transaction_data).await);
+        let result = worker.process_unconfirmed_transaction(transaction_id, transaction_data).await;
         assert!(result.is_ok());
         assert!(!worker.pending.contains(transmission_id));
         assert!(worker.ready.read().contains(transmission_id));

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -614,6 +614,7 @@ mod tests {
                 transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
+            fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Data<Transaction<N>>) -> Result<u64>;
         }
     }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -630,7 +630,7 @@ mod tests {
                 transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
-            fn compute_cost(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64>;
+            fn transaction_spent_cost_in_microcredits(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64>;
         }
     }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -212,12 +212,12 @@ impl<N: Network> Worker<N> {
     }
 
     /// Inserts the transmission at the front of the ready queue.
-    pub(crate) fn shift_insert_front(&self, key: TransmissionID<N>, value: Transmission<N>) {
+    pub(crate) fn insert_front(&self, key: TransmissionID<N>, value: Transmission<N>) {
         self.ready.write().insert_front(key, value);
     }
 
     /// Removes and returns the transmission at the front of the ready queue.
-    pub(crate) fn shift_remove_front(&self) -> Option<(TransmissionID<N>, Transmission<N>)> {
+    pub(crate) fn remove_front(&self) -> Option<(TransmissionID<N>, Transmission<N>)> {
         self.ready.write().remove_front()
     }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -211,9 +211,14 @@ impl<N: Network> Worker<N> {
         Ok((transmission_id, transmission))
     }
 
-    /// Removes up to the specified number of transmissions from the ready queue, and returns them.
-    pub(crate) fn drain(&self, num_transmissions: usize) -> impl Iterator<Item = (TransmissionID<N>, Transmission<N>)> {
-        self.ready.drain(num_transmissions).into_iter()
+    /// Inserts the transmission at the front of the ready queue.
+    pub(crate) fn shift_insert_front(&self, key: TransmissionID<N>, value: Transmission<N>) {
+        self.ready.shift_insert_front(key, value)
+    }
+
+    /// Removes and returns the transmission at the front of the ready queue.
+    pub(crate) fn shift_remove_front(&self) -> Option<(TransmissionID<N>, Transmission<N>)> {
+        self.ready.shift_remove_front()
     }
 
     /// Reinserts the specified transmission into the ready queue.
@@ -672,8 +677,7 @@ mod tests {
         assert!(worker.ready.contains(transmission_id));
         assert_eq!(worker.get_transmission(transmission_id), Some(transmission));
         // Take the transmission from the ready set.
-        let transmission: Vec<_> = worker.drain(1).collect();
-        assert_eq!(transmission.len(), 1);
+        assert!(worker.ready.shift_remove_front().is_some());
         assert!(!worker.ready.contains(transmission_id));
     }
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.3.2"
 [dependencies.snarkvm-synthesizer]
 git = "https://github.com/niklaslong/snarkVM.git"
 branch = "feat/spend-limits"
-#path = "../../../snarkVM/synthesizer"
+# path = "../../../snarkVM/synthesizer"
 # git = "https://github.com/ProvableHQ/snarkVM.git"
 # rev = "fb93f06"
 #version = "=1.3.0"

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -66,9 +66,11 @@ path = "../router"
 version = "=3.3.2"
 
 [dependencies.snarkvm-synthesizer]
-# path = "../../../snarkVM/synthesizer"
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "fb93f06"
+git = "https://github.com/niklaslong/snarkVM.git"
+branch = "feat/spend-limits"
+#path = "../../../snarkVM/synthesizer"
+# git = "https://github.com/ProvableHQ/snarkVM.git"
+# rev = "fb93f06"
 #version = "=1.3.0"
 default-features = false
 optional = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -78,11 +78,9 @@ path = "../router"
 version = "=3.3.2"
 
 [dependencies.snarkvm-synthesizer]
-git = "https://github.com/niklaslong/snarkVM.git"
-branch = "feat/spend-limits"
 # path = "../../../snarkVM/synthesizer"
-# git = "https://github.com/ProvableHQ/snarkVM.git"
-# rev = "69f97fa"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "0407e17"
 #version = "=1.3.0"
 default-features = false
 optional = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -80,7 +80,7 @@ version = "=3.3.2"
 [dependencies.snarkvm-synthesizer]
 # path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "10bcf43"
+rev = "7aaa46a"
 #version = "=1.3.0"
 default-features = false
 optional = true


### PR DESCRIPTION
This PR introduces spend limit checks on batch proposals at construction and prior to signing. ~~This requires some changes to batch construction: the workers are now drained only _after_ the transmissions have been checked for inclusion in a batch. This, to avoid reinserting transmissions into the memory pool once the spend limit is surpassed.~~ I have modified the `Ready` queue to support `O(1)` operations at the front, as well as inclusion checks and regular inserts, so the batch proposal logic could be simplified. We no longer need to defer draining and can instead optimistically remove the transmission from the queue for processing. There's an occasional `O(n)` cost to reset the internally tracked offset but this should happen at most once per epoch, when solutions are cleared from the queue. It was also necessary to expose a `compute_cost` function on the `LedgerService` trait—its internals might still be moved into snarkVM. 

This changeset will need to be refined and tested, hence the draft. CI is currently expected to fail.

Related PRs: 
- https://github.com/ProvableHQ/snarkVM/pull/2601 (required for merge)
- https://github.com/ProvableHQ/snarkVM/pull/2565 (previous discussion)

