### PR TITLE
docs: Correct minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ cargo run --release -- clean --dev <NODE_ID>
 
 ## 6.4 Feature Flags
 
-By default, the metrics feature is turnned on for some internal crates.
+By default, the metrics feature is turned on for some internal crates.
 
 * **history** -
   Enables a /history REST endpoint.


### PR DESCRIPTION
The README currently says "turnned on" instead of "turned on". This PR fixes that.