### PR TITLE
fix: avoid duplicate signature verification #3558

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ version = "1.0.1"
 default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
-#path = "../snarkVM"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "e319a75"
-version = "=1.6.0"
+# path = "../snarkVM"
+git = "https://github.com/joske/snarkVM.git"
+branch = "avoid-double-signature-check"
+#version = "=1.6.0"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -180,8 +180,10 @@ impl<N: Network> Proposal<N> {
     ) -> Result<(BatchCertificate<N>, IndexMap<TransmissionID<N>, Transmission<N>>)> {
         // Ensure the quorum threshold has been reached.
         ensure!(self.is_quorum_threshold_reached(committee), "The quorum threshold has not been reached");
+        // Basic check for the signatures - we call this and then later BatchCertificate::from_unchecked to avoid verifying the signatures again.
+        BatchCertificate::<N>::check_signature_basic(&self.batch_header, &self.signatures)?;
         // Create the batch certificate.
-        let certificate = BatchCertificate::from(self.batch_header.clone(), self.signatures.clone())?;
+        let certificate = BatchCertificate::from_unchecked(self.batch_header.clone(), self.signatures.clone())?;
         // Return the certificate and transmissions.
         Ok((certificate, self.transmissions.clone()))
     }

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -80,9 +80,9 @@ version = "=3.6.0"
 
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "e319a75"
-version = "=1.6.0"
+git = "https://github.com/joske/snarkVM.git"
+branch = "avoid-double-signature-check"
+#version = "=1.6.0"
 default-features = false
 optional = true
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Avoid double signature verification: https://github.com/ProvableHQ/snarkOS/issues/3558

## Test Plan

manually tested.

Test failures appear to be spurious.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2686

!snarkVM PR must be merged first, and the snarkVM rev must be adapted before merging this!
