### PR TITLE
[Fix] Update sync height in bft::Sync correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,7 +3988,6 @@ dependencies = [
  "snarkos-node-consensus",
  "snarkos-node-router",
  "snarkvm",
- "snarkvm-synthesizer",
  "time",
  "tokio",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ name = "snarkos-node-sync"
 version = "3.8.0"
 dependencies = [
  "anyhow",
+ "futures",
  "indexmap 2.10.0",
  "itertools 0.14.0",
  "locktick",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,15 +683,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.0"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width 0.2.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1945,14 +1945,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
+ "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.0",
- "unit-prefix",
  "web-time",
 ]
 
@@ -2532,6 +2532,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -5768,12 +5774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
-name = "unit-prefix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6159,15 +6159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ features = [ "std" ]
 [workspace.dependencies.crossterm]
 version = "0.29"
 
+[workspace.dependencies.futures]
+version = "0.3"
+
 [workspace.dependencies.proptest]
 version = "=1.6.0" # Remove this once we upgrade to rand 0.9
 

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -188,6 +188,10 @@ version = "1"
 path = "."
 features = [ "test" ]
 
+[dev-dependencies.snarkos-node-sync]
+path = "../sync"
+features = [ "test" ]
+
 [dev-dependencies.test-strategy]
 workspace = true
 

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -64,7 +64,7 @@ version = "1"
 version = "2"
 
 [dependencies.futures]
-version = "0.3.30"
+workspace = true
 features = [ "thread-pool" ]
 
 [dependencies.indexmap]

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -308,6 +308,7 @@ impl<N: Network> Sync<N> {
         // Do not attempt to sync if there are no blocks to sync.
         // This prevents redundant log messages and performing unnecessary computation.
         if !self.block_sync.can_block_sync() {
+            trace!("No blocks to sync");
             return false;
         }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -288,6 +288,10 @@ impl<N: Network> Sync<N> {
     /// This is called periodically by a tokio background task spawned in `Self::run`.
     /// Some unit tests also call this function directly to manually trigger block synchronization.
     pub(crate) async fn try_block_sync(&self) -> bool {
+        // For sanity, check that sync height is never below ledger height.
+        // (if the ledger height is lower or equal to the current sync height, this is a noop)
+        self.block_sync.set_sync_height(self.ledger.latest_block_height());
+
         // Check if any existing requests can be removed.
         // We should do this even if we cannot block sync, to ensure
         // there are no dangling block requests.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -354,6 +354,11 @@ impl<N: Network> Sync<N> {
     fn remove_peer(&self, peer_ip: SocketAddr) {
         self.block_sync.remove_peer(&peer_ip);
     }
+
+    #[cfg(test)]
+    pub fn test_update_peer_locators(&self, peer_ip: SocketAddr, locators: BlockLocators<N>) -> Result<()> {
+        self.update_peer_locators(peer_ip, locators)
+    }
 }
 
 // Methods to manage storage.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -404,7 +404,7 @@ impl<N: Network> Consensus<N> {
         self.process_unconfirmed_transactions().await
     }
 
-    /// Processes unconfirmed transctions in the mempool, and passes them to the BFT layer
+    /// Processes unconfirmed transactions in the mempool, and passes them to the BFT layer
     /// (if sufficient space is available).
     async fn process_unconfirmed_transactions(&self) -> Result<()> {
         // If the memory pool of this node is full, return early.
@@ -516,7 +516,7 @@ impl<N: Network> Consensus<N> {
         callback.send(result).ok();
     }
 
-    /// Attempts to advance the ledger to the next block, and upadtes the metrics (if enabled) accordingly.
+    /// Attempts to advance the ledger to the next block, and updates the metrics (if enabled) accordingly.
     fn try_advance_to_next_block(
         &self,
         subdag: Subdag<N>,

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -19,14 +19,13 @@ edition = "2021"
 [features]
 default = [ "parallel" ]
 parallel = [ "rayon" ]
-history = [ "snarkvm-synthesizer/history" ]
+history = [ "snarkvm/history" ]
 telemetry = [ "snarkos-node-consensus/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-consensus/cuda", "snarkos-node-router/cuda" ]
 locktick = [
   "dep:locktick",
   "snarkos-node-consensus/locktick",
   "snarkos-node-router/locktick",
-  "snarkvm-synthesizer/locktick"
 ]
 
 [dependencies.anyhow]
@@ -81,14 +80,6 @@ workspace = true
 [dependencies.snarkos-node-router]
 workspace = true
 
-[dependencies.snarkvm-synthesizer]
-#path = "../../../snarkVM/synthesizer"
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "c194f3e"
-#version = "=3.8.0"
-default-features = false
-optional = true
-
 [dependencies.rand]
 version = "0.8"
 
@@ -117,8 +108,3 @@ version = "0.1"
 
 [dev-dependencies.base64]
 workspace = true
-
-[package.metadata.cargo-machete]
-ignored = [
-  "snarkvm-synthesizer", # Needed for locktick feature
-]

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -57,6 +57,8 @@ struct SyncStatus<'a> {
     /// The greatest known block height of a peer.
     /// None, if no peers are connected yet.
     p2p_height: Option<u32>,
+    /// The number of outstanding p2p sync requests.
+    outstanding_block_requests: usize,
 }
 
 impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
@@ -158,6 +160,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             is_synced: rest.routing.is_block_synced(),
             ledger_height: rest.ledger.latest_height(),
             p2p_height: rest.routing.greatest_peer_block_height(),
+            outstanding_block_requests: rest.routing.num_outstanding_block_requests(),
         }))
     }
 

--- a/node/router/src/outbound.rs
+++ b/node/router/src/outbound.rs
@@ -32,6 +32,9 @@ pub trait Outbound<N: Network> {
     /// or `None` if not connected to peers yet.
     fn num_blocks_behind(&self) -> Option<u32>;
 
+    /// The number of blocks we requested but have not received yet from peers.
+    fn num_outstanding_block_requests(&self) -> usize;
+
     /// Sends the given message to every connected peer, excluding the sender and any specified peer IPs.
     fn propagate(&self, message: Message<N>, excluded_peers: &[SocketAddr]) {
         // TODO (howardwu): Serialize large messages once only.

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -176,6 +176,11 @@ impl<N: Network> Outbound<N> for TestRouter<N> {
     fn greatest_peer_block_height(&self) -> Option<u32> {
         None
     }
+
+    /// The number of blocks we requested but have not received yet from peers.
+    fn num_outstanding_block_requests(&self) -> usize {
+        0
+    }
 }
 
 #[async_trait]

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -71,6 +71,10 @@ impl Outbound<Network> for HeartbeatTest {
     fn num_blocks_behind(&self) -> Option<u32> {
         None
     }
+
+    fn num_outstanding_block_requests(&self) -> usize {
+        0
+    }
 }
 
 impl Heartbeat<Network> for HeartbeatTest {

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -283,8 +283,12 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         // Sleep briefly to avoid triggering spam detection.
         let _ = timeout(Self::SYNC_INTERVAL, self.sync.wait_for_update()).await;
 
+        // For sanity, check that sync height is never below ledger height.
+        // (if the ledger height is lower or equal to the current sync height, this is a noop)
+        self.sync.set_sync_height(self.ledger.latest_height());
+
         // Do not attempt to sync if there are not blocks to sync.
-        // This prevents redudant log messages and performing unnecessary computation.
+        // This prevents redundant log messages and performing unnecessary computation.
         if !self.sync.can_block_sync() {
             return;
         }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -185,6 +185,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Client<N, C> {
     fn greatest_peer_block_height(&self) -> Option<u32> {
         self.sync.greatest_peer_block_height()
     }
+
+    /// The number of blocks we requested but have not received yet from peers.
+    fn num_outstanding_block_requests(&self) -> usize {
+        self.sync.num_outstanding_block_requests()
+    }
 }
 
 #[async_trait]

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -144,6 +144,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Prover<N, C> {
     fn greatest_peer_block_height(&self) -> Option<u32> {
         None
     }
+
+    /// The number of blocks we requested but have not received yet from peers.
+    fn num_outstanding_block_requests(&self) -> usize {
+        0
+    }
 }
 
 #[async_trait]

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -157,6 +157,11 @@ impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
     fn greatest_peer_block_height(&self) -> Option<u32> {
         self.sync.greatest_peer_block_height()
     }
+
+    /// The number of blocks we requested but have not received yet from peers.
+    fn num_outstanding_block_requests(&self) -> usize {
+        self.sync.num_outstanding_block_requests()
+    }
 }
 
 #[async_trait]

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -38,6 +38,9 @@ features = [ "serde", "rayon" ]
 [dependencies.itertools]
 workspace = true
 
+[dependencies.futures]
+workspace = true
+
 [dependencies.locktick]
 version = "0.3"
 features = [ "parking_lot" ]

--- a/node/sync/communication-service/src/lib.rs
+++ b/node/sync/communication-service/src/lib.rs
@@ -21,7 +21,7 @@ extern crate async_trait;
 use std::{io, net::SocketAddr};
 use tokio::sync::oneshot;
 
-/// Abstract communcation service.
+/// Abstract communication service.
 ///
 /// Implemented by `Gateway` and `Client`.
 #[async_trait]

--- a/node/sync/src/block_sync/sync_state.rs
+++ b/node/sync/src/block_sync/sync_state.rs
@@ -40,12 +40,13 @@ impl Default for SyncState {
 }
 
 impl SyncState {
-    /// Did we catch up with the greates known peer height?
+    /// Did we catch up with the greatest known peer height?
     /// This will return false if we never synced from a peer.
     pub fn is_block_synced(&self) -> bool {
         self.is_synced
     }
 
+    /// Returns `true` if there a blocks to sync from other nodes.
     pub fn can_block_sync(&self) -> bool {
         // Return true if sync state is false even if we there are no known blocks to fetch,
         // because otherwise nodes will never  switch to synced at startup.
@@ -123,7 +124,7 @@ impl SyncState {
                 debug!("Block sync state changed to \"synced\". It took {elapsed} to catch up with the network.");
             } else {
                 // num_blocks_behind should never be None at this point,
-                // but savely unwrap just is in case.
+                // but we still use `unwrap_or` just in case.
                 let behind_msg = num_blocks_behind.map(|n| n.to_string()).unwrap_or("unknown".to_string());
 
                 debug!("Block sync state changed to \"syncing\". We are {behind_msg} blocks behind.");


### PR DESCRIPTION
I noticed two potential issues in `snarkos_node_bft::Sync`.

First, when performing the long-range (non-BFT) sync, it would not update the sync height and, thus, block sync would try to sync older blocks that we already received.

Second, there seems to be a case where it would switch to BFT sync even if the node is still behind more than GC blocks. This could only happen if you received a block right after a non-BFT sync, so it might have never been triggered in production.

The PR aims to fix both of these issues. It is very short and just changes the behavior of `Sync::try_advancing_block_synchronization` slightly, so hopefully it can get merged quickly.