### PR TITLE
[Fix] Adjust proposal cache path when using custom storage paths

### DIFF
--- a/node/bft/src/helpers/proposal_cache.rs
+++ b/node/bft/src/helpers/proposal_cache.rs
@@ -30,8 +30,11 @@ pub fn proposal_cache_path(network: u16, storage_mode: &StorageMode) -> PathBuf 
     const PROPOSAL_CACHE_FILE_NAME: &str = "current-proposal-cache";
     // Obtain the path to the ledger.
     let mut path = aleo_ledger_dir(network, storage_mode);
-    // Go to the folder right above the ledger.
-    path.pop();
+    // Go to the folder right above the ledger when using the default paths,
+    // otherwise store in the same directory as storage.
+    if !matches!(storage_mode, StorageMode::Custom(_)) {
+        path.pop();
+    }
     // Append the proposal store's file name.
     match storage_mode.dev() {
         Some(id) => path.push(format!(".{PROPOSAL_CACHE_FILE_NAME}-{}-{}", network, id)),


### PR DESCRIPTION
When using the default directory structure for Aleo resources and storage, the proposal cache is stored one level above the ledger path (`aleo_ledger_dir`). However, when a custom path is used, we can't make any assumptions about what might be above the configured ledger path and so we should store the proposal cache where the user expects it: in the configured directory.