### PR TITLE
Make MESSAGE_QUEUE_DEPTH dynamic

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1546,10 +1546,7 @@ mod prop_tests {
     use snarkos_account::Account;
     use snarkos_node_bft_ledger_service::MockLedgerService;
     use snarkos_node_bft_storage_service::BFTMemoryService;
-    use snarkos_node_tcp::{
-        P2P,
-        protocols::{Reading, Writing},
-    };
+    use snarkos_node_tcp::P2P;
     use snarkvm::{
         ledger::{
             committee::{
@@ -1559,7 +1556,7 @@ mod prop_tests {
             },
             narwhal::{BatchHeader, batch_certificate::test_helpers::sample_batch_certificate_for_round},
         },
-        prelude::{MainnetV0, Network, PrivateKey},
+        prelude::{MainnetV0, PrivateKey},
         utilities::TestRng,
     };
 

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -131,7 +131,7 @@ impl<R: Reading> ReadingInternal for R {
             framed.read_buffer_mut().reserve(Self::INITIAL_BUFFER_SIZE);
         }
 
-        let (inbound_message_sender, mut inbound_message_receiver) = mpsc::channel(Self::message_queue_depth(self));
+        let (inbound_message_sender, mut inbound_message_receiver) = mpsc::channel(self.message_queue_depth());
 
         // use a channel to know when the processing task is ready
         let (tx_processing, rx_processing) = oneshot::channel::<()>();

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -50,7 +50,9 @@ where
     /// attacks.
     ///
     /// The default value is 1024.
-    const MESSAGE_QUEUE_DEPTH: usize = 1024;
+    fn message_queue_depth(&self) -> usize {
+        1024
+    }
 
     /// The initial size of a per-connection buffer for reading inbound messages. Can be set to the maximum expected size
     /// of the inbound message in order to only allocate it once.
@@ -129,7 +131,7 @@ impl<R: Reading> ReadingInternal for R {
             framed.read_buffer_mut().reserve(Self::INITIAL_BUFFER_SIZE);
         }
 
-        let (inbound_message_sender, mut inbound_message_receiver) = mpsc::channel(Self::MESSAGE_QUEUE_DEPTH);
+        let (inbound_message_sender, mut inbound_message_receiver) = mpsc::channel(Self::message_queue_depth(self));
 
         // use a channel to know when the processing task is ready
         let (tx_processing, rx_processing) = oneshot::channel::<()>();

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -51,7 +51,9 @@ where
     /// obscure potential issues with your implementation (like slow serialization) or network.
     ///
     /// The default value is 1024.
-    const MESSAGE_QUEUE_DEPTH: usize = 1024;
+    fn message_queue_depth(&self) -> usize {
+        1024
+    }
 
     /// The type of the outbound messages; unless their serialization is expensive and the message
     /// is broadcasted (in which case it would get serialized multiple times), serialization should
@@ -196,7 +198,7 @@ impl<W: Writing> WritingInternal for W {
         let writer = conn.writer.take().expect("missing connection writer!");
         let mut framed = FramedWrite::new(writer, codec);
 
-        let (outbound_message_sender, mut outbound_message_receiver) = mpsc::channel(Self::MESSAGE_QUEUE_DEPTH);
+        let (outbound_message_sender, mut outbound_message_receiver) = mpsc::channel(Self::message_queue_depth(&self));
 
         // register the connection's message sender with the Writing protocol handler
         conn_senders.write().insert(addr, outbound_message_sender);

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -198,7 +198,7 @@ impl<W: Writing> WritingInternal for W {
         let writer = conn.writer.take().expect("missing connection writer!");
         let mut framed = FramedWrite::new(writer, codec);
 
-        let (outbound_message_sender, mut outbound_message_receiver) = mpsc::channel(Self::message_queue_depth(&self));
+        let (outbound_message_sender, mut outbound_message_receiver) = mpsc::channel(self.message_queue_depth());
 
         // register the connection's message sender with the Writing protocol handler
         conn_senders.write().insert(addr, outbound_message_sender);


### PR DESCRIPTION
## Motivation

Previously, when increasing the maximal validator set size, we had to increase `MESSAGE_QUEUE_DEPTH` to use an appropriate depth and to pass the `ensure_sufficient_rw_queue_depth` test.

This PR makes the calculation of the message queue depth dynamic by introducing `fn message_queue_depth`, and removes the `ensure_sufficient_rw_queue_depth` test.

## Other notes
* Note that for networks other than `mainnet`, this can increase the message queue depth size, if their `LATEST_MAX_CERTIFICATES` value is larger.
* Theoretically, it would be possible to make the size now dependent on the current committee size, but this might need to be more thought through.

## Related
Closes https://github.com/ProvableHQ/snarkOS/issues/3620