### PR TITLE
Update snarkVM rev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ commands:
             export RUSTC_WRAPPER="sccache"
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get dist-upgrade -y -o DPkg::Options::=--force-confold
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
       - restore_cache:
           keys:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ default-features = false
 
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "e60c5b0"
-version = "=3.7.1"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "8242f0a"
+#version = "=3.7.1"
 features = [ "circuit", "console", "rocks" ]
 
 [[bin]]

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -80,9 +80,9 @@ version = "=3.7.1"
 
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "e60c5b0"
-version = "=3.7.1"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "8242f0a"
+#version = "=3.7.1"
 default-features = false
 optional = true
 


### PR DESCRIPTION
## Motivation

Update snarkVM rev to patch `transaction/unconfirmed/{id}` endpoint.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2739