### PR TITLE
[Feature] Handle errors in `Tcp::connect` better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4065,6 +4065,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "snarkos-node-metrics",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -20,7 +20,7 @@ use snarkos_node_tcp::{
 };
 use snarkvm::prelude::Network;
 
-use core::time::Duration;
+use std::time::{Duration, Instant};
 
 #[async_trait]
 pub trait Routing<N: Network>:
@@ -46,15 +46,28 @@ pub trait Routing<N: Network>:
         debug!("Listening for peer connections at address {listen_addr:?}");
     }
 
-    /// Initialize a new instance of the heartbeat.
+    /// Spawns the heartbeat background task for this instance of `Routing`.
     fn initialize_heartbeat(&self) {
         let self_clone = self.clone();
         self.router().spawn(async move {
+            // Sleep for `HEARTBEAT_IN_SECS` seconds.
+            let min_heartbeat_interval = Duration::from_secs(Self::HEARTBEAT_IN_SECS);
+            let mut last_update = Instant::now();
+
             loop {
                 // Process a heartbeat in the router.
-                self_clone.heartbeat();
-                // Sleep for `HEARTBEAT_IN_SECS` seconds.
-                tokio::time::sleep(Duration::from_secs(Self::HEARTBEAT_IN_SECS)).await;
+                self_clone.heartbeat().await;
+
+                // Figure out how long the heartbeat took
+                let now = Instant::now();
+                let elapsed = now.saturating_duration_since(last_update);
+                last_update = now;
+
+                // (Potentially) sleep to avoid invoking heartbeat too frequently.
+                let sleep_time = min_heartbeat_interval.saturating_sub(elapsed);
+                if !sleep_time.is_zero() {
+                    tokio::time::sleep(sleep_time).await;
+                }
             }
         });
     }

--- a/node/tcp/Cargo.toml
+++ b/node/tcp/Cargo.toml
@@ -57,6 +57,9 @@ features = [ "codec" ]
 version = "0.1"
 default-features = false
 
+[dependencies.thiserror]
+version = "2"
+
 [dev-dependencies.tokio]
 workspace = true
 features = [ "macros" ]

--- a/node/tcp/src/lib.rs
+++ b/node/tcp/src/lib.rs
@@ -24,7 +24,7 @@ pub use helpers::*;
 pub mod protocols;
 
 mod tcp;
-pub use tcp::Tcp;
+pub use tcp::{ConnectError, Tcp};
 
 use std::net::IpAddr;
 

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -21,12 +21,12 @@ use common::{node::*, test_peer::TestPeer};
 
 use snarkos_node::{Client, Prover, Validator};
 use snarkos_node_router::Outbound;
-use snarkos_node_tcp::P2P;
+use snarkos_node_tcp::{ConnectError, P2P};
 use snarkvm::prelude::{MainnetV0 as CurrentNetwork, store::helpers::memory::ConsensusMemory};
 
 use pea2pea::Pea2Pea;
 
-use std::{io, net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 use tokio::time::sleep;
 
 // Trait to unify Pea2Pea and P2P traits.
@@ -34,7 +34,7 @@ use tokio::time::sleep;
 trait Connect {
     fn listening_addr(&self) -> SocketAddr;
 
-    async fn connect(&self, target: SocketAddr) -> io::Result<()>;
+    async fn connect(&self, target: SocketAddr) -> Result<(), ConnectError>;
 }
 
 // Implement the `Connect` trait for each node type.
@@ -47,7 +47,7 @@ macro_rules! impl_connect {
                     self.tcp().listening_addr().expect("node listener should exist")
                 }
 
-                async fn connect(&self, target: SocketAddr) -> io::Result<()>
+                async fn connect(&self, target: SocketAddr) -> Result<(), ConnectError>
                 where
                     Self: P2P,
                 {
@@ -70,8 +70,8 @@ where
         self.node().listening_addr().expect("node listener should exist")
     }
 
-    async fn connect(&self, target: SocketAddr) -> io::Result<()> {
-        self.node().connect(target).await
+    async fn connect(&self, target: SocketAddr) -> Result<(), ConnectError> {
+        self.node().connect(target).await.map_err(|err| err.into())
     }
 }
 


### PR DESCRIPTION
snarkos hides log output of `snarkos_node_tcp` by default. This causes connection errors due to, for example, reaching the maximum number of connected peers opaque to the user.

The proposed change introduces a new `snarkos_node_tcp::ConnectError` type that differentiates snarkos-specific errors from I/O errors.

Additionally, the PR changes the heartbeat logic to wait for connect results, so that connect errors are easier to understand and to avoid the node from attempting another connection while already connecting to the same node.

Finally, the PR also disables logging for two more external crates (axum and tower) to declutter the logs more.

