### PR TITLE
[Feature] Introduce rolling Message versions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "snarkos-account",
+ "snarkos-node-bft-ledger-service",
  "snarkos-node-metrics",
  "snarkos-node-router",
  "snarkos-node-router-messages",

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -79,6 +79,12 @@ version = "1"
 path = "../../account"
 version = "=3.5.0"
 
+[dependencies.snarkos-node-bft-ledger-service]
+path = "../bft/ledger-service"
+version = "=3.5.0"
+default-features = false
+features = [ "ledger", "prover" ]
+
 [dependencies.snarkos-node-sync-locators]
 path = "../sync/locators"
 version = "=3.5.0"
@@ -129,6 +135,10 @@ features = [ "sink" ]
 [dev-dependencies.peak_alloc]
 version = "0.2"
 
+[dev-dependencies.snarkos-node-bft-ledger-service]
+path = "../bft/ledger-service"
+features = [ "ledger-write", "test" ]
+
 [dev-dependencies.snarkos-node-sync]
 path = "../sync"
 features = [ "test" ]
@@ -140,6 +150,10 @@ features = [ "test" ]
 [dev-dependencies.snarkos-node-router-messages]
 path = "messages"
 features = [ "test" ]
+
+[dev-dependencies.snarkvm]
+workspace = true
+features = [ "test-helpers" ]
 
 [dev-dependencies.tracing-subscriber]
 version = "0.3"

--- a/node/router/messages/src/challenge_request.rs
+++ b/node/router/messages/src/challenge_request.rs
@@ -61,7 +61,7 @@ impl<N: Network> FromBytes for ChallengeRequest<N> {
 
 impl<N: Network> ChallengeRequest<N> {
     pub fn new(listener_port: u16, node_type: NodeType, address: Address<N>, nonce: u64) -> Self {
-        Self { version: Message::<N>::VERSION, listener_port, node_type, address, nonce }
+        Self { version: Message::<N>::latest_message_version(), listener_port, node_type, address, nonce }
     }
 }
 

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -112,10 +112,13 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 }
 
 impl<N: Network> Message<N> {
-    /// The version of the network protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 17;
     /// The version of the network protocol; this can is incremented for breaking changes between migration versions.
-    pub const VERSIONS: [(ConsensusVersion, u32); 1] = [(ConsensusVersion::V5, 17)];
+    pub const VERSIONS: [(ConsensusVersion, u32); 2] = [(ConsensusVersion::V4, 16), (ConsensusVersion::V5, 17)];
+
+    /// Returns the latest message version.
+    pub fn latest_message_version() -> u32 {
+        Self::VERSIONS.last().map(|(_, version)| *version).unwrap_or(0)
+    }
 
     /// Returns the message name.
     #[inline]

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -65,6 +65,7 @@ pub use snarkos_node_bft_events::DataBlocks;
 use snarkos_node_sync_locators::BlockLocators;
 use snarkvm::prelude::{
     Address,
+    ConsensusVersion,
     FromBytes,
     Network,
     Signature,
@@ -113,6 +114,8 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 impl<N: Network> Message<N> {
     /// The version of the network protocol; it can be incremented in order to force users to update.
     pub const VERSION: u32 = 17;
+    /// The version of the network protocol; this can is incremented for breaking changes between migration versions.
+    pub const VERSIONS: [(ConsensusVersion, u32); 1] = [(ConsensusVersion::V5, 17)];
 
     /// Returns the message name.
     #[inline]

--- a/node/router/messages/src/ping.rs
+++ b/node/router/messages/src/ping.rs
@@ -67,7 +67,7 @@ impl<N: Network> FromBytes for Ping<N> {
 
 impl<N: Network> Ping<N> {
     pub fn new(node_type: NodeType, block_locators: Option<BlockLocators<N>>) -> Self {
-        Self { version: <Message<N>>::VERSION, node_type, block_locators }
+        Self { version: <Message<N>>::latest_message_version(), node_type, block_locators }
     }
 }
 

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -350,7 +350,7 @@ impl<N: Network> Router<N> {
         let &ChallengeRequest { version, listener_port: _, node_type: _, address: _, nonce: _ } = message;
 
         // Ensure the message protocol version is not outdated.
-        if version < Message::<N>::VERSION {
+        if !self.is_valid_message_version(version) {
             warn!("Dropping '{peer_addr}' on version {version} (outdated)");
             return Some(DisconnectReason::OutdatedClientVersion);
         }

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -60,6 +60,9 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
     /// The maximum number of messages accepted within `MESSAGE_LIMIT_TIME_FRAME_IN_SECS`.
     const MESSAGE_LIMIT: usize = 500;
 
+    /// Returns `true` if the message version is valid.
+    fn is_valid_message_version(&self, message_version: u32) -> bool;
+
     /// Handles the inbound message from the peer.
     async fn inbound(&self, peer_addr: SocketAddr, message: Message<N>) -> Result<()> {
         // Retrieve the listener IP for the peer.
@@ -164,7 +167,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
             }
             Message::Ping(message) => {
                 // Ensure the message protocol version is not outdated.
-                if message.version < Message::<N>::VERSION {
+                if !self.is_valid_message_version(message.version) {
                     bail!("Dropping '{peer_ip}' on message version {} (outdated)", message.version);
                 }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -39,7 +39,7 @@ pub use outbound::*;
 mod routing;
 pub use routing::*;
 
-use crate::messages::NodeType;
+use crate::messages::{Message, NodeType};
 use snarkos_account::Account;
 use snarkos_node_tcp::{Config, P2P, Tcp, is_bogon_ip, is_unspecified_or_broadcast_ip};
 
@@ -249,6 +249,15 @@ impl<N: Network> Router<N> {
     /// Returns `true` if the given IP is not this node, is not a bogon address, and is not unspecified.
     pub fn is_valid_peer_ip(&self, ip: &SocketAddr) -> bool {
         !self.is_local_ip(ip) && !is_bogon_ip(ip.ip()) && !is_unspecified_or_broadcast_ip(ip.ip())
+    }
+
+    /// Returns `true` if the message version is valid.
+    pub fn is_valid_message_version(&self, message_version: u32) -> bool {
+        // TODO (raychu86) Consider the following cases:
+        //  1. Client node that is caught up
+        //  2. Validator nodes connecting to clients
+        //  3. Prover nodes that do not have blocks in their ledger.
+        message_version >= Message::<N>::VERSION
     }
 
     /// Returns the node type.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -41,6 +41,7 @@ pub use routing::*;
 
 use crate::messages::{Message, NodeType};
 use snarkos_account::Account;
+use snarkos_node_bft_ledger_service::LedgerService;
 use snarkos_node_tcp::{Config, P2P, Tcp, is_bogon_ip, is_unspecified_or_broadcast_ip};
 
 use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
@@ -81,6 +82,8 @@ pub struct InnerRouter<N: Network> {
     node_type: NodeType,
     /// The account of the node.
     account: Account<N>,
+    /// The ledger service.
+    ledger: Arc<dyn LedgerService<N>>,
     /// The cache.
     cache: Cache<N>,
     /// The resolver.
@@ -131,6 +134,7 @@ impl<N: Network> Router<N> {
         node_ip: SocketAddr,
         node_type: NodeType,
         account: Account<N>,
+        ledger: Arc<dyn LedgerService<N>>,
         trusted_peers: &[SocketAddr],
         max_peers: u16,
         rotate_external_peers: bool,
@@ -144,6 +148,7 @@ impl<N: Network> Router<N> {
             tcp,
             node_type,
             account,
+            ledger,
             cache: Default::default(),
             resolver: Default::default(),
             trusted_peers: trusted_peers.iter().copied().collect(),
@@ -253,11 +258,49 @@ impl<N: Network> Router<N> {
 
     /// Returns `true` if the message version is valid.
     pub fn is_valid_message_version(&self, message_version: u32) -> bool {
-        // TODO (raychu86) Consider the following cases:
-        //  1. Client node that is caught up
-        //  2. Validator nodes connecting to clients
-        //  3. Prover nodes that do not have blocks in their ledger.
-        message_version >= Message::<N>::VERSION
+        // Fetch the latest message version.
+        let latest_message_version = Message::<N>::latest_message_version();
+
+        // Determine the minimum message version this node will accept, based on its role.
+        // - Provers always operate at the latest message version.
+        // - Validators and clients may accept older versions, depending on their current block height.
+        //
+        // Example scenario:
+        // - At block height `X`, the protocol upgrades to message version from `Y-1` to `Y`.
+        // - Client A upgrades and starts using message version `Y`.
+        // - Client B has not upgraded and still uses message version `Y-1`.
+        // - Until block `X`, they stay connected and can communicate.
+        // - After block `X`, Client A will reject messages from Client B.
+        let lowest_accepted_message_version = match self.node_type {
+            // Provers should always use the latest version.
+            NodeType::Prover => Message::<N>::latest_message_version(),
+            // Validators and clients accept messages from lower version based on the migration height.
+            NodeType::Validator | NodeType::Client => {
+                let latest_block_height = self.ledger.latest_block_height();
+                let versions = Message::<N>::VERSIONS;
+                // TODO (raychu86): Refactor `consensus_config_value` to support generic constant types.
+                // Determine the message version to use.
+                N::CONSENSUS_VERSION(latest_block_height).map_or(latest_message_version, |seek_version| {
+                    // Search the consensus value for the specified version.
+                    match versions.binary_search_by(|(version, _)| version.cmp(&seek_version)) {
+                        // If a value was found for this consensus version, return it.
+                        Ok(index) => versions[index].1,
+                        Err(index) => {
+                            // If the specified version was not found exactly, determine whether to return an appropriate value anyway.
+                            match index {
+                                // This constant is not yet in effect at this consensus version.
+                                0 => Message::<N>::latest_message_version(),
+                                // Return the appropriate value belonging to the consensus version *lower* than the sought version.
+                                _ => versions[index - 1].1,
+                            }
+                        }
+                    }
+                })
+            }
+        };
+
+        // Check if the incoming message version is valid.
+        message_version >= lowest_accepted_message_version
     }
 
     /// Returns the node type.

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -175,6 +175,11 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
 
 #[async_trait]
 impl<N: Network> Inbound<N> for TestRouter<N> {
+    /// Returns `true` if the message version is valid.
+    fn is_valid_message_version(&self, _message_version: u32) -> bool {
+        true
+    }
+
     /// Handles a `BlockRequest` message.
     fn block_request(&self, _peer_ip: SocketAddr, _message: BlockRequest) -> bool {
         true

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -167,6 +167,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             node_ip,
             NodeType::Client,
             account,
+            ledger_service.clone(),
             trusted_peers,
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
             rotate_external_peers,

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -206,6 +206,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
 
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
+    /// Returns `true` if the message version is valid.
+    fn is_valid_message_version(&self, message_version: u32) -> bool {
+        self.router().is_valid_message_version(message_version)
+    }
+
     /// Handles a `BlockRequest` message.
     fn block_request(&self, peer_ip: SocketAddr, message: BlockRequest) -> bool {
         let BlockRequest { start_height, end_height } = &message;

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -113,6 +113,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
             node_ip,
             NodeType::Prover,
             account,
+            ledger_service.clone(),
             trusted_peers,
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
             rotate_external_peers,

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -153,6 +153,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
 
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
+    /// Returns `true` if the message version is valid.
+    fn is_valid_message_version(&self, message_version: u32) -> bool {
+        self.router().is_valid_message_version(message_version)
+    }
+
     /// Handles a `BlockRequest` message.
     fn block_request(&self, peer_ip: SocketAddr, _message: BlockRequest) -> bool {
         debug!("Disconnecting '{peer_ip}' for the following reason - {:?}", DisconnectReason::ProtocolViolation);

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -119,6 +119,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             node_ip,
             NodeType::Validator,
             account.clone(),
+            ledger_service.clone(),
             trusted_peers,
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
             rotate_external_peers,

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -175,6 +175,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
 
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
+    /// Returns `true` if the message version is valid.
+    fn is_valid_message_version(&self, message_version: u32) -> bool {
+        self.router().is_valid_message_version(message_version)
+    }
+
     /// Retrieves the blocks within the block request range, and returns the block response to the peer.
     fn block_request(&self, peer_ip: SocketAddr, message: BlockRequest) -> bool {
         let BlockRequest { start_height, end_height } = &message;


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the Message::Version used in the router to be based on a rolling migration. This allows for smoother behavior whenever there is a breaking migration that requires nodes to upgrade versions. The intention is to allow the following:

1. At block height `X`, the protocol upgrades to message version from `Y-1` to `Y`.
2. Client A upgrades and starts using message version `Y`.
3. Client B has not upgraded and still uses message version `Y-1`.
4. Until block `X`, they stay connected and can communicate.
5. After block `X`, Client A will reject messages from Client B.

This behavior will allow smoother upgrades by allowing client nodes to stay connected and process blocks up until the actual migration height rather than immediately after peers upgrade. 

Note that this does not touch Validator's `Event::Version` because we want those to stay fixed and in lock-step, at least until this change is fully tested.

## Test Plan

Basic validator + clients devnet has been run locally, but more extensive testing needs to be done to test general cases. A couple to consider are:

- Local network
  - [x] Client nodes + Prover nodes with this PR @kpandl 
- Canary network
  - [x] this PR snarkOS client @kpandl 

