### PR TITLE
Apply a missing locktick counterpart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,6 +3620,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "colored",
+ "locktick",
  "parking_lot",
  "rayon",
  "reqwest 0.11.27",

--- a/node/bft/src/helpers/telemetry.rs
+++ b/node/bft/src/helpers/telemetry.rs
@@ -22,6 +22,9 @@ use snarkvm::{
 };
 
 use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "locktick")]
+use locktick::parking_lot::RwLock;
+#[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use std::sync::Arc;

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [features]
 default = [ "parallel" ]
-locktick = [ "snarkvm/locktick" ]
+locktick = [ "dep:locktick", "snarkvm/locktick" ]
 parallel = [ "rayon" ]
 cuda = [ "snarkvm/cuda" ]
 metrics = [ "dep:snarkos-node-metrics" ]
@@ -31,6 +31,11 @@ version = "1.0"
 
 [dependencies.colored]
 version = "2"
+
+[dependencies.locktick]
+version = "0.3"
+features = [ "parking_lot" ]
+optional = true
 
 [dependencies.parking_lot]
 version = "0.12"

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -29,6 +29,9 @@ use snarkvm::prelude::{
 
 use anyhow::{Result, anyhow, bail};
 use colored::Colorize;
+#[cfg(feature = "locktick")]
+use locktick::parking_lot::Mutex;
+#[cfg(not(feature = "locktick"))]
 use parking_lot::Mutex;
 use reqwest::Client;
 use std::{


### PR DESCRIPTION
Found these while double-checking that the `locktick` feature is applied in all relevant places in snarkVM (https://github.com/ProvableHQ/snarkVM/pull/2768).