### PR TITLE
[Build] Link using LLD on Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+    # LLD is generally faster and might be the default for Rust in the future.
+    # See here: https://github.com/rust-lang/rust/issues/71515
+    "-C", "link-arg=-fuse-ld=lld",
+]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,14 +192,18 @@ commands:
           command: |
             cargo install --locked --path .
       - run:
-          name: "Run devnet test"
-          timeout: 20m  # Allow 20 minutes total
+          name: "Run DB backup test"
+          timeout: 10m  # Allow 10 minutes total
           command: |
             ./.circleci/db_backup_ci.sh # run the db checkpoint test script first, and clean the dev ledgers afterwards
             snarkos clean --dev 0
             snarkos clean --dev 1
             snarkos clean --dev 2
             snarkos clean --dev 3
+      - run:
+          name: "Run block advancement test"
+          imeout: 20m  # Allow 20 minutes total
+          command: |
             ./.circleci/devnet_ci.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>
       - clear_environment:
           cache_key: << parameters.cache_key >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
             export RUSTC_WRAPPER="sccache"
             rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
             DEBIAN_FRONTEND=noninteractive sudo apt-get update
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm pkg-config xz-utils make libssl-dev libssl-dev
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends clang llvm-dev llvm lld pkg-config xz-utils make libssl-dev libssl-dev
       - restore_cache:
           keys:
             - << parameters.cache_key >>

--- a/.circleci/db_backup_ci.sh
+++ b/.circleci/db_backup_ci.sh
@@ -77,7 +77,7 @@ sleep 15
 # Check heights periodically with a timeout
 total_wait=0
 checkpoint_created=false
-while [ $total_wait -lt 300 ]; do  # 5 minutes max
+while [ $total_wait -lt 600 ]; do  # 10 minutes max
   # Apply short-circuiting
   if [[ $checkpoint_created = true ]] || check_heights "$checkpoint_height"; then
     if [[ $checkpoint_created = false ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4172,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "blst",
  "cc",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.11.0",
@@ -4246,12 +4246,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4394,7 +4394,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4418,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4596,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4655,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4752,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "async-trait",
  "http 1.3.1",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4846,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "metrics",
 ]
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4927,7 +4927,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "colored 2.2.0",
@@ -4953,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4970,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4983,7 +4983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5004,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=668b72b#668b72bbd267fc6459e3cb7c492d4ac56e615887"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0e0e3c7#0e0e3c7d73b79084f672ed63847ba6cb368f9e05"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",


### PR DESCRIPTION
This PR changes snarkOS to build using LLD on Linux. Doing this is generally faster than using GCC's linker, as shown in [this (slightly outdated) blog post](https://blog.rust-lang.org/2024/05/17/enabling-rust-lld-on-linux/). We already require LLVM to build RocksDB, so using LLVM's linker should not create many headaches. 

The expected performance improvements by this change are mostly due to LLD being multithreaded. At a first glance, the CI runs for this PR are 1 to 2 minutes shorter than previous runs, but the benefits of a faster linker will be more noticeable during release builds.

There is a push to change the default for Rust to LLD, but, in my opinion, we should not wait and just switch now as linking snarkOS is quite slow and that slows down development. As discussed in [this Rust issue](https://github.com/rust-lang/rust/issues/71515), people already widely use LLD as a linker for their Rust projects without any problems.

The PR also changes the devnet CI to a slightly longer timeout, as I noticed it fail sometimes.

In the future, we can also consider switching to LLD for macOS, which I already did on my MacBook a few months ago. However, it might be good to do one at a time, in case something breaks.

