### PR TITLE
Change BFT Sync to process block responses as expected

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -281,7 +281,10 @@ impl<N: Network> BlockSync<N> {
         if is_request_complete { self.responses.read().get(&next_height).cloned() } else { None }
     }
 
-    /// Attempts to advance with blocks from the sync pool.
+    /// Attempts to advance synchronization by processing completed block responses.
+    ///
+    /// Validators will not call this function, but instead execute `snarkos_node_bft::Sync::try_advancing_block_synchronization`
+    /// which also updates the BFT state.
     #[inline]
     pub fn try_advancing_block_synchronization(&self) {
         // Acquire the lock to ensure this function is called only once at a time.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

Stress testing revealed an error in the recent changes to block synchronization. When validators fall behind they do not sync block properly. Meaning, the sync blocks like clients, and do not add the contained certificates to the BFT module.

This PR provides a fix for that by modifying `Sync::advance_with_sync_blocks` and adds more documentation to the `Sync` and `BlockSync` structs.

It also renames two functions to make their functionality clearer:
* `Sync::sync_storage_with_blocks` was changed to `Sync::try_advancing_block_synchronization` to make it obvious that this is the validator version of `BlockSync::try_advancing_block_synchronization`.
* `Sync::try_block_sync` was changed to `Sync::issue_block_requests` because it only create and sends them, but does not process any block responses.

Finally, the PR adds function `Sync::try_block_sync` was added that encapsulates a full iteration of a validator's block synchronization. This function is invoked manually in some unit tests (mostly in `Primary`'s tests). 

## Test Plan

We will run more stress tests before merging this into staging (thanks to @kpandl for doing most of the work here).

## Related PRs

#3543 introduced the bug that this PR fixes.