### PR TITLE
fix: Increase the max number of peers to aid consensus

### DIFF
--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -40,7 +40,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     /// The median number of peers to maintain connections with.
     const MEDIAN_NUMBER_OF_PEERS: usize = max(Self::MAXIMUM_NUMBER_OF_PEERS / 2, Self::MINIMUM_NUMBER_OF_PEERS);
     /// The maximum number of peers permitted to maintain connections with.
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 21;
+    const MAXIMUM_NUMBER_OF_PEERS: usize = 31;
     /// The maximum number of provers to maintain connections with.
     const MAXIMUM_NUMBER_OF_PROVERS: usize = Self::MAXIMUM_NUMBER_OF_PEERS / 4;
     /// The amount of time an IP address is prohibited from connecting.


### PR DESCRIPTION
## Motivation

Previously, we only had 16 validator nodes, the it was sufficient with 21 peers. However, as we have increased the number of validators to 26, we need to increase the number of maximum peers.

## Test Plan

Full integration and acceptance tests needed.

## Related PRs

None.