### PR TITLE
[CI] Do not run dist-upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ commands:
             export RUSTC_WRAPPER="sccache"
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get dist-upgrade -y -o DPkg::Options::=--force-confold
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
       - restore_cache:
           keys:


### PR DESCRIPTION
This PR changes the CI jobs to not run `apt dist-upgrade` before installing required packages to lower CI execution times and reduce flakiness.
One reasons for some CI runs to fail is that they consist of many jobs, and some of the Ubuntu package servers seem to return 403 errors if we open too many connections at once. The proposed change might not prevent these errors in all cases, but significantly reduces the number of packages we need to fetch.

Generally, a full system upgrade is not needed for every CI job, unless there is another reason for it that I am not aware of. We already use a CircleCI convenience image that is updated fairly frequently and `apt-get install` will fetch any needed updates. Security patches should not matter for CI either.