### PR TITLE
[Feature] Improve ergonomics of the CLI

### DIFF
--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -13,19 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkos_node::bft::helpers::proposal_cache_path;
-
 use aleo_std::StorageMode;
 use anyhow::{Result, bail};
 use clap::Parser;
 use colored::Colorize;
+use snarkos_node::bft::helpers::proposal_cache_path;
+use snarkvm::console::network::{CanaryV0, MainnetV0, Network};
 use std::path::PathBuf;
 
 /// Cleans the snarkOS node storage.
 #[derive(Debug, Parser)]
 pub struct Clean {
-    /// Specify the network to remove from storage.
-    #[clap(default_value = "0", long = "network")]
+    /// Specify the network to remove from storage (0 = mainnet, 1 = testnet, 2 = canary)
+    #[clap(default_value_t=MainnetV0::ID, long = "network", value_parser = clap::value_parser!(u16).range((MainnetV0::ID as i64)..=(CanaryV0::ID as i64)))]
     pub network: u16,
     /// Enables development mode, specify the unique ID of the local node to clean.
     #[clap(long)]

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snarkos_node::bft::helpers::proposal_cache_path;
+use snarkvm::console::network::{CanaryV0, MainnetV0, Network};
+
 use aleo_std::StorageMode;
 use anyhow::{Result, bail};
 use clap::Parser;
 use colored::Colorize;
-use snarkos_node::bft::helpers::proposal_cache_path;
-use snarkvm::console::network::{CanaryV0, MainnetV0, Network};
 use std::path::PathBuf;
 
 /// Cleans the snarkOS node storage.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -78,9 +78,7 @@ impl FromStr for BondedBalances {
 #[derive(Clone, Debug, Parser)]
 #[command(group(
     // Ensure at most one node type is specified
-    clap::ArgGroup::new("node_type")
-        .required(false)
-        .multiple(false)
+    clap::ArgGroup::new("node_type").required(false).multiple(false)
 ))]
 pub struct Start {
     /// Specify the network ID of this node (0 = mainnet, 1 = testnet, 2 = canary)

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -77,8 +77,8 @@ impl FromStr for BondedBalances {
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
 pub struct Start {
-    /// Specify the network ID of this node
-    #[clap(default_value = "0", long = "network")]
+    /// Specify the network ID of this node (0 = mainnet, 1 = testnet, 2 = canary)
+    #[clap(default_value_t=MainnetV0::ID, long = "network", value_parser = clap::value_parser!(u16).range((MainnetV0::ID as i64)..=(CanaryV0::ID as i64)))]
     pub network: u16,
 
     /// Specify this node as a validator

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -76,19 +76,25 @@ impl FromStr for BondedBalances {
 
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
+#[command(group(
+    // Ensure at most one node type is specified
+    clap::ArgGroup::new("node_type")
+        .required(false)
+        .multiple(false)
+))]
 pub struct Start {
     /// Specify the network ID of this node (0 = mainnet, 1 = testnet, 2 = canary)
     #[clap(default_value_t=MainnetV0::ID, long = "network", value_parser = clap::value_parser!(u16).range((MainnetV0::ID as i64)..=(CanaryV0::ID as i64)))]
     pub network: u16,
 
-    /// Specify this node as a validator
-    #[clap(long = "validator")]
+    /// Start the node as a validator
+    #[clap(long = "validator", group = "node_type")]
     pub validator: bool,
-    /// Specify this node as a prover
-    #[clap(long = "prover")]
+    /// Start the node as a prover
+    #[clap(long = "prover", group = "node_type")]
     pub prover: bool,
-    /// Specify this node as a client
-    #[clap(long = "client")]
+    /// Start the node as a client (default)
+    #[clap(long = "client", group = "node_type")]
     pub client: bool,
 
     /// Specify the account private key of the node
@@ -506,7 +512,8 @@ impl Start {
         }
     }
 
-    /// Returns the node type, from the given configurations.
+    /// Returns the node type specified in the command-line arguments.
+    /// This will return `NodeType::Client` if no node type was specified by the user.
     const fn parse_node_type(&self) -> NodeType {
         if self.validator {
             NodeType::Validator

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -72,7 +72,12 @@ fn main() -> anyhow::Result<()> {
     match cli.command.parse() {
         Ok(output) => println!("{output}\n"),
         Err(error) => {
-            println!("⚠️  {error}\n");
+            // Print the top level error and then any additional context.
+            println!("⚠️  {error}");
+            for entry in error.chain().skip(1) {
+                println!("     ↳ {entry}");
+            }
+            println!();
             exit(1);
         }
     }


### PR DESCRIPTION
## Motivation

There were a few things that made the CLI a little awkward to use for me. For example, the network type is passed an integer (network ID) and it is easy to forget which one is which. 
In some cases, the CLI would also panic on an invalid input, which is not a great user experience.

## Overview

There are four commits in this PR:
* [40d8ab5](https://github.com/ProvableHQ/snarkOS/pull/3640/commits/40d8ab5ce45e32880ba87cd281ea59ad8d988888) and [d3bcf3b](https://github.com/ProvableHQ/snarkOS/pull/3640/commits/d3bcf3b662fc3641e4e4d728929e1ba871bdb189) add a more detailed help text for the network ID. It will also only allow values in `0..=2`.

* [826217a](https://github.com/ProvableHQ/snarkOS/pull/3640/commits/826217ab5da335a94dd9fdf50dc687ea00898bf2) ensures that at most one node type can be specified and clarifies that `--client` is the default.

* [810f034](https://github.com/ProvableHQ/snarkOS/pull/3640/commits/810f0349442c8630aa592ae5c272c2bb2da01f22) ensures errors while parsing the node arguments do not cause a panic. This commit also changes how errors are printed. Please see below for more details.

### New Error Handling

Before the CLI simply printed `{error}` which only shows the top-level error, not the root cause (for this you would do `println!("{}", error.root_cause())` instead). So you would get something like this:
```
⚠️  Failed to parse node arguments
```

I decided to leave the top-level error as is and additionally print the rest of the error chain. Now it will show something like this:
```
⚠️  Failed to parse node arguments
     ↳ Missing the '--private-key' or '--private-key-file' argument
```

## Test Plan
Manually tested.

## Notes
We should consider picking a different emoji. The current one is a "warning sign", which is not a good fit for a (fatal) error.

