### PR TITLE
[Docs] Add usage guide for validator telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ To start a validator, you can also run the following command from the `snarkOS` 
 
 ### 3.2.1 Enable Validator Telemetry Metrics (Optional)
 
-You can optionally enable validator telemetry to track participation in consensus. This is controlled via the telemetry feature flag and can be enabled in one of two ways:
+Validator telemetry allows you to track participation in consensus. This is optional and can be enabled using the `telemetry` feature flag.
 
-Once enabled, telemetry metrics are exposed through:
+Once enabled, telemetry metrics are available through:
 
 1. Node logs 
 2. REST API endpoints
@@ -186,9 +186,11 @@ Once enabled, telemetry metrics are exposed through:
     // GET /{network}/validators/participation?metadata={true}
     ```
 
+You can enable telemetry in one of the following ways:
+
 #### 1. Enable via [installation](#2.3-installation)
 
-Add the feature flag to the installation command.
+Add the `telemetry` feature flag to the installation command.
 ```
 cargo install --locked --path . --features telemetry
 ```

--- a/README.md
+++ b/README.md
@@ -173,6 +173,33 @@ To start a validator, you can also run the following command from the `snarkOS` 
 ./run-validator.sh
 ```
 
+### 3.2.1 Enable Validator Telemetry Metrics (Optional)
+
+You can optionally enable validator telemetry to track participation in consensus. This is controlled via the telemetry feature flag and can be enabled in one of two ways:
+
+Once enabled, telemetry metrics are exposed through:
+
+1. Node logs 
+2. REST API endpoints
+    ``` 
+    // GET /{network}/validators/participation
+    // GET /{network}/validators/participation?metadata={true}
+    ```
+
+#### 1. Enable via [installation](#2.3-installation)
+
+Add the feature flag to the installation command.
+```
+cargo install --locked --path . --features telemetry
+```
+
+#### 2. Enable via `./run-validator.sh`
+
+Run the `./run-validator.sh` script and enable telemetry when prompted:
+```
+Do you want to enable validator telemetry? (y/n, default: y):
+```
+
 ## 3.3 Run an Aleo Prover
 
 Start by following the instructions in the [Build Guide](#2-build-guide).

--- a/devnet.sh
+++ b/devnet.sh
@@ -21,8 +21,21 @@ read -p "Do you want to clear the existing ledger history? (y/n, default: n): " 
 clear_ledger=${clear_ledger:-n}
 
 if [[ $build_binary == "y" ]]; then
-  # Build the binary using 'cargo install --path .'
-  cargo install --locked --path . || exit 1
+  # Ask the user if they want to enable validator telemetry
+  read -p "Do you want to enable validator telemetry? (y/n, default: y): " enable_telemetry
+  enable_telemetry=${enable_telemetry:-y}
+
+  # Build command
+  build_cmd="cargo install --locked --path ."
+
+  # Add the telemetry feature if requested
+  if [[ $enable_telemetry == "y" ]]; then
+    build_cmd+=" --features telemetry"
+  fi
+
+  # Build command
+  echo "Running build command: \"$build_cmd\""
+  eval "$build_cmd" || exit 1
 fi
 
 # Clear the ledger logs for each validator if the user chooses to clear ledger

--- a/run-validator.sh
+++ b/run-validator.sh
@@ -42,7 +42,20 @@ then
   exit 1
 fi
 
-COMMAND="cargo run --release -- start --nodisplay --validator --bft 0.0.0.0:5000 --node 0.0.0.0:4130 --peers ${PEERS} --validators ${VALIDATORS} --norest --private-key ${VALIDATOR_PRIVATE_KEY}"
+# Ask the user if they want to enable validator telemetry
+read -p "Do you want to enable validator telemetry? (y/n, default: y): " enable_telemetry
+enable_telemetry=${enable_telemetry:-y}
+
+# Start building the base command
+COMMAND="cargo run --release"
+
+# Add telemetry feature if enabled
+if [[ $enable_telemetry == "y" ]]; then
+  COMMAND+=" --features telemetry"
+fi
+
+# Add the arguments after the '--'
+COMMAND+=" -- start --nodisplay --validator --bft 0.0.0.0:5000 --node 0.0.0.0:4130 --peers ${PEERS} --validators ${VALIDATORS} --norest --private-key ${VALIDATOR_PRIVATE_KEY}"
 
 for word in $*;
 do


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds a usage guide for validator telemetry and integrates the feature flag usage into the `devnet.sh` and `run-validator.sh`.

The usage guide is as follows:

### 3.2.1 Enable Validator Telemetry Metrics (Optional)

Validator telemetry allows you to track participation in consensus. This is optional and can be enabled using the `telemetry` feature flag.

Once enabled, telemetry metrics are available through:

1. Node logs 
2. REST API endpoints
    ``` 
    // GET /{network}/validators/participation
    // GET /{network}/validators/participation?metadata={true}
    ```

You can enable telemetry in one of the following ways:

#### 1. Enable via [installation](#2.3-installation)

Add the `telemetry` feature flag to the installation command.
```
cargo install --locked --path . --features telemetry
```

#### 2. Enable via `./run-validator.sh`

Run the `./run-validator.sh` script and enable telemetry when prompted:
```
Do you want to enable validator telemetry? (y/n, default: y):
```



The endpoint outputs will be in the following format:
// GET /{network}/validators/participation
```
{
  validator_address_1: participation_score_as_f64,
  validator_address_2: participation_score_as_f64,
  ....
  validator_address_n: participation_score_as_f64,
}
```
// GET /{network}/validators/participation?metadata={true}
```
{
  participation_scores: {
        validator_address_1: participation_score_as_f64,
        validator_address_2: participation_score_as_f64,
        ....
        validator_address_n: participation_score_as_f64,
    },
  height: block_height
}
```

### Related Issues 

https://github.com/ProvableHQ/snarkOS/issues/3566
