### PR TITLE
[Testnet] Update release version to 3.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos"
-version = "3.2.0"
+version = "3.2.2"
 dependencies = [
  "anyhow",
  "built",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkos"
-version = "3.2.0"
+version = "3.2.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized operating system"
 homepage = "https://aleo.org"


### PR DESCRIPTION
## Motivation

This was an oversight and should have been merged into canary v3.3.2 already. This will ensure `snarkOS -V` displays `v3.3.2`
