### PR TITLE
[Feature] Add `--log-filter` flag to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14edf4007a98323f763701688bcbe3bc6ecf33e20c3a81b3eb8d6661ff01b217"
 dependencies = [
- "colored",
+ "colored 2.2.0",
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -405,7 +405,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -621,6 +621,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -632,7 +633,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -658,6 +659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,15 +683,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width 0.2.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -725,7 +735,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "serde",
  "serde_derive",
@@ -838,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -906,7 +916,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -930,7 +940,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "strsim",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -941,7 +951,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -988,6 +998,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-ex"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "structmeta 0.3.0",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,7 +1017,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1016,7 +1038,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1058,7 +1080,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1151,7 +1173,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1333,7 +1355,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1477,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1487,7 +1509,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1911,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1923,14 +1945,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.0",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1950,7 +1972,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2091,9 +2113,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.1+1.9.0"
+version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
@@ -2119,9 +2141,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2277,7 +2299,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2369,7 +2391,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2469,7 +2491,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2510,12 +2532,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2575,7 +2591,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2696,7 +2712,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2785,12 +2801,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3093,7 +3109,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3142,9 +3158,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3366,6 +3382,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,7 +3477,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3458,7 +3486,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3498,16 +3526,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3517,14 +3546,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3688,7 +3717,7 @@ dependencies = [
 name = "snarkos-account"
 version = "3.8.0"
 dependencies = [
- "colored",
+ "colored 2.2.0",
  "snarkvm",
 ]
 
@@ -3702,9 +3731,9 @@ dependencies = [
  "base64 0.22.1",
  "base64ct",
  "clap",
- "colored",
+ "colored 3.0.0",
  "crossterm 0.29.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "nix",
  "num_cpus",
@@ -3752,7 +3781,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "async-trait",
- "colored",
+ "colored 2.2.0",
  "deadline",
  "futures-util",
  "locktick",
@@ -3793,10 +3822,10 @@ dependencies = [
  "axum-extra",
  "bytes",
  "clap",
- "colored",
+ "colored 2.2.0",
  "deadline",
  "futures",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "locktick",
  "lru",
@@ -3820,7 +3849,7 @@ dependencies = [
  "snarkos-node-sync",
  "snarkos-node-tcp",
  "snarkvm",
- "test-strategy 0.4.1",
+ "test-strategy 0.4.3",
  "time",
  "tokio",
  "tokio-stream",
@@ -3837,12 +3866,12 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proptest",
  "serde",
  "snarkos-node-sync-locators",
  "snarkvm",
- "test-strategy 0.4.1",
+ "test-strategy 0.4.3",
  "time",
  "tokio-util",
  "tracing",
@@ -3854,7 +3883,7 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3871,7 +3900,7 @@ version = "3.8.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3885,7 +3914,7 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "bincode",
- "colored",
+ "colored 2.2.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -3905,8 +3934,8 @@ version = "3.8.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "colored",
- "indexmap 2.9.0",
+ "colored 2.2.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "locktick",
  "lru",
@@ -3945,7 +3974,7 @@ dependencies = [
  "axum-extra",
  "base64 0.22.1",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "jsonwebtoken",
  "locktick",
  "once_cell",
@@ -3973,7 +4002,7 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "colored",
+ "colored 2.2.0",
  "deadline",
  "futures",
  "futures-util",
@@ -4010,7 +4039,7 @@ dependencies = [
  "snarkos-node-bft-events",
  "snarkos-node-sync-locators",
  "snarkvm",
- "test-strategy 0.4.1",
+ "test-strategy 0.4.3",
  "tokio-util",
  "tracing",
 ]
@@ -4020,7 +4049,7 @@ name = "snarkos-node-sync"
 version = "3.8.0"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
@@ -4048,7 +4077,7 @@ name = "snarkos-node-sync-locators"
 version = "3.8.0"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "snarkvm",
  "tracing",
@@ -4106,7 +4135,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.4",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.11.0",
  "num-traits",
  "rand 0.8.5",
@@ -4183,7 +4212,7 @@ name = "snarkvm-circuit-environment"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.11.0",
  "nom",
  "num-traits",
@@ -4375,7 +4404,7 @@ version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "lazy_static",
  "once_cell",
  "paste",
@@ -4415,7 +4444,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -4554,7 +4583,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4591,7 +4620,7 @@ name = "snarkvm-ledger-block"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4612,7 +4641,7 @@ version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4643,7 +4672,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4656,7 +4685,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4680,7 +4709,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4720,7 +4749,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4739,8 +4768,8 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e
 dependencies = [
  "aleo-std",
  "anyhow",
- "colored",
- "indexmap 2.9.0",
+ "colored 2.2.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4776,7 +4805,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "once_cell",
  "parking_lot",
@@ -4829,7 +4858,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "cfg-if",
- "colored",
+ "colored 2.2.0",
  "curl",
  "hex",
  "lazy_static",
@@ -4851,7 +4880,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.11.0",
  "locktick",
  "lru",
@@ -4883,8 +4912,8 @@ version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
  "aleo-std",
- "colored",
- "indexmap 2.9.0",
+ "colored 2.2.0",
+ "indexmap 2.10.0",
  "locktick",
  "once_cell",
  "parking_lot",
@@ -4908,7 +4937,7 @@ name = "snarkvm-synthesizer-program"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4959,7 +4988,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5028,7 +5057,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "structmeta-derive 0.2.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5040,7 +5069,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "structmeta-derive 0.3.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5051,7 +5080,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5062,7 +5091,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5084,7 +5113,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5117,9 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -5152,7 +5181,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5214,19 +5243,20 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "structmeta 0.2.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "test-strategy"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95eb2d223f5cd3ec8dd7874cf4ada95c9cf2b5ed84ecfb1046d9aefee0c28b12"
+checksum = "43b12f9683de37f9980e485167ee624bfaa0b6b04da661e98e25ef9c2669bc1b"
 dependencies = [
+ "derive-ex",
  "proc-macro2",
  "quote 1.0.40",
  "structmeta 0.3.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5255,7 +5285,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5266,7 +5296,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5398,7 +5428,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5494,7 +5524,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5600,7 +5630,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5660,7 +5690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5737,6 +5767,12 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "untrusted"
@@ -5908,7 +5944,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -5943,7 +5979,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6059,7 +6095,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6070,7 +6106,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6081,9 +6117,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -6307,7 +6343,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6328,7 +6364,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6348,7 +6384,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6369,7 +6405,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6402,7 +6438,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6416,7 +6452,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "thiserror 2.0.12",
  "time",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "snarkos-cli"
 version = "3.8.0"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
-description = "A CLI for a decentralized operating system"
+description = "Command-line interface for snarkOS"
 homepage = "https://aleo.org"
 repository = "https://github.com/ProvableHQ/snarkOS"
 keywords = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,10 +51,10 @@ workspace = true
 
 [dependencies.clap]
 workspace = true
-features = [ "derive", "color", "unstable-styles", "help" ]
+features = [ "derive", "color", "unstable-styles", "help", "cargo", "usage", "suggestions" ]
 
 [dependencies.colored]
-version = "2"
+version = "3"
 
 [dependencies.crossterm]
 workspace = true

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -34,9 +34,15 @@ use clap::{Parser, builder::Styles};
 
 const HEADER_COLOR: Option<Color> = Some(Color::Ansi(AnsiColor::Yellow));
 const LITERAL_COLOR: Option<Color> = Some(Color::Ansi(AnsiColor::Green));
+const ERROR_COLOR: Option<Color> = Some(Color::Ansi(AnsiColor::Red));
+const INVALID_COLOR: Option<Color> = Some(Color::Ansi(AnsiColor::Magenta));
+
 const STYLES: Styles = Styles::plain()
     .header(Style::new().bold().fg_color(HEADER_COLOR))
     .usage(Style::new().bold().fg_color(HEADER_COLOR))
+    .error(Style::new().bold().fg_color(ERROR_COLOR))
+    .invalid(Style::new().fg_color(INVALID_COLOR))
+    .valid(Style::new().bold().fg_color(LITERAL_COLOR))
     .literal(Style::new().bold().fg_color(LITERAL_COLOR));
 
 // The top-level command-line argument.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -39,18 +39,18 @@ const STYLES: Styles = Styles::plain()
     .usage(Style::new().bold().fg_color(HEADER_COLOR))
     .literal(Style::new().bold().fg_color(LITERAL_COLOR));
 
-// Note: the basic clap-supplied version is overridden in the main module.
+// The top-level command-line argument.
+//
+// Metadata is sourced from Cargo.toml. However, the version will be overridden in the main module (snarkos/main.rs).
 #[derive(Debug, Parser)]
-#[clap(name = "snarkOS", author = "The Aleo Team <hello@aleo.org>", styles = STYLES, version)]
+#[clap(name = "snarkOS", author="The Aleo Team <hello@aleo.org>", about, styles = STYLES, version)]
 pub struct CLI {
-    /// Specify the verbosity [options: 0, 1, 2, 3]
-    #[clap(default_value = "2", short, long)]
-    pub verbosity: u8,
     /// Specify a subcommand.
     #[clap(subcommand)]
     pub command: Command,
 }
 
+/// The subcommand passed after `snarkos`, e.g. `Start` corresponds to `snarkos start`.
 #[derive(Debug, Parser)]
 pub enum Command {
     #[clap(subcommand)]

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -43,7 +43,7 @@ const STYLES: Styles = Styles::plain()
 //
 // Metadata is sourced from Cargo.toml. However, the version will be overridden in the main module (snarkos/main.rs).
 #[derive(Debug, Parser)]
-#[clap(name = "snarkOS", author="The Aleo Team <hello@aleo.org>", about, styles = STYLES, version)]
+#[clap(name = "snarkOS", author, about, styles = STYLES, version)]
 pub struct CLI {
     /// Specify a subcommand.
     #[clap(subcommand)]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -80,7 +80,7 @@ impl FromStr for BondedBalances {
 
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
-#[command(   
+#[command(
     // Use kebab-case for all arguments (e.g., use the `private-key` flag for the `private_key` field).
     // This is already the default, but we specify it in case clap's default changes in the future.
     rename_all = "kebab-case",

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -80,21 +80,24 @@ impl FromStr for BondedBalances {
 
 /// Starts the snarkOS node.
 #[derive(Clone, Debug, Parser)]
-#[command(
+#[command(   
     // Use kebab-case for all arguments (e.g., use the `private-key` flag for the `private_key` field).
-    // This is already the default, but specify it in case clap changes it in the future.
+    // This is already the default, but we specify it in case clap's default changes in the future.
     rename_all = "kebab-case",
 
     // Ensure at most one node type is specified.
     group(clap::ArgGroup::new("node_type").required(false).multiple(false)
 ),
 
-    // Ensure dev flags can only be set if `--dev` is set.
+    // Ensure all other dev flags can only be set if `--dev` is set.
     group(clap::ArgGroup::new("dev_flags").required(false).multiple(true).requires("dev")
 ),
     // Ensure any rest flag (including `--rest`) cannot be set
     // if `--norest` is set.
-    group(clap::ArgGroup::new("rest_flags").required(false).multiple(true).conflicts_with("norest"))
+    group(clap::ArgGroup::new("rest_flags").required(false).multiple(true).conflicts_with("norest")),
+
+    // Ensure you cannot set --verbosity and --log-filter flags at the same time.
+    group(clap::ArgGroup::new("log_flags").required(false).multiple(false)),
 )]
 pub struct Start {
     /// Specify the network ID of this node
@@ -137,7 +140,7 @@ pub struct Start {
 
     /// Specify the IP address and port of the peer(s) to connect to (as a comma-separated list).
     ///
-    /// These peers will be set as "trusted", which means the node will not  disconnect from them when performing peer rotation.
+    /// These peers will be set as "trusted", which means the node will not disconnect from them when performing peer rotation.
     ///
     /// Setting peers to "" has the same effect as not setting the flag at all, except when using `--dev`.
     #[clap(long, verbatim_doc_comment)]
@@ -147,9 +150,9 @@ pub struct Start {
     #[clap(long)]
     pub validators: Option<String>,
 
-    /// Allow untrusted peers (not listed in `--peers`) to connect (as a comma-separated list)..
+    /// Allow untrusted peers (not listed in `--peers`) to connect.
     ///
-    /// This behavior is always enabled for lient and Prover nodes ignore the flag and always allow untrusted peers to connect.
+    /// The flag will be ignored by client and prover nodes, as tis behavior is always enabled for these types of nodes.
     #[clap(long, verbatim_doc_comment)]
     pub allow_external_peers: bool,
 
@@ -185,8 +188,12 @@ pub struct Start {
 
     /// Specify the log verbosity of the node.
     /// [options: 0 (lowest log level) to 6 (highest level)]
-    #[clap(long, default_value_t = 1)]
+    #[clap(long, default_value_t = 1, group = "log_flags")]
     pub verbosity: u8,
+
+    /// Set a custom log filtering scheme, e.g., "off,snarkos_bft=trace", to show all log messages of snarkos_bft but nothing else.
+    #[clap(long, group = "log_flags")]
+    pub log_filter: Option<String>,
 
     /// Specify the path to the file where logs will be stored
     #[clap(long, default_value_os_t = std::env::temp_dir().join("snarkos.log"))]
@@ -245,8 +252,15 @@ impl Start {
         let shutdown: Arc<AtomicBool> = Default::default();
 
         // Initialize the logger.
-        let log_receiver =
-            crate::helpers::initialize_logger(self.verbosity, self.nodisplay, self.logfile.clone(), shutdown.clone());
+        let log_receiver = crate::helpers::initialize_logger(
+            self.verbosity,
+            &self.log_filter,
+            self.nodisplay,
+            self.logfile.clone(),
+            shutdown.clone(),
+        )
+        .with_context(|| "Failed to set up logger")?;
+
         // Initialize the runtime.
         Self::runtime().block_on(async move {
             // Error messages.
@@ -899,6 +913,19 @@ mod tests {
             SocketAddr::from_str("1.2.3.4:5").unwrap(),
             SocketAddr::from_str("6.7.8.9:0").unwrap()
         ]);
+    }
+
+    #[test]
+    fn test_parse_log_filter() {
+        // Ensure we cannot set, both, log-filter and verbosity
+        let result = Start::try_parse_from(["snarkos", "--verbosity=5", "--log-filter=warn"].iter());
+        assert!(result.is_err(), "Must not be able to set log-filter and verbosity at the same time");
+
+        // Ensure the values are set correctly.
+        let config = Start::try_parse_from(["snarkos", "--verbosity=5"].iter()).unwrap();
+        assert_eq!(config.verbosity, 5);
+        let config = Start::try_parse_from(["snarkos", "--log-filter=snarkos=warn"].iter()).unwrap();
+        assert_eq!(config.log_filter, Some("snarkos=warn".to_string()));
     }
 
     #[test]

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -15,6 +15,8 @@
 
 use crate::helpers::{DynamicFormatter, LogWriter};
 
+use anyhow::Result;
+
 use crossterm::tty::IsTty;
 use std::{
     fs::File,
@@ -30,6 +32,77 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
 };
 
+fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
+    // First, set default log verbosity
+    let default_log_str = match verbosity {
+        0 => "RUST_LOG=info",
+        1 => "RUST_LOG=debug",
+        2.. => "RUST_LOG=trace",
+    };
+    let filter = EnvFilter::from_str(default_log_str).unwrap();
+
+    // Now, set rules for specific crates.
+    let filter = if verbosity >= 2 {
+        filter.add_directive("snarkos_node_sync=trace".parse().unwrap())
+    } else {
+        filter.add_directive("snarkos_node_sync=debug".parse().unwrap())
+    };
+
+    let filter = if verbosity >= 3 {
+        filter
+            .add_directive("snarkos_node_bft=trace".parse().unwrap())
+            .add_directive("snarkos_node_bft::gateway=debug".parse().unwrap())
+    } else {
+        filter.add_directive("snarkos_node_bft=debug".parse().unwrap())
+    };
+
+    let filter = if verbosity >= 4 {
+        let filter = filter.add_directive("snarkos_node_bft::gateway=trace".parse().unwrap());
+
+        // At high log levels, also show warnings of third-party crates.
+        filter
+            .add_directive("mio=warn".parse().unwrap())
+            .add_directive("tokio_util=warn".parse().unwrap())
+            .add_directive("hyper=warn".parse().unwrap())
+            .add_directive("reqwest=warn".parse().unwrap())
+            .add_directive("want=warn".parse().unwrap())
+            .add_directive("h2=warn".parse().unwrap())
+            .add_directive("tower=warn".parse().unwrap())
+            .add_directive("axum=warn".parse().unwrap())
+    } else {
+        let filter = filter.add_directive("snarkos_node_bft::gateway=debug".parse().unwrap());
+
+        // Disable logs from third-party crates by default.
+        filter
+            .add_directive("mio=off".parse().unwrap())
+            .add_directive("tokio_util=off".parse().unwrap())
+            .add_directive("hyper=off".parse().unwrap())
+            .add_directive("reqwest=off".parse().unwrap())
+            .add_directive("want=off".parse().unwrap())
+            .add_directive("h2=off".parse().unwrap())
+            .add_directive("tower=off".parse().unwrap())
+            .add_directive("axum=off".parse().unwrap())
+    };
+
+    let filter = if verbosity >= 5 {
+        filter.add_directive("snarkos_node_router=trace".parse().unwrap())
+    } else {
+        filter.add_directive("snarkos_node_router=debug".parse().unwrap())
+    };
+
+    let filter = if verbosity >= 6 {
+        filter.add_directive("snarkos_node_tcp=trace".parse().unwrap())
+    } else {
+        filter.add_directive("snarkos_node_tcp=off".parse().unwrap())
+    };
+
+    Ok(filter)
+}
+
+fn parse_log_filter(filter_str: &str) -> Result<EnvFilter> {
+    EnvFilter::from_str(filter_str).map_err(|err| err.into())
+}
+
 /// Sets the log filter based on the given verbosity level.
 ///
 /// ```ignore
@@ -44,73 +117,13 @@ use tracing_subscriber::{
 /// ```
 pub fn initialize_logger<P: AsRef<Path>>(
     verbosity: u8,
+    log_filter: &Option<String>,
     nodisplay: bool,
     logfile: P,
     shutdown: Arc<AtomicBool>,
-) -> mpsc::Receiver<Vec<u8>> {
+) -> Result<mpsc::Receiver<Vec<u8>>> {
     let [stdout_filter, logfile_filter] = std::array::from_fn(|_| {
-        // First, set default log verbosity
-        let default_log_str = match verbosity {
-            0 => "RUST_LOG=info",
-            1 => "RUST_LOG=debug",
-            2.. => "RUST_LOG=trace",
-        };
-        let filter = EnvFilter::from_str(default_log_str).unwrap();
-
-        // Now, set rules for specific crates.
-        let filter = if verbosity >= 2 {
-            filter.add_directive("snarkos_node_sync=trace".parse().unwrap())
-        } else {
-            filter.add_directive("snarkos_node_sync=debug".parse().unwrap())
-        };
-
-        let filter = if verbosity >= 3 {
-            filter
-                .add_directive("snarkos_node_bft=trace".parse().unwrap())
-                .add_directive("snarkos_node_bft::gateway=debug".parse().unwrap())
-        } else {
-            filter.add_directive("snarkos_node_bft=debug".parse().unwrap())
-        };
-
-        let filter = if verbosity >= 4 {
-            let filter = filter.add_directive("snarkos_node_bft::gateway=trace".parse().unwrap());
-
-            // At high log levels, also show warnings of third-party crates.
-            filter
-                .add_directive("mio=warn".parse().unwrap())
-                .add_directive("tokio_util=warn".parse().unwrap())
-                .add_directive("hyper=warn".parse().unwrap())
-                .add_directive("reqwest=warn".parse().unwrap())
-                .add_directive("want=warn".parse().unwrap())
-                .add_directive("h2=warn".parse().unwrap())
-                .add_directive("tower=warn".parse().unwrap())
-                .add_directive("axum=warn".parse().unwrap())
-        } else {
-            let filter = filter.add_directive("snarkos_node_bft::gateway=debug".parse().unwrap());
-
-            // Disable logs from third-party crates by default.
-            filter
-                .add_directive("mio=off".parse().unwrap())
-                .add_directive("tokio_util=off".parse().unwrap())
-                .add_directive("hyper=off".parse().unwrap())
-                .add_directive("reqwest=off".parse().unwrap())
-                .add_directive("want=off".parse().unwrap())
-                .add_directive("h2=off".parse().unwrap())
-                .add_directive("tower=off".parse().unwrap())
-                .add_directive("axum=off".parse().unwrap())
-        };
-
-        let filter = if verbosity >= 5 {
-            filter.add_directive("snarkos_node_router=trace".parse().unwrap())
-        } else {
-            filter.add_directive("snarkos_node_router=debug".parse().unwrap())
-        };
-
-        if verbosity >= 6 {
-            filter.add_directive("snarkos_node_tcp=trace".parse().unwrap())
-        } else {
-            filter.add_directive("snarkos_node_tcp=off".parse().unwrap())
-        }
+        if let Some(filter) = log_filter { parse_log_filter(filter) } else { parse_log_verbosity(verbosity) }
     });
 
     // Create the directories tree for a logfile if it doesn't exist.
@@ -142,7 +155,7 @@ pub fn initialize_logger<P: AsRef<Path>>(
                 .with_writer(move || LogWriter::new(&log_sender))
                 .with_target(verbosity > 2)
                 .event_format(DynamicFormatter::new(shutdown))
-                .with_filter(stdout_filter),
+                .with_filter(stdout_filter?),
         )
         .with(
             // Add layer redirecting logs to the file
@@ -150,11 +163,11 @@ pub fn initialize_logger<P: AsRef<Path>>(
                 .with_ansi(false)
                 .with_writer(logfile)
                 .with_target(verbosity > 2)
-                .with_filter(logfile_filter),
+                .with_filter(logfile_filter?),
         )
         .try_init();
 
-    log_receiver
+    Ok(log_receiver)
 }
 
 /// Returns the welcome message as a string.
@@ -181,4 +194,18 @@ pub fn welcome_message() -> String {
     .bold();
     output += &"👋 Welcome to Aleo! We thank you for running a node and supporting privacy.\n".bold();
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_filter() {
+        let result = parse_log_filter("=");
+        assert!(result.is_err(), "must disallow invalid log filter");
+
+        let result = parse_log_filter("snarkos=trace");
+        assert!(result.is_ok(), "must allow valid log filter");
+    }
 }


### PR DESCRIPTION
##  Motivation
One can adjust log filtering using `snarkos start --verbosity`, but that does not allow for more fine-grained rules for logging.
Sometimes you might want to start a large network and only care about detailed logs for a specific crate/module. In this case, setting the filter to, for example, `--verbosity=6` creates significantly more log messages than needed. That can create a lot of unnecessary data for tools like Elasticsearch and makes it more cumbersome to search the logs later.

## New Filter Flag
This PR adds a `--log-filter` flag, that can be set instead of `--verbosity`. The log filter flag, essentially, works like setting `RUST_LOG`. If you, for example, only want to all show logs related to the BFT crate but nothing else, you can start a node like this `snarkos start --log-filter=off,snarkos_node_bft=trace`.

## Other Changes
The PR also cleans up CLI some more. I removed a top-level `verbosity` flag that is not used anywhere. I also (re-)added the `suggestions` and `usage` features, so that the displayed help information is more useful. Finally, I bumped the `colored` crate to version `3.0.0`.

The top-level help now looks like this. Note the changed description from the updated `description` field in `Cargo.toml`.
<img width="600" alt="snarkos --help" src="https://github.com/user-attachments/assets/c3a58557-bd66-43df-b1d8-fd4fd5c31f8d" />

The final commit of the PR ([cf81b0f](https://github.com/ProvableHQ/snarkOS/pull/3707/commits/cf81b0f1e0a75be7435a8db18eca6d3c52641418)) adds some missing colors, such as for invalid commands and suggestions. It now looks like this: 
<img width="439" alt="snarkos suggestion" src="https://github.com/user-attachments/assets/73170d07-203a-4caf-84c7-981eaf71326e" />


## Notes
* The authors flag for CLI is also sourced from `cli/Cargo.toml` now, but clap `4.*` does not display author information unless one specifies a custom help template. See [this note](https://docs.rs/clap/latest/clap/builder/struct.Command.html#method.author) on the clap documentation for details.
* We should consider merging `snarkos` and `snarkos-cli`. I don't see a reason to have a separate `cli` crate that is only used by `snarkos` and nothing else.