### PR TITLE
[Chore] Update snarkVM and other dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -271,7 +271,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -293,7 +293,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -388,7 +388,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.103",
 ]
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 dependencies = [
  "git2",
 ]
@@ -514,6 +514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +547,12 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ci_info"
@@ -578,7 +593,6 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -587,7 +601,7 @@ version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.103",
@@ -616,6 +630,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,7 +652,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -639,6 +667,15 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -730,15 +767,33 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.9.1",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "mio",
  "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.0.7",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -827,6 +882,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote 1.0.40",
+ "strsim",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +964,27 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.103",
@@ -1042,12 +1153,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1251,7 +1362,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1331,25 +1442,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.9.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
@@ -1416,12 +1508,6 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.3.1",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1534,7 +1620,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1557,7 +1642,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1571,20 +1656,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -1592,11 +1663,12 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.27",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1647,7 +1719,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -1741,6 +1813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,7 +1870,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -1801,6 +1879,19 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "ipnet"
@@ -1862,6 +1953,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,9 +2025,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
@@ -2053,6 +2162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,15 +2197,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "metrics"
@@ -2169,23 +2275,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -2242,15 +2337,14 @@ checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "cfg-if",
+ "cfg_aliases",
  "libc",
- "memoffset",
- "pin-utils",
 ]
 
 [[package]]
@@ -2691,11 +2785,66 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.23.1"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2715,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -2799,21 +2948,23 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.9.1",
  "cassowary",
- "crossterm",
+ "compact_str",
+ "crossterm 0.28.1",
  "indoc",
- "itertools 0.12.1",
+ "instability",
+ "itertools 0.13.0",
  "lru",
  "paste",
- "stability",
  "strum",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2911,50 +3062,6 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
@@ -2965,12 +3072,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -2979,13 +3086,16 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2993,6 +3103,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -3032,6 +3143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,38 +3185,17 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3108,17 +3204,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3193,16 +3280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,16 +3315,16 @@ dependencies = [
 
 [[package]]
 name = "self_update"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5"
+checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
 dependencies = [
  "hyper 1.6.0",
  "indicatif",
  "log",
  "quick-xml",
  "regex",
- "reqwest 0.12.20",
+ "reqwest",
  "self-replace",
  "semver",
  "serde_json",
@@ -3381,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio",
  "signal-hook",
 ]
 
@@ -3439,12 +3516,9 @@ checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -3506,7 +3580,7 @@ dependencies = [
  "base64ct",
  "clap",
  "colored",
- "crossterm",
+ "crossterm 0.29.0",
  "indexmap 2.9.0",
  "locktick",
  "nix",
@@ -3541,7 +3615,7 @@ name = "snarkos-display"
 version = "3.8.0"
 dependencies = [
  "anyhow",
- "crossterm",
+ "crossterm 0.29.0",
  "ratatui",
  "snarkos-node",
  "snarkvm",
@@ -3623,7 +3697,7 @@ dependencies = [
  "snarkos-node-sync",
  "snarkos-node-tcp",
  "snarkvm",
- "test-strategy",
+ "test-strategy 0.4.1",
  "time",
  "tokio",
  "tokio-stream",
@@ -3645,7 +3719,7 @@ dependencies = [
  "serde",
  "snarkos-node-sync-locators",
  "snarkvm",
- "test-strategy",
+ "test-strategy 0.4.1",
  "time",
  "tokio-util",
  "tracing",
@@ -3692,7 +3766,7 @@ dependencies = [
  "locktick",
  "parking_lot",
  "rayon",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "snarkos-node-metrics",
@@ -3811,7 +3885,7 @@ dependencies = [
  "snarkos-node-bft-events",
  "snarkos-node-sync-locators",
  "snarkvm",
- "test-strategy",
+ "test-strategy 0.4.1",
  "tokio-util",
  "tracing",
 ]
@@ -3822,7 +3896,7 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3873,16 +3947,13 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anstyle",
  "anyhow",
- "clap",
- "colored",
  "dotenvy",
  "num-format",
  "rand 0.8.5",
- "self_update",
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -3892,7 +3963,6 @@ dependencies = [
  "snarkvm-parameters",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.12",
  "ureq 3.0.12",
  "walkdir",
 ]
@@ -3900,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3929,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "blst",
  "cc",
@@ -3940,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3954,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -3964,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3974,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3984,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "indexmap 2.9.0",
  "itertools 0.11.0",
@@ -4003,12 +4073,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4019,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4033,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4048,7 +4118,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4061,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4070,7 +4140,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4080,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4092,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4104,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4115,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4127,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4140,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4151,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4164,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4175,7 +4245,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -4195,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4213,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4234,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4249,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4260,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4268,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4278,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4289,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4300,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4311,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4322,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4336,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4353,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4380,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4392,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4412,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -4425,13 +4495,13 @@ dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-narwhal-batch-header",
  "snarkvm-metrics",
- "test-strategy",
+ "test-strategy 0.3.1",
 ]
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4444,7 +4514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4457,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4470,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4481,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4496,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4509,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4518,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4538,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4560,11 +4630,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "async-trait",
  "http 1.3.1",
- "reqwest 0.12.20",
+ "reqwest",
  "snarkvm-console",
  "snarkvm-ledger-store",
  "snarkvm-synthesizer-program",
@@ -4574,7 +4644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4602,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4619,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "metrics",
 ]
@@ -4627,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4650,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4683,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4709,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "indexmap 2.9.0",
  "paste",
@@ -4724,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4737,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4758,7 +4828,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=323d30cd3#323d30cd312918b489c4750c7a50ae747ee6a5f4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -4805,20 +4875,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "stability"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
-dependencies = [
- "quote 1.0.40",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4834,7 +4900,19 @@ checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "structmeta-derive",
+ "structmeta-derive 0.2.0",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "structmeta-derive 0.3.0",
  "syn 2.0.103",
 ]
 
@@ -4850,21 +4928,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.25.0"
+name = "structmeta-derive"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote 1.0.40",
  "rustversion",
@@ -4912,12 +5001,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4957,34 +5040,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5024,7 +5086,19 @@ checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "structmeta",
+ "structmeta 0.2.0",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95eb2d223f5cd3ec8dd7874cf4ada95c9cf2b5ed84ecfb1046d9aefee0c28b12"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "structmeta 0.3.0",
  "syn 2.0.103",
 ]
 
@@ -5180,7 +5254,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.4",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -5212,21 +5286,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.27",
+ "rustls",
  "tokio",
 ]
 
@@ -5326,7 +5390,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5403,9 +5467,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -5519,6 +5583,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5526,9 +5601,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -5552,7 +5627,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.27",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5777,24 +5852,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5879,15 +5948,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5905,18 +5965,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5953,12 +6007,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5971,12 +6019,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5986,12 +6028,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6019,12 +6055,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6034,12 +6064,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6055,12 +6079,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6070,12 +6088,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6096,16 +6108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6149,18 +6151,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ version = "0.22"
 
 [workspace.dependencies.tokio]
 version = "1.28"
-default-features = false
 
 [workspace.dependencies.itertools]
 version = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,15 +46,41 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "323d30cd3"
+rev = "c194f3e"
 #version = "=3.8.0"
-features = [ "circuit", "console", "rocks" ]
+default-features = false
+#features = [ "circuit", "console", "rocks" ]
+
+[workspace.dependencies.anyhow]
+version = "1.0"
+
+[workspace.dependencies.clap]
+version = "4.4"
+default-features = false
+features = [ "std" ]
+
+[workspace.dependencies.crossterm]
+version = "0.29"
 
 [workspace.dependencies.proptest]
 version = "=1.6.0" # Remove this once we upgrade to rand 0.9
 
 [workspace.dependencies.base64]
 version = "0.22"
+
+[workspace.dependencies.tokio]
+version = "1.28"
+default-features = false
+
+[workspace.dependencies.itertools]
+version = "0.14"
+
+[workspace.dependencies.indexmap]
+version = "2"
+default-features = false
+
+[workspace.dependencies.test-strategy]
+version = "0.4"
 
 [[bin]]
 name = "snarkos"
@@ -90,10 +116,10 @@ locktick = [
 test_network = [ "snarkos-cli/test_network" ]
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.clap]
-version = "4.4"
+workspace = true
 features = [ "derive" ]
 
 [dependencies.locktick]
@@ -156,7 +182,7 @@ optional = true
 version = "0.11.2"
 
 [build-dependencies.built]
-version = "0.7"
+version = "0.8"
 features = [ "git2" ]
 
 [build-dependencies.toml]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,23 +44,23 @@ workspace = true
 version = "1"
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.base64]
 workspace = true
 
 [dependencies.clap]
-version = "4.4"
+workspace = true
 features = [ "derive", "color", "unstable-styles" ]
 
 [dependencies.colored]
 version = "2"
 
 [dependencies.crossterm]
-version = "0.27"
+workspace = true
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
@@ -92,7 +92,7 @@ default-features = false
 version = "1"
 
 [dependencies.self_update]
-version = "0.41"
+version = "0.42"
 features = [ "archive-zip", "compression-zip-deflate" ]
 
 [dependencies.serde]
@@ -124,6 +124,7 @@ version = "=3.8.0"
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "parameters", "circuit", "package" ]
 
 [dependencies.sys-info]
 version = "0.9"
@@ -138,7 +139,7 @@ version = "0.3"
 version = "2.0.11"
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "rt" ]
 
 [dependencies.tracing]
@@ -161,7 +162,9 @@ features = [ "derive" ]
 version = "=1.7"
 
 [target."cfg(target_family = \"unix\")".dependencies.nix]
-version = "0.26"
+version = "0.30"
+default-features = false
+features = [ "resource" ]
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/display/Cargo.toml
+++ b/display/Cargo.toml
@@ -17,13 +17,13 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.crossterm]
-version = "0.27"
+workspace = true
 
 [dependencies.ratatui]
-version = "0.25"
+version = "0.29"
 
 [dependencies.snarkos-node]
 path = "../node"
@@ -33,5 +33,5 @@ version = "=3.8.0"
 workspace = true
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "rt" ]

--- a/display/src/lib.rs
+++ b/display/src/lib.rs
@@ -136,14 +136,14 @@ impl<N: Network> Display<N> {
             .margin(1)
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
-            .split(f.size());
+            .split(f.area());
 
         /* Tabs */
 
         // Initialize the tabs.
         let block = Block::default().style(Style::default().bg(Color::Black).fg(Color::White));
-        f.render_widget(block, f.size());
-        let titles = self
+        f.render_widget(block, f.area());
+        let titles: Vec<_> = self
             .tabs
             .titles
             .iter()

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -54,7 +54,7 @@ cuda = [
 workspace = true
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.async-trait]
 version = "0.1"
@@ -130,7 +130,7 @@ workspace = true
 version = "0.3"
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "rt", "signal" ]
 
 [dependencies.tokio-util]

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -49,7 +49,7 @@ test = [
 workspace = true
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.async-recursion]
 version = "1.0"
@@ -68,7 +68,7 @@ version = "0.3.30"
 features = [ "thread-pool" ]
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
@@ -126,12 +126,13 @@ version = "=3.8.0"
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "utilities" ]
 
 [dependencies.time]
 version = "0.3"
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "macros", "rt-multi-thread", "signal" ]
 
 [dependencies.tokio-stream]
@@ -153,7 +154,8 @@ default-features = false
 features = [ "erased-json" ]
 
 [dev-dependencies.clap]
-version = "4.4"
+workspace = true
+features = [ "derive" ]
 
 [dev-dependencies.deadline]
 version = "0.2"
@@ -187,7 +189,7 @@ path = "."
 features = [ "test" ]
 
 [dev-dependencies.test-strategy]
-version = "0.3.1"
+workspace = true
 
 [dev-dependencies.tower-http]
 version = "0.6"

--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -21,13 +21,13 @@ default = [ ]
 metrics = [ "snarkvm/metrics" ]
 
 [dependencies.anyhow]
-version = "1.0"
+workspace = true
 
 [dependencies.bytes]
 version = "1"
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.serde]
@@ -39,6 +39,7 @@ version = "=3.8.0"
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "ledger", "utilities" ]
 
 [dependencies.tokio-util]
 version = "0.7"
@@ -55,7 +56,7 @@ workspace = true
 features = [ "test-helpers" ]
 
 [dev-dependencies.test-strategy]
-version = "0.3.1"
+workspace = true
 
 [dev-dependencies.time]
 version = "0.3"

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -29,13 +29,13 @@ test = [ "mock", "translucent" ]
 translucent = [ "ledger" ]
 
 [dependencies.anyhow]
-version = "1.0"
+workspace = true
 
 [dependencies.async-trait]
 version = "0.1"
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
@@ -63,9 +63,10 @@ optional = true
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "console", "ledger", "synthesizer" ]
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "macros", "rt-multi-thread" ]
 optional = true
 

--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -27,10 +27,10 @@ test = [ "memory" ]
 workspace = true
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
@@ -47,6 +47,7 @@ optional = true
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "ledger", "console", "rocks" ]
 
 [dependencies.tracing]
 version = "0.1"

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -24,7 +24,7 @@ cuda = [ "snarkvm/cuda" ]
 metrics = [ "dep:snarkos-node-metrics" ]
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.bincode]
 version = "1.0"
@@ -51,7 +51,7 @@ version = "1"
 optional = true
 
 [dependencies.reqwest]
-version = "0.11"
+version = "0.12"
 features = [ "rustls-tls" ]
 
 [dependencies.serde]
@@ -63,17 +63,17 @@ features = [ "preserve_order" ]
 
 [dependencies.snarkvm]
 workspace = true
-features = [ "synthesizer" ]
+features = [ "console", "ledger" ]
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "rt" ]
 
 [dependencies.tracing]
 version = "0.1"
 
 [dev-dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "rt", "rt-multi-thread" ]
 
 [dev-dependencies.tokio-test]

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -33,13 +33,13 @@ cuda = [ "snarkvm/cuda", "snarkos-account/cuda", "snarkos-node-bft-ledger-servic
 workspace = true
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.colored]
 version = "2"
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
@@ -87,14 +87,14 @@ version = "=3.8.0"
 workspace = true
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "macros", "rt-multi-thread", "signal" ]
 
 [dependencies.tracing]
 version = "0.1"
 
 [dev-dependencies.indexmap]
-version = "2.0"
+workspace = true
 
 [dev-dependencies.itertools]
 version = "0.12"

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -30,7 +30,7 @@ locktick = [
 ]
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.axum]
 version = "0.8"
@@ -43,7 +43,7 @@ features = [ "erased-json", "typed-header" ]
 version = "1.0"
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.jsonwebtoken]
@@ -80,7 +80,7 @@ version = "=3.8.0"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "323d30cd3"
+rev = "c194f3e"
 #version = "=3.8.0"
 default-features = false
 optional = true
@@ -99,7 +99,7 @@ workspace = true
 version = "0.3"
 
 [dependencies.tokio]
-version = "1"
+workspace = true
 
 [dependencies.tower_governor]
 version = "0.7"

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -23,7 +23,7 @@ metrics = [ "dep:metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda" ]
 
 [dependencies.anyhow]
-version = "1.0.79"
+workspace = true
 
 [dependencies.async-trait]
 version = "0.1"
@@ -87,7 +87,7 @@ workspace = true
 version = "0.3"
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [
   "io-util",
   "macros",

--- a/node/router/messages/Cargo.toml
+++ b/node/router/messages/Cargo.toml
@@ -56,4 +56,4 @@ features = [ "algorithms", "test-helpers" ]
 workspace = true
 
 [dev-dependencies.test-strategy]
-version = "0.3.1"
+workspace = true

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -29,14 +29,14 @@ cuda = [ "snarkvm/cuda", "snarkos-node-bft-ledger-service/cuda", "snarkos-node-r
 test = [ "snarkos-node-sync-locators/test" ]
 
 [dependencies.anyhow]
-version = "1.0"
+workspace = true
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.itertools]
-version = "0.12"
+workspace = true
 
 [dependencies.locktick]
 version = "0.3"

--- a/node/sync/communication-service/Cargo.toml
+++ b/node/sync/communication-service/Cargo.toml
@@ -20,5 +20,5 @@ edition = "2021"
 version = "0.1"
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "sync" ]

--- a/node/sync/locators/Cargo.toml
+++ b/node/sync/locators/Cargo.toml
@@ -21,10 +21,10 @@ default = [ ]
 test = [ ]
 
 [dependencies.anyhow]
-version = "1.0"
+workspace = true
 
 [dependencies.indexmap]
-version = "2.1"
+workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.serde]
@@ -32,6 +32,7 @@ version = "1"
 
 [dependencies.snarkvm]
 workspace = true
+features = [ "console" ]
 
 [dependencies.tracing]
 version = "0.1"

--- a/node/tcp/Cargo.toml
+++ b/node/tcp/Cargo.toml
@@ -46,7 +46,7 @@ version = "1"
 features = [ "parking_lot" ]
 
 [dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "io-util", "net", "parking_lot", "rt", "sync", "time" ]
 
 [dependencies.tokio-util]
@@ -58,5 +58,5 @@ version = "0.1"
 default-features = false
 
 [dev-dependencies.tokio]
-version = "1.28"
+workspace = true
 features = [ "macros" ]


### PR DESCRIPTION
## Motivation
Shrink dependency tree and disable unneeded features to reduce build times and binary sizes.

## Changes
* Updates to a newer snarkVM rev that allows building without default features
* Makes tokio a workspace dependency also disables default features for it
* Various minor dependency updates (crossterm, itertools, ratatui, ...)