### PR TITLE
[Optimize] Reduce Network Distribution of Invalid Solutions

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -297,6 +297,16 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             bail!("Invalid solution - expected {solution_id}, found {}", solution.id());
         }
 
+        // Check if the prover has reached their solution limit.
+        // While snarkVM will ultimately abort any excess solutions for safety, performing this check
+        // here prevents the to-be aborted solutions from propagating through the network.
+        let prover_address = solution.address();
+        if self.ledger.is_solution_limit_reached(&prover_address, 0) {
+            bail!(
+                "Invalid Solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch",
+                fmt_id(solution.id())
+            );
+        }
         // Compute the current epoch hash.
         let epoch_hash = self.ledger.latest_epoch_hash()?;
         // Retrieve the current proof target.

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -445,7 +445,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 // here prevents the to-be aborted solutions from propagating through the network.
                 let prover_address = solution.address();
                 if rest.ledger.is_solution_limit_reached(&prover_address, 0) {
-                    return Err(RestError(format!("Invalid solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch", fmt_id(solution.id()))));
+                    return Err(RestError(format!(
+                        "Invalid solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch",
+                        fmt_id(solution.id())
+                    )));
                 }
                 // Verify the solution in a blocking task.
                 match tokio::task::spawn_blocking(move || puzzle.check_solution(&solution, epoch_hash, proof_target))

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -18,7 +18,7 @@ mod router;
 use crate::traits::NodeInterface;
 
 use snarkos_account::Account;
-use snarkos_node_bft::{events::DataBlocks, ledger_service::CoreLedgerService};
+use snarkos_node_bft::{events::DataBlocks, helpers::fmt_id, ledger_service::CoreLedgerService};
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
     Heartbeat,
@@ -368,6 +368,13 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     tokio::task::spawn_blocking(move || {
                         // Retrieve the latest epoch hash.
                         if let Ok(epoch_hash) = _node.ledger.latest_epoch_hash() {
+                            // Check if the prover has reached their solution limit.
+                            // While snarkVM will ultimately abort any excess solutions for safety, performing this check
+                            // here prevents the to-be aborted solutions from propagating through the network.
+                            let prover_address = solution.address();
+                            if _node.ledger.is_solution_limit_reached(&prover_address, 0) {
+                                debug!("Invalid Solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch", fmt_id(solution.id()));
+                            }
                             // Retrieve the latest proof target.
                             let proof_target = _node.ledger.latest_block().header().proof_target();
                             // Ensure that the solution is valid for the given epoch.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR reduces the potential number of solutions send around on the network. This is not needed from a safety perspective, because snarkVM has the final underlying check to abort solutions that exceed the ARC-0046 limit.

If a prover has already reached his solution limit according to ARC-0046, then there is no need to further verify and broadcast subsequent solutions from that prover. This will reduce the number of solutions that land in subdags (if we already know the solution will be aborted). The tradeoff is that there may be more solution error logs seen from the node operators due to this new condition.
