### PR TITLE
Deny any clippy warnings in the pre-commit hook

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo clippy --workspace --all-targets --all-features && cargo +nightly fmt --all -- --check"
+pre-commit = "cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo +nightly fmt --all -- --check"
 
 [logging]
 verbose = true


### PR DESCRIPTION
## Motivation
We run `clippy` on every pre-commit hook, but it currently will succeed when encountering warnings. However, in CircleCI any warnings will cause the build to fail.

I personally abort commits if warnings pop up or amend them. It would be easier to just not commit when warnings pop up.

## Proposed changes
This adds `-D warnings` to the pre-commit hook, so that commits fail if clippy produces any warnings.

## Test Plan
Manually tested, as the commit hook does not affect any production code.


