### PR TITLE
Run devnet in CI and update snarkVM ref

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ commands:
           cache_key: << parameters.cache_key >>
 
   run_devnet:
-    description: "Build and run devnet for integration testing"
+    description: "Run devnet for integration testing"
     parameters:
       workspace_member:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,151 @@ commands:
       - clear_environment:
           cache_key: << parameters.cache_key >>
 
+  run_devnet:
+    description: "Build and run devnet for integration testing"
+    parameters:
+      workspace_member:
+        type: string
+      cache_key:
+        type: string
+      validators:
+        type: integer
+        default: 4
+      clients:
+        type: integer
+        default: 2
+      network_id:
+        type: integer
+        default: 0  # mainnet, note URL below needs to be adjusted if this is changed
+      min_height:
+        type: integer
+        default: 45
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: << parameters.cache_key >>
+      - run:
+          name: "Install snarkos"
+          command: |
+            cargo install --locked --path .
+      - run:
+          name: "Create non-interactive devnet script"
+          command: |
+            cat > devnet_ci.sh \<<EOF
+            #!/bin/bash
+            
+            # Set parameters directly
+            total_validators=<< parameters.validators >>
+            total_clients=<< parameters.clients >>
+            network_id=<< parameters.network_id >>
+            
+            # Create log directory
+            log_dir=".logs-\$(date +"%Y%m%d%H%M%S")"
+            mkdir -p "\$log_dir"
+            
+            # Array to store PIDs of all processes
+            declare -a PIDS
+            
+            # Start all validator nodes in the background
+            for ((validator_index = 0; validator_index < \$total_validators; validator_index++)); do
+              log_file="\$log_dir/validator-\$validator_index.log"
+              if [ "\$validator_index" -eq 0 ]; then
+                snarkos start --nodisplay --network \$network_id --dev \$validator_index --allow-external-peers --dev-num-validators \$total_validators --validator --logfile \$log_file --metrics &
+              else
+                snarkos start --nodisplay --network \$network_id --dev \$validator_index --allow-external-peers --dev-num-validators \$total_validators --validator --logfile \$log_file &
+              fi
+              PIDS[\$validator_index]=\$!
+              echo "Started validator \$validator_index with PID \${PIDS[\$validator_index]}"
+            done
+            
+            # Start all client nodes in the background
+            for ((client_index = 0; client_index < \$total_clients; client_index++)); do
+              node_index=\$((client_index + total_validators))
+              log_file="\$log_dir/client-\$client_index.log"
+              snarkos start --nodisplay --network \$network_id --dev \$node_index --dev-num-validators \$total_validators --client --logfile \$log_file &
+              PIDS[\$node_index]=\$!
+              echo "Started client \$client_index with PID \${PIDS[\$node_index]}"
+            done
+            
+            # Function to check block heights
+            check_heights() {
+              echo "Checking block heights on all nodes..."
+              all_reached=true
+              highest_height=0
+              for ((node_index = 0; node_index < \$((total_validators + total_clients)); node_index++)); do
+                port=\$((3030 + node_index))
+                height=\$(curl -s http://127.0.0.1:\$port/mainnet/block/height/latest || echo "0")
+                echo "Node \$node_index block height: \$height"
+                
+                # Track highest height for reporting
+                if [[ "\$height" =~ ^[0-9]+$ ]] && [ \$height -gt \$highest_height ]; then
+                  highest_height=\$height
+                fi
+                
+                if ! [[ "\$height" =~ ^[0-9]+$ ]] || [ \$height -lt << parameters.min_height >> ]; then
+                  all_reached=false
+                fi
+              done
+              
+              if \$all_reached; then
+                echo "✅ SUCCESS: All nodes reached minimum height of << parameters.min_height >>"
+                return 0
+              else
+                echo "⏳ WAITING: Not all nodes reached minimum height of << parameters.min_height >> (highest so far: \$highest_height)"
+                return 1
+              fi
+            }
+            
+            # Wait for 60 seconds to let the network start up
+            echo "Waiting 60 seconds for network to start up..."
+            sleep 60
+            
+            # Check heights periodically with a timeout
+            total_wait=0
+            while [ \$total_wait -lt 900 ]; do  # 15 minutes max
+              if check_heights; then
+                echo "🎉 Test passed! All nodes reached minimum height."
+                
+                # Cleanup: kill all processes
+                for pid in "\${PIDS[@]}"; do
+                  kill -9 \$pid 2>/dev/null || true
+                done
+                
+                exit 0
+              fi
+              
+              # Continue waiting
+              sleep 60
+              total_wait=\$((total_wait + 60))
+              echo "Waited \$total_wait seconds so far..."
+            done
+            
+            echo "❌ Test failed! Not all nodes reached minimum height within 15 minutes."
+            
+            # Print logs for debugging
+            echo "Last 20 lines of validator logs:"
+            for ((validator_index = 0; validator_index < \$total_validators; validator_index++)); do
+              echo "=== Validator \$validator_index logs ==="
+              tail -n 20 "\$log_dir/validator-\$validator_index.log"
+            done
+            
+            # Cleanup: kill all processes
+            for pid in "\${PIDS[@]}"; do
+              kill -9 \$pid 2>/dev/null || true
+            done
+            
+            exit 1
+            EOF
+            
+            chmod +x devnet_ci.sh
+      - run:
+          name: "Run devnet test"
+          no_output_timeout: 20m  # Allow 20 minutes total
+          command: |
+            ./devnet_ci.sh
+      - clear_environment:
+          cache_key: << parameters.cache_key >>
+
   install_rust_nightly:
     description: "Install Rust nightly toolchain"
     steps:
@@ -342,6 +487,15 @@ jobs:
           workspace_member: node/tcp
           cache_key: v3.3.1-rust-1.83.0-node-tcp-cache
 
+  devnet-test:
+    docker:
+      - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+    resource_class: << pipeline.parameters.large >>
+    steps:
+      - run_devnet:
+          workspace_member: .
+          cache_key: v3.3.1-rust-1.83.0-devnet-test-cache
+
   check-fmt:
     docker:
       - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
@@ -413,6 +567,7 @@ workflows:
       - node-tcp
       - check-fmt
       - check-clippy
+      - devnet-test
 
   windows-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ commands:
         default: 2
       network_id:
         type: integer
-        default: 0  # mainnet, note URL below needs to be adjusted if this is changed
+        default: 0
       min_height:
         type: integer
         default: 45
@@ -193,120 +193,11 @@ commands:
           command: |
             cargo install --locked --path .
       - run:
-          name: "Create non-interactive devnet script"
-          command: |
-            cat > devnet_ci.sh \<<EOF
-            #!/bin/bash
-            
-            # Set parameters directly
-            total_validators=<< parameters.validators >>
-            total_clients=<< parameters.clients >>
-            network_id=<< parameters.network_id >>
-            
-            # Create log directory
-            log_dir=".logs-\$(date +"%Y%m%d%H%M%S")"
-            mkdir -p "\$log_dir"
-            
-            # Array to store PIDs of all processes
-            declare -a PIDS
-            
-            # Start all validator nodes in the background
-            for ((validator_index = 0; validator_index < \$total_validators; validator_index++)); do
-              log_file="\$log_dir/validator-\$validator_index.log"
-              if [ "\$validator_index" -eq 0 ]; then
-                snarkos start --nodisplay --network \$network_id --dev \$validator_index --allow-external-peers --dev-num-validators \$total_validators --validator --logfile \$log_file --metrics &
-              else
-                snarkos start --nodisplay --network \$network_id --dev \$validator_index --allow-external-peers --dev-num-validators \$total_validators --validator --logfile \$log_file &
-              fi
-              PIDS[\$validator_index]=\$!
-              echo "Started validator \$validator_index with PID \${PIDS[\$validator_index]}"
-            done
-            
-            # Start all client nodes in the background
-            for ((client_index = 0; client_index < \$total_clients; client_index++)); do
-              node_index=\$((client_index + total_validators))
-              log_file="\$log_dir/client-\$client_index.log"
-              snarkos start --nodisplay --network \$network_id --dev \$node_index --dev-num-validators \$total_validators --client --logfile \$log_file &
-              PIDS[\$node_index]=\$!
-              echo "Started client \$client_index with PID \${PIDS[\$node_index]}"
-            done
-            
-            # Function to check block heights
-            check_heights() {
-              echo "Checking block heights on all nodes..."
-              all_reached=true
-              highest_height=0
-              for ((node_index = 0; node_index < \$((total_validators + total_clients)); node_index++)); do
-                port=\$((3030 + node_index))
-                height=\$(curl -s http://127.0.0.1:\$port/mainnet/block/height/latest || echo "0")
-                echo "Node \$node_index block height: \$height"
-                
-                # Track highest height for reporting
-                if [[ "\$height" =~ ^[0-9]+$ ]] && [ \$height -gt \$highest_height ]; then
-                  highest_height=\$height
-                fi
-                
-                if ! [[ "\$height" =~ ^[0-9]+$ ]] || [ \$height -lt << parameters.min_height >> ]; then
-                  all_reached=false
-                fi
-              done
-              
-              if \$all_reached; then
-                echo "✅ SUCCESS: All nodes reached minimum height of << parameters.min_height >>"
-                return 0
-              else
-                echo "⏳ WAITING: Not all nodes reached minimum height of << parameters.min_height >> (highest so far: \$highest_height)"
-                return 1
-              fi
-            }
-            
-            # Wait for 60 seconds to let the network start up
-            echo "Waiting 60 seconds for network to start up..."
-            sleep 60
-            
-            # Check heights periodically with a timeout
-            total_wait=0
-            while [ \$total_wait -lt 900 ]; do  # 15 minutes max
-              if check_heights; then
-                echo "🎉 Test passed! All nodes reached minimum height."
-                
-                # Cleanup: kill all processes
-                for pid in "\${PIDS[@]}"; do
-                  kill -9 \$pid 2>/dev/null || true
-                done
-                
-                exit 0
-              fi
-              
-              # Continue waiting
-              sleep 60
-              total_wait=\$((total_wait + 60))
-              echo "Waited \$total_wait seconds so far..."
-            done
-            
-            echo "❌ Test failed! Not all nodes reached minimum height within 15 minutes."
-            
-            # Print logs for debugging
-            echo "Last 20 lines of validator logs:"
-            for ((validator_index = 0; validator_index < \$total_validators; validator_index++)); do
-              echo "=== Validator \$validator_index logs ==="
-              tail -n 20 "\$log_dir/validator-\$validator_index.log"
-            done
-            
-            # Cleanup: kill all processes
-            for pid in "\${PIDS[@]}"; do
-              kill -9 \$pid 2>/dev/null || true
-            done
-            
-            exit 1
-            EOF
-            
-            chmod +x devnet_ci.sh
-      - run:
           name: "Run devnet test"
           no_output_timeout: 20m  # Allow 20 minutes total
           command: |
-            ./devnet_ci.sh
+            chmod +x .circleci/devnet_ci.sh
+            ./.circleci/devnet_ci.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>
       - clear_environment:
           cache_key: << parameters.cache_key >>
 

--- a/.circleci/devnet_ci.sh
+++ b/.circleci/devnet_ci.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Set parameters directly
+total_validators=$1
+total_clients=$2
+network_id=$3
+min_height=$4
+
+# Default values if not provided
+: "${total_validators:=4}"
+: "${total_clients:=2}"
+: "${network_id:=0}"
+: "${min_height:=45}"
+
+# Create log directory
+log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
+mkdir -p "$log_dir"
+
+# Array to store PIDs of all processes
+declare -a PIDS
+
+# Start all validator nodes in the background
+for ((validator_index = 0; validator_index < $total_validators; validator_index++)); do
+  log_file="$log_dir/validator-$validator_index.log"
+  if [ "$validator_index" -eq 0 ]; then
+    snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --metrics &
+  else
+    snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file &
+  fi
+  PIDS[$validator_index]=$!
+  echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
+done
+
+# Start all client nodes in the background
+for ((client_index = 0; client_index < $total_clients; client_index++)); do
+  node_index=$((client_index + total_validators))
+  log_file="$log_dir/client-$client_index.log"
+  snarkos start --nodisplay --network $network_id --dev $node_index --dev-num-validators $total_validators --client --logfile $log_file &
+  PIDS[$node_index]=$!
+  echo "Started client $client_index with PID ${PIDS[$node_index]}"
+done
+
+# Function to check block heights
+check_heights() {
+  echo "Checking block heights on all nodes..."
+  all_reached=true
+  highest_height=0
+  for ((node_index = 0; node_index < $((total_validators + total_clients)); node_index++)); do
+    port=$((3030 + node_index))
+    height=$(curl -s http://127.0.0.1:$port/mainnet/block/height/latest || echo "0")
+    echo "Node $node_index block height: $height"
+    
+    # Track highest height for reporting
+    if [[ "$height" =~ ^[0-9]+$ ]] && [ $height -gt $highest_height ]; then
+      highest_height=$height
+    fi
+    
+    if ! [[ "$height" =~ ^[0-9]+$ ]] || [ $height -lt $min_height ]; then
+      all_reached=false
+    fi
+  done
+  
+  if $all_reached; then
+    echo "✅ SUCCESS: All nodes reached minimum height of $min_height"
+    return 0
+  else
+    echo "⏳ WAITING: Not all nodes reached minimum height of $min_height (highest so far: $highest_height)"
+    return 1
+  fi
+}
+
+# Wait for 60 seconds to let the network start up
+echo "Waiting 60 seconds for network to start up..."
+sleep 60
+
+# Check heights periodically with a timeout
+total_wait=0
+while [ $total_wait -lt 900 ]; do  # 15 minutes max
+  if check_heights; then
+    echo "🎉 Test passed! All nodes reached minimum height."
+    
+    # Cleanup: kill all processes
+    for pid in "${PIDS[@]}"; do
+      kill -9 $pid 2>/dev/null || true
+    done
+    
+    exit 0
+  fi
+  
+  # Continue waiting
+  sleep 60
+  total_wait=$((total_wait + 60))
+  echo "Waited $total_wait seconds so far..."
+done
+
+echo "❌ Test failed! Not all nodes reached minimum height within 15 minutes."
+
+# Print logs for debugging
+echo "Last 20 lines of validator logs:"
+for ((validator_index = 0; validator_index < $total_validators; validator_index++)); do
+  echo "=== Validator $validator_index logs ==="
+  tail -n 20 "$log_dir/validator-$validator_index.log"
+done
+
+# Cleanup: kill all processes
+for pid in "${PIDS[@]}"; do
+  kill -9 $pid 2>/dev/null || true
+done
+
+exit 1

--- a/.circleci/devnet_ci.sh
+++ b/.circleci/devnet_ci.sh
@@ -12,6 +12,25 @@ min_height=$4
 : "${network_id:=0}"
 : "${min_height:=45}"
 
+# Determine network name based on network_id
+case $network_id in
+  0)
+    network_name="mainnet"
+    ;;
+  1)
+    network_name="testnet"
+    ;;
+  2)
+    network_name="canary"
+    ;;
+  *)
+    echo "Unknown network ID: $network_id, defaulting to mainnet"
+    network_name="mainnet"
+    ;;
+esac
+
+echo "Using network: $network_name (ID: $network_id)"
+
 # Create log directory
 log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
 mkdir -p "$log_dir"
@@ -47,7 +66,7 @@ check_heights() {
   highest_height=0
   for ((node_index = 0; node_index < $((total_validators + total_clients)); node_index++)); do
     port=$((3030 + node_index))
-    height=$(curl -s http://127.0.0.1:$port/mainnet/block/height/latest || echo "0")
+    height=$(curl -s "http://127.0.0.1:$port/$network_name/block/height/latest" || echo "0")
     echo "Node $node_index block height: $height"
     
     # Track highest height for reporting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3896,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3916,13 +3916,14 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "indexmap 2.7.1",
  "itertools 0.11.0",
  "nom",
  "num-traits",
  "once_cell",
+ "smallvec",
  "snarkvm-algorithms",
  "snarkvm-circuit-environment-witness",
  "snarkvm-console-network",
@@ -3934,12 +3935,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3950,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3965,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3980,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3993,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4002,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4012,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4024,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4036,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4047,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4059,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4072,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4083,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4096,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4107,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4130,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4148,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4170,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4185,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4196,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4204,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4214,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4225,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4236,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4247,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4258,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "rand",
  "rayon",
@@ -4272,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4289,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4315,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "anyhow",
  "rand",
@@ -4327,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4347,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "anyhow",
  "indexmap 2.7.1",
@@ -4366,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4379,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4392,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4405,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4416,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "indexmap 2.7.1",
  "rayon",
@@ -4431,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4444,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4453,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4473,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4494,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4507,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4534,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4549,7 +4550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4558,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4583,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4615,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4639,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "indexmap 2.7.1",
  "paste",
@@ -4654,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4667,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4688,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fb93f06#fb93f0694a06450a9c77f784f21537e91df28355"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c6558fb#c6558fb9c15da28b7455db0a6a903d1fc09ffa3c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.38",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 # path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "fb93f06"
+rev = "c6558fb"
 #version = "=1.3.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -68,7 +68,7 @@ version = "=3.3.2"
 [dependencies.snarkvm-synthesizer]
 # path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "fb93f06"
+rev = "c6558fb"
 #version = "=1.3.0"
 default-features = false
 optional = true


### PR DESCRIPTION
## Motivation

We recently experienced a merged PR where the devnet doesn't run. Running a devnet in CI would have prevented this.

This PR adds a devnet run to CI, and expects it to reach at least height 45 within 15 minutes of running (assuming a 20 second block time, which would already be quite slow, but we also need to account for some snarkos startup overhead, the duration of it is currently unclear and also depends on the network connection).

To clarify: The test checks the block height for up to 15 minutes after a 1-minute startup period, with a safety mechanism to terminate the job if there's no output for 20 consecutive minutes.

Note that it adds a new non-interactive devnet script inside the CI config to avoid required user inputs and to also avoid a tmux dependency, which can mess with CircleCI. The default values are 4 vals, 2 clients, mainnet.

## Test Plan

Ran local tests using `circleci local execute devnet-test`. Note that it needs to be run in CI next for testing purposes. Also note that in the current staging branch, the CI job is expected to fail. UPDATE: after updating the snarkVM ref to the latest snarkVM staging, it is expected to pass.

Ran the local test on a previous commit hash where the devnet script runs, and this CI test also reports success there.

Closes #3539