### PR TITLE
Ensure txs can be broadcast when we're within SYNC_LENIENCY

### DIFF
--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -66,7 +66,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
         const SYNC_LENIENCY: u32 = 10;
 
         if let Some(num) = self.num_blocks_behind() {
-            num > SYNC_LENIENCY
+            num <= SYNC_LENIENCY
         } else {
             // We have not received block locators yet.
             true


### PR DESCRIPTION
## Motivation

Transactions could not be broadcasted anymore because this criterion was reversed.

## Test Plan

- [x] Tested on a local devnet
