### PR TITLE
[fix] Fixes related to block locators.

### DIFF
--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -541,7 +541,7 @@ mod tests {
         let mut recents = IndexMap::new();
         for i in 0..NUM_RECENT_BLOCKS {
             recents.insert(i as u32, (Field::<CurrentNetwork>::from_u32(i as u32)).into());
-            let block_locators = BlockLocators::<CurrentNetwork>::new(recents.clone(), checkpoints.clone()).unwrap();
+            let block_locators = BlockLocators::<CurrentNetwork>::new_unchecked(recents.clone(), checkpoints.clone());
             block_locators.ensure_is_valid().unwrap();
         }
         // Ensure NUM_RECENT_BLOCKS + 1 is not valid.

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -206,8 +206,8 @@ impl<N: Network> BlockLocators<N> {
             .contains(&last_recent_height)
         {
             bail!(
-                "Last checkpoint height ({last_checkpoint_height}) is not the largest multiple of ".to_string()
-                    + "{CHECKPOINT_INTERVAL} that does not exceed the last recent height ({last_recent_height})"
+                "Last checkpoint height ({last_checkpoint_height}) is not the largest multiple of \
+                 {CHECKPOINT_INTERVAL} that does not exceed the last recent height ({last_recent_height})"
             )
         }
 

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -379,6 +379,8 @@ pub mod test_helpers {
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
     /// Simulates a block locator at the given height.
+    ///
+    /// The returned block locator is checked to be well-formed.
     pub fn sample_block_locators(height: u32) -> BlockLocators<CurrentNetwork> {
         // Create the recent locators.
         let mut recents = IndexMap::new();
@@ -401,6 +403,8 @@ pub mod test_helpers {
     }
 
     /// Simulates a block locator at the given height, with a fork within NUM_RECENT_BLOCKS of the given height.
+    ///
+    /// The returned block locator is checked to be well-formed.
     pub fn sample_block_locators_with_fork(height: u32, fork_height: u32) -> BlockLocators<CurrentNetwork> {
         assert!(fork_height <= height, "Fork height must be less than or equal to the given height");
         assert!(
@@ -448,7 +452,8 @@ pub mod test_helpers {
             assert_eq!(block_locators.checkpoints.len(), expected_num_checkpoints as usize);
             assert_eq!(block_locators.recents.len(), expected_num_recents as usize);
             assert_eq!(block_locators.latest_locator_height(), expected_height);
-            assert!(block_locators.is_valid());
+            // Note that `sample_block_locators` always returns well-formed block locators,
+            // so we don't need to check `is_valid()` here.
         }
     }
 }

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -557,7 +557,7 @@ mod tests {
         let checkpoints = IndexMap::from([(0, zero), (CHECKPOINT_INTERVAL, checkpoint_1)]);
         check_is_valid(
             checkpoints,
-            (CHECKPOINT_INTERVAL - NUM_RECENT_BLOCKS as u32)..(CHECKPOINT_INTERVAL * 2 - NUM_RECENT_BLOCKS as u32),
+            (CHECKPOINT_INTERVAL - NUM_RECENT_BLOCKS as u32 + 1)..(CHECKPOINT_INTERVAL * 2 - NUM_RECENT_BLOCKS as u32),
         );
     }
 

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -570,17 +570,17 @@ mod tests {
         let block_locators = BlockLocators::<CurrentNetwork>::new_unchecked(Default::default(), Default::default());
         block_locators.ensure_is_valid().unwrap_err();
 
-        // Ensure internally-mismatching genesis block locators is valid.
+        // Ensure internally-mismatching genesis block locators is not valid.
         let block_locators =
             BlockLocators::<CurrentNetwork>::new_unchecked(IndexMap::from([(0, zero)]), IndexMap::from([(0, one)]));
         block_locators.ensure_is_valid().unwrap_err();
 
-        // Ensure internally-mismatching genesis block locators is valid.
+        // Ensure internally-mismatching genesis block locators is not valid.
         let block_locators =
             BlockLocators::<CurrentNetwork>::new_unchecked(IndexMap::from([(0, one)]), IndexMap::from([(0, zero)]));
         block_locators.ensure_is_valid().unwrap_err();
 
-        // Ensure internally-mismatching block locators with two recent blocks is valid.
+        // Ensure internally-mismatching block locators with two recent blocks is not valid.
         let block_locators = BlockLocators::<CurrentNetwork>::new_unchecked(
             IndexMap::from([(0, one), (1, zero)]),
             IndexMap::from([(0, zero)]),
@@ -592,6 +592,14 @@ mod tests {
             IndexMap::from([(0, zero), (1, zero)]),
             IndexMap::from([(0, zero)]),
         );
+        block_locators.ensure_is_valid().unwrap_err();
+
+        // Ensure insufficient checkpoints are not valid.
+        let mut recents = IndexMap::new();
+        for i in 0..NUM_RECENT_BLOCKS {
+            recents.insert(10_000 + i as u32, (Field::<CurrentNetwork>::from_u32(i as u32)).into());
+        }
+        let block_locators = BlockLocators::<CurrentNetwork>::new_unchecked(recents, IndexMap::from([(0, zero)]));
         block_locators.ensure_is_valid().unwrap_err();
     }
 

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -89,6 +89,7 @@ impl<N: Network> BlockLocators<N> {
 
     /// Initializes a new instance of the block locators, without checking the validity of the block locators.
     /// This is only used for testing; note that it is non-public.
+    #[allow(dead_code)]
     fn new_unchecked(recents: IndexMap<u32, N::BlockHash>, checkpoints: IndexMap<u32, N::BlockHash>) -> Self {
         Self { recents, checkpoints }
     }

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -89,7 +89,7 @@ impl<N: Network> BlockLocators<N> {
 
     /// Initializes a new instance of the block locators, without checking the validity of the block locators.
     /// This is only used for testing; note that it is non-public.
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn new_unchecked(recents: IndexMap<u32, N::BlockHash>, checkpoints: IndexMap<u32, N::BlockHash>) -> Self {
         Self { recents, checkpoints }
     }

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -262,12 +262,14 @@ impl<N: Network> BlockLocators<N> {
             last_height = *current_height;
         }
 
-        // If the last height is below NUM_RECENT_BLOCKS, ensure the number of recent blocks matches the last height.
-        // TODO: generalize check for RECENT_INTERVAL > 1, or remove this comment if we hardwire that to 1
-        if last_height < NUM_RECENT_BLOCKS as u32 && recents.len().saturating_sub(1) as u32 != last_height {
-            bail!("As the last height is below {NUM_RECENT_BLOCKS}, the number of recent blocks must match the height")
-        }
-        // Otherwise, ensure the number of recent blocks matches NUM_RECENT_BLOCKS.
+        // At this point, if last_height < NUM_RECENT_BLOCKS`,
+        // we know that the `recents` map consists of exactly block heights from 0 to last_height,
+        // because the loop above has ensured that the first entry is for height 0,
+        // and at the end of the loop `last_height` is the last key in `recents`,
+        // and all the keys in `recents` are consecutive in increments of 1.
+        // So the `recents` map consists of NUM_RECENT_BLOCKS or fewer entries.
+
+        // If last height >= NUM_RECENT_BLOCKS, ensure the number of recent blocks matches NUM_RECENT_BLOCKS.
         // TODO: generalize check for RECENT_INTERVAL > 1, or remove this comment if we hardwire that to 1
         if last_height >= NUM_RECENT_BLOCKS as u32 && recents.len() != NUM_RECENT_BLOCKS {
             bail!("Number of recent blocks must match {NUM_RECENT_BLOCKS}")

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -250,7 +250,7 @@ impl<N: Network> BlockLocators<N> {
         // Ensure the given recent blocks increment in height, and at the correct interval.
         let mut last_height = 0;
         for (i, current_height) in recents.keys().enumerate() {
-            if i == 0 && recents.len() < NUM_RECENT_BLOCKS && *current_height != last_height {
+            if i == 0 && recents.len() < NUM_RECENT_BLOCKS && *current_height > 0 {
                 bail!("Ledgers under {NUM_RECENT_BLOCKS} blocks must have the first recent block at height 0")
             }
             if i > 0 && *current_height <= last_height {

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -420,7 +420,11 @@ impl<N: Network> BlockSync<N> {
     }
 
     /// Updates the block locators and common ancestors for the given peer IP.
-    /// This function checks that the given block locators are well-formed, however it does **not** check
+    ///
+    /// This function does not need to check that the block locators are well-formed,
+    /// because that is already done in [`BlockLocators::new()`], as noted in [`BlockLocators`].
+    ///
+    /// This function does **not** check
     /// that the block locators are consistent with the peer's previous block locators or other peers' block locators.
     pub fn update_peer_locators(&self, peer_ip: SocketAddr, locators: BlockLocators<N>) -> Result<()> {
         // If the locators match the existing locators for the peer, return early.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -204,6 +204,7 @@ impl<N: Network> BlockSync<N> {
         let latest_height = self.ledger.latest_block_height();
 
         // Initialize the recents map.
+        // TODO: generalize this for RECENT_INTERVAL > 1, or remove this comment if we hardwire that to 1
         let mut recents = IndexMap::with_capacity(NUM_RECENT_BLOCKS);
         // Retrieve the recent block hashes.
         for height in latest_height.saturating_sub((NUM_RECENT_BLOCKS - 1) as u32)..=latest_height {
@@ -416,15 +417,13 @@ impl<N: Network> BlockSync<N> {
 
     /// Updates the block locators and common ancestors for the given peer IP.
     /// This function checks that the given block locators are well-formed, however it does **not** check
-    /// that the block locators are consistent the peer's previous block locators or other peers' block locators.
+    /// that the block locators are consistent with the peer's previous block locators or other peers' block locators.
     pub fn update_peer_locators(&self, peer_ip: SocketAddr, locators: BlockLocators<N>) -> Result<()> {
         // If the locators match the existing locators for the peer, return early.
         if self.locators.read().get(&peer_ip) == Some(&locators) {
             return Ok(());
         }
 
-        // Ensure the given block locators are well-formed.
-        locators.ensure_is_valid()?;
         // Update the locators entry for the given peer IP.
         self.locators.write().insert(peer_ip, locators.clone());
 


### PR DESCRIPTION
Rectify documentation of `BlockLocators` about validation during serialization. Also introduce more explicit notion of well-formedness, since subsequent documentation refers to that.

Make `BlockLocators::new_unchecked()` constructor, which does not perform validation, non-public, leveraging language-level protection. Also document that it is only used in tests.

As discussed on Slack, fix the check that the checkpoints map cover as many blocks as possible. Also explain the check.

As discussed on Slack, fix the check about overlapping checkpoints and recents. Also explain the check.

Remove a redundant check to validate block locators in `BlockSync`, as discussed on Slack, since deserialization already checks that.

Add TODOs related to either generalizing some of the code to `RECENT_INTERVAL > 1`, or removing such TODOs if we decide to hardwire `RECENT_INTERVAL` to 1 and eliminate that constant.
