### PR TITLE
[Feature] Process transactions based on the priority fee

### DIFF
--- a/node/bft/src/helpers/mod.rs
+++ b/node/bft/src/helpers/mod.rs
@@ -37,6 +37,9 @@ pub use proposal_cache::*;
 pub mod ready;
 pub use ready::*;
 
+pub mod ready_priority;
+pub use ready_priority::*;
+
 pub mod resolver;
 pub use resolver::*;
 

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -22,7 +22,6 @@ use snarkvm::{
     },
 };
 
-use indexmap::{IndexMap, IndexSet};
 use std::collections::{HashMap, VecDeque, hash_map::Entry::Vacant};
 
 /// Maintains a queue of verified ("ready") transmissions.
@@ -77,13 +76,13 @@ impl<N: Network> Ready<N> {
     }
 
     /// Returns the transmission IDs in the ready queue.
-    pub fn transmission_ids(&self) -> IndexSet<TransmissionID<N>> {
-        self.transmission_ids.keys().copied().collect()
+    pub fn transmission_ids(&self) -> impl Iterator<Item = &TransmissionID<N>> {
+        self.transmission_ids.keys()
     }
 
     /// Returns the transmissions in the ready queue.
-    pub fn transmissions(&self) -> IndexMap<TransmissionID<N>, Transmission<N>> {
-        self.transmissions.iter().cloned().collect()
+    pub fn transmissions(&self) -> impl Iterator<Item = (&TransmissionID<N>, &Transmission<N>)> {
+        self.transmissions.iter().map(|(id, transmission)| (id, transmission))
     }
 
     /// Returns the solutions in the ready queue.
@@ -196,6 +195,7 @@ mod tests {
     use snarkvm::{ledger::narwhal::Data, prelude::Field};
 
     use ::bytes::Bytes;
+    use indexmap::IndexSet;
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
@@ -238,7 +238,7 @@ mod tests {
 
         // Check the transmission IDs.
         let transmission_ids = vec![solution_id_1, solution_id_2, solution_id_3].into_iter().collect::<IndexSet<_>>();
-        assert_eq!(ready.transmission_ids(), transmission_ids);
+        assert_eq!(ready.transmission_ids().copied().collect::<IndexSet<_>>(), transmission_ids);
         transmission_ids.iter().for_each(|id| assert!(ready.contains(*id)));
 
         // Check that an unknown solution ID is not in the ready queue.
@@ -263,7 +263,7 @@ mod tests {
         // Check the number of transmissions.
         assert!(ready.is_empty());
         // Check the transmission IDs.
-        assert_eq!(ready.transmission_ids(), IndexSet::new());
+        assert_eq!(ready.transmission_ids().collect::<IndexSet<_>>(), IndexSet::new());
         // Check the transmissions.
         assert_eq!(transmissions, vec![
             (solution_id_1, solution_1),

--- a/node/bft/src/helpers/ready.rs
+++ b/node/bft/src/helpers/ready.rs
@@ -82,6 +82,7 @@ impl<N: Network> Ready<N> {
 
     /// Returns the transmissions in the ready queue.
     pub fn transmissions(&self) -> impl Iterator<Item = (&TransmissionID<N>, &Transmission<N>)> {
+        // A little pattern destructuring magic... &(a, b) -> (&a, &b)
         self.transmissions.iter().map(|(id, transmission)| (id, transmission))
     }
 

--- a/node/bft/src/helpers/ready_priority.rs
+++ b/node/bft/src/helpers/ready_priority.rs
@@ -20,7 +20,10 @@ use std::{
 
 use snarkvm::{
     console::types::U64,
-    ledger::narwhal::{Transmission, TransmissionID},
+    ledger::{
+        Transaction,
+        narwhal::{Data, Transmission, TransmissionID},
+    },
     prelude::Network,
 };
 
@@ -63,11 +66,33 @@ impl<N: Network> ReadyPriority<N> {
         self.transmissions.len()
     }
 
+    /// Returns the transmission IDs in the priority queue.
+    pub fn transmission_ids(&self) -> impl Iterator<Item = &TransmissionID<N>> {
+        self.transmissions.keys()
+    }
+
+    /// Returns the transmissions in the priority queue.
+    pub fn transmissions(&self) -> impl Iterator<Item = (&TransmissionID<N>, &Transmission<N>)> {
+        self.transmissions.iter()
+    }
+
+    /// Returns the transactions in the priority queue.
+    pub fn transactions(&self) -> Vec<(N::TransactionID, Data<Transaction<N>>)> {
+        self.transmissions
+            .iter()
+            .filter_map(|(id, transmission)| match (id, transmission) {
+                (TransmissionID::Transaction(id, _), Transmission::Transaction(tx)) => Some((*id, tx.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Returns `true` if the priority queue contains the specified `transmission ID`.
     pub fn contains(&self, transmission_id: &TransmissionID<N>) -> bool {
         self.transmissions.contains_key(transmission_id)
     }
 
+    /// Returns the transmission, given the specified `transmission ID`.
     pub fn get(&self, transmission_id: &TransmissionID<N>) -> Option<Transmission<N>> {
         self.transmissions.get(transmission_id).cloned()
     }

--- a/node/bft/src/helpers/ready_priority.rs
+++ b/node/bft/src/helpers/ready_priority.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, HashMap, hash_map::Entry},
+};
+
+use snarkvm::{console::types::U64, ledger::Transaction, prelude::Network};
+
+#[derive(Clone, Debug)]
+pub struct ReadyPriority<N: Network> {
+    seq_counter: u64,
+    transaction_ids: BTreeMap<(Reverse<U64<N>>, u64), N::TransactionID>,
+    transactions: HashMap<N::TransactionID, Transaction<N>>,
+}
+
+impl<N: Network> Default for ReadyPriority<N> {
+    fn default() -> Self {
+        ReadyPriority {
+            seq_counter: Default::default(),
+            transaction_ids: Default::default(),
+            transactions: Default::default(),
+        }
+    }
+}
+
+impl<N: Network> ReadyPriority<N> {
+    /// Creates an empty priority queue.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn num_transactions(&self) -> usize {
+        self.transactions.len()
+    }
+
+    pub fn contains(&self, transaction_id: &N::TransactionID) -> bool {
+        self.transactions.contains_key(transaction_id)
+    }
+
+    pub fn insert(&mut self, transaction_id: N::TransactionID, transaction: Transaction<N>, fee: U64<N>) -> bool {
+        if let Entry::Vacant(entry) = self.transactions.entry(transaction_id) {
+            entry.insert(transaction);
+            self.transaction_ids.insert((Reverse(fee), self.seq_counter), transaction_id);
+            self.seq_counter += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove_front(&mut self) -> Option<(N::TransactionID, Transaction<N>)> {
+        let (_, transaction_id) = self.transaction_ids.pop_first()?;
+        self.transactions.remove(&transaction_id).map(|transaction| (transaction_id, transaction))
+    }
+}

--- a/node/bft/src/helpers/ready_priority.rs
+++ b/node/bft/src/helpers/ready_priority.rs
@@ -18,21 +18,30 @@ use std::{
     collections::{BTreeMap, HashMap, hash_map::Entry},
 };
 
-use snarkvm::{console::types::U64, ledger::Transaction, prelude::Network};
+use snarkvm::{
+    console::types::U64,
+    ledger::narwhal::{Transmission, TransmissionID},
+    prelude::Network,
+};
 
+/// Maintains a queue of verified and prioritised ("ready") transmissions.
 #[derive(Clone, Debug)]
 pub struct ReadyPriority<N: Network> {
+    /// A counter to ensure fifo ordering for transmissions with the same fee.
     seq_counter: u64,
-    transaction_ids: BTreeMap<(Reverse<U64<N>>, u64), N::TransactionID>,
-    transactions: HashMap<N::TransactionID, Transaction<N>>,
+    /// A map of transmissions ordered by fee and by fifo sequence.
+    transmission_ids: BTreeMap<(Reverse<U64<N>>, u64), TransmissionID<N>>,
+    /// A map of transmission IDs to transmissions.
+    transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
 }
 
 impl<N: Network> Default for ReadyPriority<N> {
+    /// Initializes a new instance of the priority queue.
     fn default() -> Self {
         ReadyPriority {
             seq_counter: Default::default(),
-            transaction_ids: Default::default(),
-            transactions: Default::default(),
+            transmission_ids: Default::default(),
+            transmissions: Default::default(),
         }
     }
 }
@@ -43,18 +52,28 @@ impl<N: Network> ReadyPriority<N> {
         Self::default()
     }
 
+    /// Returns the number of transmissions in the priority queue.
+    pub fn num_transmissions(&self) -> usize {
+        self.transmissions.len()
+    }
+
+    /// Returns the number of transactions in the priority queue.
     pub fn num_transactions(&self) -> usize {
-        self.transactions.len()
+        // All transmissions in the priority queue are transactions.
+        self.transmissions.len()
     }
 
-    pub fn contains(&self, transaction_id: &N::TransactionID) -> bool {
-        self.transactions.contains_key(transaction_id)
+    /// Returns `true` if the priority queue contains the specified `transmission ID`.
+    pub fn contains(&self, transmission_id: &TransmissionID<N>) -> bool {
+        self.transmissions.contains_key(transmission_id)
     }
 
-    pub fn insert(&mut self, transaction_id: N::TransactionID, transaction: Transaction<N>, fee: U64<N>) -> bool {
-        if let Entry::Vacant(entry) = self.transactions.entry(transaction_id) {
-            entry.insert(transaction);
-            self.transaction_ids.insert((Reverse(fee), self.seq_counter), transaction_id);
+    /// Inserts the specified (`transmission ID`, `transmission`) to the priority queue.
+    /// Returns `true` if the transmission is new, and was added to the priority queue.
+    pub fn insert(&mut self, transmission_id: TransmissionID<N>, transmission: Transmission<N>, fee: U64<N>) -> bool {
+        if let Entry::Vacant(entry) = self.transmissions.entry(transmission_id) {
+            entry.insert(transmission);
+            self.transmission_ids.insert((Reverse(fee), self.seq_counter), transmission_id);
             self.seq_counter += 1;
             true
         } else {
@@ -62,8 +81,9 @@ impl<N: Network> ReadyPriority<N> {
         }
     }
 
-    pub fn remove_front(&mut self) -> Option<(N::TransactionID, Transaction<N>)> {
-        let (_, transaction_id) = self.transaction_ids.pop_first()?;
-        self.transactions.remove(&transaction_id).map(|transaction| (transaction_id, transaction))
+    /// Removes and returns the transmission at the front of the priority queue.
+    pub fn remove_front(&mut self) -> Option<(TransmissionID<N>, Transmission<N>)> {
+        let (_, transmission_id) = self.transmission_ids.pop_first()?;
+        self.transmissions.remove(&transmission_id).map(|transmission| (transmission_id, transmission))
     }
 }

--- a/node/bft/src/helpers/ready_priority.rs
+++ b/node/bft/src/helpers/ready_priority.rs
@@ -68,6 +68,10 @@ impl<N: Network> ReadyPriority<N> {
         self.transmissions.contains_key(transmission_id)
     }
 
+    pub fn get(&self, transmission_id: &TransmissionID<N>) -> Option<Transmission<N>> {
+        self.transmissions.get(transmission_id).cloned()
+    }
+
     /// Inserts the specified (`transmission ID`, `transmission`) to the priority queue.
     /// Returns `true` if the transmission is new, and was added to the priority queue.
     pub fn insert(&mut self, transmission_id: TransmissionID<N>, transmission: Transmission<N>, fee: U64<N>) -> bool {

--- a/node/bft/src/helpers/ready_priority.rs
+++ b/node/bft/src/helpers/ready_priority.rs
@@ -116,3 +116,320 @@ impl<N: Network> ReadyPriority<N> {
         self.transmissions.remove(&transmission_id).map(|transmission| (transmission_id, transmission))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm::{
+        ledger::narwhal::Data,
+        prelude::{Field, TestRng, Uniform},
+    };
+
+    use ::bytes::Bytes;
+    use indexmap::IndexSet;
+    use rand::{Rng, RngCore};
+
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
+
+    #[test]
+    fn test_ready_priority() {
+        let rng = &mut TestRng::default();
+
+        // Sample random fake bytes.
+        let data = |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>()));
+
+        // Initialize the priority queue.
+        let mut ready_priority = ReadyPriority::<CurrentNetwork>::new();
+
+        // Initialize the transmission IDs.
+        let transmission_id_1 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_2 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_3 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+
+        // Initialize the transmissions.
+        let transmission_1 = Transmission::Transaction(data(rng));
+        let transmission_2 = Transmission::Transaction(data(rng));
+        let transmission_3 = Transmission::Transaction(data(rng));
+
+        // Insert the transmissions with different fees.
+        assert!(ready_priority.insert(transmission_id_1, transmission_1.clone(), U64::new(100u64)));
+        assert!(ready_priority.insert(transmission_id_2, transmission_2.clone(), U64::new(200u64)));
+        assert!(ready_priority.insert(transmission_id_3, transmission_3.clone(), U64::new(150u64)));
+
+        // Check the number of transmissions.
+        assert_eq!(ready_priority.num_transmissions(), 3);
+        assert_eq!(ready_priority.num_transactions(), 3);
+
+        // Check the transmission IDs.
+        let transmission_ids =
+            vec![transmission_id_1, transmission_id_2, transmission_id_3].into_iter().collect::<IndexSet<_>>();
+        assert_eq!(ready_priority.transmission_ids().copied().collect::<IndexSet<_>>(), transmission_ids);
+        transmission_ids.iter().for_each(|id| assert!(ready_priority.contains(id)));
+
+        // Check that an unknown transmission ID is not in the priority queue.
+        let transmission_id_unknown = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        assert!(!ready_priority.contains(&transmission_id_unknown));
+
+        // Check the transmissions.
+        assert_eq!(ready_priority.get(&transmission_id_1), Some(transmission_1.clone()));
+        assert_eq!(ready_priority.get(&transmission_id_2), Some(transmission_2.clone()));
+        assert_eq!(ready_priority.get(&transmission_id_3), Some(transmission_3.clone()));
+        assert_eq!(ready_priority.get(&transmission_id_unknown), None);
+
+        // Check that transmissions are removed in priority order (highest fee first).
+        // transmission_id_2 has fee 200 (highest)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_2);
+        assert_eq!(removed_transmission, transmission_2);
+
+        // transmission_id_3 has fee 150 (second highest)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_3);
+        assert_eq!(removed_transmission, transmission_3);
+
+        // transmission_id_1 has fee 100 (lowest)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_1);
+        assert_eq!(removed_transmission, transmission_1);
+
+        // Check the priority queue is now empty.
+        assert_eq!(ready_priority.num_transmissions(), 0);
+        assert_eq!(ready_priority.num_transactions(), 0);
+        assert!(ready_priority.remove_front().is_none());
+    }
+
+    #[test]
+    fn test_ready_priority_duplicate() {
+        let rng = &mut TestRng::default();
+
+        // Sample random fake bytes.
+        let mut vec = vec![0u8; 512];
+        rng.fill_bytes(&mut vec);
+        let data = Data::Buffer(Bytes::from(vec));
+
+        // Initialize the priority queue.
+        let mut ready_priority = ReadyPriority::<CurrentNetwork>::new();
+
+        // Initialize the transmission ID.
+        let transmission_id = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+
+        // Initialize the transmission.
+        let transmission = Transmission::Transaction(data);
+
+        // Insert the transmission ID.
+        assert!(ready_priority.insert(transmission_id, transmission.clone(), U64::new(100u64)));
+        assert!(!ready_priority.insert(transmission_id, transmission, U64::new(200u64)));
+
+        // Check the number of transmissions.
+        assert_eq!(ready_priority.num_transmissions(), 1);
+        assert_eq!(ready_priority.num_transactions(), 1);
+    }
+
+    #[test]
+    fn test_ready_priority_same_fee_fifo() {
+        let rng = &mut TestRng::default();
+
+        // Sample random fake bytes.
+        let data = |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>()));
+
+        // Initialize the priority queue.
+        let mut ready_priority = ReadyPriority::<CurrentNetwork>::new();
+
+        // Initialize the transmission IDs.
+        let transmission_id_1 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_2 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_3 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+
+        // Initialize the transmissions.
+        let transmission_1 = Transmission::Transaction(data(rng));
+        let transmission_2 = Transmission::Transaction(data(rng));
+        let transmission_3 = Transmission::Transaction(data(rng));
+
+        // Insert the transmissions with the same fee (should maintain FIFO order).
+        let fee = U64::new(100u64);
+        assert!(ready_priority.insert(transmission_id_1, transmission_1.clone(), fee));
+        assert!(ready_priority.insert(transmission_id_2, transmission_2.clone(), fee));
+        assert!(ready_priority.insert(transmission_id_3, transmission_3.clone(), fee));
+
+        // Check that transmissions are removed in FIFO order when fees are the same.
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_1);
+        assert_eq!(removed_transmission, transmission_1);
+
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_2);
+        assert_eq!(removed_transmission, transmission_2);
+
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_3);
+        assert_eq!(removed_transmission, transmission_3);
+
+        // Check the priority queue is now empty.
+        assert_eq!(ready_priority.num_transmissions(), 0);
+        assert!(ready_priority.remove_front().is_none());
+    }
+
+    #[test]
+    fn test_ready_priority_mixed_fees() {
+        let rng = &mut TestRng::default();
+
+        // Sample random fake bytes.
+        let data = |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>()));
+
+        // Initialize the priority queue.
+        let mut ready_priority = ReadyPriority::<CurrentNetwork>::new();
+
+        // Initialize the transmission IDs.
+        let transmission_id_1 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_2 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_3 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_4 = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+
+        // Initialize the transmissions.
+        let transmission_1 = Transmission::Transaction(data(rng));
+        let transmission_2 = Transmission::Transaction(data(rng));
+        let transmission_3 = Transmission::Transaction(data(rng));
+        let transmission_4 = Transmission::Transaction(data(rng));
+
+        // Insert transmissions with mixed fees and some same fees.
+        assert!(ready_priority.insert(transmission_id_1, transmission_1.clone(), U64::new(100u64))); // First with fee 100
+        assert!(ready_priority.insert(transmission_id_2, transmission_2.clone(), U64::new(200u64))); // Highest fee
+        assert!(ready_priority.insert(transmission_id_3, transmission_3.clone(), U64::new(100u64))); // Second with fee 100
+        assert!(ready_priority.insert(transmission_id_4, transmission_4.clone(), U64::new(150u64))); // Middle fee
+
+        // Check that transmissions are removed in priority order:
+        // 1. transmission_id_2 (fee 200 - highest)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_2);
+        assert_eq!(removed_transmission, transmission_2);
+
+        // 2. transmission_id_4 (fee 150 - second highest)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_4);
+        assert_eq!(removed_transmission, transmission_4);
+
+        // 3. transmission_id_1 (fee 100 - first inserted)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_1);
+        assert_eq!(removed_transmission, transmission_1);
+
+        // 4. transmission_id_3 (fee 100 - second inserted, FIFO order)
+        let (removed_id, removed_transmission) = ready_priority.remove_front().unwrap();
+        assert_eq!(removed_id, transmission_id_3);
+        assert_eq!(removed_transmission, transmission_3);
+
+        // Check the priority queue is now empty.
+        assert_eq!(ready_priority.num_transmissions(), 0);
+        assert!(ready_priority.remove_front().is_none());
+    }
+
+    #[test]
+    fn test_ready_priority_transactions_method() {
+        let rng = &mut TestRng::default();
+
+        // Sample random fake bytes.
+        let data = |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.gen::<u8>()).collect::<Vec<_>>()));
+
+        // Initialize the priority queue.
+        let mut ready_priority = ReadyPriority::<CurrentNetwork>::new();
+
+        // Initialize the transaction IDs directly.
+        let tx_id_1 = <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng));
+        let tx_id_2 = <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng));
+
+        let transmission_id_1 = TransmissionID::Transaction(
+            tx_id_1,
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        let transmission_id_2 = TransmissionID::Transaction(
+            tx_id_2,
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+
+        // Initialize the transmissions.
+        let transmission_1 = Transmission::Transaction(data(rng));
+        let transmission_2 = Transmission::Transaction(data(rng));
+
+        // Insert the transmissions.
+        assert!(ready_priority.insert(transmission_id_1, transmission_1.clone(), U64::new(100u64)));
+        assert!(ready_priority.insert(transmission_id_2, transmission_2.clone(), U64::new(200u64)));
+
+        // Check the transactions method returns all transactions.
+        let transactions = ready_priority.transactions();
+        assert_eq!(transactions.len(), 2);
+
+        // Verify both transactions are present (order doesn't matter for this test).
+        let transaction_ids: Vec<_> = transactions.iter().map(|(id, _)| *id).collect();
+        assert!(transaction_ids.contains(&tx_id_1));
+        assert!(transaction_ids.contains(&tx_id_2));
+    }
+
+    #[test]
+    fn test_ready_priority_default() {
+        let ready_priority = ReadyPriority::<CurrentNetwork>::default();
+
+        assert_eq!(ready_priority.num_transmissions(), 0);
+        assert_eq!(ready_priority.num_transactions(), 0);
+        assert!(ready_priority.transmission_ids().next().is_none());
+        assert!(ready_priority.transmissions().next().is_none());
+        assert!(ready_priority.transactions().is_empty());
+    }
+
+    #[test]
+    fn test_ready_priority_empty_operations() {
+        let mut ready_priority = ReadyPriority::<CurrentNetwork>::new();
+
+        // Test operations on empty queue
+        assert_eq!(ready_priority.num_transmissions(), 0);
+        assert_eq!(ready_priority.num_transactions(), 0);
+        assert!(ready_priority.transmission_ids().next().is_none());
+        assert!(ready_priority.transmissions().next().is_none());
+        assert!(ready_priority.transactions().is_empty());
+        assert!(ready_priority.remove_front().is_none());
+
+        // Test contains and get on empty queue
+        let rng = &mut TestRng::default();
+        let transmission_id = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.gen::<u128>()),
+        );
+        assert!(!ready_priority.contains(&transmission_id));
+        assert_eq!(ready_priority.get(&transmission_id), None);
+    }
+}

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2350,10 +2350,10 @@ mod tests {
 
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
-        // Expect 2/5 transactions to be included in the proposal in addition to the solution.
-        assert_eq!(primary.proposed_batch.read().as_ref().unwrap().transmissions().len(), 3);
+        // Expect 2/5 transactions to be included in the proposal.
+        assert_eq!(primary.proposed_batch.read().as_ref().unwrap().transmissions().len(), 2);
         // Check the transmissions were correctly drained from the workers.
-        assert_eq!(primary.workers().iter().map(|worker| worker.transmissions().len()).sum::<usize>(), 3);
+        assert_eq!(primary.workers().iter().map(|worker| worker.num_transmissions()).sum::<usize>(), 4);
     }
 
     #[tokio::test]

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use snarkos_node_bft_ledger_service::LedgerService;
 use snarkvm::{
-    console::{prelude::*, types::U64},
+    console::prelude::*,
     ledger::{
         block::Transaction,
         narwhal::{BatchHeader, Data, Transmission, TransmissionID},
@@ -238,7 +238,7 @@ impl<N: Network> Worker<N> {
         {
             let Ok(priority_fee) = transaction.priority_fee_amount() else { return };
 
-            if priority_fee != U64::zero() {
+            if !priority_fee.is_zero() {
                 self.ready_priority.write().insert(transmission_id, transmission, priority_fee);
                 return;
             }
@@ -275,7 +275,7 @@ impl<N: Network> Worker<N> {
         {
             let Ok(priority_fee) = transaction.priority_fee_amount() else { return false };
 
-            if priority_fee != U64::zero() {
+            if !priority_fee.is_zero() {
                 self.ready_priority.write().insert(transmission_id, transmission, priority_fee);
                 return true;
             }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -370,7 +370,7 @@ impl<N: Network> Worker<N> {
             return;
         }
 
-        let log_confirmation_trace = || {
+        let log_insert_trace = || {
             trace!(
                 "Worker {} - Added transmission '{}.{}' from '{peer_ip}'",
                 self.id,
@@ -397,14 +397,14 @@ impl<N: Network> Worker<N> {
             let Ok(priority_fee) = tx.priority_fee_amount() else { return };
             if !priority_fee.is_zero() {
                 self.ready_priority.write().insert(transmission_id, transmission, priority_fee);
-                log_confirmation_trace();
+                log_insert_trace();
                 return;
             }
         }
 
         // Otherwise, insert the transmission into the ready queue.
         if self.ready.write().insert(transmission_id, transmission) {
-            log_confirmation_trace()
+            log_insert_trace()
         }
     }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -118,7 +118,7 @@ impl<N: Network> Worker<N> {
 
     /// Returns the number of transmissions in the ready queue.
     pub fn num_transmissions(&self) -> usize {
-        self.ready_priority.read().num_transactions().saturating_add(self.ready.read().num_transmissions())
+        self.ready_priority.read().num_transmissions().saturating_add(self.ready.read().num_transmissions())
     }
 
     /// Returns the number of ratifications in the ready queue.
@@ -171,7 +171,8 @@ impl<N: Network> Worker<N> {
     pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         let transmission_id = transmission_id.into();
         // Check if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
-        self.ready.read().contains(transmission_id)
+        self.ready_priority.read().contains(&transmission_id)
+            || self.ready.read().contains(transmission_id)
             || self.proposed_batch.read().as_ref().map_or(false, |p| p.contains_transmission(transmission_id))
             || self.storage.contains_transmission(transmission_id)
             || self.ledger.contains_transmission(&transmission_id).unwrap_or(false)
@@ -223,13 +224,13 @@ impl<N: Network> Worker<N> {
     pub(crate) fn insert_front(&self, transmission_id: TransmissionID<N>, transmission: Transmission<N>) {
         // If a priority fee is present and isn't zero, insert into the transmission into the
         // priority queue.
-        if let (TransmissionID::Transaction(transaction_id, _), Transmission::Transaction(Data::Object(transaction))) =
+        if let (TransmissionID::Transaction(_, _), Transmission::Transaction(Data::Object(transaction))) =
             (transmission_id, transmission.clone())
         {
             let Ok(priority_fee) = transaction.priority_fee_amount() else { return };
 
             if priority_fee != U64::zero() {
-                self.ready_priority.write().insert(transaction_id, transaction, priority_fee);
+                self.ready_priority.write().insert(transmission_id, transmission, priority_fee);
                 return;
             }
         }
@@ -242,13 +243,7 @@ impl<N: Network> Worker<N> {
     ///
     /// Note: it is assumed this method is called with a deserialized transmission.
     pub(crate) fn remove_front(&self) -> Option<(TransmissionID<N>, Transmission<N>)> {
-        if let Some((transaction_id, transaction)) = self.ready_priority.write().remove_front() {
-            // Reconstruct the transmission from the transaction.
-            let transaction = Data::Object(transaction);
-            let checksum = transaction.to_checksum::<N>().ok()?;
-            let transmission_id = TransmissionID::Transaction(transaction_id, checksum);
-            let transmission = Transmission::Transaction(transaction);
-
+        if let Some((transmission_id, transmission)) = self.ready_priority.write().remove_front() {
             return Some((transmission_id, transmission));
         }
 
@@ -266,13 +261,13 @@ impl<N: Network> Worker<N> {
 
         // If a priority fee is present and isn't zero, insert into the transmission into the
         // priority queue.
-        if let (TransmissionID::Transaction(transaction_id, _), Transmission::Transaction(Data::Object(transaction))) =
+        if let (TransmissionID::Transaction(_, _), Transmission::Transaction(Data::Object(transaction))) =
             (transmission_id, transmission.clone())
         {
             let Ok(priority_fee) = transaction.priority_fee_amount() else { return false };
 
             if priority_fee != U64::zero() {
-                self.ready_priority.write().insert(transaction_id, transaction, priority_fee);
+                self.ready_priority.write().insert(transmission_id, transmission, priority_fee);
                 return true;
             }
         }
@@ -453,7 +448,7 @@ impl<N: Network> Worker<N> {
         // priority queue, otherwise insert into the ready queue.
         let priority_fee = transaction.priority_fee_amount()?;
         let is_inserted = if priority_fee != U64::zero() {
-            self.ready_priority.write().insert(transaction_id, transaction, priority_fee)
+            self.ready_priority.write().insert(transmission_id, transmission, priority_fee)
         } else {
             self.ready.write().insert(transmission_id, transmission)
         };
@@ -903,7 +898,7 @@ mod tests {
         assert!(result.is_ok());
         assert!(!worker.pending.contains(transmission_id));
         assert!(!worker.ready.read().contains(transmission_id));
-        assert!(worker.ready_priority.read().contains(&transaction_id));
+        assert!(worker.ready_priority.read().contains(&transmission_id));
     }
 
     #[tokio::test]
@@ -1021,7 +1016,7 @@ mod tests {
         assert_eq!(worker.pending.num_sent_requests(transmission_id), 0);
         assert_eq!(worker.pending.num_callbacks(transmission_id), 0);
         assert!(!worker.pending.contains(transmission_id));
-        assert!(worker.ready_priority.read().contains(&transaction_id));
+        assert!(worker.ready_priority.read().contains(&transmission_id));
     }
 
     #[tokio::test]

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -138,14 +138,19 @@ impl<N: Network> Worker<N> {
 }
 
 impl<N: Network> Worker<N> {
-    /// Returns the transmission IDs in the ready queue.
+    /// Returns the transmission IDs in the ready and priority queues.
     pub fn transmission_ids(&self) -> IndexSet<TransmissionID<N>> {
-        self.ready.read().transmission_ids()
+        self.ready_priority.read().transmission_ids().chain(self.ready.read().transmission_ids()).copied().collect()
     }
 
     /// Returns the transmissions in the ready queue.
     pub fn transmissions(&self) -> IndexMap<TransmissionID<N>, Transmission<N>> {
-        self.ready.read().transmissions()
+        self.ready_priority
+            .read()
+            .transmissions()
+            .chain(self.ready.read().transmissions())
+            .map(|(id, transmission)| (*id, transmission.clone()))
+            .collect()
     }
 
     /// Returns the solutions in the ready queue.
@@ -155,7 +160,7 @@ impl<N: Network> Worker<N> {
 
     /// Returns the transactions in the ready queue.
     pub fn transactions(&self) -> impl '_ + Iterator<Item = (N::TransactionID, Data<Transaction<N>>)> {
-        self.ready.read().transactions().into_iter()
+        self.ready_priority.read().transactions().into_iter().chain(self.ready.read().transactions())
     }
 }
 
@@ -284,8 +289,6 @@ impl<N: Network> Worker<N> {
     pub(crate) fn broadcast_ping(&self) {
         // Retrieve the transmission IDs.
         let transmission_ids = self
-            .ready
-            .read()
             .transmission_ids()
             .into_iter()
             .choose_multiple(&mut rand::thread_rng(), Self::MAX_TRANSMISSIONS_PER_WORKER_PING)
@@ -308,7 +311,7 @@ impl<N: Network> Worker<N> {
         }
         // If the ready queue is full, then skip this transmission.
         // Note: We must prioritize the unconfirmed solutions and unconfirmed transactions, not transmissions.
-        if self.ready.read().num_transmissions() > Self::MAX_TRANSMISSIONS_PER_WORKER {
+        if self.num_transmissions() > Self::MAX_TRANSMISSIONS_PER_WORKER {
             return;
         }
         // Attempt to fetch the transmission from the peer.
@@ -470,7 +473,7 @@ impl<N: Network> Worker<N> {
         // If a priority fee is present, insert into the transmission into the
         // priority queue, otherwise insert into the ready queue.
         let priority_fee = transaction.priority_fee_amount()?;
-        let is_inserted = if priority_fee != U64::zero() {
+        let is_inserted = if !priority_fee.is_zero() {
             self.ready_priority.write().insert(transmission_id, transmission, priority_fee)
         } else {
             self.ready.write().insert(transmission_id, transmission)
@@ -484,6 +487,7 @@ impl<N: Network> Worker<N> {
                 fmt_id(checksum).dimmed()
             );
         }
+
         Ok(())
     }
 }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -19,12 +19,12 @@ use crate::{
     ProposedBatch,
     Transport,
     events::{Event, TransmissionRequest, TransmissionResponse},
-    helpers::{Pending, Ready, Storage, WorkerReceiver, fmt_id, max_redundant_requests},
+    helpers::{Pending, Ready, ReadyPriority, Storage, WorkerReceiver, fmt_id, max_redundant_requests},
     spawn_blocking,
 };
 use snarkos_node_bft_ledger_service::LedgerService;
 use snarkvm::{
-    console::prelude::*,
+    console::{prelude::*, types::U64},
     ledger::{
         block::Transaction,
         narwhal::{BatchHeader, Data, Transmission, TransmissionID},
@@ -58,6 +58,8 @@ pub struct Worker<N: Network> {
     proposed_batch: Arc<ProposedBatch<N>>,
     /// The ready queue.
     ready: Arc<RwLock<Ready<N>>>,
+    /// The priority queue.
+    ready_priority: Arc<RwLock<ReadyPriority<N>>>,
     /// The pending transmissions queue.
     pending: Arc<Pending<TransmissionID<N>, Transmission<N>>>,
     /// The spawned handles.
@@ -83,6 +85,7 @@ impl<N: Network> Worker<N> {
             ledger,
             proposed_batch,
             ready: Default::default(),
+            ready_priority: Default::default(),
             pending: Default::default(),
             handles: Default::default(),
         })
@@ -115,7 +118,7 @@ impl<N: Network> Worker<N> {
 
     /// Returns the number of transmissions in the ready queue.
     pub fn num_transmissions(&self) -> usize {
-        self.ready.read().num_transmissions()
+        self.ready_priority.read().num_transactions().saturating_add(self.ready.read().num_transmissions())
     }
 
     /// Returns the number of ratifications in the ready queue.
@@ -130,7 +133,7 @@ impl<N: Network> Worker<N> {
 
     /// Returns the number of transactions in the ready queue.
     pub fn num_transactions(&self) -> usize {
-        self.ready.read().num_transactions()
+        self.ready_priority.read().num_transactions().saturating_add(self.ready.read().num_transactions())
     }
 }
 
@@ -215,23 +218,67 @@ impl<N: Network> Worker<N> {
     }
 
     /// Inserts the transmission at the front of the ready queue.
-    pub(crate) fn insert_front(&self, key: TransmissionID<N>, value: Transmission<N>) {
-        self.ready.write().insert_front(key, value);
+    ///
+    /// Note: it is assumed this method is called with a deserialized transmission.
+    pub(crate) fn insert_front(&self, transmission_id: TransmissionID<N>, transmission: Transmission<N>) {
+        // If a priority fee is present and isn't zero, insert into the transmission into the
+        // priority queue.
+        if let (TransmissionID::Transaction(transaction_id, _), Transmission::Transaction(Data::Object(transaction))) =
+            (transmission_id, transmission.clone())
+        {
+            let Ok(priority_fee) = transaction.priority_fee_amount() else { return };
+
+            if priority_fee != U64::zero() {
+                self.ready_priority.write().insert(transaction_id, transaction, priority_fee);
+                return;
+            }
+        }
+
+        // Otherwise, insert into the ready queue.
+        self.ready.write().insert_front(transmission_id, transmission);
     }
 
     /// Removes and returns the transmission at the front of the ready queue.
+    ///
+    /// Note: it is assumed this method is called with a deserialized transmission.
     pub(crate) fn remove_front(&self) -> Option<(TransmissionID<N>, Transmission<N>)> {
+        if let Some((transaction_id, transaction)) = self.ready_priority.write().remove_front() {
+            // Reconstruct the transmission from the transaction.
+            let transaction = Data::Object(transaction);
+            let checksum = transaction.to_checksum::<N>().ok()?;
+            let transmission_id = TransmissionID::Transaction(transaction_id, checksum);
+            let transmission = Transmission::Transaction(transaction);
+
+            return Some((transmission_id, transmission));
+        }
+
         self.ready.write().remove_front()
     }
 
     /// Reinserts the specified transmission into the ready queue.
+    ///
+    /// Note: it is assumed this method is called with a deserialized transmission.
     pub(crate) fn reinsert(&self, transmission_id: TransmissionID<N>, transmission: Transmission<N>) -> bool {
-        // Check if the transmission ID exists.
-        if !self.contains_transmission(transmission_id) {
-            // Insert the transmission into the ready queue.
-            return self.ready.write().insert(transmission_id, transmission);
+        // Return early if the transmission already exists.
+        if self.contains_transmission(transmission_id) {
+            return false;
         }
-        false
+
+        // If a priority fee is present and isn't zero, insert into the transmission into the
+        // priority queue.
+        if let (TransmissionID::Transaction(transaction_id, _), Transmission::Transaction(Data::Object(transaction))) =
+            (transmission_id, transmission.clone())
+        {
+            let Ok(priority_fee) = transaction.priority_fee_amount() else { return false };
+
+            if priority_fee != U64::zero() {
+                self.ready_priority.write().insert(transaction_id, transaction, priority_fee);
+                return true;
+            }
+        }
+
+        // Otherwise, insert into the ready queue.
+        self.ready.write().insert(transmission_id, transmission)
     }
 
     /// Broadcasts a worker ping event.
@@ -294,6 +341,8 @@ impl<N: Network> Worker<N> {
     }
 
     /// Handles the incoming transmission from a peer.
+    ///
+    /// Note: it is assumed this method is called with a deserialized transmission.
     pub(crate) fn process_transmission_from_peer(
         &self,
         peer_ip: SocketAddr,
@@ -398,9 +447,18 @@ impl<N: Network> Worker<N> {
         })?;
 
         // Check that the transaction is well-formed and unique.
-        self.ledger.check_transaction_basic(transaction_id, transaction).await?;
-        // Adds the transaction to the ready queue.
-        if self.ready.write().insert(transmission_id, transmission) {
+        self.ledger.check_transaction_basic(transaction_id, transaction.clone()).await?;
+
+        // If a priority fee is present, insert into the transmission into the
+        // priority queue, otherwise insert into the ready queue.
+        let priority_fee = transaction.priority_fee_amount()?;
+        let is_inserted = if priority_fee != U64::zero() {
+            self.ready_priority.write().insert(transaction_id, transaction, priority_fee)
+        } else {
+            self.ready.write().insert(transmission_id, transmission)
+        };
+
+        if is_inserted {
             trace!(
                 "Worker {}.{} - Added unconfirmed transaction '{}'",
                 self.id,
@@ -844,7 +902,8 @@ mod tests {
         let result = worker.process_unconfirmed_transaction(transaction_id, transaction_data).await;
         assert!(result.is_ok());
         assert!(!worker.pending.contains(transmission_id));
-        assert!(worker.ready.read().contains(transmission_id));
+        assert!(!worker.ready.read().contains(transmission_id));
+        assert!(worker.ready_priority.read().contains(&transaction_id));
     }
 
     #[tokio::test]
@@ -962,7 +1021,7 @@ mod tests {
         assert_eq!(worker.pending.num_sent_requests(transmission_id), 0);
         assert_eq!(worker.pending.num_callbacks(transmission_id), 0);
         assert!(!worker.pending.contains(transmission_id));
-        assert!(worker.ready.read().contains(transmission_id));
+        assert!(worker.ready_priority.read().contains(&transaction_id));
     }
 
     #[tokio::test]

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -183,6 +183,10 @@ impl<N: Network> Worker<N> {
     /// Note: We explicitly forbid retrieving a transmission from the ledger, as transmissions
     /// in the ledger are not guaranteed to be invalid for the current batch.
     pub fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>> {
+        // Check if the transmission ID exists in the priority queue.
+        if let Some(transmission) = self.ready_priority.read().get(&transmission_id) {
+            return Some(transmission);
+        }
         // Check if the transmission ID exists in the ready queue.
         if let Some(transmission) = self.ready.read().get(transmission_id) {
             return Some(transmission);
@@ -358,6 +362,20 @@ impl<N: Network> Worker<N> {
             // All other combinations are clearly invalid.
             _ => false,
         };
+
+        if !is_well_formed {
+            return;
+        }
+
+        let log_confirmation_trace = || {
+            trace!(
+                "Worker {} - Added transmission '{}.{}' from '{peer_ip}'",
+                self.id,
+                fmt_id(transmission_id),
+                fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed()
+            )
+        };
+
         // If the transmission is a deserialized execution, verify it immediately.
         // This takes heavy transaction verification out of the hot path during block generation.
         if let (TransmissionID::Transaction(tx_id, _), Transmission::Transaction(Data::Object(tx))) =
@@ -370,15 +388,20 @@ impl<N: Network> Worker<N> {
                     let _ = self_.ledger.check_transaction_basic(tx_id, tx_).await;
                 });
             }
+
+            // If a priority fee is present and isn't zero, insert into the transmission into the
+            // priority queue.
+            let Ok(priority_fee) = tx.priority_fee_amount() else { return };
+            if !priority_fee.is_zero() {
+                self.ready_priority.write().insert(transmission_id, transmission, priority_fee);
+                log_confirmation_trace();
+                return;
+            }
         }
-        // If the transmission ID and transmission type matches, then insert the transmission into the ready queue.
-        if is_well_formed && self.ready.write().insert(transmission_id, transmission) {
-            trace!(
-                "Worker {} - Added transmission '{}.{}' from '{peer_ip}'",
-                self.id,
-                fmt_id(transmission_id),
-                fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed()
-            );
+
+        // Otherwise, insert the transmission into the ready queue.
+        if self.ready.write().insert(transmission_id, transmission) {
+            log_confirmation_trace()
         }
     }
 


### PR DESCRIPTION
This PR introduces a priority queue for transactions containing a nonzero priority fee. These are drained before the pre-existing ready queue by the worker when building batches. 

A few notes on the current design:
1. Priority fees for transactions already in the mempool cannot be updated.
2. There is no protection against starvation: if the priority pool stays full enough, transmissions from the ready queue will not be included in the batches.
3. Batch building is **not** an atomic operation, the queues can be updated in the background. 

