### PR TITLE
Remove debug ERRORs from the default verbosity

### DIFF
--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -104,7 +104,7 @@ pub fn initialize_logger<P: AsRef<Path>>(
         if verbosity >= 6 {
             filter.add_directive("snarkos_node_tcp=trace".parse().unwrap())
         } else {
-            filter.add_directive("snarkos_node_tcp=warn".parse().unwrap())
+            filter.add_directive("snarkos_node_tcp=off".parse().unwrap())
         }
     });
 


### PR DESCRIPTION
## Motivation

We've been testing snarkOs a lot and our tests are trying to detect problems with this new verbosity change we are getting a lot of ERROR logs of the type:

```
2025-06-27T08:51:53.757689Z ERROR tcp{name=“0”}: handshake with 18.237.141.71:4130 failed: ‘18.237.141.71:4130’ disconnected before sending “Message::ChallengeResponse”
```

So we talked with @vicsn to set the logging back to `off` when the verbosity is not `>= 6`.

## Test Plan

Can be seen by running `devnet.sh` without this fix and with it.
