### PR TITLE
Bump message and event versions

### DIFF
--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -118,7 +118,7 @@ impl<N: Network> From<DisconnectReason> for Event<N> {
 
 impl<N: Network> Event<N> {
     /// The version of the event protocol; it can be incremented in order to force users to update.
-    pub const VERSION: u32 = 9;
+    pub const VERSION: u32 = 10;
 
     /// Returns the event name.
     #[inline]

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -114,7 +114,7 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 impl<N: Network> Message<N> {
     /// The version of the network protocol; this can is incremented for breaking changes between migration versions.
     pub const VERSIONS: [(ConsensusVersion, u32); 3] =
-        [(ConsensusVersion::V4, 16), (ConsensusVersion::V5, 17), (ConsensusVersion::V7, 18)];
+        [(ConsensusVersion::V5, 17), (ConsensusVersion::V7, 18), (ConsensusVersion::V8, 19)];
 
     /// Returns the latest message version.
     pub fn latest_message_version() -> u32 {

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -312,4 +312,19 @@ mod tests {
         consensus_constants_increasing_heights::<TestnetV0>();
         consensus_constants_increasing_heights::<CanaryV0>();
     }
+
+    #[test]
+    fn test_latest_consensus_version() {
+        let message_consensus_version = Message::<MainnetV0>::VERSIONS.last().unwrap().0;
+        let expected_consensus_version = MainnetV0::CONSENSUS_VERSION_HEIGHTS.last().unwrap().0;
+        assert_eq!(message_consensus_version, expected_consensus_version);
+
+        let message_consensus_version = Message::<TestnetV0>::VERSIONS.last().unwrap().0;
+        let expected_consensus_version = TestnetV0::CONSENSUS_VERSION_HEIGHTS.last().unwrap().0;
+        assert_eq!(message_consensus_version, expected_consensus_version);
+
+        let message_consensus_version = Message::<CanaryV0>::VERSIONS.last().unwrap().0;
+        let expected_consensus_version = CanaryV0::CONSENSUS_VERSION_HEIGHTS.last().unwrap().0;
+        assert_eq!(message_consensus_version, expected_consensus_version);
+    }
 }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps the Event version and the Message versions for ConsensusVersion::V8.

Note: `canary` was already restarted successfully without this. If a node upgrades to this version without the rest of the validators and clients, there will be connection issues and potentially halting