### PR TITLE
[Doc] Clarify the rest body size limit only applies to requests

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -211,7 +211,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .layer(middleware::from_fn(log_middleware))
             // Enable CORS.
             .layer(cors)
-            // Cap body size at 512KiB.
+            // Cap the request body size at 512KiB.
             .layer(DefaultBodyLimit::max(512 * 1024))
             .layer(GovernorLayer {
                 // We can leak this because it is created only once and it persists.


### PR DESCRIPTION
Otherwise one might believe it also applies to responses. Axum [documentation](https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html). 