### PR TITLE
[Fix] Check certificate validity early.

### DIFF
--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -22,14 +22,13 @@ use snarkvm::{
         narwhal::{BatchCertificate, BatchHeader, Transmission, TransmissionID},
     },
     prelude::{Address, Field, Network, Result, anyhow, bail, ensure},
-    utilities::{cfg_into_iter, cfg_sorted_by},
+    utilities::{cfg_into_iter, cfg_iter, cfg_sorted_by},
 };
 
 use indexmap::{IndexMap, IndexSet, map::Entry};
 use lru::LruCache;
 use parking_lot::RwLock;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use snarkvm::algorithms::cfg_iter;
 use std::{
     collections::{HashMap, HashSet},
     num::NonZeroUsize,

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -28,7 +28,8 @@ use snarkvm::{
 use indexmap::{IndexMap, IndexSet, map::Entry};
 use lru::LruCache;
 use parking_lot::RwLock;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use snarkvm::algorithms::cfg_iter;
 use std::{
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
@@ -492,6 +493,49 @@ impl<N: Network> Storage<N> {
             }
         }
         Ok(missing_transmissions)
+    }
+
+    /// Check the validity of a certificate coming from another validator.
+    ///
+    /// It suffices to check that the signers (author and endorsers) are members of the applicable committee
+    /// and that they form a quorum in the committee.
+    /// Under the fundamental fault tolerance assumption of at most `f` (stake of) faulty validators,
+    /// the quorum check on signers guarantees that at least one correct validator
+    /// has ensured the validity of the proposal contained in the certificate,
+    /// either by construction (by the author) or by checking (by an endorser):
+    /// given `N > 0` total stake, and `f` the largest integer `< N/3` (where `/` is exact rational division),
+    /// we have `N >= 3f + 1`, which implies `N - f >= 2f + 1`, which is always `> f`;
+    /// `N - f` is the quorum stake.
+    pub fn check_incoming_certificate(&self, certificate: &BatchCertificate<N>) -> Result<()> {
+        // Retrieve the certificate author and round.
+        let certificate_author = certificate.author();
+        let certificate_round = certificate.round();
+
+        // Retrieve the committee lookback.
+        let committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
+
+        // Ensure that the signers of the certificate reach the quorum threshold.
+        // Note that certificate.signatures() only returns the endorsing signatures, not the author's signature.
+        let mut signers: HashSet<Address<N>> =
+            certificate.signatures().map(|signature| signature.to_address()).collect();
+        signers.insert(certificate_author);
+        ensure!(
+            committee_lookback.is_quorum_threshold_reached(&signers),
+            "Certificate '{}' for round {certificate_round} does not meet quorum requirements",
+            certificate.id()
+        );
+
+        // Ensure that the signers of the certificate are in the committee.
+        cfg_iter!(signers).try_for_each(|signer| {
+            ensure!(
+                committee_lookback.is_committee_member(*signer),
+                "Signer '{signer}' of certificate '{}' for round {certificate_round} is not in the committee",
+                certificate.id()
+            );
+            Ok(())
+        })?;
+
+        Ok(())
     }
 
     /// Checks the given `certificate` for validity, returning the missing transmissions from storage.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -955,14 +955,50 @@ impl<N: Network> Primary<N> {
             bail!("Received a batch certificate for myself ({author})");
         }
 
+        // Retrieve the committee lookback.
+        let committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
+
+        // Ensure that the signers of the certificate reach the quorum threshold.
+        let signers = certificate.signatures().map(|signature| signature.to_address()).collect();
+        ensure!(
+            committee_lookback.is_quorum_threshold_reached(&signers),
+            "Certificate '{}' for round {certificate_round} does not meet quorum requirements",
+            certificate.id()
+        );
+
+        // Ensure that the signers of the certificate are in the committee.
+        for signer in signers {
+            ensure!(
+                committee_lookback.is_committee_member(signer),
+                "Signer '{signer}' of certificate '{}' for round {certificate_round} is not in the committee",
+                certificate.id()
+            )
+        }
+
+        // Under the fundamental fault tolerance assumption of at most f (stake of) faulty validators,
+        // the above check on signers guarantees that at least one correct validator
+        // has ensured the validity of the proposal,
+        // either by construction (by the author) or by checking (by an endorser):
+        // given N > 0 and f the largest integer < N/3 (where / is exact rational division),
+        // we have N >= 3f + 1, which implies N - f >= 2f + 1, which is always > f.
+        // With the above check that the signers are in the committee,
+        // at this point we know that the certificate is valid.
+
         // Store the certificate, after ensuring it is valid.
+        // The following call recursively fetches and stores
+        // the previous certificates referenced from this certificate.
+        // It is critical to make the following call this after validating the certificate above.
+        // The reason is that a sequence of malformed certificates,
+        // with references to previous certificates with non-decreasing rounds,
+        // cause the recursive fetching of certificates to crash the validator due to resource exhaustion.
+        // Note that if the following call, if not returning an error, guarantees the backward closure of the DAG
+        // (i.e. that all the referenced previous certificates are in the DAG before storing this one),
+        // then all the validity checks in [`Storage::check_certificate`] should be redundant.
         self.sync_with_certificate_from_peer::<false>(peer_ip, certificate).await?;
 
         // If there are enough certificates to reach quorum threshold for the certificate round,
         // then proceed to advance to the next round.
 
-        // Retrieve the committee lookback.
-        let committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
         // Retrieve the certificate authors.
         let authors = self.storage.get_certificate_authors_for_round(certificate_round);
         // Check if the certificates have reached the quorum threshold.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -970,13 +970,14 @@ impl<N: Network> Primary<N> {
         );
 
         // Ensure that the signers of the certificate are in the committee.
-        for signer in signers {
+        cfg_iter!(signers).try_for_each(|signer| {
             ensure!(
-                committee_lookback.is_committee_member(signer),
+                committee_lookback.is_committee_member(*signer),
                 "Signer '{signer}' of certificate '{}' for round {certificate_round} is not in the committee",
                 certificate.id()
-            )
-        }
+            );
+            Ok(())
+        })?;
 
         // Under the fundamental fault tolerance assumption of at most f (stake of) faulty validators,
         // the above check on signers guarantees that at least one correct validator

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -959,7 +959,10 @@ impl<N: Network> Primary<N> {
         let committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
 
         // Ensure that the signers of the certificate reach the quorum threshold.
-        let signers = certificate.signatures().map(|signature| signature.to_address()).collect();
+        // Note that certificate.signatures() only returns the endorsing signatures, not the author's signature.
+        let mut signers: HashSet<Address<N>> =
+            certificate.signatures().map(|signature| signature.to_address()).collect();
+        signers.insert(author);
         ensure!(
             committee_lookback.is_quorum_threshold_reached(&signers),
             "Certificate '{}' for round {certificate_round} does not meet quorum requirements",


### PR DESCRIPTION
Before recursively fetching previous certificates.

Closes #2935.

Since it looks like we had working code to run the exploit, it would be good to revive it and make sure it no  longer crashes the validator.
