### PR TITLE
Fix missing certificate fetching

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1697,9 +1697,9 @@ impl<N: Network> Primary<N> {
             }
         }
 
-        // If there are no missing certificates, return early.
+        // If there are no certificates to fetch, return early with the existing unprocessed certificates.
         match fetch_certificates.is_empty() {
-            true => return Ok(Default::default()),
+            true => return Ok(missing_certificates),
             false => trace!(
                 "Fetching {} missing certificates for round {round} from '{peer_ip}'...",
                 fetch_certificates.len(),

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -628,6 +628,7 @@ impl<N: Network> Sync<N> {
             );
         }
         // Wait for the certificate to be fetched.
+        // TODO (raychu86): Consider making the timeout dynamic based on network traffic and/or the number of validators.
         match tokio::time::timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver).await {
             // If the certificate was fetched, return it.
             Ok(result) => Ok(result?),


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR fixes an edge case in `fetch_missing_certificates` where the call will terminate early without results if all of the certificate IDs already exist in the `unprocessed_certificate` cache. The fix ensures that we no longer ignore certificates in the cache if there are no certificates to send via the network.

### Example

The following scenario is an example of how the edge case could occur:

1. Validator node receives `BatchCertificate` via `process_batch_certificate_from_peer` 
    - This adds the certificate to the `unprocessed_certificate` cache
3. Validator node starts processing the data and requests missing transmissions/certificates
4. Validator node receives **ALL** other `BatchCertificates` of the missing certificates in step 3 from other sources (like the `BatchCertificate` message in **Step 1**)
5. Validator never finishes processing the `BatchCertificate` in **Step 1**
6. Validator is now stuck in a loop of being unable to process incoming certificates with a `Missing previous certificate ...` message

## Related PRs

https://github.com/ProvableHQ/snarkOS/pull/3439
