### PR TITLE
 Ureq default features to enable tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,6 +3312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4125,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4148,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4177,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "blst",
  "cc",
@@ -4188,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4202,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4212,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4222,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4232,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.11.0",
@@ -4251,12 +4260,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4267,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4281,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4296,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4309,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4318,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4328,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4340,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4352,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4363,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4375,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4388,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4399,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4412,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4423,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4443,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4461,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4482,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4497,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4508,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4516,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4526,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4537,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4548,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4559,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4570,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4584,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4601,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4628,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4640,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4660,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4679,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4692,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4705,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4718,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4729,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4744,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4757,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4766,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4786,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4809,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "async-trait",
  "http 1.3.1",
@@ -4823,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4851,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4868,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "metrics",
 ]
@@ -4876,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4899,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4932,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "colored 2.2.0",
@@ -4958,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4975,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4988,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5009,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=f3a639da3#f3a639da36e5eec35d974ef5d5c0265232925805"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -5827,12 +5836,17 @@ checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
+ "flate2",
  "log",
  "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "ureq-proto",
  "utf-8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "blst",
  "cc",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.11.0",
@@ -4260,12 +4260,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4408,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4452,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4525,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4546,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4610,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4714,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4727,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "async-trait",
  "http 1.3.1",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "metrics",
 ]
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4908,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4941,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "colored 2.2.0",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=244a577a9#244a577a9377d624657104d45031b4983168a99f"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "blst",
  "cc",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.11.0",
@@ -4260,12 +4260,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4408,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4452,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4517,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4525,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4546,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4610,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4669,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4714,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4727,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "async-trait",
  "http 1.3.1",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "once_cell",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "metrics",
 ]
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4908,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4941,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "colored 2.2.0",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.8.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ecfed9a45#ecfed9a455db554ce61252946f041f956ad4bf35"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b82dd4a97#b82dd4a97e4cfbe15c397c6d99eeed04cc44f33c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "f3a639da3"
+rev = "244a577a9"
 #version = "=3.8.0"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "ecfed9a45"
+rev = "b82dd4a97"
 #version = "=3.8.0"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "244a577a9"
+rev = "ecfed9a45"
 #version = "=3.8.0"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -152,6 +152,7 @@ features = [ "env-filter" ]
 [dependencies.ureq]
 version = "2.9"
 features = ["json"]
+default-features = true
 
 [dependencies.zeroize]
 version = "1"


### PR DESCRIPTION
## Motivation

rusttls is part of ureq's default features.
But because we're since recently enabling json, we need to manually enable default-features

## Test Plan

Tested snarkos developer execute on macOS.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2817

CI issues:

- [x] Output record must be Version 0 before Consensus V8 - caused by some test innapropriately sampling record version 1 in combination with https://github.com/ProvableHQ/snarkVM/pull/2800