### PR TITLE
build: add LLD package to build_ubuntu.sh

### DIFF
--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -14,6 +14,7 @@ sudo apt-get install -y \
 	gcc \
 	libssl-dev \
 	llvm \
+	lld \
 	make \
 	pkg-config \
 	tmux \


### PR DESCRIPTION
Now that #3731 is merged, the build script for Ubuntu has to also install LLD. 
