### PR TITLE
[Fix] Report is_synced=false while fetching from CDN

### DIFF
--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -158,7 +158,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(SyncStatus {
             sync_mode,
             cdn_height,
-            is_synced: rest.routing.is_block_synced(),
+            is_synced: !cdn_sync && rest.routing.is_block_synced(),
             ledger_height: rest.ledger.latest_height(),
             p2p_height: rest.routing.greatest_peer_block_height(),
             outstanding_block_requests: rest.routing.num_outstanding_block_requests(),


### PR DESCRIPTION
This PR ensures that `is_synced` in the REST API shows up as false while a client is fetching from CDN.

The reason for clients incorrectly reporting `is_synced` was that `BlockSync` is initialized as synced and only switches to "syncing" when it receives block locators from peers.
