### PR TITLE
[Feature] Prometheus Metrics for Telemetry

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,7 +39,7 @@ metrics = [
   "snarkos-node-tcp/metrics"
 ]
 history = [ "snarkos-node-rest/history" ]
-telemetry = [ "snarkos-node-bft/telemetry", "snarkos-node-rest/telemetry" ]
+telemetry = [ "snarkos-node-bft/telemetry", "snarkos-node-consensus/telemetry", "snarkos-node-rest/telemetry" ]
 cuda = [
   "snarkvm/cuda",
   "snarkos-account/cuda",

--- a/node/bft/src/helpers/telemetry.rs
+++ b/node/bft/src/helpers/telemetry.rs
@@ -36,11 +36,18 @@ use std::{collections::BTreeMap, sync::Arc};
 //  - Various stake weight considerations
 //  - The latest seen IP address of each validator (useful for debugging purposes)
 
+/// The participation scores for each validator.
+///     Certificate Score: The % of rounds the validator has a valid certificate
+///     Signature Score: The % of certificates the validator has a valid signature for
+///     Combined Score: The weighted score using the certificate and signature scores
+type ParticipationScores = (f64, f64, f64);
+
 /// Tracker for the participation metrics of validators.
 #[derive(Clone, Debug)]
 pub struct Telemetry<N: Network> {
     /// The certificates seen for each round
     /// A mapping of `round` to set of certificate IDs.
+    /// Note that this map is sorted to allow grouped iteration over rounds.
     tracked_certificates: Arc<RwLock<BTreeMap<u64, IndexSet<Field<N>>>>>,
 
     /// The total number of signatures seen for a validator, including for their own certificates.
@@ -51,11 +58,8 @@ pub struct Telemetry<N: Network> {
     /// A mapping of `address` to a list of rounds.
     validator_certificates: Arc<RwLock<IndexMap<Address<N>, IndexSet<u64>>>>,
 
-    /// The certificate, signature, and combined participation scores for each validator.
-    ///     Certificate Score: The % of rounds the validator has a valid certificate
-    ///     Signature Score: The % of certificates the validator has a valid signature for
-    ///     Combined Score: The weighted score using the certificate and signature scores
-    participation_scores: Arc<RwLock<IndexMap<Address<N>, (f64, f64, f64)>>>,
+    /// The certificate, signature, and participation scores for each validator.
+    participation_scores: Arc<RwLock<IndexMap<Address<N>, ParticipationScores>>>,
 }
 
 impl<N: Network> Default for Telemetry<N> {

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -26,6 +26,7 @@ locktick = [
   "snarkvm/locktick"
 ]
 metrics = [ "dep:metrics" ]
+telemetry = [ "snarkos-node-bft/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda", "snarkos-node-bft-ledger-service/cuda" ]
 
 [dependencies.aleo-std]

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -563,7 +563,15 @@ impl<N: Network> Consensus<N> {
                 let participation_scores =
                     self.bft().primary().gateway().validator_telemetry().get_participation_scores(&latest_committee);
 
-                // TODO: Log participation metrics
+                // Log the participation scores.
+                for (address, participation_score) in participation_scores {
+                    metrics::histogram_label(
+                        metrics::consensus::VALIDATOR_PARTICIPATION,
+                        "validator_address",
+                        address.to_string(),
+                        participation_score,
+                    )
+                }
             }
         }
         Ok(())

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -82,6 +82,7 @@ pub mod consensus {
     pub const UNCONFIRMED_SOLUTIONS: &str = "snarkos_consensus_unconfirmed_solutions_total";
     pub const TRANSMISSION_LATENCY: &str = "snarkos_consensus_transmission_latency";
     pub const STALE_UNCONFIRMED_TRANSMISSIONS: &str = "snarkos_consensus_stale_unconfirmed_transmissions";
+    pub const VALIDATOR_PARTICIPATION: &str = "snarkos_consensus_validator_participation";
 }
 
 pub mod router {

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 default = [ "parallel" ]
 parallel = [ "rayon" ]
 history = [ "snarkvm-synthesizer/history" ]
-telemetry = [ ]
+telemetry = [ "snarkos-node-consensus/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-consensus/cuda", "snarkos-node-router/cuda" ]
 locktick = [
   "dep:locktick",


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds Prometheus Metrics for the validator telemetry participation scores.

Additionally, this adjusts the scoring in two ways:
1. Calculate weighted at time of insertion rather than query.
2. Increase participation leniency for certificates to be every two rounds rather than every round.
