### PR TITLE
[Refactor] Move the committee cache to snarkVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,7 +3591,6 @@ version = "3.3.2"
 dependencies = [
  "async-trait",
  "indexmap 2.7.1",
- "lru",
  "parking_lot",
  "rand",
  "rayon",
@@ -3811,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3842,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3872,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3886,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3897,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3907,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3917,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "indexmap 2.7.1",
  "itertools 0.11.0",
@@ -3935,12 +3934,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3951,7 +3950,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3966,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3981,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3994,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4003,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4013,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4025,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4037,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4048,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4060,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4073,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4084,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4097,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4108,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4131,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4149,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4171,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4186,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4197,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4205,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4215,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4226,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4237,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4248,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4259,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "rand",
  "rayon",
@@ -4273,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4290,11 +4289,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap 2.7.1",
+ "lru",
  "parking_lot",
  "rand",
  "rayon",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "anyhow",
  "rand",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4416,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4534,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "indexmap 2.7.1",
  "paste",
@@ -4654,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ version = "=0.1.24"
 default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
-#path = "../snarkVM"
+# path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "3ced248"
+rev = "fb93f06"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [features]
 default = [ ]
-ledger = [ "lru", "parking_lot", "rand", "rayon", "tokio", "tracing" ]
+ledger = [ "parking_lot", "rand", "rayon", "tokio", "tracing" ]
 ledger-write = [ ]
 metrics = [ "dep:metrics", "snarkvm/metrics" ]
 mock = [ "parking_lot", "tracing" ]
@@ -33,10 +33,6 @@ version = "0.1"
 [dependencies.indexmap]
 version = "2.1"
 features = [ "serde", "rayon" ]
-
-[dependencies.lru]
-version = "0.12"
-optional = true
 
 [dependencies.metrics]
 package = "snarkos-node-metrics"

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -27,8 +27,7 @@ use snarkvm::{
 };
 
 use indexmap::IndexMap;
-use lru::LruCache;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use rayon::prelude::*;
 use std::{
     collections::BTreeMap,
@@ -41,8 +40,6 @@ use std::{
     },
 };
 
-/// The capacity of the LRU holding the recently queried committees.
-const COMMITTEE_CACHE_SIZE: usize = 16;
 /// The capacity of the cache holding the highest blocks.
 const BLOCK_CACHE_SIZE: usize = 10;
 
@@ -50,7 +47,6 @@ const BLOCK_CACHE_SIZE: usize = 10;
 #[allow(clippy::type_complexity)]
 pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     ledger: Ledger<N, C>,
-    committee_cache: Arc<Mutex<LruCache<u64, Committee<N>>>>,
     block_cache: Arc<RwLock<BTreeMap<u32, Block<N>>>>,
     latest_leader: Arc<RwLock<Option<(u64, Address<N>)>>>,
     shutdown: Arc<AtomicBool>,
@@ -59,9 +55,8 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
 impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     /// Initializes a new core ledger service.
     pub fn new(ledger: Ledger<N, C>, shutdown: Arc<AtomicBool>) -> Self {
-        let committee_cache = Arc::new(Mutex::new(LruCache::new(COMMITTEE_CACHE_SIZE.try_into().unwrap())));
         let block_cache = Arc::new(RwLock::new(BTreeMap::new()));
-        Self { ledger, committee_cache, block_cache, latest_leader: Default::default(), shutdown }
+        Self { ledger, block_cache, latest_leader: Default::default(), shutdown }
     }
 }
 
@@ -169,29 +164,9 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     /// Returns the committee for the given round.
     fn get_committee_for_round(&self, round: u64) -> Result<Committee<N>> {
-        // Check if the committee is already in the cache.
-        if let Some(committee) = self.committee_cache.lock().get(&round) {
-            return Ok(committee.clone());
-        }
-
         match self.ledger.get_committee_for_round(round)? {
-            // Return the committee if it exists.
-            Some(committee) => {
-                // Insert the committee into the cache.
-                self.committee_cache.lock().push(round, committee.clone());
-                // Return the committee.
-                Ok(committee)
-            }
-            // Return the current committee if the round is equivalent.
-            None => {
-                // Retrieve the current committee.
-                let current_committee = self.current_committee()?;
-                // Return the current committee if the round is equivalent.
-                match current_committee.starting_round() == round {
-                    true => Ok(current_committee),
-                    false => bail!("No committee found for round {round} in the ledger"),
-                }
-            }
+            Some(committee) => Ok(committee),
+            None => bail!("No committee found for round {round} in the ledger"),
         }
     }
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -66,9 +66,9 @@ path = "../router"
 version = "=3.3.2"
 
 [dependencies.snarkvm-synthesizer]
-#path = "../../../snarkVM/synthesizer"
+# path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "3ced248"
+rev = "fb93f06"
 #version = "=1.3.0"
 default-features = false
 optional = true


### PR DESCRIPTION
The snarkOS-side counterpart to https://github.com/ProvableHQ/snarkVM/pull/2626.

note: this PR will remain in draft status until the snarkVM one is merged.