### PR TITLE
[Deps] Update snarkVM rev and run cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,8 +3893,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3925,8 +3925,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3957,8 +3957,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms-cuda"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "blst",
  "cc",
@@ -3968,8 +3968,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3982,8 +3982,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3993,8 +3993,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4003,8 +4003,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4013,8 +4013,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "indexmap 2.8.0",
  "itertools 0.11.0",
@@ -4032,13 +4032,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4048,8 +4048,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4063,8 +4063,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4078,8 +4078,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4091,8 +4091,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4100,8 +4100,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4110,8 +4110,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4122,8 +4122,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4134,8 +4134,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4145,8 +4145,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4157,8 +4157,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4170,8 +4170,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4181,8 +4181,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4194,8 +4194,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4205,8 +4205,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4228,8 +4228,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4246,8 +4246,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4268,8 +4268,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4283,8 +4283,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4294,16 +4294,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4312,8 +4312,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4323,8 +4323,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4334,8 +4334,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4345,8 +4345,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4356,8 +4356,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "rand",
  "rayon",
@@ -4370,8 +4370,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4387,8 +4387,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4414,8 +4414,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "anyhow",
  "rand",
@@ -4426,8 +4426,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4446,8 +4446,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",
@@ -4465,8 +4465,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4478,8 +4478,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4491,8 +4491,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4504,8 +4504,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4515,8 +4515,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "indexmap 2.8.0",
  "rayon",
@@ -4530,8 +4530,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4543,8 +4543,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4552,8 +4552,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4573,8 +4573,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4595,8 +4595,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4608,8 +4608,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4636,8 +4636,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4652,8 +4652,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-metrics"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4661,8 +4661,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4687,8 +4687,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4720,8 +4720,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4745,8 +4745,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "indexmap 2.8.0",
  "paste",
@@ -4760,8 +4760,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4773,8 +4773,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4794,8 +4794,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "1.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7aaa46a#7aaa46ae2a01891f2d843e3413f2529688715118"
+version = "1.4.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a296d35#a296d3563e5ba99a49f36aed870ec5cc91610fb2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1665,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -1689,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
 dependencies = [
  "parking_lot_core",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
 ]
@@ -3101,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "7aaa46a"
+rev = "a296d35"
 #version = "=1.4.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -81,7 +81,7 @@ version = "=3.4.0"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "7aaa46a"
+rev = "a296d35"
 #version = "=1.4.0"
 default-features = false
 optional = true


### PR DESCRIPTION
Checking if we can unblock https://github.com/ProvableHQ/snarkOS/pull/3562 for merging.