### PR TITLE
Limit number of outstanding block requests

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -168,6 +168,7 @@ impl<N: Network> Gateway<N> {
         };
         // Initialize the TCP stack.
         let tcp = Tcp::new(Config::new(ip, Committee::<N>::max_committee_size()?));
+
         // Return the gateway.
         Ok(Self {
             account,
@@ -215,8 +216,10 @@ impl<N: Network> Gateway<N> {
         self.enable_writing().await;
         self.enable_disconnect().await;
         self.enable_on_connect().await;
+
         // Enable the TCP listener. Note: This must be called after the above protocols.
-        let _listening_addr = self.tcp.enable_listener().await.expect("Failed to enable the TCP listener");
+        let listen_addr = self.tcp.enable_listener().await.expect("Failed to enable the TCP listener");
+        debug!("Listening for validator connections at address {listen_addr:?}");
 
         // Initialize the heartbeat.
         self.initialize_heartbeat();

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -788,14 +788,17 @@ impl<N: Network> Sync<N> {
 impl<N: Network> Sync<N> {
     /// Returns `true` if the node is synced and has connected peers.
     pub fn is_synced(&self) -> bool {
+        // Ensure the validator is connected to other validators,
+        // not just clients.
         if self.gateway.number_of_connected_peers() == 0 {
             return false;
         }
+
         self.block_sync.is_block_synced()
     }
 
     /// Returns the number of blocks the node is behind the greatest peer height.
-    pub fn num_blocks_behind(&self) -> u32 {
+    pub fn num_blocks_behind(&self) -> Option<u32> {
         self.block_sync.num_blocks_behind()
     }
 

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use snarkos_node_router::{SYNC_LENIENCY, messages::UnconfirmedSolution};
+use snarkos_node_router::messages::UnconfirmedSolution;
 use snarkvm::{
     ledger::puzzle::Solution,
     prelude::{Address, Identifier, LimitedWriter, Plaintext, ToBytes, block::Transaction},
@@ -348,7 +348,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Path(validator): Path<Address<N>>,
     ) -> Result<ErasedJson, RestError> {
         // Do not process the request if the node is too far behind to avoid sending outdated data.
-        if rest.routing.num_blocks_behind() > SYNC_LENIENCY {
+        if !rest.routing.is_within_sync_leniency() {
             return Err(RestError("Unable to  request delegators (node is syncing)".to_string()));
         }
 
@@ -426,7 +426,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Json(tx): Json<Transaction<N>>,
     ) -> Result<ErasedJson, RestError> {
         // Do not process the transaction if the node is too far behind.
-        if rest.routing.num_blocks_behind() > SYNC_LENIENCY {
+        if !rest.routing.is_within_sync_leniency() {
             return Err(RestError(format!("Unable to broadcast transaction '{}' (node is syncing)", fmt_id(tx.id()))));
         }
 
@@ -464,7 +464,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Json(solution): Json<Solution<N>>,
     ) -> Result<ErasedJson, RestError> {
         // Do not process the solution if the node is too far behind.
-        if rest.routing.num_blocks_behind() > SYNC_LENIENCY {
+        if !rest.routing.is_within_sync_leniency() {
             return Err(RestError(format!(
                 "Unable to broadcast solution '{}' (node is syncing)",
                 fmt_id(solution.id())

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -43,10 +43,6 @@ use tokio::task::spawn_blocking;
 /// The max number of peers to send in a `PeerResponse` message.
 const MAX_PEERS_TO_SEND: usize = u8::MAX as usize;
 
-/// The maximum number of blocks the client can be behind it's latest peer before it skips
-/// processing incoming transactions and solutions.
-pub const SYNC_LENIENCY: u32 = 10;
-
 #[async_trait]
 pub trait Inbound<N: Network>: Reading + Outbound<N> {
     /// The maximum number of puzzle requests per interval.
@@ -62,6 +58,20 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
 
     /// Returns `true` if the message version is valid.
     fn is_valid_message_version(&self, message_version: u32) -> bool;
+
+    /// Is the node synced enough to process unconfirmed transactions and solutions?
+    fn is_within_sync_leniency(&self) -> bool {
+        // The maximum number of blocks the client can be behind it's latest peer before it skips
+        // processing incoming transactions and solutions.
+        const SYNC_LENIENCY: u32 = 10;
+
+        if let Some(num) = self.num_blocks_behind() {
+            num > SYNC_LENIENCY
+        } else {
+            // We have not received block locators yet.
+            true
+        }
+    }
 
     /// Handles the inbound message from the peer.
     async fn inbound(&self, peer_addr: SocketAddr, message: Message<N>) -> Result<()> {
@@ -237,10 +247,11 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
             }
             Message::UnconfirmedSolution(message) => {
                 // Do not process unconfirmed solutions if the node is too far behind.
-                if self.num_blocks_behind() > SYNC_LENIENCY {
+                if !self.is_within_sync_leniency() {
                     trace!("Skipped processing unconfirmed solution '{}' (node is syncing)", message.solution_id);
                     return Ok(());
                 }
+
                 // Update the timestamp for the unconfirmed solution.
                 let seen_before = self.router().cache.insert_inbound_solution(peer_ip, message.solution_id).is_some();
                 // Determine whether to propagate the solution.
@@ -266,8 +277,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
             }
             Message::UnconfirmedTransaction(message) => {
-                // Do not process unconfirmed transactions if the node is too far behind.
-                if self.num_blocks_behind() > SYNC_LENIENCY {
+                // Do not process unconfirmed solutions if the node is too far behind.
+                if !self.is_within_sync_leniency() {
                     trace!("Skipped processing unconfirmed transaction '{}' (node is syncing)", message.transaction_id);
                     return Ok(());
                 }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -152,6 +152,7 @@ impl<N: Network> Router<N> {
     ) -> Result<Self> {
         // Initialize the TCP stack.
         let tcp = Tcp::new(Config::new(node_ip, max_peers));
+
         // Initialize the router.
         Ok(Self(Arc::new(InnerRouter {
             tcp,

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -28,8 +28,9 @@ pub trait Outbound<N: Network> {
     /// Returns the greatest block height of any connected peer.
     fn greatest_peer_block_height(&self) -> Option<u32>;
 
-    /// Returns the number of blocks this node is behind the greatest peer height.
-    fn num_blocks_behind(&self) -> u32;
+    /// Returns the number of blocks this node is behind the greatest peer height,
+    /// or `None` if not connected to peers yet.
+    fn num_blocks_behind(&self) -> Option<u32>;
 
     /// Sends the given message to every connected peer, excluding the sender and any specified peer IPs.
     fn propagate(&self, message: Message<N>, excluded_peers: &[SocketAddr]) {

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -42,7 +42,8 @@ pub trait Routing<N: Network>:
 
     // Start listening for inbound connections.
     async fn enable_listener(&self) {
-        self.tcp().enable_listener().await.expect("Failed to enable the TCP listener");
+        let listen_addr = self.tcp().enable_listener().await.expect("Failed to enable the TCP listener");
+        debug!("Listening for peer connections at address {listen_addr:?}");
     }
 
     /// Initialize a new instance of the heartbeat.

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -168,8 +168,8 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
     }
 
     /// Returns the number of blocks this node is behind the greatest peer height.
-    fn num_blocks_behind(&self) -> u32 {
-        0
+    fn num_blocks_behind(&self) -> Option<u32> {
+        None
     }
 
     /// Returns the greatest block height of any connected peer.

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -68,8 +68,8 @@ impl Outbound<Network> for HeartbeatTest {
         None
     }
 
-    fn num_blocks_behind(&self) -> u32 {
-        0
+    fn num_blocks_behind(&self) -> Option<u32> {
+        None
     }
 }
 

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -175,8 +175,9 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
         self.sync.is_block_synced()
     }
 
-    /// Returns the number of blocks this node is behind the greatest peer height.
-    fn num_blocks_behind(&self) -> u32 {
+    /// Returns the number of blocks this node is behind the greatest peer height,
+    /// or `None` if not connected to peers yet.
+    fn num_blocks_behind(&self) -> Option<u32> {
         self.sync.num_blocks_behind()
     }
 

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -133,9 +133,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
         true
     }
 
-    /// Returns the number of blocks this node is behind the greatest peer height.
-    fn num_blocks_behind(&self) -> u32 {
-        0
+    /// Returns the number of blocks this node is behind the greatest peer height,
+    /// or `None` if not connected to peers yet.
+    fn num_blocks_behind(&self) -> Option<u32> {
+        //TODO(kaimast): should this return None instead?
+        Some(0)
     }
 
     /// Returns the greatest block height of any connected peer.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -147,8 +147,9 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
         self.sync.is_block_synced()
     }
 
-    /// Returns the number of blocks this node is behind the greatest peer height.
-    fn num_blocks_behind(&self) -> u32 {
+    /// Returns the number of blocks this node is behind the greatest peer height,
+    /// or `None` if not connected to peers yet.
+    fn num_blocks_behind(&self) -> Option<u32> {
         self.sync.num_blocks_behind()
     }
 

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -154,11 +154,11 @@ impl<N: Network> BlockSync<N> {
         self.sync_state.read().can_block_sync()
     }
 
-    /// Returns the number of blocks the node is behind the greatest peer height.
+    /// Returns the number of blocks the node is behind the greatest peer height,
+    /// or `None` if no peers are connected yet.
     #[inline]
-    pub fn num_blocks_behind(&self) -> u32 {
-        // TODO(kaimast): return u32::MAX if unknown peer height?
-        self.sync_state.read().num_blocks_behind().unwrap_or(0)
+    pub fn num_blocks_behind(&self) -> Option<u32> {
+        self.sync_state.read().num_blocks_behind()
     }
 
     /// Returns the greatest block height of any connected peer.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -58,6 +58,9 @@ const EXTRA_REDUNDANCY_FACTOR: usize = REDUNDANCY_FACTOR * 3;
 const NUM_SYNC_CANDIDATE_PEERS: usize = REDUNDANCY_FACTOR * 5;
 
 const BLOCK_REQUEST_TIMEOUT_IN_SECS: u64 = 600; // 600 seconds
+
+/// The maximum number of outstanding block requests.
+/// Once a node hits this limit, it will not issue any new requests until existing requests time out or receive responses.
 const MAX_BLOCK_REQUESTS: usize = 50; // 50 requests
 
 /// The maximum number of blocks tolerated before the primary is considered behind its peers.
@@ -484,14 +487,23 @@ impl<N: Network> BlockSync<N> {
         let mut state = self.sync_state.write();
         let current_height = state.get_sync_height();
 
+        // Ensure to not exceed the maximum number of block requests.
+        let max_requests = MAX_BLOCK_REQUESTS.saturating_sub(self.requests.read().len());
+
         // Prepare the block requests.
-        if let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(current_height) {
+        if max_requests == 0 {
+            trace!(
+                "Already reached the maximum number of outstanding block requests ({MAX_BLOCK_REQUESTS}). Will not issue more."
+            );
+            // Return an empty list of block requests.
+            (Default::default(), Default::default())
+        } else if let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(current_height) {
             // Retrieve the highest block height.
             let greatest_peer_height = sync_peers.values().map(|l| l.latest_locator_height()).max().unwrap_or(0);
             // Update the state of `is_block_synced` for the sync module.
             state.set_greatest_peer_height(greatest_peer_height);
             // Return the list of block requests.
-            (self.construct_requests(&sync_peers, min_common_ancestor), sync_peers)
+            (self.construct_requests(&sync_peers, min_common_ancestor, max_requests), sync_peers)
         } else {
             // Update `is_block_synced` if there are no pending requests or responses.
             if self.requests.read().is_empty() && self.responses.read().is_empty() {
@@ -825,6 +837,7 @@ impl<N: Network> BlockSync<N> {
         &self,
         sync_peers: &IndexMap<SocketAddr, BlockLocators<N>>,
         min_common_ancestor: u32,
+        max_requests: usize,
     ) -> Vec<(u32, PrepareSyncRequest<N>)> {
         // Retrieve the latest ledger height.
         let latest_ledger_height = self.ledger.latest_block_height();
@@ -837,7 +850,7 @@ impl<N: Network> BlockSync<N> {
         // Compute the start height for the block request.
         let start_height = latest_ledger_height + 1;
         // Compute the end height for the block request.
-        let max_blocks_to_request = MAX_BLOCK_REQUESTS as u32 * DataBlocks::<N>::MAXIMUM_NUMBER_OF_BLOCKS as u32;
+        let max_blocks_to_request = max_requests as u32 * DataBlocks::<N>::MAXIMUM_NUMBER_OF_BLOCKS as u32;
         let end_height = (min_common_ancestor + 1).min(start_height + max_blocks_to_request);
 
         // Construct the block hashes to request.


### PR DESCRIPTION
So far, the only limit on outstanding block requests is how often `prepare_block_requests` is called. 

This PR changes `BlockSync` to always have at most `MAX_BLOCK_REQUESTS` (set to 50 right now) outstanding requests. This should lighten the load on the network and increase sync performance.