### PR TITLE
[CI] Fix devnet test flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ commands:
           cache_key: << parameters.cache_key >>
       - run:
           name: "Install snarkos"
+          no_output_timeout: 20m
           command: |
             cargo install --locked --path .
       - run:
@@ -381,7 +382,7 @@ jobs:
   devnet-test:
     docker:
       - image: cimg/rust:1.83.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: << pipeline.parameters.xlarge >>
+    resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_devnet:
           workspace_member: .


### PR DESCRIPTION
## Motivation

Recently, the devnet script CI test has been flaky and failed with "Too long with no output (exceeded 10m0s): context deadline exceeded" in the "Install snarkos" task ([example](https://github.com/ProvableHQ/snarkOS/pull/3549)).
The exact reason is unclear, it could be a random influence from CircleCI resource availabilities.

## Fix

This PR tries to fix it by:
* doubling the instance size the test runs on
* set the timeout to 20 minutes instead of the default value of 10

## Alternatives

An alternative approach could be to cargo install with `verbose`, but it would likely make the logs bigger.

## Test Plan

Testing it in this PR.

## Related PRs
https://github.com/ProvableHQ/snarkOS/pull/3542