### PR TITLE
[Fix] Enable help feature for clap and test for it

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ workspace = true
 
 [dependencies.clap]
 workspace = true
-features = [ "derive", "color", "unstable-styles" ]
+features = [ "derive", "color", "unstable-styles", "help" ]
 
 [dependencies.colored]
 version = "2"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -20,6 +20,8 @@
 extern crate thiserror;
 
 pub mod commands;
+pub use commands::CLI;
+
 pub mod helpers;
 
 use anyhow::Result;

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{Parser, error::ErrorKind};
+
+use snarkos_cli::CLI;
+
+#[test]
+fn pass_help_argument() {
+    // Test for top level...
+    let result = CLI::try_parse_from(["snarkos", "--help"]);
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+
+    // ...and for sub commands
+    let result = CLI::try_parse_from(["snarkos", "account", "-h"]);
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+
+    let result = CLI::try_parse_from(["snarkos", "account", "--help"]);
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
+}
+
+#[test]
+fn pass_valid_command() {
+    let result = CLI::try_parse_from(["snarkos", "start"]);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn pass_invalid_command() {
+    let result = CLI::try_parse_from(["snarkos", "bisect"]);
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidSubcommand);
+}


### PR DESCRIPTION
A recent PR (#3687) broke the `--help` command because it disabled the `help` feature on `clap.

This PR fixes that and also adds a few simple end-to-end tests for the CLI.
