### PR TITLE
fix: missed version update

### DIFF
--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -81,7 +81,7 @@ version = "=3.6.0"
 
 [dependencies.snarkos-node-bft-ledger-service]
 path = "../bft/ledger-service"
-version = "=3.5.0"
+version = "=3.6.0"
 default-features = false
 features = [ "ledger", "prover" ]
 


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

snarkOS fails to build because one instance of the snarkOS version was forgotten.

## Test Plan

build now works
