### PR TITLE
[Feature] Immediately send a Ping after generating new blocks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ commands:
             cargo install --locked --path .
       - run:
           name: "Run devnet test"
-          no_output_timeout: 20m  # Allow 20 minutes total
+          timeout: 20m  # Allow 20 minutes total
           command: |
             chmod +x .circleci/devnet_ci.sh
             ./.circleci/devnet_ci.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,6 +3906,7 @@ dependencies = [
  "snarkos-node-sync-communication-service",
  "snarkos-node-sync-locators",
  "snarkvm",
+ "tokio",
  "tracing",
 ]
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -186,7 +186,7 @@ pub struct Start {
     pub nodisplay: bool,
 
     /// Specify the log verbosity of the node.
-    /// [options: 0 for INFO, 1 for DEBUG, 2 or greater for TRACE]
+    /// [options: 0 (lowest log level) to 6 (highest level)]
     #[clap(long, default_value_t = 1)]
     pub verbosity: u8,
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -82,110 +82,161 @@ impl FromStr for BondedBalances {
 
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
-#[command(group(
-    // Ensure at most one node type is specified
-    clap::ArgGroup::new("node_type").required(false).multiple(false)
-))]
+#[command(
+    // Use kebab-case for all arguments (e.g., use the `private-key` flag for the `private_key` field).
+    // This is already the default, but specify it in case clap changes it in the future.
+    rename_all = "kebab-case",
+
+    // Ensure at most one node type is specified.
+    group(clap::ArgGroup::new("node_type").required(false).multiple(false)
+),
+
+    // Ensure dev flags can only be set if `--dev` is set.
+    group(clap::ArgGroup::new("dev_flags").required(false).multiple(true).requires("dev")
+),
+    // Ensure any rest flag (including `--rest`) cannot be set
+    // if `--norest` is set.
+    group(clap::ArgGroup::new("rest_flags").required(false).multiple(true).conflicts_with("norest"))
+)]
 pub struct Start {
-    /// Specify the network ID of this node (0 = mainnet, 1 = testnet, 2 = canary)
-    #[clap(default_value_t=MainnetV0::ID, long = "network", value_parser = clap::value_parser!(u16).range((MainnetV0::ID as i64)..=(CanaryV0::ID as i64)))]
+    /// Specify the network ID of this node
+    /// [options: 0 = mainnet, 1 = testnet, 2 = canary]
+    #[clap(long, default_value_t=MainnetV0::ID, long, value_parser = clap::value_parser!(u16).range((MainnetV0::ID as i64)..=(CanaryV0::ID as i64)))]
     pub network: u16,
 
-    /// Start the node as a validator
-    #[clap(long = "validator", group = "node_type")]
-    pub validator: bool,
-    /// Start the node as a prover
-    #[clap(long = "prover", group = "node_type")]
+    /// Start the node as a prover.
+    #[clap(long, group = "node_type")]
     pub prover: bool,
-    /// Start the node as a client (default)
-    #[clap(long = "client", group = "node_type")]
+
+    /// Start the node as a client (default).
+    ///
+    /// Client are "full nodes", i.e, validate and execute all blocks they receive, but they do not participate in AleoBFT consensus.
+    #[clap(long, group = "node_type", verbatim_doc_comment)]
     pub client: bool,
 
+    /// Start the node as a validator.
+    ///
+    /// Validators are "full nodes", like clients, but also participate in AleoBFT.
+    #[clap(long, group = "node_type", verbatim_doc_comment)]
+    pub validator: bool,
+
     /// Specify the account private key of the node
-    #[clap(long = "private-key")]
+    #[clap(long)]
     pub private_key: Option<String>,
+
     /// Specify the path to a file containing the account private key of the node
     #[clap(long = "private-key-file")]
     pub private_key_file: Option<PathBuf>,
 
-    /// Specify the IP address and port for the node server
-    #[clap(long = "node")]
+    /// Set the IP address and port used for P2P communication.
+    #[clap(long)]
     pub node: Option<SocketAddr>,
-    /// Specify the IP address and port for the BFT
-    #[clap(long = "bft")]
+
+    /// Set the IP address and port used for BFT communication.
+    /// This argument is only allowed for validator nodes.
+    #[clap(long, requires = "validator")]
     pub bft: Option<SocketAddr>,
-    /// Specify the IP address and port of the peer(s) to connect to
-    #[clap(default_value = "", long = "peers")]
-    pub peers: String,
-    /// Specify the IP address and port of the validator(s) to connect to
-    #[clap(default_value = "", long = "validators")]
-    pub validators: String,
-    /// If the flag is set, a validator will allow untrusted peers to connect.
-    /// Client and Prover nodes ignore the flag and always allow untrusted peers
-    /// to connect.
-    #[clap(long = "allow-external-peers")]
+
+    /// Specify the IP address and port of the peer(s) to connect to (as a comma-separated list).
+    ///
+    /// These peers will be set as "trusted", which means the node will not  disconnect from them when performing peer rotation.
+    ///
+    /// Setting peers to "" has the same effect as not setting the flag at all, except when using `--dev`.
+    #[clap(long, verbatim_doc_comment)]
+    pub peers: Option<String>,
+
+    /// Specify the IP address and port of the validator(s) to connect to.
+    #[clap(long)]
+    pub validators: Option<String>,
+
+    /// Allow untrusted peers (not listed in `--peers`) to connect (as a comma-separated list)..
+    ///
+    /// This behavior is always enabled for lient and Prover nodes ignore the flag and always allow untrusted peers to connect.
+    #[clap(long, verbatim_doc_comment)]
     pub allow_external_peers: bool,
+
     /// If the flag is set, a client will periodically evict more external peers
-    #[clap(long = "rotate-external-peers")]
+    #[clap(long)]
     pub rotate_external_peers: bool,
 
     /// Specify the IP address and port for the REST server
-    #[clap(long = "rest")]
+    #[clap(long, group = "rest_flags")]
     pub rest: Option<SocketAddr>,
+
     /// Specify the requests per second (RPS) rate limit per IP for the REST server
-    #[clap(default_value = "10", long = "rest-rps")]
+    #[clap(long, default_value_t = 10, group = "rest_flags")]
     pub rest_rps: u32,
+
     /// Specify the JWT secret for the REST server (16B, base64-encoded).
-    #[clap(long)]
+    #[clap(long, group = "rest_flags")]
     pub jwt_secret: Option<String>,
+
     /// Specify the JWT creation timestamp; can be any time in the last 10 years.
-    #[clap(long)]
+    #[clap(long, group = "rest_flags")]
     pub jwt_timestamp: Option<i64>,
-    /// If the flag is set, the node will not initialize the REST server
+
+    /// If the flag is set, the node will not initialize the REST server.
     #[clap(long)]
     pub norest: bool,
 
-    /// If the flag is set, the node will not render the display
-    #[clap(long)]
+    /// Write log message to stdout instead of showing a terminal UI.
+    ///
+    /// This is useful, for example, for running a node as a service instead of in the foreground or to pipe its output into a file.
+    #[clap(long, verbatim_doc_comment)]
     pub nodisplay: bool,
-    /// Specify the verbosity of the node [options: 0, 1, 2, 3, 4]
-    #[clap(default_value = "1", long = "verbosity")]
+
+    /// Specify the log verbosity of the node.
+    /// [options: 0 for INFO, 1 for DEBUG, 2 or greater for TRACE]
+    #[clap(long, default_value_t = 1)]
     pub verbosity: u8,
+
     /// Specify the path to the file where logs will be stored
-    #[clap(default_value_os_t = std::env::temp_dir().join("snarkos.log"), long = "logfile")]
+    #[clap(long, default_value_os_t = std::env::temp_dir().join("snarkos.log"))]
     pub logfile: PathBuf,
 
-    /// Enables the metrics exporter
+    /// Enable the metrics exporter
     #[cfg(feature = "metrics")]
-    #[clap(default_value = "false", long = "metrics")]
+    #[clap(long)]
     pub metrics: bool,
+
     /// Specify the IP address and port for the metrics exporter
     #[cfg(feature = "metrics")]
-    #[clap(long = "metrics-ip")]
+    #[clap(long, requires = "metrics")]
     pub metrics_ip: Option<SocketAddr>,
 
-    /// Specify the path to a directory containing the storage database for the ledger. Overrides
-    /// the default path (also for dev).
-    #[clap(long = "storage")]
+    /// Specify the path to a directory containing the storage database for the ledger.
+    /// This flag overrides the default path, even when `--dev` is set.
+    #[clap(long)]
     pub storage: Option<PathBuf>,
+
     /// Enables the node to prefetch initial blocks from a CDN
-    #[clap(long = "cdn")]
+    #[clap(long, conflicts_with = "nocdn")]
     pub cdn: Option<String>,
+
     /// If the flag is set, the node will not prefetch from a CDN
     #[clap(long)]
     pub nocdn: bool,
 
-    /// Enables development mode, specify a unique ID for this node
-    #[clap(long)]
+    /// Enables development mode used to set up test networks.
+    ///
+    /// The purpose of this flag is to run multiple nodes on the same machine and in the same working directory.
+    /// To do this, set the value to a unique ID within the test work. For example if there are four nodes in the network, pass `--dev 0` for the first node, `--dev 1` for the second, and so forth.
+    ///
+    /// If you do not explicitly set the `--peers` flag, this will also populate the set of trusted peers, so that the network is fully connected.
+    /// Additionally, if you do not set the `--rest` or the `--norest` flags, it will also set the REST port to `3030` for the first node, `3031` for the second, and so forth.
+    #[clap(long, verbatim_doc_comment)]
     pub dev: Option<u16>,
-    /// If development mode is enabled, specify the number of genesis validators (default: 4)
-    #[clap(long)]
-    pub dev_num_validators: Option<u16>,
-    /// If development mode is enabled, specify whether node 0 should generate traffic to drive the network
-    #[clap(default_value = "false", long = "no-dev-txs")]
+
+    /// If development mode is enabled, specify the number of genesis validator.
+    #[clap(long, group = "dev-flags", default_value_t=DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS)]
+    pub dev_num_validators: u16,
+
+    /// If development mode is enabled, specify whether node 0 should generate traffic to drive the network.
+    #[clap(long, group = "dev-flag")]
     pub no_dev_txs: bool,
-    /// If development mode is enabled, specify the custom bonded balances as a JSON object (default: None)
-    #[clap(long)]
+
+    /// If development mode is enabled, specify the custom bonded balances as a JSON object.
+    #[clap(long, group = "dev-flags")]
     pub dev_bonded_balances: Option<BondedBalances>,
 }
 
@@ -248,10 +299,9 @@ impl Start {
 impl Start {
     /// Returns the initial peer(s) to connect to, from the given configurations.
     fn parse_trusted_peers(&self) -> Result<Vec<SocketAddr>> {
-        match self.peers.is_empty() {
-            true => Ok(vec![]),
-            false => Ok(self
-                .peers
+        match &self.peers {
+            None => Ok(vec![]),
+            Some(peers) => Ok(peers
                 .split(',')
                 .flat_map(|ip| match ip.parse::<SocketAddr>() {
                     Ok(ip) => Some(ip),
@@ -266,10 +316,9 @@ impl Start {
 
     /// Returns the initial validator(s) to connect to, from the given configurations.
     fn parse_trusted_validators(&self) -> Result<Vec<SocketAddr>> {
-        match self.validators.is_empty() {
-            true => Ok(vec![]),
-            false => Ok(self
-                .validators
+        match &self.validators {
+            None => Ok(vec![]),
+            Some(validators) => Ok(validators
                 .split(',')
                 .flat_map(|ip| match ip.parse::<SocketAddr>() {
                     Ok(ip) => Some(ip),
@@ -399,10 +448,7 @@ impl Start {
     fn parse_genesis<N: Network>(&self) -> Result<Block<N>> {
         if self.dev.is_some() {
             // Determine the number of genesis committee members.
-            let num_committee_members = match self.dev_num_validators {
-                Some(num_committee_members) => num_committee_members,
-                None => DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS,
-            };
+            let num_committee_members = self.dev_num_validators;
             ensure!(
                 num_committee_members >= DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS,
                 "Number of genesis committee members is too low"
@@ -516,11 +562,6 @@ impl Start {
             // Construct the genesis block.
             load_or_compute_genesis(dev_keys[0], committee, public_balances, bonded_balances, &mut rng)
         } else {
-            // If the `dev_num_validators` flag is set, inform the user that it is ignored.
-            if self.dev_num_validators.is_some() {
-                eprintln!("The '--dev-num-validators' flag is ignored because '--dev' is not set");
-            }
-
             Block::from_bytes_le(N::genesis_bytes())
         }
     }
@@ -1074,8 +1115,8 @@ mod tests {
             assert_eq!(start.cdn, Some("CDN".to_string()));
             assert_eq!(start.rest, Some("127.0.0.1:3030".parse().unwrap()));
             assert_eq!(start.network, 0);
-            assert_eq!(start.peers, "IP1,IP2,IP3");
-            assert_eq!(start.validators, "IP1,IP2,IP3");
+            assert_eq!(start.peers, Some("IP1,IP2,IP3".to_string()));
+            assert_eq!(start.validators, Some("IP1,IP2,IP3".to_string()));
         } else {
             panic!("Unexpected result of clap parsing!");
         }

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -299,36 +299,42 @@ impl Start {
 impl Start {
     /// Returns the initial peer(s) to connect to, from the given configurations.
     fn parse_trusted_peers(&self) -> Result<Vec<SocketAddr>> {
-        match &self.peers {
-            None => Ok(vec![]),
-            Some(peers) => Ok(peers
-                .split(',')
-                .flat_map(|ip| match ip.parse::<SocketAddr>() {
-                    Ok(ip) => Some(ip),
-                    Err(e) => {
-                        eprintln!("The IP supplied to --peers ('{ip}') is malformed: {e}");
-                        None
-                    }
-                })
-                .collect()),
+        let Some(peers) = &self.peers else { return Ok(vec![]) };
+
+        // Split on an empty string returns an empty string.
+        if peers.is_empty() {
+            return Ok(vec![]);
         }
+
+        let mut result = vec![];
+        for ip in peers.split(',') {
+            match ip.parse::<SocketAddr>() {
+                Ok(ip) => result.push(ip),
+                Err(err) => bail!("An address supplied to --peers ('{ip}') is malformed: {err}"),
+            }
+        }
+
+        Ok(result)
     }
 
     /// Returns the initial validator(s) to connect to, from the given configurations.
     fn parse_trusted_validators(&self) -> Result<Vec<SocketAddr>> {
-        match &self.validators {
-            None => Ok(vec![]),
-            Some(validators) => Ok(validators
-                .split(',')
-                .flat_map(|ip| match ip.parse::<SocketAddr>() {
-                    Ok(ip) => Some(ip),
-                    Err(e) => {
-                        eprintln!("The IP supplied to --validators ('{ip}') is malformed: {e}");
-                        None
-                    }
-                })
-                .collect()),
+        let Some(validators) = &self.validators else { return Ok(vec![]) };
+
+        // Split on an empty string returns an empty string.
+        if validators.is_empty() {
+            return Ok(vec![]);
         }
+
+        let mut result = vec![];
+        for ip in validators.split(',') {
+            match ip.parse::<SocketAddr>() {
+                Ok(ip) => result.push(ip),
+                Err(err) => bail!("An address supplied to --validators ('{ip}') is malformed: {err}"),
+            }
+        }
+
+        Ok(result)
     }
 
     /// Returns the CDN to prefetch initial blocks from, from the given configurations.

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -55,12 +55,12 @@ pub fn initialize_logger<P: AsRef<Path>>(
     // Filter out undesirable logs. (unfortunately EnvFilter cannot be cloned)
     let [filter, filter2] = std::array::from_fn(|_| {
         let filter = EnvFilter::from_default_env()
-            .add_directive("mio=off".parse().unwrap())
-            .add_directive("tokio_util=off".parse().unwrap())
-            .add_directive("hyper=off".parse().unwrap())
-            .add_directive("reqwest=off".parse().unwrap())
-            .add_directive("want=off".parse().unwrap())
-            .add_directive("h2=off".parse().unwrap());
+            .add_directive("mio=warn".parse().unwrap())
+            .add_directive("tokio_util=warn".parse().unwrap())
+            .add_directive("hyper=warn".parse().unwrap())
+            .add_directive("reqwest=warn".parse().unwrap())
+            .add_directive("want=warn".parse().unwrap())
+            .add_directive("h2=warn".parse().unwrap());
 
         let filter = if verbosity >= 2 {
             filter.add_directive("snarkos_node_sync=trace".parse().unwrap())
@@ -91,7 +91,7 @@ pub fn initialize_logger<P: AsRef<Path>>(
         if verbosity >= 6 {
             filter.add_directive("snarkos_node_tcp=trace".parse().unwrap())
         } else {
-            filter.add_directive("snarkos_node_tcp=off".parse().unwrap())
+            filter.add_directive("snarkos_node_tcp=warn".parse().unwrap())
         }
     });
 

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -54,13 +54,26 @@ pub fn initialize_logger<P: AsRef<Path>>(
 
     // Filter out undesirable logs. (unfortunately EnvFilter cannot be cloned)
     let [filter, filter2] = std::array::from_fn(|_| {
-        let filter = EnvFilter::from_default_env()
-            .add_directive("mio=warn".parse().unwrap())
-            .add_directive("tokio_util=warn".parse().unwrap())
-            .add_directive("hyper=warn".parse().unwrap())
-            .add_directive("reqwest=warn".parse().unwrap())
-            .add_directive("want=warn".parse().unwrap())
-            .add_directive("h2=warn".parse().unwrap());
+        let filter = EnvFilter::from_default_env();
+
+        // At high log levels, also show warnings of dependencies
+        let filter = if verbosity < 4 {
+            filter
+                .add_directive("mio=off".parse().unwrap())
+                .add_directive("tokio_util=off".parse().unwrap())
+                .add_directive("hyper=off".parse().unwrap())
+                .add_directive("reqwest=off".parse().unwrap())
+                .add_directive("want=off".parse().unwrap())
+                .add_directive("h2=off".parse().unwrap())
+        } else {
+            filter
+                .add_directive("mio=warn".parse().unwrap())
+                .add_directive("tokio_util=warn".parse().unwrap())
+                .add_directive("hyper=warn".parse().unwrap())
+                .add_directive("reqwest=warn".parse().unwrap())
+                .add_directive("want=warn".parse().unwrap())
+                .add_directive("h2=warn".parse().unwrap())
+        };
 
         let filter = if verbosity >= 2 {
             filter.add_directive("snarkos_node_sync=trace".parse().unwrap())

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -147,7 +147,7 @@ pub async fn start_bft(
     let mut bft =
         BFT::<CurrentNetwork>::new(account, storage, ledger, block_sync, ip, &trusted_validators, storage_mode)?;
     // Run the BFT instance.
-    bft.run(Some(consensus_sender), sender.clone(), receiver).await?;
+    bft.run(None, Some(consensus_sender), sender.clone(), receiver).await?;
     // Retrieve the BFT's primary.
     let primary = bft.primary();
     // Handle OS signals.
@@ -187,7 +187,7 @@ pub async fn start_primary(
     let mut primary =
         Primary::<CurrentNetwork>::new(account, storage, ledger, block_sync, ip, &trusted_validators, storage_mode)?;
     // Run the primary instance.
-    primary.run(None, sender.clone(), receiver).await?;
+    primary.run(None, None, sender.clone(), receiver).await?;
     // Handle OS signals.
     handle_signals(&primary);
     // Return the primary instance.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use snarkos_account::Account;
 use snarkos_node_bft_ledger_service::LedgerService;
-use snarkos_node_sync::BlockSync;
+use snarkos_node_sync::{BlockSync, Ping};
 use snarkvm::{
     console::account::Address,
     ledger::{
@@ -114,6 +114,7 @@ impl<N: Network> BFT<N> {
     /// The function must not be called more than once per instance.
     pub async fn run(
         &mut self,
+        ping: Option<Arc<Ping<N>>>,
         consensus_sender: Option<ConsensusSender<N>>,
         primary_sender: PrimarySender<N>,
         primary_receiver: PrimaryReceiver<N>,
@@ -124,7 +125,7 @@ impl<N: Network> BFT<N> {
         // First, start the BFT handlers.
         self.start_handlers(bft_receiver);
         // Next, run the primary instance.
-        self.primary.run(Some(bft_sender), primary_sender, primary_receiver).await?;
+        self.primary.run(ping, Some(bft_sender), primary_sender, primary_receiver).await?;
         // Lastly, set the consensus sender.
         // Note: This ensures during initial syncing, that the BFT does not advance the ledger.
         if let Some(consensus_sender) = consensus_sender {

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -44,7 +44,7 @@ use crate::{
 use snarkos_account::Account;
 use snarkos_node_bft_events::PrimaryPing;
 use snarkos_node_bft_ledger_service::LedgerService;
-use snarkos_node_sync::{BlockSync, DUMMY_SELF_IP};
+use snarkos_node_sync::{BlockSync, DUMMY_SELF_IP, Ping};
 use snarkvm::{
     console::{
         prelude::*,
@@ -194,6 +194,7 @@ impl<N: Network> Primary<N> {
     /// Run the primary instance.
     pub async fn run(
         &mut self,
+        ping: Option<Arc<Ping<N>>>,
         bft_sender: Option<BFTSender<N>>,
         primary_sender: PrimarySender<N>,
         primary_receiver: PrimaryReceiver<N>,
@@ -239,7 +240,7 @@ impl<N: Network> Primary<N> {
         // Next, load and process the proposal cache before running the sync module.
         self.load_proposal_cache().await?;
         // Next, run the sync module.
-        self.sync.run(sync_receiver).await?;
+        self.sync.run(ping, sync_receiver).await?;
         // Next, initialize the gateway.
         self.gateway.run(primary_sender, worker_senders, Some(sync_sender)).await;
         // Lastly, start the primary handlers.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -198,7 +198,10 @@ impl<N: Network> Sync<N> {
                 let new_blocks = self_.try_block_sync().await;
                 if new_blocks {
                     if let Some(ping) = &ping {
-                        ping.on_new_blocks();
+                        match self_.get_block_locators() {
+                            Ok(locators) => ping.update_block_locators(locators),
+                            Err(err) => error!("Failed to update block locators: {err}"),
+                        }
                     }
                 }
             }

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -221,10 +221,10 @@ impl TestNetwork {
 
             if let Some(bft) = validator.bft.get_mut() {
                 // Setup the channels and start the bft.
-                bft.run(None, primary_sender, primary_receiver).await.unwrap();
+                bft.run(None, None, primary_sender, primary_receiver).await.unwrap();
             } else {
                 // Setup the channels and start the primary.
-                validator.primary.run(None, primary_sender, primary_receiver).await.unwrap();
+                validator.primary.run(None, None, primary_sender, primary_receiver).await.unwrap();
             }
 
             if let Some(interval_ms) = self.config.fire_transmissions {

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -553,6 +553,9 @@ impl<N: Network> Consensus<N> {
         let locators = self.block_sync.get_block_locators()?;
         self.ping.update_block_locators(locators);
 
+        // Make block sync aware of the new block.
+        self.block_sync.set_sync_height(next_block.height());
+
         // TODO(kaimast): This should also remove any transmissions/solutions contained in the block from the mempool.
         // Removal currently happens when Consensus eventually passes them to the worker, which then just discards them.
 

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -35,7 +35,8 @@ use snarkos_node_bft::{
 };
 use snarkos_node_bft_ledger_service::LedgerService;
 use snarkos_node_bft_storage_service::BFTPersistentStorage;
-use snarkos_node_sync::BlockSync;
+use snarkos_node_sync::{BlockSync, Ping};
+
 use snarkvm::{
     ledger::{
         block::Transaction,
@@ -114,6 +115,8 @@ pub struct Consensus<N: Network> {
     transmissions_queue_timestamps: Arc<Mutex<HashMap<TransmissionID<N>, i64>>>,
     /// The handles of all spawned tasks.
     handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    /// The ping logic.
+    ping: Arc<Ping<N>>,
 }
 
 impl<N: Network> Consensus<N> {
@@ -125,6 +128,7 @@ impl<N: Network> Consensus<N> {
         ip: Option<SocketAddr>,
         trusted_validators: &[SocketAddr],
         storage_mode: StorageMode,
+        ping: Arc<Ping<N>>,
     ) -> Result<Self> {
         // Initialize the primary channels.
         let (primary_sender, primary_receiver) = init_primary_channels::<N>();
@@ -146,6 +150,7 @@ impl<N: Network> Consensus<N> {
             #[cfg(feature = "metrics")]
             transmissions_queue_timestamps: Default::default(),
             handles: Default::default(),
+            ping: ping.clone(),
         };
 
         info!("Starting the consensus instance...");
@@ -155,7 +160,7 @@ impl<N: Network> Consensus<N> {
         // Then, start the consensus handlers.
         _self.start_handlers(consensus_receiver);
         // Lastly, also start BFTs handlers.
-        _self.bft.run(Some(consensus_sender), _self.primary_sender.clone(), primary_receiver).await?;
+        _self.bft.run(Some(ping), Some(consensus_sender), _self.primary_sender.clone(), primary_receiver).await?;
 
         Ok(_self)
     }
@@ -540,6 +545,9 @@ impl<N: Network> Consensus<N> {
             // Clear the worker solutions.
             self.bft.primary().clear_worker_solutions();
         }
+
+        // Notify peers that we have a new block.
+        self.ping.on_new_blocks();
 
         // TODO(kaimast): This should also remove any transmissions/solutions contained in the block from the mempool.
         // Removal currently happens when Consensus eventually passes them to the worker, which then just discards them.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -58,6 +58,9 @@ use tower_http::{
     trace::TraceLayer,
 };
 
+/// The default port used for the REST API
+pub const DEFAULT_REST_PORT: u16 = 3030;
+
 /// A REST API server for the ledger.
 #[derive(Clone)]
 pub struct Rest<N: Network, C: ConsensusStorage<N>, R: Routing<N>> {

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -323,7 +323,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 .collect(),
         };
         // Send a `PeerResponse` message to the peer.
-        self.send(peer_ip, Message::PeerResponse(PeerResponse { peers }));
+        self.router().send(peer_ip, Message::PeerResponse(PeerResponse { peers }));
         true
     }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -67,6 +67,9 @@ use std::{
 };
 use tokio::task::JoinHandle;
 
+/// The default port used by the router.
+pub const DEFAULT_NODE_PORT: u16 = 4130;
+
 /// The router keeps track of connected and connecting peers.
 /// The actual network communication happens in Inbound/Outbound,
 /// which is implemented by Validator, Prover, and Client.

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -13,19 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    Router,
-    messages::{Message, Ping},
-};
-use snarkos_node_sync_locators::BlockLocators;
-use snarkos_node_tcp::protocols::Writing;
+use crate::{Router, messages::Message};
 use snarkvm::prelude::Network;
-use std::io;
 
 use std::net::SocketAddr;
-use tokio::sync::oneshot;
 
-pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
+pub trait Outbound<N: Network> {
     /// Returns a reference to the router.
     fn router(&self) -> &Router<N>;
 
@@ -34,55 +27,6 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
 
     /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32;
-
-    /// Sends a "Ping" message to the given peer.
-    fn send_ping(&self, peer_ip: SocketAddr, block_locators: Option<BlockLocators<N>>) {
-        self.send(peer_ip, Message::Ping(Ping::new(self.router().node_type(), block_locators)));
-    }
-
-    /// Sends the given message to specified peer.
-    ///
-    /// This function returns as soon as the message is queued to be sent,
-    /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
-    /// which can be used to determine when and whether the message has been delivered.
-    fn send(&self, peer_ip: SocketAddr, message: Message<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
-        // Determine whether to send the message.
-        if !self.can_send(peer_ip, &message) {
-            return None;
-        }
-        // Resolve the listener IP to the (ambiguous) peer address.
-        let peer_addr = match self.router().resolve_to_ambiguous(&peer_ip) {
-            Some(peer_addr) => peer_addr,
-            None => {
-                warn!("Unable to resolve the listener IP address '{peer_ip}'");
-                return None;
-            }
-        };
-        // If the message type is a block request, add it to the cache.
-        if let Message::BlockRequest(request) = message {
-            self.router().cache.insert_outbound_block_request(peer_ip, request);
-        }
-        // If the message type is a puzzle request, increment the cache.
-        if matches!(message, Message::PuzzleRequest(_)) {
-            self.router().cache.increment_outbound_puzzle_requests(peer_ip);
-        }
-        // If the message type is a peer request, increment the cache.
-        if matches!(message, Message::PeerRequest(_)) {
-            self.router().cache.increment_outbound_peer_requests(peer_ip);
-        }
-        // Retrieve the message name.
-        let name = message.name();
-        // Send the message to the peer.
-        trace!("Sending '{name}' to '{peer_ip}'");
-        let result = self.unicast(peer_addr, message);
-        // If the message was unable to be sent, disconnect.
-        if let Err(e) = &result {
-            warn!("Failed to send '{name}' to '{peer_ip}': {e}");
-            debug!("Disconnecting from '{peer_ip}' (unable to send)");
-            self.router().disconnect(peer_ip);
-        }
-        result.ok()
-    }
 
     /// Sends the given message to every connected peer, excluding the sender and any specified peer IPs.
     fn propagate(&self, message: Message<N>, excluded_peers: &[SocketAddr]) {
@@ -108,7 +52,7 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
 
         // Iterate through all peers that are not the sender and excluded peers.
         for peer_ip in peers {
-            self.send(*peer_ip, message.clone());
+            self.router().send(*peer_ip, message.clone());
         }
     }
 
@@ -136,34 +80,7 @@ pub trait Outbound<N: Network>: Writing<Message = Message<N>> {
 
         // Iterate through all validators that are not the sender and excluded validators.
         for peer_ip in peers {
-            self.send(*peer_ip, message.clone());
-        }
-    }
-
-    /// Returns `true` if the message can be sent.
-    fn can_send(&self, peer_ip: SocketAddr, message: &Message<N>) -> bool {
-        // Ensure the peer is connected before sending.
-        if !self.router().is_connected(&peer_ip) {
-            warn!("Attempted to send to a non-connected peer {peer_ip}");
-            return false;
-        }
-        // Determine whether to send the message.
-        match message {
-            Message::UnconfirmedSolution(message) => {
-                // Update the timestamp for the unconfirmed solution.
-                let seen_before = self.router().cache.insert_outbound_solution(peer_ip, message.solution_id).is_some();
-                // Determine whether to send the solution.
-                !seen_before
-            }
-            Message::UnconfirmedTransaction(message) => {
-                // Update the timestamp for the unconfirmed transaction.
-                let seen_before =
-                    self.router().cache.insert_outbound_transaction(peer_ip, message.transaction_id).is_some();
-                // Determine whether to send the transaction.
-                !seen_before
-            }
-            // For all other message types, return `true`.
-            _ => true,
+            self.router().send(*peer_ip, message.clone());
         }
     }
 }

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -16,7 +16,7 @@
 use crate::{Heartbeat, Inbound, Outbound};
 use snarkos_node_tcp::{
     P2P,
-    protocols::{Disconnect, Handshake, OnConnect},
+    protocols::{Disconnect, Handshake, OnConnect, Writing},
 };
 use snarkvm::prelude::Network;
 
@@ -31,7 +31,7 @@ pub trait Routing<N: Network>:
         // Enable the TCP protocols.
         self.enable_handshake().await;
         self.enable_reading().await;
-        self.enable_writing().await;
+        self.router().enable_writing().await;
         self.enable_disconnect().await;
         self.enable_on_connect().await;
         // Enable the TCP listener. Note: This must be called after the above protocols.

--- a/node/router/src/writing.rs
+++ b/node/router/src/writing.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use snarkos_node_sync_locators::BlockLocators;
+use snarkos_node_tcp::protocols::Writing;
+
+use std::io;
+use tokio::sync::oneshot;
+
+impl<N: Network> Router<N> {
+    /// Sends a "Ping" message to the given peer.
+    pub fn send_ping(&self, peer_ip: SocketAddr, block_locators: Option<BlockLocators<N>>) {
+        self.send(peer_ip, Message::Ping(messages::Ping::new(self.node_type(), block_locators)));
+    }
+
+    /// Sends the given message to specified peer.
+    ///
+    /// This function returns as soon as the message is queued to be sent,
+    /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
+    /// which can be used to determine when and whether the message has been delivered.
+    pub fn send(&self, peer_ip: SocketAddr, message: Message<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
+        // Determine whether to send the message.
+        if !self.can_send(peer_ip, &message) {
+            return None;
+        }
+        // Resolve the listener IP to the (ambiguous) peer address.
+        let peer_addr = match self.resolve_to_ambiguous(&peer_ip) {
+            Some(peer_addr) => peer_addr,
+            None => {
+                warn!("Unable to resolve the listener IP address '{peer_ip}'");
+                return None;
+            }
+        };
+        // If the message type is a block request, add it to the cache.
+        if let Message::BlockRequest(request) = message {
+            self.cache.insert_outbound_block_request(peer_ip, request);
+        }
+        // If the message type is a puzzle request, increment the cache.
+        if matches!(message, Message::PuzzleRequest(_)) {
+            self.cache.increment_outbound_puzzle_requests(peer_ip);
+        }
+        // If the message type is a peer request, increment the cache.
+        if matches!(message, Message::PeerRequest(_)) {
+            self.cache.increment_outbound_peer_requests(peer_ip);
+        }
+        // Retrieve the message name.
+        let name = message.name();
+        // Send the message to the peer.
+        trace!("Sending '{name}' to '{peer_ip}'");
+        let result = self.unicast(peer_addr, message);
+        // If the message was unable to be sent, disconnect.
+        if let Err(e) = &result {
+            warn!("Failed to send '{name}' to '{peer_ip}': {e}");
+            debug!("Disconnecting from '{peer_ip}' (unable to send)");
+            self.disconnect(peer_ip);
+        }
+        result.ok()
+    }
+
+    /// Returns `true` if the message can be sent.
+    fn can_send(&self, peer_ip: SocketAddr, message: &Message<N>) -> bool {
+        // Ensure the peer is connected before sending.
+        if !self.is_connected(&peer_ip) {
+            warn!("Attempted to send to a non-connected peer {peer_ip}");
+            return false;
+        }
+        // Determine whether to send the message.
+        match message {
+            Message::UnconfirmedSolution(message) => {
+                // Update the timestamp for the unconfirmed solution.
+                let seen_before = self.cache.insert_outbound_solution(peer_ip, message.solution_id).is_some();
+                // Determine whether to send the solution.
+                !seen_before
+            }
+            Message::UnconfirmedTransaction(message) => {
+                // Update the timestamp for the unconfirmed transaction.
+                let seen_before = self.cache.insert_outbound_transaction(peer_ip, message.transaction_id).is_some();
+                // Determine whether to send the transaction.
+                !seen_before
+            }
+            // For all other message types, return `true`.
+            _ => true,
+        }
+    }
+}
+#[async_trait]
+impl<N: Network> Writing for Router<N> {
+    type Codec = MessageCodec<N>;
+    type Message = Message<N>;
+
+    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
+    /// The `side` parameter indicates the connection side **from the node's perspective**.
+    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+        Default::default()
+    }
+}

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -523,7 +523,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
         self.shutdown.store(true, std::sync::atomic::Ordering::Release);
 
         // Abort the tasks.
-        trace!("Stopping backgroudn tasks...");
+        trace!("Shutting down the client...");
         self.handles.lock().iter().for_each(|handle| handle.abort());
 
         // Shut down the router.

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -63,9 +63,12 @@ use std::{
             Ordering::{Acquire, Relaxed},
         },
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
-use tokio::{task::JoinHandle, time::sleep};
+use tokio::{
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
 
 /// The maximum number of deployments to verify in parallel.
 /// Note: worst case memory to verify a deployment (MAX_DEPLOYMENT_CONSTRAINTS = 1 << 20) is ~2 GiB.
@@ -238,10 +241,14 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
+    const SYNC_INTERVAL: Duration = std::time::Duration::from_secs(5);
+
     /// Initializes the sync pool.
     fn initialize_sync(&self) {
         // Start the sync loop.
         let _self = self.clone();
+        let mut last_update = Instant::now();
+
         self.handles.lock().push(tokio::spawn(async move {
             loop {
                 // If the Ctrl-C handler registered the signal, stop the node.
@@ -250,17 +257,33 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     break;
                 }
 
-                // Sleep briefly to avoid triggering spam detection.
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                // Make sure we do not sync too often
+                let now = Instant::now();
+                let elapsed = now.saturating_duration_since(last_update);
+                let sleep_time = Self::SYNC_INTERVAL.saturating_sub(elapsed);
+
+                if !sleep_time.is_zero() {
+                    sleep(sleep_time).await;
+                }
 
                 // Perform the sync routine.
                 _self.try_block_sync().await;
+                last_update = now;
             }
         }));
     }
 
     /// Client-side version of `snarkvm_node_bft::Sync::try_block_sync()`.
     async fn try_block_sync(&self) {
+        // Sleep briefly to avoid triggering spam detection.
+        let _ = timeout(Self::SYNC_INTERVAL, self.sync.wait_for_update()).await;
+
+        // Do not attempt to sync if there are not blocks to sync.
+        // This prevents redudant log messages and performing unnecessary computation.
+        if !self.sync.can_block_sync() {
+            return;
+        }
+
         // First see if any peers need removal.
         let peers_to_ban = self.sync.remove_timed_out_block_requests();
         for peer_ip in peers_to_ban {
@@ -277,13 +300,12 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         // Prepare the block requests, if any.
         // In the process, we update the state of `is_block_synced` for the sync module.
         let (block_requests, sync_peers) = self.sync.prepare_block_requests();
-        trace!("Prepared {} block requests", block_requests.len());
 
         // If there are no block requests, but there are pending block responses in the sync pool,
         // then try to advance the ledger using these pending block responses.
         if block_requests.is_empty() && self.sync.has_pending_responses() {
             // Try to advance the ledger with the sync pool.
-            trace!("No block requests to send, but there are still pending block responses.");
+            trace!("No block requests to send. Will process pending responses.");
             let has_new_blocks = self.sync.try_advancing_block_synchronization();
 
             if has_new_blocks {
@@ -292,7 +314,14 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     Err(err) => error!("Failed to get block locators: {err}"),
                 }
             }
+        } else if block_requests.is_empty() {
+            warn!(
+                "Not block synced yet, and there are no outstanding block requests or \
+                 new block requests to send"
+            );
         } else {
+            trace!("Prepared {} new block requests.", block_requests.len());
+
             // Issues the block requests in batches.
             for requests in block_requests.chunks(DataBlocks::<N>::MAXIMUM_NUMBER_OF_BLOCKS as usize) {
                 if !self.sync.send_block_requests(self, &sync_peers, requests).await {
@@ -494,7 +523,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
         self.shutdown.store(true, std::sync::atomic::Ordering::Release);
 
         // Abort the tasks.
-        trace!("Shutting down the validator...");
+        trace!("Stopping backgroudn tasks...");
         self.handles.lock().iter().for_each(|handle| handle.abort());
 
         // Shut down the router.

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -72,16 +72,8 @@ impl<N: Network, C: ConsensusStorage<N>> OnConnect for Client<N, C> {
         if self.router.bootstrap_peers().contains(&peer_ip) {
             self.router().send(peer_ip, Message::PeerRequest(PeerRequest));
         }
-        // Retrieve the block locators.
-        let block_locators = match self.sync.get_block_locators() {
-            Ok(block_locators) => Some(block_locators),
-            Err(e) => {
-                error!("Failed to get block locators: {e}");
-                return;
-            }
-        };
         // Send the first `Ping` message to the peer.
-        self.router().send_ping(peer_ip, block_locators);
+        self.ping.on_peer_connected(peer_ip);
     }
 }
 

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -36,7 +36,7 @@ use snarkvm::{
     prelude::{Network, block::Transaction},
 };
 
-use std::{io, net::SocketAddr, time::Duration};
+use std::{io, net::SocketAddr};
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Client<N, C> {
     /// Returns a reference to the TCP instance.
@@ -62,10 +62,7 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Client<N, C> {
 }
 
 #[async_trait]
-impl<N: Network, C: ConsensusStorage<N>> OnConnect for Client<N, C>
-where
-    Self: Outbound<N>,
-{
+impl<N: Network, C: ConsensusStorage<N>> OnConnect for Client<N, C> {
     async fn on_connect(&self, peer_addr: SocketAddr) {
         // Resolve the peer address to the listener address.
         let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) else { return };
@@ -73,7 +70,7 @@ where
         self.router().insert_connected_peer(peer_ip);
         // If it's a bootstrap peer, first request its peers.
         if self.router.bootstrap_peers().contains(&peer_ip) {
-            Outbound::send(self, peer_ip, Message::PeerRequest(PeerRequest));
+            self.router().send(peer_ip, Message::PeerRequest(PeerRequest));
         }
         // Retrieve the block locators.
         let block_locators = match self.sync.get_block_locators() {
@@ -84,7 +81,7 @@ where
             }
         };
         // Send the first `Ping` message to the peer.
-        self.send_ping(peer_ip, block_locators);
+        self.router().send_ping(peer_ip, block_locators);
     }
 }
 
@@ -96,18 +93,6 @@ impl<N: Network, C: ConsensusStorage<N>> Disconnect for Client<N, C> {
             self.sync.remove_peer(&peer_ip);
             self.router.remove_connected_peer(peer_ip);
         }
-    }
-}
-
-#[async_trait]
-impl<N: Network, C: ConsensusStorage<N>> Writing for Client<N, C> {
-    type Codec = MessageCodec<N>;
-    type Message = Message<N>;
-
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` parameter indicates the connection side **from the node's perspective**.
-    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
-        Default::default()
     }
 }
 
@@ -149,7 +134,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             warn!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' for protocol violation");
-                Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+                self.router().send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
                 // Disconnect from this peer.
                 self.router().disconnect(peer_ip);
             }
@@ -178,7 +163,7 @@ impl<N: Network, C: ConsensusStorage<N>> CommunicationService for Client<N, C> {
         peer_ip: SocketAddr,
         message: Self::Message,
     ) -> Option<tokio::sync::oneshot::Receiver<io::Result<()>>> {
-        Outbound::send(self, peer_ip, message)
+        self.router().send(peer_ip, message)
     }
 }
 
@@ -224,7 +209,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
             }
         };
         // Send the `BlockResponse` message to the peer.
-        Outbound::send(self, peer_ip, Message::BlockResponse(BlockResponse { request: message, blocks }));
+        self.router().send(peer_ip, Message::BlockResponse(BlockResponse { request: message, blocks }));
         true
     }
 
@@ -254,27 +239,13 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         }
 
         // Send a `Pong` message to the peer.
-        Outbound::send(self, peer_ip, Message::Pong(Pong { is_fork: Some(false) }));
+        self.router().send(peer_ip, Message::Pong(Pong { is_fork: Some(false) }));
         true
     }
 
     /// Sleeps for a period and then sends a `Ping` message to the peer.
     fn pong(&self, peer_ip: SocketAddr, _message: Pong) -> bool {
-        // Spawn an asynchronous task for the `Ping` request.
-        let self_ = self.clone();
-        tokio::spawn(async move {
-            // Sleep for the preset time before sending a `Ping` request.
-            tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
-            // Check that the peer is still connected.
-            if self_.router().is_connected(&peer_ip) {
-                // Retrieve the block locators.
-                match self_.sync.get_block_locators() {
-                    // Send a `Ping` message to the peer.
-                    Ok(block_locators) => self_.send_ping(peer_ip, Some(block_locators)),
-                    Err(e) => error!("Failed to get block locators - {e}"),
-                }
-            }
-        });
+        self.ping.on_pong_received(peer_ip);
         true
     }
 
@@ -291,7 +262,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         // Retrieve the latest block header.
         let block_header = Data::Object(self.ledger.latest_header());
         // Send the `PuzzleResponse` message to the peer.
-        Outbound::send(self, peer_ip, Message::PuzzleResponse(PuzzleResponse { epoch_hash, block_header }));
+        self.router().send(peer_ip, Message::PuzzleResponse(PuzzleResponse { epoch_hash, block_header }));
         true
     }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -445,7 +445,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
         self.shutdown.store(true, std::sync::atomic::Ordering::Release);
 
         // Abort the tasks.
-        trace!("Shutting down the validator...");
+        trace!("Stopping background tasks...");
         self.handles.lock().iter().for_each(|handle| handle.abort());
 
         // Shut down the router.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -445,7 +445,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
         self.shutdown.store(true, std::sync::atomic::Ordering::Release);
 
         // Abort the tasks.
-        trace!("Stopping background tasks...");
+        trace!("Shutting down the validator...");
         self.handles.lock().iter().for_each(|handle| handle.abort());
 
         // Shut down the router.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -133,7 +133,8 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
 
         // Initialize the block synchronization logic.
         let sync = Arc::new(BlockSync::new(ledger_service.clone()));
-        let ping = Arc::new(Ping::new(router.clone(), sync.clone()));
+        let locators = sync.get_block_locators()?;
+        let ping = Arc::new(Ping::new(router.clone(), locators));
 
         // Initialize the consensus layer.
         let consensus = Consensus::new(

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -31,7 +31,7 @@ use snarkvm::{
     prelude::{Network, block::Transaction, error},
 };
 
-use std::{io, net::SocketAddr, time::Duration};
+use std::{io, net::SocketAddr};
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Validator<N, C> {
     /// Returns a reference to the TCP instance.
@@ -66,16 +66,8 @@ where
         let Some(peer_ip) = self.router.resolve_to_listener(&peer_addr) else { return };
         // Promote the peer's status from "connecting" to "connected".
         self.router().insert_connected_peer(peer_ip);
-        // Retrieve the block locators.
-        let block_locators = match self.sync.get_block_locators() {
-            Ok(block_locators) => Some(block_locators),
-            Err(e) => {
-                error!("Failed to get block locators: {e}");
-                return;
-            }
-        };
         // Send the first `Ping` message to the peer.
-        self.send_ping(peer_ip, block_locators);
+        self.ping.on_peer_connected(peer_ip);
     }
 }
 
@@ -87,18 +79,6 @@ impl<N: Network, C: ConsensusStorage<N>> Disconnect for Validator<N, C> {
             self.sync.remove_peer(&peer_ip);
             self.router.remove_connected_peer(peer_ip);
         }
-    }
-}
-
-#[async_trait]
-impl<N: Network, C: ConsensusStorage<N>> Writing for Validator<N, C> {
-    type Codec = MessageCodec<N>;
-    type Message = Message<N>;
-
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` parameter indicates the connection side **from the node's perspective**.
-    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
-        Default::default()
     }
 }
 
@@ -140,7 +120,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             warn!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' for protocol violation");
-                Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
+                self.router().send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
                 // Disconnect from this peer.
                 self.router().disconnect(peer_ip);
             }
@@ -193,7 +173,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
             }
         };
         // Send the `BlockResponse` message to the peer.
-        Outbound::send(self, peer_ip, Message::BlockResponse(BlockResponse { request: message, blocks }));
+        self.router().send(peer_ip, Message::BlockResponse(BlockResponse { request: message, blocks }));
         true
     }
 
@@ -217,27 +197,13 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         // Instead, locators are fetched from other validators in `Gateway` using `PrimaryPing` messages.
 
         // Send a `Pong` message to the peer.
-        Outbound::send(self, peer_ip, Message::Pong(Pong { is_fork: Some(false) }));
+        self.router().send(peer_ip, Message::Pong(Pong { is_fork: Some(false) }));
         true
     }
 
-    /// Sleeps for a period and then sends a `Ping` message to the peer.
+    /// Process a Pong message (response to a Ping).
     fn pong(&self, peer_ip: SocketAddr, _message: Pong) -> bool {
-        // Spawn an asynchronous task for the `Ping` request.
-        let self_ = self.clone();
-        tokio::spawn(async move {
-            // Sleep for the preset time before sending a `Ping` request.
-            tokio::time::sleep(Duration::from_secs(Self::PING_SLEEP_IN_SECS)).await;
-            // Check that the peer is still connected.
-            if self_.router().is_connected(&peer_ip) {
-                // Retrieve the block locators.
-                match self_.sync.get_block_locators() {
-                    // Send a `Ping` message to the peer.
-                    Ok(block_locators) => self_.send_ping(peer_ip, Some(block_locators)),
-                    Err(e) => error!("Failed to get block locators - {e}"),
-                }
-            }
-        });
+        self.ping.on_pong_received(peer_ip);
         true
     }
 
@@ -254,7 +220,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         // Retrieve the latest block header.
         let block_header = Data::Object(self.ledger.latest_header());
         // Send the `PuzzleResponse` message to the peer.
-        Outbound::send(self, peer_ip, Message::PuzzleResponse(PuzzleResponse { epoch_hash, block_header }));
+        self.router().send(peer_ip, Message::PuzzleResponse(PuzzleResponse { epoch_hash, block_header }));
         true
     }
 

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -46,6 +46,10 @@ optional = true
 [dependencies.parking_lot]
 version = "0.12"
 
+[dependencies.tokio]
+workspace = true
+features = [ "sync" ]
+
 [dependencies.rand]
 version = "0.8"
 

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -34,12 +34,13 @@ use rand::seq::{IteratorRandom, SliceRandom};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicU32, Ordering},
-    },
+    sync::Arc,
     time::{Duration, Instant},
 };
+use tokio::sync::Notify;
+
+mod sync_state;
+use sync_state::SyncState;
 
 // The redudancy factor decreases the possiblity of a malicious peers sending us an invalid block locator
 // by requiring multiple peers to advertise the same (prefix of) block locators.
@@ -91,7 +92,6 @@ pub const DUMMY_SELF_IP: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1
 /// Initially, they have no keys (see `new()`), thus establishing the invariant.
 /// All the functions that change the keys of one map, also change the keys of the other map in the same way,
 /// thus preserving the invariant.
-#[derive(Debug)]
 pub struct BlockSync<N: Network> {
     /// The ledger.
     ledger: Arc<dyn LedgerService<N>>,
@@ -111,11 +111,11 @@ pub struct BlockSync<N: Network> {
     /// This map is used to determine which requests to remove if they have been pending for too long.
     request_timestamps: RwLock<BTreeMap<u32, Instant>>,
     /// The boolean indicator of whether the node is synced up to the latest block (within the given tolerance).
-    is_block_synced: AtomicBool,
-    /// The number of blocks the peer is behind the greatest peer height.
-    num_blocks_behind: AtomicU32,
+    sync_state: RwLock<SyncState>,
     /// The lock to guarantee advance_with_sync_blocks() is called only once at a time.
     advance_with_sync_blocks_lock: Mutex<()>,
+    /// Gets notified when there was an update to the locators, a peer disconnected, or we received a new block response.
+    notify: Notify,
 }
 
 impl<N: Network> BlockSync<N> {
@@ -123,27 +123,42 @@ impl<N: Network> BlockSync<N> {
     pub fn new(ledger: Arc<dyn LedgerService<N>>) -> Self {
         Self {
             ledger,
+            sync_state: Default::default(),
+            notify: Default::default(),
             locators: Default::default(),
             common_ancestors: Default::default(),
             requests: Default::default(),
             responses: Default::default(),
             request_timestamps: Default::default(),
-            is_block_synced: Default::default(),
-            num_blocks_behind: Default::default(),
             advance_with_sync_blocks_lock: Default::default(),
         }
+    }
+
+    pub async fn wait_for_update(&self) {
+        self.notify.notified().await
     }
 
     /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
     #[inline]
     pub fn is_block_synced(&self) -> bool {
-        self.is_block_synced.load(Ordering::SeqCst)
+        self.sync_state.read().is_block_synced()
+    }
+
+    /// Returns `true` if there a blocks to sync from other nodes.
+    ///
+    /// This will always return true if [`Self::is_block_synced`] returns false,
+    /// but it can return true when [`Self::is_block_synced`] returns true
+    /// (due to the latter having a tolerance of one block).
+    #[inline]
+    pub fn can_block_sync(&self) -> bool {
+        self.sync_state.read().can_block_sync()
     }
 
     /// Returns the number of blocks the node is behind the greatest peer height.
     #[inline]
     pub fn num_blocks_behind(&self) -> u32 {
-        self.num_blocks_behind.load(Ordering::SeqCst)
+        // TODO(kaimast): return u32::MAX if unknown peer height?
+        self.sync_state.read().num_blocks_behind().unwrap_or(0)
     }
 }
 
@@ -343,9 +358,14 @@ impl<N: Network> BlockSync<N> {
             if !advanced {
                 break;
             }
+
             // Update the latest height.
             new_blocks = true;
             current_height = self.ledger.latest_block_height();
+        }
+
+        if new_blocks {
+            self.set_sync_height(current_height);
         }
 
         new_blocks
@@ -357,12 +377,9 @@ impl<N: Network> BlockSync<N> {
     /// This function returns peers that are consistent with each other, and have a block height
     /// that is greater than the ledger height of this node.
     pub fn find_sync_peers(&self) -> Option<(IndexMap<SocketAddr, u32>, u32)> {
-        self.find_sync_peers_at_height(self.ledger.latest_block_height())
-    }
+        // Retrieve the current sync height.
+        let current_height = self.sync_state.read().get_sync_height();
 
-    /// Same as `Self::find_sync_peers`, but allows specifiying a custom height
-    /// (must be greater than the ledger height).
-    pub fn find_sync_peers_at_height(&self, current_height: u32) -> Option<(IndexMap<SocketAddr, u32>, u32)> {
         if let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(current_height) {
             // Map the locators into the latest height.
             let sync_peers =
@@ -426,6 +443,14 @@ impl<N: Network> BlockSync<N> {
             common_ancestors.insert(PeerPair(peer_ip, *other_ip), ancestor);
         }
 
+        // Update is_synced
+        if let Some(greatest_peer_height) = self.locators.read().values().map(|l| l.latest_locator_height()).max() {
+            self.sync_state.write().set_greatest_peer_height(greatest_peer_height);
+        }
+
+        // Notify the sync loop that something changed.
+        self.notify.notify_one();
+
         Ok(())
     }
 
@@ -437,6 +462,9 @@ impl<N: Network> BlockSync<N> {
         self.locators.write().remove(peer_ip);
         // Remove all block requests to the peer.
         self.remove_block_requests_to_peer(peer_ip);
+
+        // Notify the sync loop that something changed.
+        self.notify.notify_one();
     }
 }
 
@@ -447,24 +475,16 @@ impl<N: Network> BlockSync<N> {
     /// Returns a list of block requests and the sync peers, if the node needs to sync.
     ///
     /// You usually want to call `remove_timed_out_block_requests` before invoking this function.
-    ///
-    /// `current_height` should either be the ledger height, or the height of the pending blocks (for validators).
     pub fn prepare_block_requests(&self) -> BlockRequestBatch<N> {
-        self.prepare_block_requests_at_height(self.ledger.latest_block_height())
-    }
+        let mut state = self.sync_state.write();
+        let current_height = state.get_sync_height();
 
-    /// Returns a list of block requests and the sync peers, if the node needs to sync.
-    ///
-    /// You usually want to call `remove_timed_out_block_requests` before invoking this function.
-    ///
-    /// `current_height` should either be the ledger height, or the height of the pending blocks (for validators).
-    pub fn prepare_block_requests_at_height(&self, current_height: u32) -> BlockRequestBatch<N> {
         // Prepare the block requests.
         if let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(current_height) {
             // Retrieve the highest block height.
             let greatest_peer_height = sync_peers.values().map(|l| l.latest_locator_height()).max().unwrap_or(0);
             // Update the state of `is_block_synced` for the sync module.
-            self.update_is_block_synced(greatest_peer_height, current_height, MAX_BLOCKS_BEHIND);
+            state.set_greatest_peer_height(greatest_peer_height);
             // Return the list of block requests.
             (self.construct_requests(&sync_peers, min_common_ancestor), sync_peers)
         } else {
@@ -472,7 +492,8 @@ impl<N: Network> BlockSync<N> {
             if self.requests.read().is_empty() && self.responses.read().is_empty() {
                 trace!("All requests have been processed. Will set block synced to true.");
                 // Update the state of `is_block_synced` for the sync module.
-                self.update_is_block_synced(0, current_height, MAX_BLOCKS_BEHIND);
+                // TODO(kaimast): remove this workaround
+                state.set_greatest_peer_height(0);
             } else {
                 trace!("No new blocks can be requests, but there are still outstanding requests.");
             }
@@ -482,25 +503,8 @@ impl<N: Network> BlockSync<N> {
         }
     }
 
-    /// Updates the state of `is_block_synced` for the sync module.
-    fn update_is_block_synced(&self, greatest_peer_height: u32, current_height: u32, max_blocks_behind: u32) {
-        // Retrieve the latest block height.
-        let ledger_height = self.ledger.latest_block_height();
-        trace!(
-            "Updating is_block_synced: greatest_peer_height = {greatest_peer_height}, ledger_height = {ledger_height},
-            current_height = {current_height}"
-        );
-        // Compute the number of blocks that we are behind by.
-        let num_blocks_behind = greatest_peer_height.saturating_sub(current_height);
-        // Determine if the primary is synced.
-        let is_synced = num_blocks_behind <= max_blocks_behind;
-        // Update the num blocks behind.
-        self.num_blocks_behind.store(num_blocks_behind, Ordering::SeqCst);
-        // Update the sync status.
-        self.is_block_synced.store(is_synced, Ordering::SeqCst);
-        // Update the `IS_SYNCED` metric.
-        #[cfg(feature = "metrics")]
-        metrics::gauge(metrics::bft::IS_SYNCED, is_synced);
+    pub fn set_sync_height(&self, new_height: u32) {
+        self.sync_state.write().set_sync_height(new_height);
     }
 
     /// Inserts a block request for the given height.
@@ -551,6 +555,9 @@ impl<N: Network> BlockSync<N> {
                 bail!("Candidate block {height} from '{peer_ip}' is malformed");
             }
         }
+
+        // Notify the sync loop that something changed.
+        self.notify.notify_one();
 
         Ok(())
     }
@@ -1006,14 +1013,14 @@ mod tests {
     /// Returns a duplicate (deep copy) of the sync pool with a different ledger height.
     fn duplicate_sync_at_new_height(sync: &BlockSync<CurrentNetwork>, height: u32) -> BlockSync<CurrentNetwork> {
         BlockSync::<CurrentNetwork> {
+            notify: Notify::new(),
             ledger: Arc::new(sample_ledger_service(height)),
             locators: RwLock::new(sync.locators.read().clone()),
             common_ancestors: RwLock::new(sync.common_ancestors.read().clone()),
             requests: RwLock::new(sync.requests.read().clone()),
             responses: RwLock::new(sync.responses.read().clone()),
             request_timestamps: RwLock::new(sync.request_timestamps.read().clone()),
-            is_block_synced: AtomicBool::new(sync.is_block_synced.load(Ordering::SeqCst)),
-            num_blocks_behind: AtomicU32::new(sync.num_blocks_behind.load(Ordering::SeqCst)),
+            sync_state: RwLock::new(sync.sync_state.read().clone()),
             advance_with_sync_blocks_lock: Default::default(),
         }
     }

--- a/node/sync/src/block_sync/sync_state.rs
+++ b/node/sync/src/block_sync/sync_state.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::MAX_BLOCKS_BEHIND;
+
+use std::time::Instant;
+
+#[derive(Clone)]
+pub(super) struct SyncState {
+    /// The height we synced to already
+    /// Note: This can be greater than the current ledger height,
+    ///       if blocks are not fully committed yet
+    sync_height: u32,
+    /// The largest height of a peer's block locator.
+    /// Is `None` if we never received a peer loator
+    greatest_peer_height: Option<u32>,
+    /// Are we synced?
+    /// Allows keeping track of when the sync state changes.
+    is_synced: bool,
+    /// Last time the sync state changed
+    last_change: Instant,
+}
+
+impl Default for SyncState {
+    fn default() -> Self {
+        Self { sync_height: 0, greatest_peer_height: None, is_synced: false, last_change: Instant::now() }
+    }
+}
+
+impl SyncState {
+    /// Did we catch up with the greates known peer height?
+    /// This will return false if we never synced from a peer.
+    pub fn is_block_synced(&self) -> bool {
+        self.is_synced
+    }
+
+    pub fn can_block_sync(&self) -> bool {
+        // Return true if sync state is false even if we there are no known blocks to fetch,
+        // because otherwise nodes will never  switch to synced at startup.
+        !self.is_synced || self.num_blocks_behind().map(|n| n > 0).unwrap_or(false)
+    }
+
+    /// Returns the sync height (this is always greater or equal than the ledger height).
+    pub fn get_sync_height(&self) -> u32 {
+        self.sync_height
+    }
+
+    // Compute the number of blocks that we are behind by.
+    // Returns None, if there is no known peer height.
+    pub fn num_blocks_behind(&self) -> Option<u32> {
+        self.greatest_peer_height.map(|peer_height| peer_height.saturating_sub(self.sync_height))
+    }
+
+    /// Update the height we are synced to.
+    /// If the value is lower than the current height, the sync height remains unchanged.
+    pub fn set_sync_height(&mut self, sync_height: u32) {
+        if sync_height <= self.sync_height {
+            return;
+        }
+
+        self.sync_height = sync_height;
+        self.update_is_block_synced();
+    }
+
+    /// Update the greatest known height of a connected peer.
+    pub fn set_greatest_peer_height(&mut self, peer_height: u32) {
+        if let Some(old_height) = self.greatest_peer_height {
+            if old_height == peer_height {
+                return;
+            }
+        }
+
+        self.greatest_peer_height = Some(peer_height);
+        self.update_is_block_synced();
+    }
+
+    /// Updates the state of `is_block_synced` for the sync module.
+    fn update_is_block_synced(&mut self) {
+        trace!(
+            "Updating is_block_synced: greatest_peer_height={greatest_peer:?}, current_height={current}, is_synced={is_synced}",
+            greatest_peer = self.greatest_peer_height,
+            current = self.sync_height,
+            is_synced = self.is_synced,
+        );
+
+        let num_blocks_behind = self.num_blocks_behind();
+        let old_sync_val = self.is_synced;
+
+        let new_sync_val = if let Some(num_blocks_behind) = num_blocks_behind {
+            num_blocks_behind <= MAX_BLOCKS_BEHIND
+        } else {
+            false
+        };
+
+        // Print a message if the state changed
+        if new_sync_val != old_sync_val {
+            // Measure how long sync took.
+            let now = Instant::now();
+            let elapsed = now.saturating_duration_since(self.last_change).as_secs();
+            self.last_change = now;
+
+            if new_sync_val {
+                let elapsed =
+                    if elapsed < 60 { format!("{elapsed} seconds") } else { format!("{} minutes", elapsed / 60) };
+
+                debug!("Block sync state changed to \"synced\". It took {elapsed} to catch up with the network.");
+            } else {
+                // num_blocks_behind should never be None at this point,
+                // but savely unwrap just is in case.
+                let behind_msg = num_blocks_behind.map(|n| n.to_string()).unwrap_or("unknown".to_string());
+
+                debug!("Block sync state changed to \"syncing\". We are {behind_msg} blocks behind.");
+            }
+        }
+
+        self.is_synced = new_sync_val;
+
+        // Update the `IS_SYNCED` metric.
+        #[cfg(feature = "metrics")]
+        metrics::gauge(metrics::bft::IS_SYNCED, new_sync_val);
+    }
+}

--- a/node/sync/src/lib.rs
+++ b/node/sync/src/lib.rs
@@ -21,6 +21,9 @@ extern crate tracing;
 pub use snarkos_node_sync_communication_service as communication_service;
 pub use snarkos_node_sync_locators as locators;
 
+mod ping;
+pub use ping::Ping;
+
 mod block_sync;
 pub use block_sync::*;
 

--- a/node/sync/src/ping.rs
+++ b/node/sync/src/ping.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{BlockSync, locators::BlockLocators};
+use snarkos_node_router::Router;
+use snarkvm::prelude::Network;
+
+use parking_lot::Mutex;
+use std::{
+    collections::BTreeMap,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::{sync::Notify, time::timeout};
+
+/// Internal state of the ping logic
+///
+/// Essentially, ping keeps an ordered map `next_ping` of time(rs) to peer IPs.
+/// When a new peer connects or a Pong message is received, an entry in next ping is created
+/// for when a peer should next be pinged.
+///
+/// TODO (kaimast): maybe keep track of the last ping too, to not trigger spam detection?
+#[derive(Default)]
+struct PingInner {
+    /// The next time we should ping a peer.
+    next_ping: BTreeMap<Instant, SocketAddr>,
+}
+
+/// Manages sending Ping messages to all connected peers.
+pub struct Ping<N: Network> {
+    router: Router<N>,
+    sync: Arc<BlockSync<N>>,
+    inner: Arc<Mutex<PingInner>>,
+    notify: Arc<Notify>,
+}
+
+impl<N: Network> Ping<N> {
+    /// The duration in seconds to wait between sending ping requests to a peer.
+    const MAX_PING_INTERVAL: Duration = Duration::from_secs(20);
+
+    /// Create a new instance of the ping logic.
+    /// There should only be one per node.
+    pub fn new(router: Router<N>, sync: Arc<BlockSync<N>>) -> Self {
+        let notify = Arc::new(Notify::default());
+        let inner = Arc::new(Mutex::new(PingInner::default()));
+
+        {
+            let inner = inner.clone();
+            let sync = sync.clone();
+            let router = router.clone();
+            let notify = notify.clone();
+
+            tokio::spawn(async move {
+                Self::ping_task(&inner, &*sync, &router, &notify).await;
+            });
+        }
+
+        Self { inner, sync, router, notify }
+    }
+
+    /// Notify the ping logic that we received a Pong response.
+    pub fn on_pong_received(&self, peer_ip: SocketAddr) {
+        let now = Instant::now();
+        let mut inner = self.inner.lock();
+
+        inner.next_ping.insert(now + Self::MAX_PING_INTERVAL, peer_ip);
+
+        // self.notify.notify() is not needed as ping_task wakes up every MAX_PING_INTERVAL
+    }
+
+    /// Notify the ping logic that a new peer connected.
+    pub fn on_peer_connected(&self, peer_ip: SocketAddr) {
+        // Send the first ping.
+        let locators = match self.sync.get_block_locators() {
+            Ok(block_locators) => Some(block_locators),
+            Err(err) => {
+                error!("Failed to get block locators: {err}");
+                return;
+            }
+        };
+
+        self.router.send_ping(peer_ip, locators);
+    }
+
+    /// Notify the ping logic that new blocks were created or synced.
+    pub fn on_new_blocks(&self) {
+        // wake up the ping task
+        self.notify.notify_one();
+    }
+
+    /// Background task that periodically sends out new ping messages.
+    async fn ping_task(inner: &Mutex<PingInner>, sync: &BlockSync<N>, router: &Router<N>, notify: &Notify) {
+        let mut new_block = false;
+
+        loop {
+            // Do not hold the lock while waiting.
+            let sleep_time = {
+                let mut inner = inner.lock();
+                let now = Instant::now();
+
+                // Ping peers.
+                if new_block {
+                    Self::ping_all_peers(&mut inner, sync, router);
+                    new_block = false;
+                } else {
+                    Self::ping_expired_peers(now, &mut inner, sync, router);
+                }
+
+                // Figure out how long to sleep.
+                if let Some((time, _)) = inner.next_ping.first_key_value() {
+                    time.saturating_duration_since(now)
+                } else {
+                    Self::MAX_PING_INTERVAL
+                }
+            };
+
+            // wait to be woke up, either by timer or notify
+            if timeout(sleep_time, notify.notified()).await.is_ok() {
+                // If the timer is not expired, it means we got woken up by a new block.
+                new_block = true;
+            }
+        }
+    }
+
+    /// Ping all peers that have an expired timer.
+    fn ping_expired_peers(now: Instant, inner: &mut PingInner, sync: &BlockSync<N>, router: &Router<N>) {
+        let mut block_locators: Option<BlockLocators<N>> = None;
+
+        loop {
+            // Find next peer to contact.
+            let peer_ip = {
+                let Some((time, peer_ip)) = inner.next_ping.first_key_value() else {
+                    return;
+                };
+
+                if *time > now {
+                    return;
+                }
+
+                *peer_ip
+            };
+
+            // Try to cache the block locators
+            if let Some(locators) = &block_locators {
+                router.send_ping(peer_ip, Some(locators.clone()));
+            } else {
+                let locators = match sync.get_block_locators() {
+                    Ok(block_locators) => block_locators,
+                    Err(err) => {
+                        error!("Failed to get block locators: {err}");
+                        return;
+                    }
+                };
+
+                router.send_ping(peer_ip, Some(locators.clone()));
+                block_locators = Some(locators);
+            }
+
+            // Update state
+            inner.next_ping.pop_first();
+            inner.next_ping.insert(now + Self::MAX_PING_INTERVAL, peer_ip);
+        }
+    }
+
+    /// Ping all known peers.
+    fn ping_all_peers(inner: &mut PingInner, sync: &BlockSync<N>, router: &Router<N>) {
+        let locators = match sync.get_block_locators() {
+            Ok(block_locators) => block_locators,
+            Err(err) => {
+                error!("Failed to get block locators: {err}");
+                return;
+            }
+        };
+
+        // Remove timers.
+        let peers: Vec<SocketAddr> = inner.next_ping.values().copied().collect();
+        inner.next_ping.clear();
+
+        for peer_ip in peers {
+            router.send_ping(peer_ip, Some(locators.clone()));
+        }
+    }
+}


### PR DESCRIPTION
## Motivation
It can take many seconds for a client to detect that its transaction was confirmed, because block propagation is sometimes slow.
This needs to be fixed to improve the user experience.

## Overview
This PR introduces a `Ping` struct that keeps track of all ping messages (to be) sent to other peers. When a new block is received or created, nodes update the block locators in `Ping`, which immediately sends new ping messages.
This should reduce block propagation time, as the old approach introduces up to 20 seconds of delay for each network hop.

Every iteration, Ping's worker task waits on a `tokio::Notify` (similar to a condition variable), which gets notified whenever the block locators change. It also set a timeout to the earliest time we have to send a new ping message to a peer.
If there are a no peers, the task still wakes up every 20 seconds. The latter should not be needed, but I left it in place to make sure the task never gets stuck.

This change also moves the `Writer` implementation from `Validator`/`Client`/`Prover` to `Router`, which deduplicates some code and also makes the code more modular.

## Notes/Considerations
* This change means we now send a ping every block, so roughly every 4 seconds or so. This could cause issues, and we can consider changing it to not trigger a new ping message on every block. I also have ideas to make `BlockLocators` smaller so that Ping messages do not cause a noticeable overhead.
* I did not change the `Gateway`/`PrimaryPing` code. The `PrimaryPing` is really only used during initial sync. During normal operations, validators build blocks themselves and the pings do not affect latency.

## Result
Client block height is now identical to that of validators.
<img width="1189" alt="Screenshot 2025-06-22 at 6 14 34 PM" src="https://github.com/user-attachments/assets/78f8dc7f-a021-4f47-afea-1463ccc063f1" />
