### PR TITLE
Fix client sync off by one

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1095,8 +1095,8 @@ impl<N: Network> BlockSync<N> {
             start_height
         };
 
-        // If the minimum common ancestor is at or below the latest ledger height, then return early.
-        if min_common_ancestor <= start_height {
+        // If the minimum common ancestor is below the start height, then return early.
+        if min_common_ancestor < start_height {
             if start_height < greatest_peer_height {
                 trace!(
                     "No request to construct. Height for the next block request is {start_height}, but minimum common block locator ancestor is only {min_common_ancestor} (sync_height={sync_height} greatest_peer_height={greatest_peer_height})"


### PR DESCRIPTION
## Motivation

One more syncing off by one which had a very small chance of triggering:
```
quest to construct. Height for the next block request is 10000, but minimum common block locator ancestor is only 10000 (sync_height=9999 greatest_pee│
```


## Test Plan

- [ ] Deployed to devnet succesfully