### PR TITLE
Add "--store-format" option to snarkos develop

### DIFF
--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -35,6 +35,7 @@ use snarkvm::{
 use aleo_std::StorageMode;
 use anyhow::{Result, bail};
 use clap::Parser;
+use crate::commands::StoreFormat;
 use colored::Colorize;
 use std::{path::PathBuf, str::FromStr};
 use zeroize::Zeroize;
@@ -71,6 +72,10 @@ pub struct Deploy {
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
+    /// If --store is specified, the format in which the transaction should be stored : string or
+    /// bytes, by default : bytes.
+    #[clap(long, value_enum, default_value_t = StoreFormat::Bytes)]
+    store_format: StoreFormat,
     /// Specify the path to a directory containing the ledger. Overrides the default path (also for
     /// dev).
     #[clap(long = "storage_path")]
@@ -173,7 +178,7 @@ impl Deploy {
         println!("✅ Created deployment transaction for '{}'", program_id.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, transaction, program_id.to_string())
+        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, self.store_format, transaction, program_id.to_string())
     }
 }
 

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::commands::StoreFormat;
 use super::Developer;
+use crate::commands::StoreFormat;
 use snarkvm::{
     circuit::{Aleo, AleoCanaryV0, AleoTestnetV0, AleoV0},
     console::{
@@ -178,7 +178,14 @@ impl Deploy {
         println!("✅ Created deployment transaction for '{}'", program_id.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, self.store_format, transaction, program_id.to_string())
+        Developer::handle_transaction(
+            &self.broadcast,
+            self.dry_run,
+            &self.store,
+            self.store_format,
+            transaction,
+            program_id.to_string(),
+        )
     }
 }
 

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::commands::StoreFormat;
 use super::Developer;
 use snarkvm::{
     circuit::{Aleo, AleoCanaryV0, AleoTestnetV0, AleoV0},
@@ -35,7 +36,6 @@ use snarkvm::{
 use aleo_std::StorageMode;
 use anyhow::{Result, bail};
 use clap::Parser;
-use crate::commands::StoreFormat;
 use colored::Colorize;
 use std::{path::PathBuf, str::FromStr};
 use zeroize::Zeroize;

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::commands::StoreFormat;
 use super::Developer;
 use snarkvm::{
     console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
@@ -35,7 +36,6 @@ use aleo_std::StorageMode;
 use anyhow::{Result, anyhow, bail};
 use clap::Parser;
 use colored::Colorize;
-use crate::commands::StoreFormat;
 use std::{path::PathBuf, str::FromStr};
 use zeroize::Zeroize;
 

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::commands::StoreFormat;
 use super::Developer;
+use crate::commands::StoreFormat;
 use snarkvm::{
     console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     ledger::store::helpers::memory::BlockMemory,
@@ -210,7 +210,14 @@ impl Execute {
         println!("✅ Created execution transaction for '{}'", locator.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, self.store_format, transaction, locator.to_string())
+        Developer::handle_transaction(
+            &self.broadcast,
+            self.dry_run,
+            &self.store,
+            self.store_format,
+            transaction,
+            locator.to_string(),
+        )
     }
 }
 

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -35,6 +35,7 @@ use aleo_std::StorageMode;
 use anyhow::{Result, anyhow, bail};
 use clap::Parser;
 use colored::Colorize;
+use crate::commands::StoreFormat;
 use std::{path::PathBuf, str::FromStr};
 use zeroize::Zeroize;
 
@@ -74,6 +75,10 @@ pub struct Execute {
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
+    /// If --store is specified, the format in which the transaction should be stored : string or
+    /// bytes, by default : bytes.
+    #[clap(long, value_enum, default_value_t = StoreFormat::Bytes)]
+    store_format: StoreFormat,
     /// Specify the path to a directory containing the ledger. Overrides the default path (also for
     /// dev).
     #[clap(long = "storage_path")]
@@ -205,7 +210,7 @@ impl Execute {
         println!("✅ Created execution transaction for '{}'", locator.to_string().bold());
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, transaction, locator.to_string())
+        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, self.store_format, transaction, locator.to_string())
     }
 }
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -31,6 +31,7 @@ use snarkvm::{
 use aleo_std::StorageMode;
 use anyhow::{Result, bail};
 use clap::Parser;
+use crate::commands::StoreFormat;
 use std::{path::PathBuf, str::FromStr};
 use zeroize::Zeroize;
 
@@ -70,6 +71,10 @@ pub struct TransferPrivate {
     /// Store generated deployment transaction to a local file.
     #[clap(long)]
     store: Option<String>,
+    /// If --store is specified, the format in which the transaction should be stored : string or
+    /// bytes, by default : bytes.
+    #[clap(long, value_enum, default_value_t = StoreFormat::Bytes)]
+    store_format: StoreFormat,
     /// Specify the path to a directory containing the ledger. Overrides the default path (also for
     /// dev).
     #[clap(long = "storage_path")]
@@ -156,6 +161,6 @@ impl TransferPrivate {
         println!("✅ Created private transfer of {} microcredits to {}\n", &self.amount, recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, transaction, locator.to_string())
+        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, self.store_format, transaction, locator.to_string())
     }
 }

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::commands::StoreFormat;
 use super::Developer;
 use snarkvm::{
     console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
@@ -31,7 +32,6 @@ use snarkvm::{
 use aleo_std::StorageMode;
 use anyhow::{Result, bail};
 use clap::Parser;
-use crate::commands::StoreFormat;
 use std::{path::PathBuf, str::FromStr};
 use zeroize::Zeroize;
 

--- a/cli/src/commands/developer/transfer_private.rs
+++ b/cli/src/commands/developer/transfer_private.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::commands::StoreFormat;
 use super::Developer;
+use crate::commands::StoreFormat;
 use snarkvm::{
     console::network::{CanaryV0, MainnetV0, Network, TestnetV0},
     ledger::store::helpers::memory::BlockMemory,
@@ -161,6 +161,13 @@ impl TransferPrivate {
         println!("✅ Created private transfer of {} microcredits to {}\n", &self.amount, recipient);
 
         // Determine if the transaction should be broadcast, stored, or displayed to the user.
-        Developer::handle_transaction(&self.broadcast, self.dry_run, &self.store, self.store_format, transaction, locator.to_string())
+        Developer::handle_transaction(
+            &self.broadcast,
+            self.dry_run,
+            &self.store,
+            self.store_format,
+            transaction,
+            locator.to_string(),
+        )
     }
 }


### PR DESCRIPTION
## Motivation

We want to be able to store transactions in string/JSON format so we can broadcast them via the API easily when testing SnarkOS.

Basically with this option we can do:

```
snarkos developer execute --private-key <PK> --query http://localhost:3030 credits.aleo transfer_public <addr> 1000u64 --network 1  --store tx.json --store-format string
```

And then later we can load this transaction and broadcast it with:

```
curl -X POST http://localhost:3030/testnet/transaction/broadcast   -H "Content-Type: application/json"   --data-binary @tx.json
```

The old functionality of storing transactions in bytes format is still kept and if `--store-format` is not passed it will behave like before, so this is just  new logic in addition to the old one.

## Test Plan

Tested VS testnet locally and also tested with `./devnet.sh`
