### PR TITLE
[Feature] Make height metric available during CDN sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "snarkos-node-metrics",
  "snarkvm",
  "tokio",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [features]
-default = [ "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-cli/metrics" ]
+default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics" ]
 history = [ "snarkos-node/history" ]
 telemetry = [ "snarkos-node/telemetry" ]
 cuda = [

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -21,6 +21,7 @@ default = [ "parallel" ]
 locktick = [ "dep:locktick", "snarkvm/locktick" ]
 parallel = [ "rayon" ]
 cuda = [ "snarkvm/cuda" ]
+metrics = [ "dep:snarkos-node-metrics" ]
 test_targets = [ "snarkvm/test_targets" ]
 
 [dependencies.anyhow]
@@ -42,6 +43,12 @@ optional = true
 
 [dependencies.parking_lot]
 version = "0.12"
+
+[dependencies.snarkos-node-metrics]
+path = "../metrics"
+version = "=3.5.0"
+optional = true
+features = [ "metrics" ]
 
 [dependencies.rayon]
 version = "1"

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -52,7 +52,7 @@ const MAXIMUM_REQUEST_ATTEMPTS: u8 = 10;
 /// Updates the metrics during CDN sync.
 #[cfg(feature = "metrics")]
 fn update_block_metrics(height: u32) {
-    // Update the BFT height metric
+    // Update the BFT height metric.
     crate::metrics::gauge(crate::metrics::bft::HEIGHT, height as f64);
 }
 

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -49,6 +49,13 @@ const MAXIMUM_PENDING_BLOCKS: u32 = BLOCKS_PER_FILE * CONCURRENT_REQUESTS * 2;
 /// Maximum number of attempts for a request to the CDN.
 const MAXIMUM_REQUEST_ATTEMPTS: u8 = 10;
 
+/// Updates the metrics during CDN sync.
+#[cfg(feature = "metrics")]
+fn update_block_metrics(height: u32) {
+    // Update the BFT height metric
+    crate::metrics::gauge(crate::metrics::bft::HEIGHT, height as f64);
+}
+
 /// Loads blocks from a CDN into the ledger.
 ///
 /// On success, this function returns the completed block height.
@@ -219,6 +226,10 @@ pub async fn load_blocks<N: Network>(
 
                     // Update the current height.
                     current_height = block_height;
+
+                    // Update metrics.
+                    #[cfg(feature = "metrics")]
+                    update_block_metrics(current_height);
 
                     // Log the progress.
                     log_progress::<BLOCKS_PER_FILE>(timer, current_height, cdn_start, cdn_end, "block");

--- a/node/cdn/src/lib.rs
+++ b/node/cdn/src/lib.rs
@@ -18,5 +18,8 @@
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "metrics")]
+pub use snarkos_node_metrics as metrics;
+
 mod blocks;
 pub use blocks::{load_blocks, sync_ledger_with_cdn};


### PR DESCRIPTION
## Motivation

Previously, metrics would show height 0 during CDN sync.
This PR fixes it - a node syncing through CDN will export the current sync height through the metrics.

## Test Plan

Run `snarkos start --client --nodisplay --rest 0.0.0.0:3030 --bft 0.0.0.0:5000 --node 0.0.0.0:4130 --verbosity 0 --metrics --network 0`. Once the node is syncing, open `http://localhost:9000/metrics`.

Under `snarkos_bft_height_total`, it should show the current syncing height. Previously, it showed only 0.