### PR TITLE
fix: avoid rebuilding snarkOS binary every single time

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,9 +51,6 @@ fn check_file_licenses<P: AsRef<Path>>(path: P) {
             );
         }
     }
-
-    // Re-run upon any changes to the workspace.
-    println!("cargo:rerun-if-changed=.");
 }
 
 // The build script; it currently only checks the licenses.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

When you issue `cargo run` or even `cargo test` with no code changes at all, `cargo` would still re-build the snarkOS binary (and this can take a long time) on every single invocation. The cause for this is `cargo:rerun-if-changed=.`, this line is not needed at all, and `cargo` will still notice when the code changes and rebuild as needed. With this line removed, you will no longer have a rebuild on every run. The `cargo:rerun-if-changed=` directive should only be used on extra things, like json schema's  or generated code.

## Test Plan

manually tested (and only build.rs changes)

