### PR TITLE
Remove mainnet check for test_networks

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -543,7 +543,7 @@ impl Start {
         if cfg!(feature = "test_network") && self.dev.is_none() {
             bail!("The 'test_network' feature is enabled, but the '--dev' flag is not set");
         }
-        
+
         // Parse the trusted peers to connect to.
         let mut trusted_peers = self.parse_trusted_peers()?;
         // Parse the trusted validators to connect to.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -520,7 +520,7 @@ impl Start {
     async fn parse_node<N: Network>(&mut self, shutdown: Arc<AtomicBool>) -> Result<Node<N>> {
         // Print the welcome.
         println!("{}", crate::helpers::welcome_message());
-        
+
         // Check if we are running with the lower coinbase and proof targets. This should only be
         // allowed in --dev mode and should not be allowed in mainnet mode.
         if cfg!(feature = "test_network") && self.dev.is_none() {

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -520,7 +520,13 @@ impl Start {
     async fn parse_node<N: Network>(&mut self, shutdown: Arc<AtomicBool>) -> Result<Node<N>> {
         // Print the welcome.
         println!("{}", crate::helpers::welcome_message());
-
+        
+        // Check if we are running with the lower coinbase and proof targets. This should only be
+        // allowed in --dev mode and should not be allowed in mainnet mode.
+        if cfg!(feature = "test_network") && self.dev.is_none() {
+            bail!("The 'test_network' feature is enabled, but the '--dev' flag is not set");
+        }
+        
         // Parse the trusted peers to connect to.
         let mut trusted_peers = self.parse_trusted_peers()?;
         // Parse the trusted validators to connect to.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -521,15 +521,6 @@ impl Start {
         // Print the welcome.
         println!("{}", crate::helpers::welcome_message());
 
-        // Check if we are running with the lower coinbase and proof targets. This should only be
-        // allowed in --dev mode and should not be allowed in mainnet mode.
-        if cfg!(feature = "test_network") && self.dev.is_none() {
-            bail!("The 'test_network' feature is enabled, but the '--dev' flag is not set");
-        }
-        if cfg!(feature = "test_network") && N::ID == MainnetV0::ID {
-            bail!("The 'test_network' feature is enabled, but you are trying to use mainnet. This is not supported.");
-        }
-
         // Parse the trusted peers to connect to.
         let mut trusted_peers = self.parse_trusted_peers()?;
         // Parse the trusted validators to connect to.


### PR DESCRIPTION
## Motivation

As the stress tests are ran for a cluster in mainnet mode, but also need the feature `test_network` enabled, based on this conversation with @vicsn : https://github.com/ProvableHQ/stress-testing/pull/288#discussion_r2104512301 I'm proposing removing these checks, so we don't have to patch it for the tests.

## Test Plan

The current PR in the stress tests repository https://github.com/ProvableHQ/stress-testing/pull/288 for using the `test_network` feature works by doing this change with a manual patch. The tests pass (can be checked by running the upgrade test, for example from this PR). After this change I can remove the patch.

## Related PRs

https://github.com/ProvableHQ/snarkOS/pull/3572
