### PR TITLE
[Feat] Support Migration for Record Versioning Upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4172,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "blst",
  "cc",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.11.0",
@@ -4246,12 +4246,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4394,7 +4394,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4418,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4596,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4655,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4752,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "async-trait",
  "http 1.3.1",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4846,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "metrics",
 ]
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4927,7 +4927,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "colored 2.2.0",
@@ -4953,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4970,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4983,7 +4983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5004,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3971,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "blst",
  "cc",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4045,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "indexmap 2.9.0",
  "itertools 0.11.0",
@@ -4074,12 +4074,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4104,7 +4104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -4266,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4320,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4331,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4424,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -4502,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4515,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "indexmap 2.9.0",
  "rayon",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4626,12 +4626,13 @@ dependencies = [
  "snarkvm-ledger-puzzle",
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-program",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "async-trait",
  "http 1.3.1",
@@ -4645,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4673,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4690,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "metrics",
 ]
@@ -4698,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4721,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4754,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4780,22 +4781,24 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "indexmap 2.9.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rayon",
  "serde_json",
  "snarkvm-circuit",
  "snarkvm-console",
  "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4808,7 +4811,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4829,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=c194f3e#c194f3e7083e2eaae254458b4074828e690d2a9d"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
 dependencies = [
  "jobserver",
  "libc",
@@ -604,7 +604,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -697,7 +697,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "log",
  "serde",
  "serde_derive",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -878,7 +878,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -902,7 +902,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "strsim",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -913,7 +913,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -959,6 +959,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-ex"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba95f299f6b9cd47f68a847eca2ae9060a2713af532dc35c342065544845407"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "structmeta 0.3.0",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +978,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -987,7 +999,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1029,7 +1041,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1116,7 +1128,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1298,7 +1310,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1442,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1452,7 +1464,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1851,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1890,7 +1902,18 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2031,9 +2054,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.1+1.9.0"
+version = "0.18.2+1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
 dependencies = [
  "cc",
  "libc",
@@ -2059,9 +2082,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2217,7 +2240,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2309,7 +2332,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2409,7 +2432,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2515,7 +2538,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2636,7 +2659,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2725,12 +2748,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3062,9 +3085,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3357,7 +3380,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3366,7 +3389,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3581,7 +3604,7 @@ dependencies = [
  "clap",
  "colored",
  "crossterm 0.29.0",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "nix",
  "num_cpus",
@@ -3673,7 +3696,7 @@ dependencies = [
  "colored",
  "deadline",
  "futures",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "locktick",
  "lru",
@@ -3697,7 +3720,7 @@ dependencies = [
  "snarkos-node-sync",
  "snarkos-node-tcp",
  "snarkvm",
- "test-strategy 0.4.1",
+ "test-strategy 0.4.3",
  "time",
  "tokio",
  "tokio-stream",
@@ -3714,12 +3737,12 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proptest",
  "serde",
  "snarkos-node-sync-locators",
  "snarkvm",
- "test-strategy 0.4.1",
+ "test-strategy 0.4.3",
  "time",
  "tokio-util",
  "tracing",
@@ -3731,7 +3754,7 @@ version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3748,7 +3771,7 @@ version = "3.8.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -3783,7 +3806,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "locktick",
  "lru",
@@ -3822,7 +3845,7 @@ dependencies = [
  "axum-extra",
  "base64 0.22.1",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "jsonwebtoken",
  "locktick",
  "once_cell",
@@ -3885,7 +3908,7 @@ dependencies = [
  "snarkos-node-bft-events",
  "snarkos-node-sync-locators",
  "snarkvm",
- "test-strategy 0.4.1",
+ "test-strategy 0.4.3",
  "tokio-util",
  "tracing",
 ]
@@ -3895,7 +3918,7 @@ name = "snarkos-node-sync"
 version = "3.8.0"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
@@ -3923,7 +3946,7 @@ name = "snarkos-node-sync-locators"
 version = "3.8.0"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "snarkvm",
  "tracing",
@@ -3980,7 +4003,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.4",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.11.0",
  "num-traits",
  "rand 0.8.5",
@@ -4057,7 +4080,7 @@ name = "snarkvm-circuit-environment"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.11.0",
  "nom",
  "num-traits",
@@ -4249,7 +4272,7 @@ version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "lazy_static",
  "once_cell",
  "paste",
@@ -4289,7 +4312,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -4428,7 +4451,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4465,7 +4488,7 @@ name = "snarkvm-ledger-block"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4486,7 +4509,7 @@ version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4517,7 +4540,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4530,7 +4553,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4554,7 +4577,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4594,7 +4617,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4614,7 +4637,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4651,7 +4674,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "once_cell",
  "parking_lot",
@@ -4726,7 +4749,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.11.0",
  "locktick",
  "lru",
@@ -4759,7 +4782,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3
 dependencies = [
  "aleo-std",
  "colored",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "locktick",
  "once_cell",
  "parking_lot",
@@ -4783,7 +4806,7 @@ name = "snarkvm-synthesizer-program"
 version = "3.8.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3bfc3992a685e9045a1e2c956806e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4836,7 +4859,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=4642f9b#4642f9b30fc3
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4905,7 +4928,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "structmeta-derive 0.2.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4917,7 +4940,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "structmeta-derive 0.3.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4928,7 +4951,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4939,7 +4962,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4961,7 +4984,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4994,9 +5017,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -5029,7 +5052,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5091,19 +5114,20 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "structmeta 0.2.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "test-strategy"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95eb2d223f5cd3ec8dd7874cf4ada95c9cf2b5ed84ecfb1046d9aefee0c28b12"
+checksum = "43b12f9683de37f9980e485167ee624bfaa0b6b04da661e98e25ef9c2669bc1b"
 dependencies = [
+ "derive-ex",
  "proc-macro2",
  "quote 1.0.40",
  "structmeta 0.3.0",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5132,7 +5156,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5143,7 +5167,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5251,17 +5275,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -5275,7 +5301,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5371,7 +5397,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5477,7 +5503,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5537,7 +5563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5785,7 +5811,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -5820,7 +5846,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5923,9 +5949,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -6149,7 +6175,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6170,7 +6196,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6190,7 +6216,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6211,7 +6237,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6244,7 +6270,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6258,7 +6284,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "thiserror 2.0.12",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "c194f3e"
+rev = "4642f9b"
 #version = "=3.8.0"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 version = "1.0.1"
 default-features = false
 
-[workspace.dependencies.snarkvm] # If this is updated, the rev in `node/rest/Cargo.toml` must be updated as well.
+[workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 rev = "4642f9b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "4642f9b"
+rev = "668b72b"
 #version = "=3.8.0"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -83,6 +83,7 @@ mod tests {
         PrivateKey,
         Scalar,
         TestRng,
+        U8,
         Uniform,
         ViewKey,
     };
@@ -108,6 +109,7 @@ mod tests {
                 .into_iter(),
             ),
             N::g_scalar_multiply(&randomizer),
+            U8::<N>::rand(rng),
         )?;
         // Encrypt the record.
         let ciphertext = record.encrypt(randomizer)?;

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -69,8 +69,6 @@ impl Decrypt {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use indexmap::IndexMap;
     use snarkvm::prelude::{
         Address,
         Entry,
@@ -78,6 +76,7 @@ mod tests {
         Identifier,
         Literal,
         Network,
+        One,
         Owner,
         Plaintext,
         PrivateKey,
@@ -86,7 +85,11 @@ mod tests {
         U8,
         Uniform,
         ViewKey,
+        Zero,
     };
+
+    use indexmap::IndexMap;
+    use rand::Rng;
 
     type CurrentNetwork = MainnetV0;
 
@@ -99,6 +102,10 @@ mod tests {
     ) -> Result<Record<N, Ciphertext<N>>> {
         // Prepare the record.
         let randomizer = Scalar::rand(rng);
+        let version = match rng.gen() {
+            true => U8::<N>::one(),
+            false => U8::<N>::zero(),
+        };
         let record = Record::<N, Plaintext<N>>::from_plaintext(
             owner,
             IndexMap::from_iter(
@@ -109,7 +116,7 @@ mod tests {
                 .into_iter(),
             ),
             N::g_scalar_multiply(&randomizer),
-            U8::<N>::rand(rng),
+            version,
         )?;
         // Encrypt the record.
         let ciphertext = record.encrypt(randomizer)?;

--- a/node/bft/events/src/disconnect.rs
+++ b/node/bft/events/src/disconnect.rs
@@ -64,7 +64,7 @@ impl FromBytes for Disconnect {
             Ok(1) => DisconnectReason::NoReasonGiven,
             Ok(2) => DisconnectReason::ProtocolViolation,
             Ok(3) => DisconnectReason::OutdatedClientVersion,
-            _ => return Err(io::Error::new(io::ErrorKind::Other, "Invalid 'Disconnect' event")),
+            _ => return Err(io::Error::other("Invalid 'Disconnect' event")),
         };
 
         Ok(Self { reason })

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -80,7 +80,7 @@ version = "=3.8.0"
 [dependencies.snarkvm-synthesizer]
 #path = "../../../snarkVM/synthesizer"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "c194f3e"
+rev = "4642f9b"
 #version = "=3.8.0"
 default-features = false
 optional = true

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -152,6 +152,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route(&format!("/{network}/program/{{id}}/mapping/{{name}}"), get(Self::get_mapping_values))
             .route_layer(middleware::from_fn(auth_middleware))
 
+             // Get ../consensus_version
+            .route(&format!("/{network}/consensus_version"), get(Self::get_consensus_version))
+
             // GET ../block/..
             .route(&format!("/{network}/block/height/latest"), get(Self::get_block_height_latest))
             .route(&format!("/{network}/block/hash/latest"), get(Self::get_block_hash_latest))
@@ -174,7 +177,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // GET ../find/..
             .route(&format!("/{network}/find/blockHash/{{tx_id}}"), get(Self::find_block_hash))
             .route(&format!("/{network}/find/blockHeight/{{state_root}}"), get(Self::find_block_height_from_state_root))
-            .route(&format!("/{network}/find/transactionID/deployment/{{program_id}}"), get(Self::find_transaction_id_from_program_id))
+            .route(&format!("/{network}/find/transactionID/deployment/{{program_id}}"), get(Self::find_latest_transaction_id_from_program_id))
+            .route(&format!("/{network}/find/transactionID/deployment/{{program_id}}/{{edition}}"), get(Self::find_transaction_id_from_program_id_and_edition))
             .route(&format!("/{network}/find/transactionID/{{transition_id}}"), get(Self::find_transaction_id_from_transition_id))
             .route(&format!("/{network}/find/transitionID/{{input_or_output_id}}"), get(Self::find_transition_id))
 
@@ -185,6 +189,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
             // GET ../program/..
             .route(&format!("/{network}/program/{{id}}"), get(Self::get_program))
+            .route(&format!("/{network}/program/{{id}}/latest_edition"), get(Self::get_latest_program_edition))
+            .route(&format!("/{network}/program/{{id}}/{{edition}}"), get(Self::get_program_for_edition))
             .route(&format!("/{network}/program/{{id}}/mappings"), get(Self::get_mapping_names))
             .route(&format!("/{network}/program/{{id}}/mapping/{{name}}/{{key}}"), get(Self::get_mapping_value))
 

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -357,7 +357,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(program_id): Path<ProgramID<N>>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_transaction_id_from_program_id(&program_id)?))
+        Ok(ErasedJson::pretty(rest.ledger.find_latest_transaction_id_from_program_id(&program_id)?))
     }
 
     // GET /<network>/find/transactionID/{transitionID}


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR adds support for the new Record Versioning and Inclusion updates. In addition, migration logic is added to support the transition between the consensus versions that activates the new features.


Two new rules are added:
1. Do not include deployments in new proposals if you are behind `ConsenusVersion::V8`.
2. Do not sign proposals that have deployments if you are behind `ConsenusVersion::V8`. 

These two rules can be removed after the migration occurs on each network