### PR TITLE
Fix/inbound logging

### DIFF
--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -148,7 +148,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         if let Err(error) = self.inbound(peer_addr, message).await {
             error!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
-                warn!("Disconnecting from '{peer_ip}' - {error}");
+                warn!("Disconnecting from '{peer_ip}' for protocol violation");
                 Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
                 // Disconnect from this peer.
                 self.router().disconnect(peer_ip);

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -146,6 +146,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
     ) {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
+            error!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' - {error}");
                 Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -137,6 +137,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
     ) {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
+            error!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' - {error}");
                 Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -139,7 +139,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         if let Err(error) = self.inbound(peer_addr, message).await {
             error!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
-                warn!("Disconnecting from '{peer_ip}' - {error}");
+                warn!("Disconnecting from '{peer_ip}' for protocol violation");
                 Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
                 // Disconnect from this peer.
                 self.router().disconnect(peer_ip);


### PR DESCRIPTION
## Motivation

> Currently when self.inbound() fails, sometimes, nothing is logged, and you don't see that anything went wrong.
> This tripped me up when diagnosing sync issues.

## Test Plan

No need.

## Related PRs

Replaced https://github.com/ProvableHQ/snarkOS-fork/pull/13