### PR TITLE
[CI] Set environment variables correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             refreshenv
             # Install rust with rustup.
             Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "C:\rustup-init.exe"
-            & C:\rustup-init.exe -y --default-toolchain "1.83.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+            & C:\rustup-init.exe -y --default-toolchain "1.88.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
             $Env:Path += ";$Env:USERPROFILE\.cargo\bin"
             # Verify the installation.
             cargo --version --verbose
@@ -68,7 +68,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v3.3.1-rust-1.83.0-snarkos-stable-cache
+        default: v3.3.1-rust-1.88.0-snarkos-stable-cache
     steps:
       - run:
           name: Set environment variables
@@ -76,7 +76,7 @@ commands:
             # CircleCI runs a new shell for every step, so exported variables are lost
             # This workaround is suggested here: https://circleci.com/docs/env-vars/#parameters-and-bash-environment
             echo 'set -e' >> "$BASH_ENV"
-            echo 'export SCCACHE_CACHE_SIZE=200M' >> "$BASH_ENV"
+            echo 'export SCCACHE_CACHE_SIZE=1G' >> "$BASH_ENV"
             echo 'export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"' >> "$BASH_ENV"
             echo 'export RUSTC_WRAPPER="$CIRCLE_WORKING_DIRECTORY/.bin/sccache"' >> "$BASH_ENV"
             # Disable incremental builds so that sccache works as expected
@@ -136,7 +136,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v3.3.1-rust-1.83.0-snarkos-stable-cache
+        default: v3.3.1-rust-1.88.0-snarkos-stable-cache
     steps:
       - run:
           name: Show sccache statistics
@@ -144,45 +144,28 @@ commands:
       - store_cache:
           cache_key: << parameters.cache_key >>
 
-  run_serial:
+  run_test:
     description: "Build and run tests"
     parameters:
       workspace_member:
         type: string
-      cache_key:
-        type: string
       flags:
         type: string
         default: ""
     steps:
       - checkout
       - setup_environment:
-          cache_key:  v3.3.1-rust-1.88.0-<< parameters.cache_key >>-cache
+          cache_key:  v4.0.0-rust-1.88.0-<< parameters.workspace_member >>-cache
       - run:
-          no_output_timeout: 30m
-          command: cd << parameters.workspace_member >> && cargo test << parameters.flags >>
-      - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-<< parameters.cache_key >>-cache
-
-  run_serial_long:
-    description: "Build and run long running tests"
-    parameters:
-      workspace_member:
-        type: string
-      cache_key:
-        type: string
-      flags:
-        type: string
-        default: ""
-    steps:
-      - checkout
-      - setup_environment:
-          cache_key: << parameters.cache_key >>
+          name: Build Tests
+          timeout: 15m
+          command: cargo test --package=<< parameters.workspace_member >> --no-run << parameters.flags >>
       - run:
-          no_output_timeout: 300m
-          command: cd << parameters.workspace_member >> && cargo test << parameters.flags >>
+          name: Run Tests
+          timeout: 15m
+          command: cargo test --package=<< parameters.workspace_member >> << parameters.flags >>
       - clear_environment:
-          cache_key: << parameters.cache_key >>
+          cache_key: v4.0.0-rust-1.88.0-<< parameters.workspace_member >>-cache
 
   run_devnet:
     description: "Run devnet for integration testing"
@@ -236,139 +219,122 @@ commands:
 jobs:
   snarkos:
     executor: rust-docker
-    resource_class: << pipeline.parameters.xlarge >>
+    resource_class: << pipeline.parameters.twoxlarge >>
     steps:
-      - run_serial:
-          workspace_member: .
-          cache_key: stable
+      - run_test:
+          workspace_member: snarkos
 
   account:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: account
-          cache_key: account
+      - run_test:
+          workspace_member: snarkos-account
 
   cli:
     executor: rust-docker
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
-      - run_serial:
-          workspace_member: cli
-          cache_key: cli
+      - run_test:
+          workspace_member: snarkos-cli
 
   node:
     executor: rust-docker
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
-      - run_serial:
-          workspace_member: node
-          cache_key: node
+      - run_test:
+          workspace_member: snarkos-node
 
   node-bft:
     executor: rust-docker
     resource_class: << pipeline.parameters.twoxlarge >>
     steps:
-      - run_serial:
-          workspace_member: node/bft
-          cache_key: node-bft
+      - run_test:
+          workspace_member: snarkos-node-bft
 
   node-bft-events:
     executor: rust-docker
     resource_class: << pipeline.parameters.large >>
     steps:
-      - run_serial:
-          workspace_member: node/bft/events
-          cache_key: node-bft-events
+      - run_test:
+          workspace_member: snarkos-node-bft-events
 
   node-bft-ledger-service:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/bft/ledger-service
-          cache_key: node-bft-ledger-service
+      - run_test:
+          workspace_member: snarkos-node-bft-ledger-service
 
   node-bft-storage-service:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/bft/storage-service
-          cache_key: node-bft-storage-service
+      - run_test:
+          workspace_member: snarkos-node-bft-storage-service
 
   node-cdn:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/cdn
-          cache_key: node-cdn
+      - run_test:
+          workspace_member: snarkos-node-cdn
 
   node-consensus:
     executor: rust-docker
     resource_class: << pipeline.parameters.large >>
     steps:
-      - run_serial:
-          workspace_member: node/consensus
-          cache_key: node-consensus
+      - run_test:
+          workspace_member: snarkos-node-consensus
 
   node-rest:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/rest
-          cache_key: node-rest
+      - run_test:
+          workspace_member: snarkos-node-rest
 
   node-router:
     executor: rust-docker
     resource_class: << pipeline.parameters.large >>
     steps:
-      - run_serial:
-          workspace_member: node/router
-          cache_key: node-router
+      - run_test:
+          workspace_member: snarkos-node-router
 
   node-router-messages:
     executor: rust-docker
     resource_class: << pipeline.parameters.large >>
     steps:
-      - run_serial:
-          workspace_member: node/router/messages
-          cache_key: node-router-messages-
+      - run_test:
+          workspace_member: snarkos-node-router-messages
 
   node-sync:
     executor: rust-docker
     resource_class: << pipeline.parameters.xlarge >>
     steps:
-      - run_serial:
-          workspace_member: node/sync
-          cache_key: node-sync
+      - run_test:
+          workspace_member: snarkos-node-sync
 
   node-sync-communication-service:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/sync/communication-service
-          cache_key: node-sync-communication-service
+      - run_test:
+          workspace_member: snarkos-node-sync-communication-service
 
   node-sync-locators:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/sync/locators
-          cache_key: node-sync-locators
+      - run_test:
+          workspace_member: snarkos-node-sync-locators
 
   node-tcp:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
     steps:
-      - run_serial:
-          workspace_member: node/tcp
-          cache_key: node-tcp
+      - run_test:
+          workspace_member: snarkos-node-tcp
 
   devnet-test:
     executor: rust-docker
@@ -376,7 +342,7 @@ jobs:
     steps:
       - run_devnet:
           workspace_member: .
-          cache_key: v3.3.1-rust-1.88.0-devnet-test-cache
+          cache_key: v4.0.0-rust-1.88.0-devnet-test-cache
 
   # Check crates that do not have any tests individually
   check-other-crates:
@@ -404,13 +370,13 @@ jobs:
       - checkout
       - install_rust_nightly
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-fmt-cache
+          cache_key: v4.0.0-rust-1.88.0-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-fmt-cache
+          cache_key: v4.0.0-rust-1.88.0-fmt-cache
 
   check-unused-dependencies:
     executor: rust-docker
@@ -418,7 +384,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-machete-cache
+          cache_key: v4.0.0-rust-1.88.0-machete-cache
       - run:
           name: Check for unused dependencies
           no_output_timeout: 10m
@@ -426,7 +392,7 @@ jobs:
             cargo install cargo-machete@0.7.0
             cargo machete
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-machete-cache
+          cache_key: v4.0.0-rust-1.88.0-machete-cache
 
   check-cargo-audit:
     executor: rust-docker
@@ -434,7 +400,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.0.0-rust-1.88.0-cargo-audit-cache
       - run:
           name: Check for security vulnerabilities
           no_output_timeout: 10m
@@ -442,7 +408,7 @@ jobs:
             cargo install cargo-audit@0.21.2 --locked
             cargo audit -D warnings
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.0.0-rust-1.88.0-cargo-audit-cache
 
   check-clippy:
     executor: rust-docker
@@ -450,7 +416,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-clippy-cache
+          cache_key: v4.0.O-rust-1.88.0-clippy-cache
       - run:
           name: Check lint
           no_output_timeout: 35m
@@ -458,7 +424,7 @@ jobs:
             cargo clippy --workspace --all-targets -- -D warnings
             cargo clippy --workspace --all-targets --all-features -- -D warnings
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-clippy-cache
+          cache_key: v4.0.0-rust-1.88.0-clippy-cache
 
   verify-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,36 @@ commands:
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev libssl-dev
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
+      - fetch_cache:
+          cache_key: << parameters.cache_key >>
+
+  fetch_cache:
+    description: "Fetch the cached data"
+    parameters:
+      cache_key:
+        type: string
+    steps:
+      - run:
+          name: Generate daily cache key
+          command: |
+            CACHE_DATE=$(date +%Y-%m-%d)
+            echo "Cache date is $CACHE_DATE"
+            echo "$CACHE_DATE" >> cache-key-suffix
       - restore_cache:
           keys:
-            - << parameters.cache_key >>
+            - << parameters.cache_key >>-{{ checksum "cache-key-suffix" }}
+
+  store_cache:
+    description: "Store the updated cache (once per day)"
+    parameters:
+      cache_key:
+        type: string
+    steps:
+      - save_cache:
+          key: << parameters.cache_key >>-{{ checksum "cache-key-suffix" }}
+          paths:
+            - .cache/sccache
+            - .cargo
 
   clear_environment:
     description: "Clear environment"
@@ -109,11 +136,8 @@ commands:
       - run:
           name: Show sccache statistics
           command: $CIRCLE_WORKING_DIRECTORY/.bin/sccache -s
-      - save_cache:
-          key: << parameters.cache_key >>
-          paths:
-            - .cache/sccache
-            - .cargo
+      - store_cache:
+          cache_key: << parameters.cache_key >>
 
   run_serial:
     description: "Build and run tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,22 +68,33 @@ commands:
         type: string
         default: v3.3.1-rust-1.83.0-snarkos-stable-cache
     steps:
-      - run: set -e
       - run:
-          name: Prepare environment and install dependencies
+          name: Set environment variables
           command: |
-            export SCCACHE_CACHE_SIZE=200M
-            export WORK_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"
-            export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"
+            # CircleCI runs a new shell for every step, so exported variables are lost
+            # This workaround is suggested here: https://circleci.com/docs/env-vars/#parameters-and-bash-environment
+            echo 'set -e' >> "$BASH_ENV"
+            echo 'export SCCACHE_CACHE_SIZE=200M' >> "$BASH_ENV"
+            echo 'export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"' >> "$BASH_ENV"
+            echo 'export RUSTC_WRAPPER="$CIRCLE_WORKING_DIRECTORY/.bin/sccache"' >> "$BASH_ENV"  
+
+      - run:
+          name: Install sccache
+          command: |
             mkdir -p "$CIRCLE_WORKING_DIRECTORY/.bin"
-            wget https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-            tar -C "$CIRCLE_WORKING_DIRECTORY/.bin" -xvf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
-            mv $CIRCLE_WORKING_DIRECTORY/.bin/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache $CIRCLE_WORKING_DIRECTORY/.bin/sccache
-            export PATH="$PATH:$CIRCLE_WORKING_DIRECTORY/.bin"
-            export RUSTC_WRAPPER="sccache"
+            export SCCACHE_VERSION=v0.10.0
+            export SCCACHE_PKG="sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl"
+            wget "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_PKG.tar.gz"
+            tar -C "$CIRCLE_WORKING_DIRECTORY/.bin" -xvf "$SCCACHE_PKG.tar.gz"
+            mv "$CIRCLE_WORKING_DIRECTORY/.bin/$SCCACHE_PKG/sccache" "$CIRCLE_WORKING_DIRECTORY/.bin/sccache"
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
+
+      - run:
+          name: Install debian packages
+          command: |
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev libssl-dev
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
       - restore_cache:
           keys:
             - << parameters.cache_key >>
@@ -95,8 +106,9 @@ commands:
         type: string
         default: v3.3.1-rust-1.83.0-snarkos-stable-cache
     steps:
-      - run: (sccache -s||true)
-      - run: set +e
+      - run:
+          name: Show sccache statistics
+          command: $CIRCLE_WORKING_DIRECTORY/.bin/sccache -s
       - save_cache:
           key: << parameters.cache_key >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,9 @@ commands:
             echo 'set -e' >> "$BASH_ENV"
             echo 'export SCCACHE_CACHE_SIZE=200M' >> "$BASH_ENV"
             echo 'export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"' >> "$BASH_ENV"
-            echo 'export RUSTC_WRAPPER="$CIRCLE_WORKING_DIRECTORY/.bin/sccache"' >> "$BASH_ENV"  
+            echo 'export RUSTC_WRAPPER="$CIRCLE_WORKING_DIRECTORY/.bin/sccache"' >> "$BASH_ENV"
+            # Disable incremental builds so that sccache works as expected
+            echo 'export CARGO_INCREMENTAL=0' >> "$BASH_ENV"
 
       - run:
           name: Install sccache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}i
+            - cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
             - cargo-cache-{{ arch }}- # fallback to an older version
       - run:
           name: "Install Rust and run cargo check"
@@ -71,17 +71,28 @@ commands:
         default: v3.3.1-rust-1.88.0-snarkos-stable-cache
     steps:
       - run:
+          name: "Setup GCP"
+          command: |
+            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+            sudo apt-get update
+            sudo apt-get install google-cloud-cli -y
+            echo $GCLOUD_SERVICE_KEY > /home/circleci/gcloud-key.json
+            gcloud auth activate-service-account --key-file=/home/circleci/gcloud-key.json
+            gcloud config set project protocol-development-sandbox
+      - run:
           name: Set environment variables
           command: |
             # CircleCI runs a new shell for every step, so exported variables are lost
             # This workaround is suggested here: https://circleci.com/docs/env-vars/#parameters-and-bash-environment
             echo 'set -e' >> "$BASH_ENV"
-            echo 'export SCCACHE_CACHE_SIZE=1G' >> "$BASH_ENV"
-            echo 'export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"' >> "$BASH_ENV"
+            echo 'export SCCACHE_CACHE_SIZE=10G' >> "$BASH_ENV"
+            echo 'export SCCACHE_GCS_KEY_PATH=/home/circleci/gcloud-key.json' >> "$BASH_ENV"
+            echo 'export SCCACHE_GCS_BUCKET=ci_sccache' >> "$BASH_ENV"
+            echo 'export SCCACHE_GCS_RW_MODE=READ_WRITE' >> "$BASH_ENV"
             echo 'export RUSTC_WRAPPER="$CIRCLE_WORKING_DIRECTORY/.bin/sccache"' >> "$BASH_ENV"
             # Disable incremental builds so that sccache works as expected
             echo 'export CARGO_INCREMENTAL=0' >> "$BASH_ENV"
-
       - run:
           name: Install sccache
           command: |
@@ -94,7 +105,7 @@ commands:
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
 
       - run:
-          name: Install debian packages
+          name: Install Debian packages
           command: |
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev libssl-dev
@@ -128,7 +139,6 @@ commands:
       - save_cache:
           key: << parameters.cache_key >>-{{ checksum "cache-key-suffix" }}
           paths:
-            - .cache/sccache
             - .cargo
 
   clear_environment:
@@ -136,7 +146,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v3.3.1-rust-1.88.0-snarkos-stable-cache
+        default: v4.0.0-rust-1.88.0-snarkos-stable-cache
     steps:
       - run:
           name: Show sccache statistics
@@ -152,6 +162,9 @@ commands:
       flags:
         type: string
         default: ""
+      extra_build_flags:
+        type: string
+        default: ""
     steps:
       - checkout
       - setup_environment:
@@ -159,11 +172,11 @@ commands:
       - run:
           name: Build Tests
           timeout: 15m
-          command: cargo test --package=<< parameters.workspace_member >> --no-run << parameters.flags >>
+          command: cargo test --package=<< parameters.workspace_member >> --locked --no-run << parameters.flags >> << parameters.extra_build_flags >>
       - run:
           name: Run Tests
           timeout: 15m
-          command: cargo test --package=<< parameters.workspace_member >> << parameters.flags >>
+          command: cargo test --package=<< parameters.workspace_member >> --locked << parameters.flags >>
       - clear_environment:
           cache_key: v4.0.0-rust-1.88.0-<< parameters.workspace_member >>-cache
 
@@ -244,6 +257,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkos-node
+          extra_build_flags: "-j2"
 
   node-bft:
     executor: rust-docker
@@ -251,6 +265,7 @@ jobs:
     steps:
       - run_test:
           workspace_member: snarkos-node-bft
+          extra_build_flags: "-j4"
 
   node-bft-events:
     executor: rust-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          keys:
+            - cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}i
+            - cargo-cache-{{ arch }}- # fallback to an older version
       - run:
           name: "Install Rust and run cargo check"
           command: |
@@ -59,7 +61,7 @@ commands:
             - C:\Users\circleci\.cargo\registry
             - C:\Users\circleci\.cargo\git
             - target
-          key: cargo-cache-{{ arch }}-{{ checksum "rust-version" }}-{{ checksum "Cargo.lock" }}
+          key: cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
 
   setup_environment:
     description: "Setup testing environment"
@@ -113,6 +115,7 @@ commands:
       - restore_cache:
           keys:
             - << parameters.cache_key >>-{{ checksum "cache-key-suffix" }}
+            - << parameters.cache_key >>-  # fallback to a different day
 
   store_cache:
     description: "Store the updated cache (once per day)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ commands:
           cache_key:  v3.3.1-rust-1.88.0-<< parameters.cache_key >>-cache
       - run:
           no_output_timeout: 30m
-          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
+          command: cd << parameters.workspace_member >> && cargo test << parameters.flags >>
       - clear_environment:
           cache_key: v3.3.1-rust-1.88.0-<< parameters.cache_key >>-cache
 
@@ -180,7 +180,7 @@ commands:
           cache_key: << parameters.cache_key >>
       - run:
           no_output_timeout: 300m
-          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
+          command: cd << parameters.workspace_member >> && cargo test << parameters.flags >>
       - clear_environment:
           cache_key: << parameters.cache_key >>
 


### PR DESCRIPTION
## Motivation
I noticed a few issues with the CircleCI setups:
- We didn't set the environment variables properly, so sccache seems to not run at all. Maybe CircleCI's behavior changed and this used to work.
- The windows workflows used different keys to load and restore its cache
- We only regenerated the cache for Linux when they expired.

## Proposed Changes
- Set the environment variables for sccache correctly
- Generate a daily cache for all Linux jobs
- Update from sccache 0.3 to 0.10
- Use xlarge for the router tests as they sometimes fail due to lack of memory

## Notes
* While we now get cache hits, compilation still takes some time. I have a bigger PR that aims to share build artifacts using CircleCI workspaces, but this smaller one should be merged first.

* It would be good if we could have the cache files expire quicker, maybe after five days or so. There should be a setting in CircleCI, but I might not have permission to change it.

* I did not change the prefix for the cache keys, but it might still be good to remove the version number, as the keys are getting quite long with this change.

* Windows builds seem to generate a new cache entry whenever the `Cargo.lock` file changes. That might be too infrequent, so opted for daily updates. However, it might make sense to unify the behavior between the two.