### PR TITLE
Fix broken Aleo language documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ nvcc --version   # Check installed CUDA version
 2. Sign a message with your private key using `snarkos account sign --raw -m "Message" --private-key-file=<PRIVATE_KEY_FILE>`
 3. Verify your signature with `snarkos account verify --raw -m "Message" -s sign1SignatureHere -a aleo1YourAccountAddress`
 
-Note, using the `--raw` flag with the command will sign plaintext messages as bytes rather than [Aleo](https://developer.aleo.org/aleo/language#data-types-and-values) values such as `1u8` or `100field`.
+Note, using the `--raw` flag with the command will sign plaintext messages as bytes rather than [Aleo](https://developer.aleo.org/guides/aleo/language/#data-types-and-values) values such as `1u8` or `100field`.
 
 
 ## 5. Command Line Interface


### PR DESCRIPTION
## Motivation
Update the link to Aleo language documentation in the README.md file.
Replace the old broken URL "https://developer.aleo.org/aleo/language#data-types-and-values" 
with the current URL "https://developer.aleo.org/guides/aleo/language/#data-types-and-values".

