### PR TITLE
[Fix] Harden the router's resolver

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -211,7 +211,7 @@ impl<N: Network> Router<N> {
         // Finalize the connecting peer information.
         self.connecting_peers.lock().insert(peer_ip, Some(Peer::new(peer_ip, peer_addr, &peer_request)));
         // Adds a bidirectional map between the listener address and (ambiguous) peer address.
-        self.resolver.insert_peer(peer_ip, peer_addr);
+        self.resolver.write().insert_peer(peer_ip, peer_addr);
 
         Ok((peer_ip, framed))
     }
@@ -296,7 +296,7 @@ impl<N: Network> Router<N> {
         // Finalize the connecting peer information.
         self.connecting_peers.lock().insert(peer_ip, Some(Peer::new(peer_ip, peer_addr, &peer_request)));
         // Adds a bidirectional map between the listener address and (ambiguous) peer address.
-        self.resolver.insert_peer(peer_ip, peer_addr);
+        self.resolver.write().insert_peer(peer_ip, peer_addr);
 
         Ok((peer_ip, framed))
     }

--- a/node/router/src/helpers/mod.rs
+++ b/node/router/src/helpers/mod.rs
@@ -20,4 +20,4 @@ mod peer;
 pub use peer::*;
 
 mod resolver;
-pub use resolver::*;
+pub(crate) use resolver::*;

--- a/node/router/src/helpers/resolver.rs
+++ b/node/router/src/helpers/resolver.rs
@@ -15,7 +15,7 @@
 
 use std::{collections::HashMap, net::SocketAddr};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Resolver {
     /// The map of the listener address to (ambiguous) peer address.
     from_listener: HashMap<SocketAddr, SocketAddr>,
@@ -23,19 +23,7 @@ pub struct Resolver {
     to_listener: HashMap<SocketAddr, SocketAddr>,
 }
 
-impl Default for Resolver {
-    /// Initializes a new instance of the resolver.
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Resolver {
-    /// Initializes a new instance of the resolver.
-    pub fn new() -> Self {
-        Self { from_listener: Default::default(), to_listener: Default::default() }
-    }
-
     /// Returns the listener address for the given (ambiguous) peer address, if it exists.
     pub fn get_listener(&self, peer_addr: &SocketAddr) -> Option<SocketAddr> {
         self.to_listener.get(peer_addr).copied()

--- a/node/router/src/helpers/resolver.rs
+++ b/node/router/src/helpers/resolver.rs
@@ -15,6 +15,9 @@
 
 use std::{collections::HashMap, net::SocketAddr};
 
+/// The `Resolver` provides the means to map the connected address (used in the lower-level
+/// `tcp` module internals, and provided by the OS) to the listener address (used as the
+/// unique peer identifier in the higher-level functions), and the other way around.
 #[derive(Debug, Default)]
 pub struct Resolver {
     /// The map of the listener address to (ambiguous) peer address.

--- a/node/router/src/helpers/resolver.rs
+++ b/node/router/src/helpers/resolver.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, net::SocketAddr};
 /// `tcp` module internals, and provided by the OS) to the listener address (used as the
 /// unique peer identifier in the higher-level functions), and the other way around.
 #[derive(Debug, Default)]
-pub struct Resolver {
+pub(crate) struct Resolver {
     /// The map of the listener address to (ambiguous) peer address.
     from_listener: HashMap<SocketAddr, SocketAddr>,
     /// The map of the (ambiguous) peer address to listener address.

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -78,7 +78,10 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
         // Retrieve the listener IP for the peer.
         let peer_ip = match self.router().resolve_to_listener(&peer_addr) {
             Some(peer_ip) => peer_ip,
-            None => bail!("Unable to resolve the (ambiguous) peer address '{peer_addr}'"),
+            None => {
+                // No longer connected to the peer.
+                return Ok(());
+            }
         };
 
         // Drop the peer, if they have sent more than `MESSAGE_LIMIT` messages

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -82,6 +82,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
             Some(peer_ip) => peer_ip,
             None => {
                 // No longer connected to the peer.
+                trace!("Dropping a {} from {peer_addr} - no longer connected.", message.name());
                 return Ok(false);
             }
         };

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -158,7 +158,10 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 bail!("Peer '{peer_ip}' is not following the protocol")
             }
             Message::Disconnect(message) => {
-                bail!("{:?}", message.reason)
+                // The peer informs us that they had disconnected. Disconnect from them too.
+                debug!("Peer '{peer_ip}' decided to disconnect due to '{:?}'", message.reason);
+                self.router().disconnect(peer_ip);
+                Ok(())
             }
             Message::PeerRequest(..) => match self.peer_request(peer_ip) {
                 true => Ok(()),

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -613,10 +613,10 @@ impl<N: Network> Router<N> {
         self.connected_peers.write().remove(&peer_ip);
         // Removes the bidirectional map between the listener address and (ambiguous) peer address.
         self.resolver.write().remove_peer(&peer_ip);
-        // Add the peer to the candidate peers.
-        self.candidate_peers.write().insert(peer_ip);
         // Clear cached entries applicable to the peer.
         self.cache.clear_peer_entries(peer_ip);
+        // Add the peer to the candidate peers.
+        self.candidate_peers.write().insert(peer_ip);
         #[cfg(feature = "metrics")]
         self.update_metrics();
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -609,10 +609,10 @@ impl<N: Network> Router<N> {
 
     /// Removes the connected peer and adds them to the candidate peers.
     pub fn remove_connected_peer(&self, peer_ip: SocketAddr) {
-        // Removes the bidirectional map between the listener address and (ambiguous) peer address.
-        self.resolver.write().remove_peer(&peer_ip);
         // Remove this peer from the connected peers, if it exists.
         self.connected_peers.write().remove(&peer_ip);
+        // Removes the bidirectional map between the listener address and (ambiguous) peer address.
+        self.resolver.write().remove_peer(&peer_ip);
         // Add the peer to the candidate peers.
         self.candidate_peers.write().insert(peer_ip);
         // Clear cached entries applicable to the peer.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -261,6 +261,12 @@ impl<N: Network> Router<N> {
                 }
                 disconnected
             } else {
+                // FIXME (ljedrz): this shouldn't be necessary; it's a double-check
+                //  that the higher-level collection is consistent with the resolver.
+                if router.is_connected(&peer_ip) {
+                    warn!("Fallback connection artifact cleanup (report this to @ljedrz)");
+                    router.remove_connected_peer(peer_ip);
+                }
                 false
             }
         })

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -533,6 +533,12 @@ impl<N: Network> Router<N> {
 
     /// Inserts the given peer into the connected peers.
     pub fn insert_connected_peer(&self, peer_ip: SocketAddr) {
+        // Hold the write locks for the duration of this function to
+        // avoid any of them from becoming unaligned with the others.
+        let mut connected_peers = self.connected_peers.write();
+        let mut candidate_peers = self.candidate_peers.write();
+        let mut restricted_peers = self.restricted_peers.write();
+
         // Move the peer from "connecting" to "connected".
         let peer = match self.connecting_peers.lock().remove(&peer_ip) {
             Some(Some(peer)) => peer,
@@ -545,12 +551,13 @@ impl<N: Network> Router<N> {
                 return;
             }
         };
-        // Add an entry for this `Peer` in the connected peers.
-        self.connected_peers.write().insert(peer_ip, peer);
+
         // Remove this peer from the candidate peers, if it exists.
-        self.candidate_peers.write().remove(&peer_ip);
+        candidate_peers.remove(&peer_ip);
+        // Add an entry for this `Peer` in the connected peers.
+        connected_peers.insert(peer_ip, peer);
         // Remove this peer from the restricted peers, if it exists.
-        self.restricted_peers.write().remove(&peer_ip);
+        restricted_peers.remove(&peer_ip);
         #[cfg(feature = "metrics")]
         self.update_metrics();
         info!("Connected to '{peer_ip}'");
@@ -615,14 +622,20 @@ impl<N: Network> Router<N> {
 
     /// Removes the connected peer and adds them to the candidate peers.
     pub fn remove_connected_peer(&self, peer_ip: SocketAddr) {
-        // Remove this peer from the connected peers, if it exists.
-        self.connected_peers.write().remove(&peer_ip);
+        // Hold the write locks for the duration of this function to
+        // avoid any of them from becoming unaligned with the others.
+        let mut resolver = self.resolver.write();
+        let mut connected_peers = self.connected_peers.write();
+        let mut candidate_peers = self.candidate_peers.write();
+
         // Removes the bidirectional map between the listener address and (ambiguous) peer address.
-        self.resolver.write().remove_peer(&peer_ip);
+        resolver.remove_peer(&peer_ip);
+        // Remove this peer from the connected peers, if it exists.
+        connected_peers.remove(&peer_ip);
+        // Add the peer to the candidate peers.
+        candidate_peers.insert(peer_ip);
         // Clear cached entries applicable to the peer.
         self.cache.clear_peer_entries(peer_ip);
-        // Add the peer to the candidate peers.
-        self.candidate_peers.write().insert(peer_ip);
         #[cfg(feature = "metrics")]
         self.update_metrics();
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -96,7 +96,7 @@ pub struct InnerRouter<N: Network> {
     /// The cache.
     cache: Cache<N>,
     /// The resolver.
-    resolver: Resolver,
+    resolver: RwLock<Resolver>,
     /// The set of trusted peers.
     trusted_peers: HashSet<SocketAddr>,
     /// The map of connected peer IPs to their peer handlers.
@@ -337,12 +337,12 @@ impl<N: Network> Router<N> {
 
     /// Returns the listener IP address from the (ambiguous) peer address.
     pub fn resolve_to_listener(&self, peer_addr: &SocketAddr) -> Option<SocketAddr> {
-        self.resolver.get_listener(peer_addr)
+        self.resolver.read().get_listener(peer_addr)
     }
 
     /// Returns the (ambiguous) peer address from the listener IP address.
     pub fn resolve_to_ambiguous(&self, peer_ip: &SocketAddr) -> Option<SocketAddr> {
-        self.resolver.get_ambiguous(peer_ip)
+        self.resolver.read().get_ambiguous(peer_ip)
     }
 
     /// Returns `true` if the node is connected to the given peer IP.
@@ -610,7 +610,7 @@ impl<N: Network> Router<N> {
     /// Removes the connected peer and adds them to the candidate peers.
     pub fn remove_connected_peer(&self, peer_ip: SocketAddr) {
         // Removes the bidirectional map between the listener address and (ambiguous) peer address.
-        self.resolver.remove_peer(&peer_ip);
+        self.resolver.write().remove_peer(&peer_ip);
         // Remove this peer from the connected peers, if it exists.
         self.connected_peers.write().remove(&peer_ip);
         // Add the peer to the candidate peers.


### PR DESCRIPTION
While investigating a potential issue with some trusted peers being periodically dropped, I've noticed a lot of instances of `Unable to resolve the (...) address` in the log extracts from different networks. I believe most of them are triggered unnecessarily, but we need to be sure, and this PR aims to address this.

The proposed changes are as follows:
- 1e8dc493916cce871686dcdb71bc1db2b6d3091a - changes the dual-lock setup of the resolver to a single-lock one in order to avoid any possibility of mismatch between the address maps; it should also slightly improve its performance
- 260e84bc2d9949e53c4beaa270c905834859c711 - the `inbound` method is "fed" from a lower-level queue which doesn't have an awareness of the address resolver, so the entries that fail to resolve there are basically guaranteed to be post-disconnect "stragglers" and may be ignored (instead of triggering potentially many redundant disconnect attempts, which result in further resolver-related warnings)
- 6bb8a74b95149d4df04033586e6e0237d6de21fe - this swaps the order of disconnect-related operations, altering the resolver only after a peer is no longer marked as connected; this will avoid situations where an outbound message is greenlit to be sent to a peer (who is marked as connected) only to fail at address resolution right afterwards, triggering a bogus warning
- bccf29a99753eaf4e1b204666e7051651451677a - this is a loosely-related drive-by; we should clear any peer-related cache before marking them as a candidate for connections, in order to avoid a (highly unlikely) scenario where the peer is reconnected to while having outdated cache entries, or even having new and applicable cache entries cleared
- 7ee66b44d318dc1363f633cd4ce8052958c89d92 - when a peer sends us a `Message::Disconnect`, we shouldn't report it as a protocol violation; this is mostly a cleanup of one or two misleading logs
- b673d7b1b8ccd9ce49f8202a3056674341f5dc2c - since I've seen some instances of the heartbeat process reporting lingering inactive peers, we should have a fallback cleanup of high-level connection artifacts in case the resolver can't find the physically connected address

Update: the PR was rebased due to a conflict, and while these commit hashes have changed, their contents or order haven't.