### PR TITLE
Add unconfirmed/{transactionID} endpoint to help track tx status

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -162,6 +162,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // GET and POST ../transaction/..
             .route(&format!("/{network}/transaction/:id"), get(Self::get_transaction))
             .route(&format!("/{network}/transaction/confirmed/:id"), get(Self::get_confirmed_transaction))
+            .route(&format!("/{network}/transaction/unconfirmed/:id"), get(Self::get_unconfirmed_transaction))
             .route(&format!("/{network}/transaction/broadcast"), post(Self::transaction_broadcast))
 
             // POST ../solution/broadcast

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -157,6 +157,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(rest.ledger.get_confirmed_transaction(tx_id)?))
     }
 
+    // GET /<network>/transaction/unconfirmed/{transactionID}
+    pub(crate) async fn get_unconfirmed_transaction(
+        State(rest): State<Self>,
+        Path(tx_id): Path<N::TransactionID>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(rest.ledger.get_unconfirmed_transaction(&tx_id)?))
+    }
+
     // GET /<network>/memoryPool/transmissions
     pub(crate) async fn get_memory_pool_transmissions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {


### PR DESCRIPTION
## Motivation

Currently, in order to know whether a transaction was rejected, one has to track and store its fee transition id, and match that to the rejected transaction's fee transition id. This requires exchanges, explorers and other users to track extra information. At least one exchange, one explorer and multiple developers have complained about this, and they continue to do so, showing its a real issue.

This PR adds an endpoint to query for an unconfirmed transaction (which includes its id) by confirmed_id

Closes https://github.com/ProvableHQ/snarkVM/issues/2683

## Test Plan

- [x] Gather feedback from stakeholders if this is sufficient.
- [ ] Run a local client, query the endpoint to confirm it works as expected.