### PR TITLE
Add additional transmission type checks

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -218,7 +218,9 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         transmission: &mut Transmission<N>,
     ) -> Result<()> {
         match (transmission_id, transmission) {
-            (TransmissionID::Ratification, Transmission::Ratification) => {}
+            (TransmissionID::Ratification, Transmission::Ratification) => {
+                bail!("Ratification transmissions are currently not supported.")
+            }
             (
                 TransmissionID::Transaction(expected_transaction_id, expected_checksum),
                 Transmission::Transaction(transaction_data),

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -727,6 +727,13 @@ impl<N: Network> Primary<N> {
             bail!("Malicious peer - {e} from '{peer_ip}'");
         }
 
+        // Ensure the batch header does not contain any ratifications.
+        if batch_header.contains(TransmissionID::Ratification) {
+            // Proceed to disconnect the validator.
+            self.gateway.disconnect(peer_ip);
+            bail!("Malicious peer - proposed batch contains an unsupported ratification transmissionID",);
+        }
+
         // If the peer is ahead, use the batch header to sync up to the peer.
         let mut transmissions = self.sync_with_batch_header_from_peer::<false>(peer_ip, &batch_header).await?;
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds additional checks for the `Ratification` transmission type that is not currently supported. Previously there were checks on the BFT level, but now the checks are extended to the proposal level as well.


NOTICE: This PR is a hotfix into `mainnet` and will be rolled into `staging` post release.