### PR TITLE
[Hotfix] [Canary] Optimize deployment loading on initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "indexmap 2.7.1",
  "itertools 0.11.0",
@@ -3935,12 +3935,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4003,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "rand",
  "rayon",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "anyhow",
  "rand",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4416,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4534,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "indexmap 2.7.1",
  "paste",
@@ -4654,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c15997f#c15997f21e553e025d295c4a1d8acc22db7a0c26"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3907,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "indexmap 2.7.1",
  "itertools 0.11.0",
@@ -3935,12 +3935,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4003,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4037,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "rand",
  "rayon",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "anyhow",
  "rand",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4416,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4534,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "indexmap 2.7.1",
  "paste",
@@ -4654,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=3ced248#3ced248d4015c929f5240ce8fa5693ac3ae3b51b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6d09e41#6d09e41e7dd2f3acd214c31db42caf336d93b598"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "6d09e41"
+rev = "c15997f"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "3ced248"
+rev = "6d09e41"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.3.2"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "3ced248"
+rev = "6d09e41"
 #version = "=1.3.0"
 default-features = false
 optional = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.3.2"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "6d09e41"
+rev = "c15997f"
 #version = "=1.3.0"
 default-features = false
 optional = true


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps the snarkVM rev to [6d09e41](https://github.com/ProvableHQ/snarkVM/pull/2644/commits/6d09e41e7dd2f3acd214c31db42caf336d93b598) to include the deployment loading optimization hotfix. This Rev should be updated once the snarkVM PR is officially merged.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2644
