### PR TITLE
Log tx type of unconfirmed txs

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -433,7 +433,13 @@ impl<N: Network> Consensus<N> {
         // Iterate over the transactions.
         for transaction in transactions.into_iter() {
             let transaction_id = transaction.id();
-            trace!("Adding unconfirmed transaction '{}' to the memory pool...", fmt_id(transaction_id));
+            // Determine the type of the transaction. The fee type is technically not possible here.
+            let tx_type_str = match transaction {
+                Transaction::Deploy(..) => "deployment",
+                Transaction::Execute(..) => "execution",
+                Transaction::Fee(..) => "fee",
+            };
+            trace!("Adding unconfirmed {tx_type_str} transaction '{}' to the memory pool...", fmt_id(transaction_id));
             // Send the unconfirmed transaction to the primary.
             if let Err(e) =
                 self.primary_sender.send_unconfirmed_transaction(transaction_id, Data::Object(transaction)).await
@@ -441,7 +447,7 @@ impl<N: Network> Consensus<N> {
                 // If the BFT is synced, then log the warning.
                 if self.bft.is_synced() {
                     warn!(
-                        "Failed to add unconfirmed transaction '{}' to the memory pool - {e}",
+                        "Failed to add unconfirmed {tx_type_str} transaction '{}' to the memory pool - {e}",
                         fmt_id(transaction_id)
                     );
                 }


### PR DESCRIPTION
## Motivation

This helps debugging when transactions fail to land.

I'm not aware of any services which depend on the specific format of these logs at the moment. We have some outdated transaction propagation tracking which may need a minor rewrite, but we didn't touch that in a while anyway.