### PR TITLE
[Fix] Handle duplicate TMUX session better and pass --metrics to first validator

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -92,20 +92,15 @@ for validator_index in "${validator_indices[@]}"; do
   name="validator-$validator_index"
   log_file="$log_dir/$name.log"
   window_index=$((validator_index + index_offset))
-  metrics_flag=""
+  metrics_port=$((validator_index + 9000))
 
-  if [ "$validator_index" -eq 0 ]; then
+  if [ "$validator_index" -ne 0 ]; then
     # We don't need to create a window for the first validator because the tmux session already starts with one window.
-
-    # Enable metrics only for the first validator.
-    metrics_flag="--metrics"
-  else
-    # Create a new window with a unique name
     tmux new-window -t "devnet:$window_index" -n $name
   fi
 
   # Send the command to start the validator to the new window and capture output to the log file
-  tmux send-keys -t "devnet:$window_index" "snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity $metrics_flag" C-m
+  tmux send-keys -t "devnet:$window_index" "snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity --metrics --metrics-ip=0.0.0.0:$metrics_port" C-m
 done
 
 if [ "$total_clients" -ne 0 ]; then

--- a/devnet.sh
+++ b/devnet.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "$TMUX" ]]; then
+  echo "Detected nested tmux session. Try again after unsetting \$TMUX, e.g., using \`unset TMUX\` in bash."
+  exit 1
+fi
+
 # Read the total number of validators from the user or use a default value of 4
 read -p "Enter the total number of validators (default: 4): " total_validators
 total_validators=${total_validators:-4}
@@ -66,6 +71,10 @@ mkdir -p "$log_dir"
 
 # Create a new tmux session named "devnet"
 tmux new-session -d -s "devnet" -n "validator-0"
+if [[ $? -ne 0 ]]; then
+  echo "Failed to create new TMUX session."
+  exit 1
+fi
 
 # Get the tmux's base-index for windows
 # we have to create all windows with index offset by this much
@@ -83,16 +92,20 @@ for validator_index in "${validator_indices[@]}"; do
   name="validator-$validator_index"
   log_file="$log_dir/$name.log"
   window_index=$((validator_index + index_offset))
+  metrics_flag=""
 
-  # We don't need to create a window for the first validator because the tmux
-  # session already starts with one window.
-  if [ "$validator_index" -ne 0 ]; then
+  if [ "$validator_index" -eq 0 ]; then
+    # We don't need to create a window for the first validator because the tmux session already starts with one window.
+
+    # Enable metrics only for the first validator.
+    metrics_flag="--metrics"
+  else
     # Create a new window with a unique name
     tmux new-window -t "devnet:$window_index" -n $name
   fi
 
   # Send the command to start the validator to the new window and capture output to the log file
-  tmux send-keys -t "devnet:$window_index" "snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity" C-m
+  tmux send-keys -t "devnet:$window_index" "snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity $metrics_flag" C-m
 done
 
 if [ "$total_clients" -ne 0 ]; then


### PR DESCRIPTION
After the recent change (#3619), `./devnet.sh` does not pass `--metrics` to the first validator anymore.

This PR fixes that, and also handles nested or duplicate TMUX sessions better.
