### PR TITLE
Reduce stale transmissions

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -518,11 +518,15 @@ impl<N: Network> Primary<N> {
             while let Some((id, transmission)) = worker.remove_front() {
                 // Check the selected transmissions are below the batch limit.
                 if transmissions.len() >= BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH {
+                    // Reinsert the transmission into the worker.
+                    worker.insert_front(id, transmission);
                     break 'outer;
                 }
 
                 // Check the max transmissions per worker is not exceeded.
                 if num_worker_transmissions >= Worker::<N>::MAX_TRANSMISSIONS_PER_WORKER {
+                    // Reinsert the transmission into the worker.
+                    worker.insert_front(id, transmission);
                     continue 'outer;
                 }
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/ProvableHQ/snarkOS/issues/3514

Also fixes a potential bug introduced by https://github.com/ProvableHQ/snarkOS/pull/3471 where transmissions surpassing `MAX_TRANSMISSIONS_PER_BATCH` or `MAX_TRANSMISSIONS_PER_WORKER` may be dropped needlessly.

## Test Plan

- [x] Run test network and observe stale transmissions - https://aleostresstest.grafana.net/d/single-region-tests-kp/single-region-tests-kp?from=2025-06-23T14:59:52.748Z&to=2025-06-23T16:48:31.155Z&refresh=5s&timezone=browser&orgId=1
