### PR TITLE
Update snarkvm rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,8 +3887,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf37d312d4e4ff136e6069dee9cc4531b22d2feccfd9b9a77bd91b514b806ada"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3920,8 +3919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fffa809d4e257a92e7f6b94c1eb535f1fc3617ae2a033b7d553421f08501ee"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3953,8 +3951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73aff16d379225c3ac2a07d53c7db75e9391e0005d09a0d971a2eeadd5cf506b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "blst",
  "cc",
@@ -3965,8 +3962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb19bd384219f70ca4bcfa8d0d6edd36f8e1613c2676beb94489baa611dc7d08"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3980,8 +3976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deeb745fe09098c337bc61624e01bb1b1849840fb7e43b727d055aa2d079fd8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3992,8 +3987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d576ae294cd532d0b50591a68124b42b68aed2d733a712094eab22e2035fbc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4003,8 +3997,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0729f197322fd6cb3e218939167bed46995c4fc40379c91159bf164cdb7b05"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4014,8 +4007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffe6cb213a009904202a72d14ac64ca87350ec2b09c9c0b55f4b44eb30d19a5"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "indexmap 2.9.0",
  "itertools 0.11.0",
@@ -4034,14 +4026,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a85d2022bf1f702cf9be7bf79ff032c705556955bb6a030d5ea85d11616ba"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63be96d61f3f011b49c83f8d92182c5fe4d454d77676acf69c471289a098c22"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4052,8 +4042,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bfe8c4fb7c2474e279f77caf2692ccaa80f8f5c4c23ae261a98884dcc5d3f1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4068,8 +4057,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bb58922d50c24e113e1b54b70b66b8f614d890866aa28135177d988892602b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4084,8 +4072,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d360e7c83745a4b1bd04cb8e88aa1dbbec53f14895ffd01d4f32d3bccfb49548"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4098,8 +4085,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101a907a4bb23e8b285f1388f9a9c733826a98d631339923114aa759cffb34ea"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4108,8 +4094,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5810059099cf2eaa76749674385a40d415c1bd862edff00c485172cb0a29a576"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4119,8 +4104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b173a77f6170756369d822a6506bded19f0484f245ea61ed630092abb6cc44e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4132,8 +4116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45277423b5644b7587a292dbfdab05531ddd3621c0c6784acd83b5bf289319ab"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4145,8 +4128,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b8c45f2cccf97a2f5435df42baf10a069e408ffbaf962023658034ae3272ed"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4157,8 +4139,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabcdb62d8e9ee681e2d6ccbd9d7371c4d0d74eb68975786c3ed6121d592e9f1"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4170,8 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296807db2fd2a8ee53d3773318b00b168b2adc4a7fd47f7ff4dfe92b1e4f9220"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4184,8 +4164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101d0692253c66a183b3668820466285c1000f61a183ef956f441f2907a48a45"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4196,8 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833fecd5700892b15e1ff177d2cadf8069d77316d707b7a9d64d82c79fec7f0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4210,8 +4188,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577d28315dcabc182abf3e322e1cde35f5579f33d7c2486bfd5d664f3b3fc2e4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4222,8 +4199,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f987cb455434bdc13b6f779f0102dbdd6e786870ac2a5a311b76898c80bd59b4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -4246,8 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbfd866dc2313b49b940af5a265a5c7aa845bd5fee06acb69bfbc8f2ef4c5bc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4265,8 +4240,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b9aaf0fb564fad30ffa5ddb91f34c4f27464930c1a0caa96a0ef994f78386e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4288,8 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8091fba11035efd54d2db72e2204ce572c81fb4d0cfbd70f4bfbad2c851494c"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4304,8 +4277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bf17086e4124ecc4b009edd10c25237f18af960d57175089a3cf5b4d995958"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4316,8 +4288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63e37ad96e6f5203421636796e15465aed98f190acf6e6dd38dfe0e2091246d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4325,8 +4296,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ada7a5ef76bada1a7cd4f14a84a978e7178da053fc377b3723af1e1c9dbee0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4336,8 +4306,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc16744965161380550c05f8168f49948f2adfa55cea2d8e2b6b0b2c62eb7243"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4348,8 +4317,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c16bd51cbe6c4c8cfecb1f9f7f5453344cc6fc15a1bb567c9b454f4e10b317"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4360,8 +4328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002ca826de69f4604eb8b3dd3766ce990667d3efad0d81dc435accd63011a6be"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4372,8 +4339,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d413e22abf87734729ebd12d45df37b416999536ba4e0499d6d9f3fb552e523e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4384,8 +4350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8300a3c8e48141d0677d82dee744d418a6d9c14e07ec87854831b24abfb79fc6"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "rand",
  "rayon",
@@ -4399,8 +4364,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d147d413e785b14acef62dea4bd0699deef15c088683740d1cfe4e0d9a1da74"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4417,8 +4381,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84324b8e1fe39ccf9167e444a4baee4667e9311c9bb439622082ac0ee995189"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4445,8 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322ef4d956b82996a5a461a3f64b8e433eabdc05dcdd0e3793cc66297e00b75"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "anyhow",
  "rand",
@@ -4458,8 +4420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2754c5de3afbf71180b81070fdeefe68da0c7659d40715814e0d0fc15cf8d06"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4479,8 +4440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8db17f8fa2fa4cfb7ae70857dea0fe96f93e28a04ff5594465bce37ebd9558a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -4499,8 +4459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe82f96877eb0b5f8468cbc5c2bcf8087042e375d118f5374f70c7b159e6bb70"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4513,8 +4472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c25490f849da5b29483a3df504616c14a12292ad8bac3a6ae1358365548c8e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4527,8 +4485,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6696ed360f70e9a54e768db62c2dc39809501b5de2a37d72c66392db81d06358"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4541,8 +4498,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0798fa906227b5d8dc43692fead66d73064d1d93199ba9da285d01c2feca2e4d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4553,8 +4509,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcffefe2a669dd10e622caf5ea8a29b6ebe34ecc930b53e00d3032157c448446"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4569,8 +4524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9ecac3ddd9725922729cf1d6fd32c0e8c666a359d9036d8b9ceb9187da708d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4583,8 +4537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028003aa140dd14ba51df0c220044f12abb67738f1a9d5996f26aa4cc10def2d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4593,8 +4546,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cdbe80e3ebe53c1f85323a67f473adab3bac6e6b53fcefb4c071bea10bd1b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4615,8 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b192aaf4b18423a237bf6efbb44ba999b5696c707a66b49883a34e7f8f2095a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4638,8 +4589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e117c1db6afef99bfb4accbee9e47ea1b501cdb189ac1cd509bed9cd4b06c917"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4652,8 +4602,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382a51e48675b22986fb003ec942df1cc536f3b6347054084c3ed038b5de3f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4681,8 +4630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff492f7674642489d0dd75a784cf57048bbc58e1b5692658163f78cf111c07d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4699,8 +4647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b506be4dd9d94b7ac067e13efd185362b6ea3698b5d4b2dca5b2f6eff00d64"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4709,8 +4656,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2405ff5b402dd8bad8c49a489c291dcb859ec5cbe858f5d1ed89d11abba8ea59"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4736,8 +4682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d323215b7ad961b1045cded5a426ec7fd52386c4fd3abe7000b280615b7dca6"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4770,8 +4715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0165983b31116d86e774785894de1309121a7577056e4b29e31e5e1dc6ce7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4797,8 +4741,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275eb56be43514bfd76b9c0f9056bb123ad15d300d34cde8219b99d92fc2d9c5"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "indexmap 2.9.0",
  "paste",
@@ -4813,8 +4756,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f644c628015cd0076d5073594454d4075451fc41a203937f04c612f82bb442"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4827,8 +4769,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e123260bba19329389396326be6926ce3573d9376f3a8c898435805a595bb8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4849,8 +4790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c47bd83dca6c5bb12d4818a2244297a39486020a2ae6bed19c8933764986eb"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=629cccc#629cccc116194fe1c02566f2cad54de6a5647f1d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "e319a75"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "629cccc"
 version = "=1.6.0"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1163,7 +1163,7 @@ impl<N: Network> Reading for Gateway<N> {
     type Message = Event<N>;
 
     /// The maximum queue depth of incoming messages for a single peer.
-    const MESSAGE_QUEUE_DEPTH: usize = 300_000;
+    const MESSAGE_QUEUE_DEPTH: usize = 350_000;
 
     /// Creates a [`Decoder`] used to interpret messages from the network.
     /// The `side` param indicates the connection side **from the node's perspective**.
@@ -1193,7 +1193,7 @@ impl<N: Network> Writing for Gateway<N> {
     type Message = Event<N>;
 
     /// The maximum queue depth of outgoing messages for a single peer.
-    const MESSAGE_QUEUE_DEPTH: usize = 300_000;
+    const MESSAGE_QUEUE_DEPTH: usize = 350_000;
 
     /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
     /// The `side` parameter indicates the connection side **from the node's perspective**.

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1784,6 +1784,8 @@ mod prop_tests {
     // process the maximum expected load at any givent moment. Due to the number of certificates
     // not being const, those values are currently hardcoded, and the test below will alert us
     // if they need to be increased.
+    // For example, if `BatchHeader::MAX_CERTIFICATES` is increased in snarkVM, the two
+    // MESSAGE_QUEUE_DEPTH values need to be increased accordingly.
     #[test]
     fn ensure_sufficient_rw_queue_depth() {
         let desired_rw_queue_depth = 2

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -80,8 +80,8 @@ version = "=3.6.0"
 
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "e319a75"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "629cccc"
 version = "=1.6.0"
 default-features = false
 optional = true

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -81,7 +81,7 @@ version = "=3.6.0"
 
 [dependencies.snarkos-node-bft-ledger-service]
 path = "../bft/ledger-service"
-version = "=3.5.0"
+version = "=3.6.0"
 default-features = false
 features = [ "ledger", "prover" ]
 


### PR DESCRIPTION
## Motivation

This PR updates the snarkVM ref.
Furthermore, it increases the two `MESSAGE_QUEUE_DEPTH` values, since snarkVM `BatchHeader::MAX_CERTIFICATES` increased, and adds a comment to the `ensure_sufficient_rw_queue_depth` test which failed previously.

## Test Plan

Stress-tests are ongoing but look healthy so far.