### PR TITLE
[Logs] Remove the low-level h2 entries

### DIFF
--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -60,7 +60,7 @@ pub fn initialize_logger<P: AsRef<Path>>(
             .add_directive("hyper=off".parse().unwrap())
             .add_directive("reqwest=off".parse().unwrap())
             .add_directive("want=off".parse().unwrap())
-            .add_directive("warp=off".parse().unwrap());
+            .add_directive("h2=off".parse().unwrap());
 
         let filter = if verbosity >= 2 {
             filter.add_directive("snarkos_node_sync=trace".parse().unwrap())

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -87,7 +87,7 @@ pub fn initialize_logger(verbosity: u8) {
             .add_directive("hyper=off".parse().unwrap())
             .add_directive("reqwest=off".parse().unwrap())
             .add_directive("want=off".parse().unwrap())
-            .add_directive("warp=off".parse().unwrap());
+            .add_directive("h2=off".parse().unwrap());
 
         let filter = if verbosity > 3 {
             filter.add_directive("snarkos_node_bft::gateway=trace".parse().unwrap())

--- a/node/bft/tests/common/utils.rs
+++ b/node/bft/tests/common/utils.rs
@@ -71,7 +71,7 @@ pub fn initialize_logger(verbosity: u8) {
             .add_directive("hyper=off".parse().unwrap())
             .add_directive("reqwest=off".parse().unwrap())
             .add_directive("want=off".parse().unwrap())
-            .add_directive("warp=off".parse().unwrap());
+            .add_directive("h2=off".parse().unwrap());
 
         if verbosity > 3 {
             filter.add_directive("snarkos_node_tcp=trace".parse().unwrap())


### PR DESCRIPTION
They are very verbose and we don't really need to see them. In addition, the directive related to `warp` is removed, as we don't use it anymore.