### PR TITLE
Use correct CDN link for record scanning command

### DIFF
--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -15,7 +15,7 @@
 
 #![allow(clippy::type_complexity)]
 
-use crate::commands::CDN_BASE_URL;
+use snarkos_node_cdn::CDN_BASE_URL;
 use snarkvm::{
     console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     prelude::{Ciphertext, Field, FromBytes, Plaintext, PrivateKey, Record, ViewKey, block::Block},
@@ -177,9 +177,9 @@ impl Scan {
     /// Returns the CDN to prefetch initial blocks from, from the given configurations.
     fn parse_cdn<N: Network>() -> Result<String> {
         match N::ID {
-            MainnetV0::ID => Ok(format!("{CDN_BASE_URL}/v0/blocks/mainnet")),
-            TestnetV0::ID => Ok(format!("{CDN_BASE_URL}/v0/blocks/testnet")),
-            CanaryV0::ID => Ok(format!("{CDN_BASE_URL}/v0/blocks/canary")),
+            MainnetV0::ID => Ok(format!("{CDN_BASE_URL}/mainnet")),
+            TestnetV0::ID => Ok(format!("{CDN_BASE_URL}/testnet")),
+            CanaryV0::ID => Ok(format!("{CDN_BASE_URL}/canary")),
             _ => bail!("Unknown network ID ({})", N::ID),
         }
     }

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -305,7 +305,7 @@ impl Scan {
 
         // Scan the blocks via the CDN.
         rt.block_on(async move {
-            let _ = snarkos_node_cdn::load_blocks(
+            let result = snarkos_node_cdn::load_blocks(
                 &cdn,
                 cdn_request_start,
                 Some(cdn_request_end),
@@ -336,6 +336,9 @@ impl Scan {
                 },
             )
             .await;
+            if let Err(error) = result {
+                eprintln!("Error loading blocks from CDN - (height, error):{error:?}");
+            }
         });
 
         Ok(())

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -177,9 +177,9 @@ impl Scan {
     /// Returns the CDN to prefetch initial blocks from, from the given configurations.
     fn parse_cdn<N: Network>() -> Result<String> {
         match N::ID {
-            MainnetV0::ID => Ok(format!("{CDN_BASE_URL}/mainnet/v0")),
-            TestnetV0::ID => Ok(format!("{CDN_BASE_URL}/testnet/v0")),
-            CanaryV0::ID => Ok(format!("{CDN_BASE_URL}/canary/v0")),
+            MainnetV0::ID => Ok(format!("{CDN_BASE_URL}/v0/blocks/mainnet")),
+            TestnetV0::ID => Ok(format!("{CDN_BASE_URL}/v0/blocks/testnet")),
+            CanaryV0::ID => Ok(format!("{CDN_BASE_URL}/v0/blocks/canary")),
             _ => bail!("Unknown network ID ({})", N::ID),
         }
     }

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -16,6 +16,7 @@
 use snarkos_account::Account;
 use snarkos_display::Display;
 use snarkos_node::{Node, bft::MEMORY_POOL_PORT, router::messages::NodeType};
+use snarkos_node_cdn::CDN_BASE_URL;
 use snarkvm::{
     console::{
         account::{Address, PrivateKey},
@@ -59,9 +60,6 @@ const DEVELOPMENT_MODE_RNG_SEED: u64 = 1234567890u64;
 
 /// The development mode number of genesis committee members.
 const DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS: u16 = 4;
-
-/// The CDN base url.
-pub(crate) const CDN_BASE_URL: &str = "https://cdn.provable.com";
 
 /// A mapping of `staker_address` to `(validator_address, withdrawal_address, amount)`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -301,9 +299,9 @@ impl Start {
                 },
                 // If no CDN URL is provided, determine the CDN URL based on the network ID.
                 None => match N::ID {
-                    MainnetV0::ID => Some(format!("{CDN_BASE_URL}/v0/blocks/mainnet")),
-                    TestnetV0::ID => Some(format!("{CDN_BASE_URL}/v0/blocks/testnet")),
-                    CanaryV0::ID => Some(format!("{CDN_BASE_URL}/v0/blocks/canary")),
+                    MainnetV0::ID => Some(format!("{CDN_BASE_URL}/mainnet")),
+                    TestnetV0::ID => Some(format!("{CDN_BASE_URL}/testnet")),
+                    CanaryV0::ID => Some(format!("{CDN_BASE_URL}/canary")),
                     _ => None,
                 },
             }

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -52,6 +52,9 @@ const MAXIMUM_PENDING_BLOCKS: u32 = BLOCKS_PER_FILE * CONCURRENT_REQUESTS * 2;
 /// Maximum number of attempts for a request to the CDN.
 const MAXIMUM_REQUEST_ATTEMPTS: u8 = 10;
 
+/// The CDN base url.
+pub const CDN_BASE_URL: &str = "https://cdn.provable.com/v0/blocks";
+
 /// Updates the metrics during CDN sync.
 #[cfg(feature = "metrics")]
 fn update_block_metrics(height: u32) {
@@ -448,7 +451,7 @@ fn log_progress<const OBJECTS_PER_FILE: u32>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        blocks::{BLOCKS_PER_FILE, cdn_height, log_progress},
+        blocks::{BLOCKS_PER_FILE, CDN_BASE_URL, cdn_height, log_progress},
         load_blocks,
     };
     use snarkvm::prelude::{MainnetV0, block::Block};
@@ -458,8 +461,6 @@ mod tests {
 
     type CurrentNetwork = MainnetV0;
 
-    const TEST_BASE_URL: &str = "https://cdn.provable.com/v0/blocks/mainnet";
-
     fn check_load_blocks(start: u32, end: Option<u32>, expected: usize) {
         let blocks = Arc::new(RwLock::new(Vec::new()));
         let blocks_clone = blocks.clone();
@@ -468,9 +469,12 @@ mod tests {
             Ok(())
         };
 
+        let testnet_cdn_url = format!("{CDN_BASE_URL}/mainnet");
+
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let completed_height = load_blocks(TEST_BASE_URL, start, end, Default::default(), process).await.unwrap();
+            let completed_height =
+                load_blocks(&testnet_cdn_url, start, end, Default::default(), process).await.unwrap();
             assert_eq!(blocks.read().len(), expected);
             if expected > 0 {
                 assert_eq!(blocks.read().last().unwrap().height(), completed_height);
@@ -514,8 +518,9 @@ mod tests {
     fn test_cdn_height() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let client = reqwest::Client::builder().use_rustls_tls().build().unwrap();
+        let testnet_cdn_url = format!("{CDN_BASE_URL}/mainnet");
         rt.block_on(async {
-            let height = cdn_height::<BLOCKS_PER_FILE>(&client, TEST_BASE_URL).await.unwrap();
+            let height = cdn_height::<BLOCKS_PER_FILE>(&client, &testnet_cdn_url).await.unwrap();
             assert!(height > 0);
         });
     }

--- a/node/cdn/src/lib.rs
+++ b/node/cdn/src/lib.rs
@@ -22,4 +22,4 @@ extern crate tracing;
 pub use snarkos_node_metrics as metrics;
 
 mod blocks;
-pub use blocks::{load_blocks, sync_ledger_with_cdn};
+pub use blocks::{CDN_BASE_URL, load_blocks, sync_ledger_with_cdn};


### PR DESCRIPTION
## Motivation

The record scanning command used an outdated CDN link.

## Test Plan

- [x] Tested by manually running record scanning for a few minutes.
- [x] DRY up the base URL so we re-use it directly in one of the existing tests.