### PR TITLE
[Fix] Set up log filters correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,6 @@ commands:
           name: "Run devnet test"
           timeout: 20m  # Allow 20 minutes total
           command: |
-            chmod +x .circleci/devnet_ci.sh
             ./.circleci/devnet_ci.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>
       - clear_environment:
           cache_key: << parameters.cache_key >>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,12 +74,25 @@ version = "0.22"
 [workspace.dependencies.tokio]
 version = "1.28"
 
+[workspace.dependencies.tokio-util]
+version = "0.7"
+
 [workspace.dependencies.itertools]
 version = "0.14"
 
 [workspace.dependencies.indexmap]
 version = "2"
 default-features = false
+
+[workspace.dependencies.tracing]
+version = "0.1"
+default-features = false
+
+[workspace.dependencies.tracing-test]
+version = "0.2"
+
+[workspace.dependencies.tracing-subscriber]
+version = "0.3"
 
 [workspace.dependencies.test-strategy]
 version = "0.4"
@@ -186,7 +199,7 @@ version = "=3.8.0"
 tikv-jemallocator = "0.5"
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 optional = true
 
 [dev-dependencies.rusty-hook]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -143,10 +143,10 @@ workspace = true
 features = [ "rt" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dependencies.tracing-subscriber]
-version = "0.3"
+workspace = true
 features = [ "env-filter" ]
 
 [dependencies.ureq]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -134,10 +134,10 @@ workspace = true
 features = [ "rt", "signal" ]
 
 [dependencies.tokio-util]
-version = "0.7"
+workspace = true
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.deadline]
 version = "0.2"
@@ -153,7 +153,7 @@ path = "./router"
 features = [ "test" ]
 
 [dev-dependencies.tracing-subscriber]
-version = "0.3"
+workspace = true
 features = [ "env-filter", "fmt" ]
 
 [dev-dependencies.rand_chacha]

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -139,11 +139,11 @@ features = [ "macros", "rt-multi-thread", "signal" ]
 version = "=0.1"
 
 [dependencies.tokio-util]
-version = "0.7"
+workspace = true
 features = [ "codec" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.axum]
 version = "0.8"
@@ -200,11 +200,11 @@ version = "0.6"
 features = [ "fs", "trace" ]
 
 [dev-dependencies.tracing-subscriber]
-version = "0.3"
+workspace = true
 features = [ "env-filter" ]
 
 [dev-dependencies.tracing-test]
-version = "0.2"
+workspace = true
 
 [dev-dependencies.mockall]
 version = "0.12.1"

--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -42,11 +42,11 @@ workspace = true
 features = [ "ledger", "utilities" ]
 
 [dependencies.tokio-util]
-version = "0.7"
+workspace = true
 features = [ "codec" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.proptest]
 workspace = true

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -71,5 +71,5 @@ features = [ "macros", "rt-multi-thread" ]
 optional = true
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 optional = true

--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -50,7 +50,7 @@ workspace = true
 features = [ "ledger", "console", "rocks" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 optional = true
 
 [dev-dependencies.snarkvm]

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -70,7 +70,7 @@ workspace = true
 features = [ "rt" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.tokio]
 workspace = true

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -466,6 +466,7 @@ async fn cdn_get<T: 'static + DeserializeOwned + Send>(client: Client, url: &str
         Ok(bytes) => bytes,
         Err(error) => bail!("Failed to parse {ctx} - {error}"),
     };
+
     // Parse the objects.
     match tokio::task::spawn_blocking(move || bincode::deserialize::<T>(&bytes)).await {
         Ok(Ok(objects)) => Ok(objects),

--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -92,6 +92,7 @@ impl CdnBlockSync {
             tokio::spawn(async move { Self::worker(base_url, ledger, shutdown).await })
         };
 
+        debug!("Started sync from CDN at {base_url}");
         Self { done: AtomicBool::new(false), base_url, task: Mutex::new(Some(task)) }
     }
 

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -91,7 +91,7 @@ workspace = true
 features = [ "macros", "rt-multi-thread", "signal" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.indexmap]
 workspace = true
@@ -103,4 +103,4 @@ version = "0.12"
 version = "1.19"
 
 [dev-dependencies.tracing-test]
-version = "0.2"
+workspace = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -104,7 +104,7 @@ version = "0.6"
 features = [ "cors", "trace" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.base64]
 workspace = true

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -143,10 +143,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let (cdn_sync, cdn_height) = if let Some(cdn_sync) = &rest.cdn_sync {
             let done = cdn_sync.is_done();
 
-            // do not show CDN height if we are already done syncing from the CDN
+            // Do not show CDN height if we are already done syncing from the CDN.
             let cdn_height = if done { None } else { Some(cdn_sync.get_cdn_height().await?) };
 
-            (done, cdn_height)
+            // Report CDN sync until it is finished.
+            (!done, cdn_height)
         } else {
             (false, None)
         };

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -99,14 +99,14 @@ features = [
 ]
 
 [dependencies.tokio-util]
-version = "0.7"
+workspace = true
 features = [ "codec" ]
 
 [dependencies.tokio-stream]
 version = "=0.1"
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.deadline]
 version = "0.2"
@@ -139,5 +139,5 @@ workspace = true
 features = [ "test-helpers" ]
 
 [dev-dependencies.tracing-subscriber]
-version = "0.3"
+workspace = true
 features = [ "env-filter", "fmt" ]

--- a/node/router/messages/Cargo.toml
+++ b/node/router/messages/Cargo.toml
@@ -38,11 +38,11 @@ version = "=3.8.0"
 workspace = true
 
 [dependencies.tokio-util]
-version = "0.7"
+workspace = true
 features = [ "codec" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.snarkos-node-sync-locators]
 path = "../../sync/locators"

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -198,8 +198,10 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         };
 
         // Perform sync with CDN (if enabled).
-        let cdn_sync = cdn.map(|base_url| Arc::new(CdnBlockSync::new(base_url, ledger.clone(), shutdown)));
-
+        let cdn_sync = cdn.map(|base_url| {
+            trace!("CDN sync is enabled");
+            Arc::new(CdnBlockSync::new(base_url, ledger.clone(), shutdown))
+        });
         // Initialize the REST server.
         if let Some(rest_ip) = rest_ip {
             node.rest = Some(
@@ -207,7 +209,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             );
         }
 
-        // Set up everythign else after CDN sync is done.
+        // Set up everything else after CDN sync is done.
         if let Some(cdn_sync) = cdn_sync {
             if let Err(error) = cdn_sync.wait().await {
                 crate::log_clean_error(&storage_mode);

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -83,7 +83,7 @@ version = "=3.8.0"
 workspace = true
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true
 
 [dev-dependencies.snarkos-node-bft-ledger-service]
 path = "../bft/ledger-service"

--- a/node/sync/locators/Cargo.toml
+++ b/node/sync/locators/Cargo.toml
@@ -35,4 +35,4 @@ workspace = true
 features = [ "console" ]
 
 [dependencies.tracing]
-version = "0.1"
+workspace = true

--- a/node/tcp/Cargo.toml
+++ b/node/tcp/Cargo.toml
@@ -50,12 +50,11 @@ workspace = true
 features = [ "io-util", "net", "parking_lot", "rt", "sync", "time" ]
 
 [dependencies.tokio-util]
-version = "0.7"
+workspace = true
 features = [ "codec" ]
 
 [dependencies.tracing]
-version = "0.1"
-default-features = false
+workspace = true
 
 [dependencies.thiserror]
 version = "2"


### PR DESCRIPTION
I recently changed log filter to not use environment variables anymore (because `std::env::set_var` is unsafe in Rust 2024). For this to work correctly, the log filter cannot be prefixed with `RUST_LOG=` anymore. This caused the issue reported in #3710.

This PR also fixes the sync mode being reported incorrectly and makes `tracing` a workspace dependency. The former was caused by a missing `!`. The latter is just to avoid different versions of tracing causing logging issues, and adding workspace gradually instead of in one large commit, seems easier to manage.

Finally, I added a test to the devnet_ci script that tests for nodes creating any log messages. This is a good sanity check to have and does not add a noticeable overhead to testing.