### PR TITLE
[Feature] Add sync_status REST endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +570,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "ci_info"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1052,6 +1081,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ed25519"
@@ -1727,6 +1762,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +1906,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3017,6 +3077,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,6 +3354,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,6 +3494,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "schemars",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3831,6 +3954,8 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serde_with",
+ "snarkos-node-cdn",
  "snarkos-node-consensus",
  "snarkos-node-router",
  "snarkvm",
@@ -5910,6 +6035,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,18 @@ default-features = false
 [workspace.dependencies.test-strategy]
 version = "0.4"
 
+[workspace.dependencies.snarkos-node-consensus]
+path = "node/consensus"
+version = "=3.8.0"
+
+[workspace.dependencies.snarkos-node-cdn]
+path = "node/cdn"
+version = "=3.8.0"
+
+[workspace.dependencies.snarkos-node-router]
+path = "./node/router"
+version = "=3.8.0"
+
 [[bin]]
 name = "snarkos"
 path = "snarkos/main.rs"
@@ -142,24 +154,21 @@ path = "./node/bft"
 version = "=3.8.0"
 
 [dependencies.snarkos-node-cdn]
-path = "./node/cdn"
-version = "=3.8.0"
+workspace = true
 
 [dependencies.snarkos-node-consensus]
-path = "./node/consensus"
-version = "=3.8.0"
+workspace = true
 
 [dependencies.snarkos-node-metrics]
 path = "./node/metrics"
 version = "=3.8.0"
 optional = true
 
+[dependencies.snarkos-node-router]
+workspace = true
+
 [dependencies.snarkos-node-rest]
 path = "./node/rest"
-version = "=3.8.0"
-
-[dependencies.snarkos-node-router]
-path = "./node/router"
 version = "=3.8.0"
 
 [dependencies.snarkos-node-sync]

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -42,6 +42,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
+use tokio::{sync::Mutex as TMutex, task::JoinHandle};
 
 /// The number of blocks per file.
 const BLOCKS_PER_FILE: u32 = 50;
@@ -59,49 +60,101 @@ fn update_block_metrics(height: u32) {
     crate::metrics::gauge(crate::metrics::bft::HEIGHT, height as f64);
 }
 
-/// Loads blocks from a CDN into the ledger.
+pub type SyncResult = Result<u32, (u32, anyhow::Error)>;
+
+/// Manages the CDN sync task.
 ///
-/// On success, this function returns the completed block height.
-/// On failure, this function returns the last successful block height (if any), along with the error.
-pub async fn sync_ledger_with_cdn<N: Network, C: ConsensusStorage<N>>(
-    base_url: &str,
-    ledger: Ledger<N, C>,
-    shutdown: Arc<AtomicBool>,
-) -> Result<u32, (u32, anyhow::Error)> {
-    // Fetch the node height.
-    let start_height = ledger.latest_height() + 1;
-    // Load the blocks from the CDN into the ledger.
-    let ledger_clone = ledger.clone();
-    let result = load_blocks(base_url, start_height, None, shutdown, move |block: Block<N>| {
-        ledger_clone.advance_to_next_block(&block)
-    })
-    .await;
+/// This is used, for example, in snarkos_node_rest to query how
+/// far along the CDN sync is.
+pub struct CdnBlockSync {
+    base_url: String,
+    /// The background tasks that performs the sync operation.
+    task: Mutex<Option<JoinHandle<SyncResult>>>,
+    /// This flag will be set to true once the sync task has been successfully awaited.
+    done: AtomicBool,
+}
 
-    // TODO (howardwu): Find a way to resolve integrity failures.
-    // If the sync failed, check the integrity of the ledger.
-    if let Err((completed_height, error)) = &result {
-        warn!("{error}");
+impl CdnBlockSync {
+    /// Spawn a background task that loads blocks from a CDN into the ledger.
+    ///
+    /// On success, this function returns the completed block height.
+    /// On failure, this function returns the last successful block height (if any), along with the error.
+    pub fn new<N: Network, C: ConsensusStorage<N>>(
+        base_url: String,
+        ledger: Ledger<N, C>,
+        shutdown: Arc<AtomicBool>,
+    ) -> Self {
+        let task = {
+            let base_url = base_url.clone();
+            tokio::spawn(async move { Self::worker(base_url, ledger, shutdown).await })
+        };
 
-        // If the sync made any progress, then check the integrity of the ledger.
-        if *completed_height != start_height {
-            debug!("Synced the ledger up to block {completed_height}");
+        Self { done: AtomicBool::new(false), base_url, task: Mutex::new(Some(task)) }
+    }
 
-            // Retrieve the latest height, according to the ledger.
-            let node_height = cow_to_copied!(ledger.vm().block_store().heights().max().unwrap_or_default());
-            // Check the integrity of the latest height.
-            if &node_height != completed_height {
-                return Err((*completed_height, anyhow!("The ledger height does not match the last sync height")));
-            }
+    /// Did the CDN sync finish?
+    ///
+    /// Note: This can only return true if you call wait()
+    pub fn is_done(&self) -> bool {
+        self.done.load(Ordering::SeqCst)
+    }
 
-            // Fetch the latest block from the ledger.
-            if let Err(err) = ledger.get_block(node_height) {
-                return Err((*completed_height, err));
-            }
-        }
+    /// Wait for CDN sync to finish. Can only be called once.
+    pub async fn wait(&self) -> Result<SyncResult> {
+        let Some(hdl) = self.task.lock().take() else {
+            bail!("CDN task was already awaited");
+        };
 
-        Ok(*completed_height)
-    } else {
+        let result = hdl.await.map_err(|err| anyhow!("Failed to wait for CDN task: {err}"));
+        self.done.store(true, Ordering::SeqCst);
         result
+    }
+
+    async fn worker<N: Network, C: ConsensusStorage<N>>(
+        base_url: String,
+        ledger: Ledger<N, C>,
+        shutdown: Arc<AtomicBool>,
+    ) -> SyncResult {
+        // Fetch the node height.
+        let start_height = ledger.latest_height() + 1;
+        // Load the blocks from the CDN into the ledger.
+        let ledger_clone = ledger.clone();
+        let result = load_blocks(&base_url, start_height, None, shutdown, move |block: Block<N>| {
+            ledger_clone.advance_to_next_block(&block)
+        })
+        .await;
+
+        // TODO (howardwu): Find a way to resolve integrity failures.
+        // If the sync failed, check the integrity of the ledger.
+        if let Err((completed_height, error)) = &result {
+            warn!("{error}");
+
+            // If the sync made any progress, then check the integrity of the ledger.
+            if *completed_height != start_height {
+                debug!("Synced the ledger up to block {completed_height}");
+
+                // Retrieve the latest height, according to the ledger.
+                let node_height = cow_to_copied!(ledger.vm().block_store().heights().max().unwrap_or_default());
+                // Check the integrity of the latest height.
+                if &node_height != completed_height {
+                    return Err((*completed_height, anyhow!("The ledger height does not match the last sync height")));
+                }
+
+                // Fetch the latest block from the ledger.
+                if let Err(err) = ledger.get_block(node_height) {
+                    return Err((*completed_height, err));
+                }
+            }
+
+            Ok(*completed_height)
+        } else {
+            result
+        }
+    }
+
+    pub async fn get_cdn_height(&self) -> anyhow::Result<u32> {
+        let client = Client::builder().use_rustls_tls().build()?;
+        cdn_height::<BLOCKS_PER_FILE>(&client, &self.base_url).await
     }
 }
 
@@ -158,7 +211,7 @@ pub async fn load_blocks<N: Network>(
     }
 
     // A collection of downloaded blocks pending insertion into the ledger.
-    let pending_blocks: Arc<Mutex<Vec<Block<N>>>> = Default::default();
+    let pending_blocks: Arc<TMutex<Vec<Block<N>>>> = Default::default();
 
     // Start a timer.
     let timer = Instant::now();
@@ -181,7 +234,7 @@ pub async fn load_blocks<N: Network>(
             std::process::exit(0);
         }
 
-        let mut candidate_blocks = pending_blocks.lock();
+        let mut candidate_blocks = pending_blocks.lock().await;
 
         // Obtain the height of the nearest pending block.
         let Some(next_height) = candidate_blocks.first().map(|b| b.height()) else {
@@ -254,7 +307,7 @@ async fn download_block_bundles<N: Network>(
     base_url: String,
     cdn_start: u32,
     cdn_end: u32,
-    pending_blocks: Arc<Mutex<Vec<Block<N>>>>,
+    pending_blocks: Arc<TMutex<Vec<Block<N>>>>,
     shutdown: Arc<AtomicBool>,
 ) {
     // Keep track of the number of concurrent requests.
@@ -268,7 +321,7 @@ async fn download_block_bundles<N: Network>(
         }
 
         // Avoid collecting too many blocks in order to restrict memory use.
-        let num_pending_blocks = pending_blocks.lock().len();
+        let num_pending_blocks = pending_blocks.lock().await.len();
         if num_pending_blocks >= MAXIMUM_PENDING_BLOCKS as usize {
             debug!("Maximum number of pending blocks reached ({num_pending_blocks}), waiting...");
             tokio::time::sleep(Duration::from_secs(5)).await;
@@ -317,7 +370,7 @@ async fn download_block_bundles<N: Network>(
                     match cdn_get(client_clone.clone(), &blocks_url, &ctx).await {
                         Ok::<Vec<Block<N>>, _>(blocks) => {
                             // Keep the collection of pending blocks sorted by the height.
-                            let mut pending_blocks = pending_blocks_clone.lock();
+                            let mut pending_blocks = pending_blocks_clone.lock().await;
                             for block in blocks {
                                 match pending_blocks.binary_search_by_key(&block.height(), |b| b.height()) {
                                     Ok(_idx) => warn!("Found a duplicate pending block at height {}", block.height()),
@@ -447,10 +500,8 @@ fn log_progress<const OBJECTS_PER_FILE: u32>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        blocks::{BLOCKS_PER_FILE, cdn_height, log_progress},
-        load_blocks,
-    };
+    use super::{BLOCKS_PER_FILE, cdn_height, load_blocks, log_progress};
+
     use snarkvm::prelude::{MainnetV0, block::Block};
 
     use parking_lot::RwLock;

--- a/node/cdn/src/lib.rs
+++ b/node/cdn/src/lib.rs
@@ -22,4 +22,4 @@ extern crate tracing;
 pub use snarkos_node_metrics as metrics;
 
 mod blocks;
-pub use blocks::{load_blocks, sync_ledger_with_cdn};
+pub use blocks::{CdnBlockSync, load_blocks};

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -69,13 +69,17 @@ features = [ "derive" ]
 version = "1"
 features = [ "preserve_order" ]
 
+[dependencies.serde_with]
+version = "3"
+
+[dependencies.snarkos-node-cdn]
+workspace = true
+
 [dependencies.snarkos-node-consensus]
-path = "../consensus"
-version = "=3.8.0"
+workspace = true
 
 [dependencies.snarkos-node-router]
-path = "../router"
-version = "=3.8.0"
+workspace = true
 
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -168,6 +168,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // POST ../solution/broadcast
             .route(&format!("/{network}/solution/broadcast"), post(Self::solution_broadcast))
 
+
             // GET ../find/..
             .route(&format!("/{network}/find/blockHash/{{tx_id}}"), get(Self::find_block_hash))
             .route(&format!("/{network}/find/blockHeight/{{state_root}}"), get(Self::find_block_height_from_state_root))
@@ -186,6 +187,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/program/{{id}}/mapping/{{name}}/{{key}}"), get(Self::get_mapping_value))
 
             // GET misc endpoints.
+            .route(&format!("/{network}/status"), get(Self::get_status))
             .route(&format!("/{network}/blocks"), get(Self::get_blocks))
             .route(&format!("/{network}/height/{{hash}}"), get(Self::get_height))
             .route(&format!("/{network}/memoryPool/transmissions"), get(Self::get_memory_pool_transmissions))

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -23,6 +23,7 @@ pub use helpers::*;
 
 mod routes;
 
+use snarkos_node_cdn::CdnBlockSync;
 use snarkos_node_consensus::Consensus;
 use snarkos_node_router::{
     Routing,
@@ -61,6 +62,8 @@ use tower_http::{
 /// A REST API server for the ledger.
 #[derive(Clone)]
 pub struct Rest<N: Network, C: ConsensusStorage<N>, R: Routing<N>> {
+    /// CDN sync (only if node is using the CDN to sync).
+    cdn_sync: Option<Arc<CdnBlockSync>>,
     /// The consensus module.
     consensus: Option<Consensus<N>>,
     /// The ledger.
@@ -79,9 +82,10 @@ impl<N: Network, C: 'static + ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> 
         consensus: Option<Consensus<N>>,
         ledger: Ledger<N, C>,
         routing: Arc<R>,
+        cdn_sync: Option<Arc<CdnBlockSync>>,
     ) -> Result<Self> {
         // Initialize the server.
-        let mut server = Self { consensus, ledger, routing, handles: Default::default() };
+        let mut server = Self { consensus, ledger, routing, cdn_sync, handles: Default::default() };
         // Spawn the server.
         server.spawn_server(rest_ip, rest_rps).await;
         // Return the server.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -194,7 +194,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/program/{{id}}/mapping/{{name}}/{{key}}"), get(Self::get_mapping_value))
 
             // GET misc endpoints.
-            .route(&format!("/{network}/status"), get(Self::get_status))
+            .route(&format!("/{network}/sync_status"), get(Self::get_sync_status))
             .route(&format!("/{network}/blocks"), get(Self::get_blocks))
             .route(&format!("/{network}/height/{{hash}}"), get(Self::get_height))
             .route(&format!("/{network}/memoryPool/transmissions"), get(Self::get_memory_pool_transmissions))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -42,14 +42,21 @@ pub(crate) struct Metadata {
     all: Option<bool>,
 }
 
-/// The return value for a `status` query.
+/// The return value for a `sync_status` query.
 #[skip_serializing_none]
 #[derive(Copy, Clone, Serialize)]
-struct NodeStatus<'a> {
+struct SyncStatus<'a> {
+    /// Is this node fully synced with the network?
     is_synced: bool,
+    /// The block height of this node.
     ledger_height: u32,
+    /// Which way are we sync'ing (either "cdn" or "p2p")
     sync_mode: &'a str,
+    /// The block height of the CDN (if connected to a CDN).
     cdn_height: Option<u32>,
+    /// The greatest known block height of a peer.
+    /// None, if no peers are connected yet.
+    p2p_height: Option<u32>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
@@ -129,22 +136,28 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     // GET /<network>/status
-    pub(crate) async fn get_status(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
-        // Get the CDN height (if we are connected to a CDN)
-        let cdn_height =
-            if let Some(cdn_sync) = &rest.cdn_sync { Some(cdn_sync.get_cdn_height().await?) } else { None };
+    pub(crate) async fn get_sync_status(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
+        // Get the CDN height (if we are syncing from a CDN)
+        let (cdn_sync, cdn_height) = if let Some(cdn_sync) = &rest.cdn_sync {
+            let done = cdn_sync.is_done();
 
-        // Generate a string representing the current sync mode.
-        let sync_mode = {
-            let is_syncing_from_cdn = rest.cdn_sync.map(|s| !s.is_done()).unwrap_or(false);
-            if is_syncing_from_cdn { "cdn" } else { "p2p" }
+            // do not show CDN height if we are already done syncing from the CDN
+            let cdn_height = if done { None } else { Some(cdn_sync.get_cdn_height().await?) };
+
+            (done, cdn_height)
+        } else {
+            (false, None)
         };
 
-        Ok(ErasedJson::pretty(NodeStatus {
+        // Generate a string representing the current sync mode.
+        let sync_mode = if cdn_sync { "cdn" } else { "p2p" };
+
+        Ok(ErasedJson::pretty(SyncStatus {
             sync_mode,
             cdn_height,
             is_synced: rest.routing.is_block_synced(),
             ledger_height: rest.ledger.latest_height(),
+            p2p_height: rest.routing.greatest_peer_block_height(),
         }))
     }
 

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -41,6 +41,13 @@ pub(crate) struct Metadata {
     all: Option<bool>,
 }
 
+/// The return value for a `status` query.
+#[derive(Copy, Clone, Serialize)]
+struct NodeStatus {
+    is_synced: bool,
+    ledger_height: u32,
+}
+
 impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     // GET /<network>/block/height/latest
     pub(crate) async fn get_block_height_latest(State(rest): State<Self>) -> ErasedJson {
@@ -115,6 +122,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             Ok(json) => json,
             Err(err) => Err(RestError(format!("Failed to get blocks '{start_height}..{end_height}' - {err}"))),
         }
+    }
+
+    // GET /<network>/status
+    pub(crate) async fn get_status(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(NodeStatus {
+            is_synced: rest.routing.is_block_synced(),
+            ledger_height: rest.ledger.latest_height(),
+        }))
     }
 
     // GET /<network>/height/{blockHash}

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -25,6 +25,9 @@ pub trait Outbound<N: Network> {
     /// Returns `true` if the node is synced up to the latest block (within the given tolerance).
     fn is_block_synced(&self) -> bool;
 
+    /// Returns the greatest block height of any connected peer.
+    fn greatest_peer_block_height(&self) -> Option<u32>;
+
     /// Returns the number of blocks this node is behind the greatest peer height.
     fn num_blocks_behind(&self) -> u32;
 

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -171,6 +171,11 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
     fn num_blocks_behind(&self) -> u32 {
         0
     }
+
+    /// Returns the greatest block height of any connected peer.
+    fn greatest_peer_block_height(&self) -> Option<u32> {
+        None
+    }
 }
 
 #[async_trait]

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -64,6 +64,10 @@ impl Outbound<Network> for HeartbeatTest {
         true
     }
 
+    fn greatest_peer_block_height(&self) -> Option<u32> {
+        None
+    }
+
     fn num_blocks_behind(&self) -> u32 {
         0
     }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -19,6 +19,7 @@ use crate::traits::NodeInterface;
 
 use snarkos_account::Account;
 use snarkos_node_bft::{events::DataBlocks, ledger_service::CoreLedgerService};
+use snarkos_node_cdn::CdnBlockSync;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
     Heartbeat,
@@ -146,17 +147,6 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         // Initialize the ledger.
         let ledger = Ledger::<N, C>::load(genesis.clone(), storage_mode.clone())?;
 
-        // Initialize the CDN.
-        if let Some(base_url) = cdn {
-            // Sync the ledger with the CDN.
-            if let Err((_, error)) =
-                snarkos_node_cdn::sync_ledger_with_cdn(&base_url, ledger.clone(), shutdown.clone()).await
-            {
-                crate::log_clean_error(&storage_mode);
-                return Err(error);
-            }
-        }
-
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone(), shutdown.clone()));
         // Determine if the client should allow external peers.
@@ -194,13 +184,28 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             num_verifying_deploys: Default::default(),
             num_verifying_executions: Default::default(),
             handles: Default::default(),
-            shutdown,
+            shutdown: shutdown.clone(),
         };
+
+        // Perform sync with CDN (if enabled).
+        let cdn_sync = cdn.map(|base_url| Arc::new(CdnBlockSync::new(base_url, ledger.clone(), shutdown)));
 
         // Initialize the REST server.
         if let Some(rest_ip) = rest_ip {
-            node.rest = Some(Rest::start(rest_ip, rest_rps, None, ledger.clone(), Arc::new(node.clone())).await?);
+            node.rest = Some(
+                Rest::start(rest_ip, rest_rps, None, ledger.clone(), Arc::new(node.clone()), cdn_sync.clone()).await?,
+            );
         }
+
+        // Set up everythign else after CDN sync is done.
+        if let Some(cdn_sync) = cdn_sync {
+            if let Err(error) = cdn_sync.wait().await {
+                crate::log_clean_error(&storage_mode);
+                node.shut_down().await;
+                return Err(error);
+            }
+        }
+
         // Initialize the routing.
         node.initialize_routing().await;
         // Initialize the sync module.

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -179,6 +179,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
     fn num_blocks_behind(&self) -> u32 {
         self.sync.num_blocks_behind()
     }
+
+    /// Returns the greatest block height of any connected peer.
+    fn greatest_peer_block_height(&self) -> Option<u32> {
+        self.sync.greatest_peer_block_height()
+    }
 }
 
 #[async_trait]

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -137,6 +137,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
     fn num_blocks_behind(&self) -> u32 {
         0
     }
+
+    /// Returns the greatest block height of any connected peer.
+    fn greatest_peer_block_height(&self) -> Option<u32> {
+        None
+    }
 }
 
 #[async_trait]

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -18,6 +18,7 @@ mod router;
 use crate::traits::NodeInterface;
 use snarkos_account::Account;
 use snarkos_node_bft::{ledger_service::CoreLedgerService, spawn_blocking};
+use snarkos_node_cdn::CdnBlockSync;
 use snarkos_node_consensus::Consensus;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
@@ -97,17 +98,6 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         // Initialize the ledger.
         let ledger = Ledger::load(genesis, storage_mode.clone())?;
 
-        // Initialize the CDN.
-        if let Some(base_url) = cdn {
-            // Sync the ledger with the CDN.
-            if let Err((_, error)) =
-                snarkos_node_cdn::sync_ledger_with_cdn(&base_url, ledger.clone(), shutdown.clone()).await
-            {
-                crate::log_clean_error(&storage_mode);
-                return Err(error);
-            }
-        }
-
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), shutdown.clone()));
 
@@ -150,16 +140,39 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             rest: None,
             sync,
             handles: Default::default(),
-            shutdown,
+            shutdown: shutdown.clone(),
         };
-        // Initialize the transaction pool.
-        node.initialize_transaction_pool(storage_mode, dev_txs)?;
+
+        // Perform sync with CDN (if enabled).
+        let cdn_sync = cdn.map(|base_url| Arc::new(CdnBlockSync::new(base_url, ledger.clone(), shutdown)));
 
         // Initialize the REST server.
         if let Some(rest_ip) = rest_ip {
-            node.rest =
-                Some(Rest::start(rest_ip, rest_rps, Some(consensus), ledger.clone(), Arc::new(node.clone())).await?);
+            node.rest = Some(
+                Rest::start(
+                    rest_ip,
+                    rest_rps,
+                    Some(consensus),
+                    ledger.clone(),
+                    Arc::new(node.clone()),
+                    cdn_sync.clone(),
+                )
+                .await?,
+            );
         }
+
+        // Set up everythign else after CDN sync is done.
+        if let Some(cdn_sync) = cdn_sync {
+            if let Err(error) = cdn_sync.wait().await {
+                crate::log_clean_error(&storage_mode);
+                node.shut_down().await;
+                return Err(error);
+            }
+        }
+
+        // Initialize the transaction pool.
+        node.initialize_transaction_pool(storage_mode, dev_txs)?;
+
         // Initialize the routing.
         node.initialize_routing().await;
         // Initialize the notification message loop.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -151,6 +151,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
     fn num_blocks_behind(&self) -> u32 {
         self.sync.num_blocks_behind()
     }
+
+    /// Returns the greatest block height of any connected peer.
+    fn greatest_peer_block_height(&self) -> Option<u32> {
+        self.sync.greatest_peer_block_height()
+    }
 }
 
 #[async_trait]

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -160,6 +160,11 @@ impl<N: Network> BlockSync<N> {
         // TODO(kaimast): return u32::MAX if unknown peer height?
         self.sync_state.read().num_blocks_behind().unwrap_or(0)
     }
+
+    /// Returns the greatest block height of any connected peer.
+    pub fn greatest_peer_block_height(&self) -> Option<u32> {
+        self.sync_state.read().get_greatest_peer_height()
+    }
 }
 
 // Helper functions needed for testing

--- a/node/sync/src/block_sync/sync_state.rs
+++ b/node/sync/src/block_sync/sync_state.rs
@@ -63,6 +63,11 @@ impl SyncState {
         self.greatest_peer_height.map(|peer_height| peer_height.saturating_sub(self.sync_height))
     }
 
+    /// Returns the greatest block height of any connected peer.
+    pub fn get_greatest_peer_height(&self) -> Option<u32> {
+        self.greatest_peer_height
+    }
+
     /// Update the height we are synced to.
     /// If the value is lower than the current height, the sync height remains unchanged.
     pub fn set_sync_height(&mut self, sync_height: u32) {


### PR DESCRIPTION
This adds a `<network>/sync_status` endpoint to the REST API. A call to it will return something like the following:
```json
~> curl http://localhost:3030/mainnet/sync_status
{
  "is_synced": false,
  "ledger_height": 2443,
  "sync_mode": "p2p",
  "cdn_height": 8167950,
}
```

`sync_mode` will switch to `p2p` once the initial sync is done. 

If the node is not connected to a CDN, the `cdn_height` field is omitted.
```json
~> curl http://localhost:3030/mainnet/sync_status
{
  "is_synced": false,
  "ledger_height": 2795,
  "sync_mode": "p2p",
  "p2p_height": 8638987
}
```

p2p height is only added to the response once a peer is connected 