### PR TITLE
[Chore] Update tower dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,13 +265,13 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -291,7 +291,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -299,13 +299,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -320,25 +319,24 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
- "fastrand",
  "futures-util",
  "headers",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "typed-json",
@@ -644,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -831,11 +829,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1267,9 +1266,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1299,22 +1300,25 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if",
  "dashmap",
- "futures",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
+ "getrandom 0.3.3",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.1",
  "smallvec",
  "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -2051,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2193,23 +2197,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.3.1",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -2654,8 +2641,8 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -2721,8 +2708,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2732,7 +2729,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2745,13 +2752,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2760,7 +2776,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2951,8 +2967,8 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
- "tower-http 0.6.4",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3385,7 +3401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3480,7 +3496,7 @@ version = "3.7.1"
 dependencies = [
  "anyhow",
  "colored",
- "rand",
+ "rand 0.8.5",
  "snarkvm",
 ]
 
@@ -3500,8 +3516,8 @@ dependencies = [
  "nix",
  "num_cpus",
  "parking_lot",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "self_update 0.41.0",
  "serde",
@@ -3554,8 +3570,8 @@ dependencies = [
  "parking_lot",
  "paste",
  "pea2pea",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "serde_json",
  "snarkos-account",
@@ -3600,8 +3616,8 @@ dependencies = [
  "paste",
  "pea2pea",
  "proptest",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "rayon",
  "serde",
@@ -3619,7 +3635,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber 0.3.19",
  "tracing-test 0.1.0",
@@ -3653,7 +3669,7 @@ dependencies = [
  "indexmap 2.9.0",
  "locktick",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "snarkos-node-metrics",
  "snarkvm",
@@ -3709,7 +3725,7 @@ dependencies = [
  "lru",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "snarkos-account",
  "snarkos-node-bft",
  "snarkos-node-bft-ledger-service",
@@ -3748,7 +3764,7 @@ dependencies = [
  "locktick",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
@@ -3758,8 +3774,8 @@ dependencies = [
  "snarkvm-synthesizer",
  "time",
  "tokio",
- "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower",
+ "tower-http",
  "tower_governor",
  "tracing",
 ]
@@ -3781,7 +3797,7 @@ dependencies = [
  "locktick",
  "parking_lot",
  "peak_alloc",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "reqwest 0.11.27",
  "serde",
@@ -3831,7 +3847,7 @@ dependencies = [
  "locktick",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "serde",
  "snarkos-node-bft-ledger-service",
  "snarkos-node-metrics",
@@ -3894,7 +3910,7 @@ dependencies = [
  "num-format",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "self_update 0.38.0",
  "serde_json",
@@ -3928,9 +3944,9 @@ dependencies = [
  "locktick",
  "num-traits",
  "parking_lot",
- "rand",
- "rand_chacha",
- "rand_core",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "rayon",
  "serde",
  "sha2",
@@ -4224,7 +4240,7 @@ dependencies = [
  "itertools 0.11.0",
  "nom",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -4347,7 +4363,7 @@ name = "snarkvm-curves"
 version = "3.7.1"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=382198c#382198c0b96171bc79da60269d877f485e60167e"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "rayon",
  "rustc_version",
  "serde",
@@ -4365,7 +4381,7 @@ dependencies = [
  "anyhow",
  "itertools 0.11.0",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "snarkvm-utilities",
@@ -4384,7 +4400,7 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "snarkvm-console",
  "snarkvm-ledger-authority",
@@ -4406,7 +4422,7 @@ version = "3.7.1"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=382198c#382198c0b96171bc79da60269d877f485e60167e"
 dependencies = [
  "anyhow",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-subdag",
@@ -4440,8 +4456,8 @@ dependencies = [
  "anyhow",
  "indexmap 2.9.0",
  "proptest",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "rayon",
  "serde_json",
@@ -4551,8 +4567,8 @@ dependencies = [
  "lru",
  "once_cell",
  "parking_lot",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -4571,8 +4587,8 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4666,7 +4682,7 @@ dependencies = [
  "locktick",
  "parking_lot",
  "paste",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "sha2",
  "snarkvm-curves",
@@ -4686,7 +4702,7 @@ dependencies = [
  "locktick",
  "lru",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
@@ -4718,8 +4734,8 @@ dependencies = [
  "locktick",
  "once_cell",
  "parking_lot",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -4740,8 +4756,8 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=382198c#382198c0b961
 dependencies = [
  "indexmap 2.9.0",
  "paste",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde_json",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4771,7 +4787,7 @@ dependencies = [
  "bincode",
  "num-bigint",
  "num_cpus",
- "rand",
+ "rand 0.8.5",
  "rand_xorshift",
  "rayon",
  "serde",
@@ -4801,12 +4817,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinning_top"
@@ -5322,17 +5332,6 @@ checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -5349,31 +5348,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.9.1",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
@@ -5383,11 +5357,20 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
- "tower 0.5.2",
+ "tokio",
+ "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5404,17 +5387,17 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_governor"
-version = "0.3.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3790eac6ad3fb8d9d96c2b040ae06e2517aa24b067545d1078b96ae72f7bb9a7"
+checksum = "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
 dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
  "http 1.3.1",
  "pin-project",
- "thiserror 1.0.69",
- "tower 0.4.13",
+ "thiserror 2.0.12",
+ "tower",
  "tracing",
 ]
 
@@ -5894,7 +5877,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -142,10 +142,10 @@ features = [ "codec" ]
 version = "0.1"
 
 [dev-dependencies.axum]
-version = "0.7"
+version = "0.8"
 
 [dev-dependencies.axum-extra]
-version = "0.9"
+version = "0.10"
 default-features = false
 features = [ "erased-json" ]
 
@@ -196,7 +196,7 @@ features = [ "test-helpers" ]
 version = "0.3.1"
 
 [dev-dependencies.tower-http]
-version = "0.5"
+version = "0.6"
 features = [ "fs", "trace" ]
 
 [dev-dependencies.tracing-subscriber]

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -33,10 +33,10 @@ locktick = [
 version = "1.0.79"
 
 [dependencies.axum]
-version = "0.7"
+version = "0.8"
 
 [dependencies.axum-extra]
-version = "0.9.0"
+version = "0.10"
 features = [ "erased-json", "typed-header" ]
 
 [dependencies.http]
@@ -102,13 +102,13 @@ version = "0.3"
 version = "1"
 
 [dependencies.tower]
-version = "0.4"
+version = "0.5"
 
 [dependencies.tower_governor]
-version = "0.3"
+version = "0.7"
 
 [dependencies.tower-http]
-version = "0.5"
+version = "0.6"
 features = [ "cors", "trace" ]
 
 [dependencies.tracing]

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -146,34 +146,34 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
             .route(&format!("/{network}/node/address"), get(Self::get_node_address))
-            .route(&format!("/{network}/program/:id/mapping/:name"), get(Self::get_mapping_values))
+            .route(&format!("/{network}/program/{{id}}/mapping/{{name}}"), get(Self::get_mapping_values))
             .route_layer(middleware::from_fn(auth_middleware))
 
             // GET ../block/..
             .route(&format!("/{network}/block/height/latest"), get(Self::get_block_height_latest))
             .route(&format!("/{network}/block/hash/latest"), get(Self::get_block_hash_latest))
             .route(&format!("/{network}/block/latest"), get(Self::get_block_latest))
-            .route(&format!("/{network}/block/:height_or_hash"), get(Self::get_block))
+            .route(&format!("/{network}/block/{{height_or_hash}}"), get(Self::get_block))
             // The path param here is actually only the height, but the name must match the route
             // above, otherwise there'll be a conflict at runtime.
-            .route(&format!("/{network}/block/:height_or_hash/header"), get(Self::get_block_header))
-            .route(&format!("/{network}/block/:height_or_hash/transactions"), get(Self::get_block_transactions))
+            .route(&format!("/{network}/block/{{height_or_hash}}/header"), get(Self::get_block_header))
+            .route(&format!("/{network}/block/{{height_or_hash}}/transactions"), get(Self::get_block_transactions))
 
             // GET and POST ../transaction/..
-            .route(&format!("/{network}/transaction/:id"), get(Self::get_transaction))
-            .route(&format!("/{network}/transaction/confirmed/:id"), get(Self::get_confirmed_transaction))
-            .route(&format!("/{network}/transaction/unconfirmed/:id"), get(Self::get_unconfirmed_transaction))
+            .route(&format!("/{network}/transaction/{{id}}"), get(Self::get_transaction))
+            .route(&format!("/{network}/transaction/confirmed/{{id}}"), get(Self::get_confirmed_transaction))
+            .route(&format!("/{network}/transaction/unconfirmed/{{id}}"), get(Self::get_unconfirmed_transaction))
             .route(&format!("/{network}/transaction/broadcast"), post(Self::transaction_broadcast))
 
             // POST ../solution/broadcast
             .route(&format!("/{network}/solution/broadcast"), post(Self::solution_broadcast))
 
             // GET ../find/..
-            .route(&format!("/{network}/find/blockHash/:tx_id"), get(Self::find_block_hash))
-            .route(&format!("/{network}/find/blockHeight/:state_root"), get(Self::find_block_height_from_state_root))
-            .route(&format!("/{network}/find/transactionID/deployment/:program_id"), get(Self::find_transaction_id_from_program_id))
-            .route(&format!("/{network}/find/transactionID/:transition_id"), get(Self::find_transaction_id_from_transition_id))
-            .route(&format!("/{network}/find/transitionID/:input_or_output_id"), get(Self::find_transition_id))
+            .route(&format!("/{network}/find/blockHash/{{tx_id}}"), get(Self::find_block_hash))
+            .route(&format!("/{network}/find/blockHeight/{{state_root}}"), get(Self::find_block_height_from_state_root))
+            .route(&format!("/{network}/find/transactionID/deployment/{{program_id}}"), get(Self::find_transaction_id_from_program_id))
+            .route(&format!("/{network}/find/transactionID/{{transition_id}}"), get(Self::find_transaction_id_from_transition_id))
+            .route(&format!("/{network}/find/transitionID/{{input_or_output_id}}"), get(Self::find_transition_id))
 
             // GET ../peers/..
             .route(&format!("/{network}/peers/count"), get(Self::get_peers_count))
@@ -181,22 +181,22 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/peers/all/metrics"), get(Self::get_peers_all_metrics))
 
             // GET ../program/..
-            .route(&format!("/{network}/program/:id"), get(Self::get_program))
-            .route(&format!("/{network}/program/:id/mappings"), get(Self::get_mapping_names))
-            .route(&format!("/{network}/program/:id/mapping/:name/:key"), get(Self::get_mapping_value))
+            .route(&format!("/{network}/program/{{id}}"), get(Self::get_program))
+            .route(&format!("/{network}/program/{{id}}/mappings"), get(Self::get_mapping_names))
+            .route(&format!("/{network}/program/{{id}}/mapping/{{name}}/{{key}}"), get(Self::get_mapping_value))
 
             // GET misc endpoints.
             .route(&format!("/{network}/blocks"), get(Self::get_blocks))
-            .route(&format!("/{network}/height/:hash"), get(Self::get_height))
+            .route(&format!("/{network}/height/{{hash}}"), get(Self::get_height))
             .route(&format!("/{network}/memoryPool/transmissions"), get(Self::get_memory_pool_transmissions))
             .route(&format!("/{network}/memoryPool/solutions"), get(Self::get_memory_pool_solutions))
             .route(&format!("/{network}/memoryPool/transactions"), get(Self::get_memory_pool_transactions))
-            .route(&format!("/{network}/statePath/:commitment"), get(Self::get_state_path_for_commitment))
+            .route(&format!("/{network}/statePath/{{commitment}}"), get(Self::get_state_path_for_commitment))
             .route(&format!("/{network}/stateRoot/latest"), get(Self::get_state_root_latest))
-            .route(&format!("/{network}/stateRoot/:height"), get(Self::get_state_root))
+            .route(&format!("/{network}/stateRoot/{{height}}"), get(Self::get_state_root))
             .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
-            .route(&format!("/{network}/committee/:height"), get(Self::get_committee))
-            .route(&format!("/{network}/delegators/:validator"), get(Self::get_delegators_for_validator));
+            .route(&format!("/{network}/committee/{{height}}"), get(Self::get_committee))
+            .route(&format!("/{network}/delegators/{{validator}}"), get(Self::get_delegators_for_validator));
 
             // If the node is a validator and `telemetry` features is enabled, enable the additional endpoint.
             #[cfg(feature = "telemetry")]
@@ -211,7 +211,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // If the `history` feature is enabled, enable the additional endpoint.
             #[cfg(feature = "history")]
             let routes =
-                routes.route(&format!("/{network}/block/:blockHeight/history/:mapping"), get(Self::get_history));
+                routes.route(&format!("/{network}/block/{{blockHeight}}/history/{{mapping}}"), get(Self::get_history));
 
             routes
             // Pass in `Rest` to make things convenient.
@@ -225,8 +225,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // Cap the request body size at 512KiB.
             .layer(DefaultBodyLimit::max(512 * 1024))
             .layer(GovernorLayer {
-                // We can leak this because it is created only once and it persists.
-                config: Box::leak(governor_config),
+                config: governor_config.into(),
             })
         };
 


### PR DESCRIPTION
snarkos depends on multiple versions of tower. This PR updates the axum and tower dependencies to only require the most recent version of tower.

There is one major axum API change that required changing parameters from `:param` to `{param}` (explained [here](https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0)).