### PR TITLE
Add releases gantt

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,19 +9,19 @@ gantt
 
     section Canary Releases
     v3.4.0 (03/05) :active, 03/05/2025, 1d
-    v3.5.0 :active, c2, 04/01/2025, 1d
+    v3.5.0 (04/01) :active, c2, 04/01/2025, 1d
     Consensus V4 activates block height 5_530_000:active, 04/03/2025, 1d
-    v3.6.0 :active, c2, 4/29/2025, 1d
+    v3.6.0 (04/29):active, c2, 4/29/2025, 1d
     
     section Testnet Releases
-    v3.4.0 :active, t1, 03/11/2025, 1d
-    v3.5.0 :active, t2, 04/08/2025, 1d
+    v3.4.0 (03/11):active, t1, 03/11/2025, 1d
+    v3.5.0 (04/08):active, t2, 04/08/2025, 1d
     Consensus V4 activates block height 6_625_000:active, t3, 04/13/2025, 1d
-    v3.6.0 :active, c2, 5/13/2025, 1d
+    v3.6.0 (05/13):active, c2, 5/13/2025, 1d
     
     section Mainnet Releases
-    v3.4.0 :active, m1, 03/25/2025, 1d
-    v3.5.0 :active, m2, 04/22/2025, 1d
+    v3.4.0 (03/25):active, m1, 03/25/2025, 1d
+    v3.5.0 (04/22):active, m2, 04/22/2025, 1d
     Consensus V4 activates block height 7_100_000:active, m3, 05/06/2025, 1d
-    v3.6.0 :active, c2, 5/20/2025, 1d
+    v3.6.0 (05/20):active, c2, 5/20/2025, 1d
 ```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,30 @@
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"ganttTextFill": "#FFFFFF", "ganttBarHeight": 18, "ganttBarProgressionColor": "#ff6f61"}}}%%
+---
+displayMode: compact
+---
+gantt
+    title Aleo Release Schedule
+    dateFormat  YYYY-MM-DD
+    tickInterval 1week
+    section -
+    - : 02/28/2025,
+
+    section Canary Releases
+    v3.4.0 (03/05) :active, 03/05/2025, 1d
+    v3.5.0 :active, c2, 04/01/2025, 1d
+    Consensus V4 activates block height 5_530_000:active, 04/03/2025, 1d
+    v3.6.0 :active, c2, 4/29/2025, 1d
+    
+    section Testnet Releases
+    v3.4.0 :active, t1, 03/11/2025, 1d
+    v3.5.0 :active, t2, 04/08/2025, 1d
+    Consensus V4 activates block height 6_625_000:active, t3, 04/13/2025, 1d
+    v3.6.0 :active, c2, 5/13/2025, 1d
+    
+    section Mainnet Releases
+    v3.4.0 :active, m1, 03/25/2025, 1d
+    v3.5.0 :active, m2, 04/22/2025, 1d
+    Consensus V4 activates block height 7_100_000:active, m3, 05/06/2025, 1d
+    v3.6.0 :active, c2, 5/20/2025, 1d
+```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,8 +1,5 @@
 ```mermaid
 %%{init: {"theme": "dark", "themeVariables": {"ganttTextFill": "#FFFFFF", "ganttBarHeight": 18, "ganttBarProgressionColor": "#ff6f61"}}}%%
----
-displayMode: compact
----
 gantt
     title Aleo Release Schedule
     dateFormat  YYYY-MM-DD


### PR DESCRIPTION
## Motivation

Currently, releases are tracked in a spreadsheet, which looks untrustworthy to a new reader and is not easy to interpret.

This PR adds a file rendering expected release dates in pretty Markdown: https://github.com/ProvableHQ/snarkOS/blob/ef1482334b68e6b3127122f8382ee5a26262c824/RELEASES.md

Like any release schedule, it will need to be maintained, which should not be too much work, adjusting 3 lines roughly once a month.