### PR TITLE
Label tmux windows in devnet as validators or clients

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -29,7 +29,7 @@ if [[ $build_binary == "y" ]]; then
   enable_telemetry=${enable_telemetry:-y}
 
   # Build command
-  build_cmd="cargo install --locked --path . --offline --debug"
+  build_cmd="cargo install --locked --path ."
 
   # Add the telemetry feature if requested
   if [[ $enable_telemetry == "y" ]]; then


### PR DESCRIPTION
## Overview
This PR labels the tmux windows spawned by `devnet.sh` more clearly. Each validator spawns in a window labeled `validator-i` (where i is its index) and each client in a window labeled `client-i`.

The change makes it a little easier to figure out which windows run validators, not clients. The labels are also identical to the files in which each node's log is stored.

Finally, the PR also makes log verbosity a constant, so you can change it (albeit only by modifying the file) to increase log output when you are debugging.

## Test Plan
`devnet.sh` is only used for local development and not in production. CI also has its own devnet script at `.circle/devnet_ci.sh`.
So, I ran the script locally and verified it works as expected, which should be sufficient for a change like this.