### PR TITLE
[Chore] Make all snarkos crates workspace dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,14 +217,6 @@ jobs:
           workspace_member: cli
           cache_key: cli
 
-  display:
-    executor: rust-docker
-    resource_class: << pipeline.parameters.medium >>
-    steps:
-      - run_serial:
-          workspace_member: display
-          cache_key: v3.3.1-rust-1.83.0-display-cache
-
   node:
     executor: rust-docker
     resource_class: << pipeline.parameters.twoxlarge >>
@@ -345,6 +337,25 @@ jobs:
           workspace_member: .
           cache_key: v3.3.1-rust-1.88.0-devnet-test-cache
 
+  # Check crates that do not have any tests individually
+  check-other-crates:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.medium >>
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: v3.3.1-rust-1.88.0-check-other-crates-cache
+      - run:
+          name: Check snarkos-node-metrics crate
+          no_output_timeout: 10m
+          command: cargo check --package=snarkos-node-metrics --all-features
+      - run:
+          name: Check snarkos-display crate
+          no_output_timeout: 10m
+          command: cargo check --package=snarkos-node-metrics --all-features
+      - clear_environment:
+          cache_key: v3.3.1-rust-1.88.0-check-other-crates-cache
+
   check-fmt:
     executor: rust-docker
     resource_class: << pipeline.parameters.medium >>
@@ -429,7 +440,6 @@ workflows:
       - snarkos
       - account
       - cli
-      - display
       - node
       - node-bft
       - node-bft-events
@@ -448,6 +458,7 @@ workflows:
       - check-clippy
       - check-unused-dependencies
       - check-cargo-audit
+      - check-other-crates
       - devnet-test
 
   windows-workflow:
@@ -461,4 +472,3 @@ workflows:
                 display,
                 node
               ]
-      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
 
   cli:
     executor: rust-docker
-    resource_class: << pipeline.parameters.xlarge >>
+    resource_class: << pipeline.parameters.twoxlarge >>
     steps:
       - run_serial:
           workspace_member: cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2255,6 +2255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+dependencies = [
+ "hashbrown 0.15.4",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,7 +3061,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -3812,7 +3821,7 @@ dependencies = [
  "futures-util",
  "indexmap 2.10.0",
  "locktick",
- "lru",
+ "lru 0.16.0",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -3855,7 +3864,7 @@ dependencies = [
  "indexmap 2.10.0",
  "itertools 0.12.1",
  "locktick",
- "lru",
+ "lru 0.16.0",
  "mockall",
  "open",
  "parking_lot",
@@ -3929,7 +3938,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.10.0",
  "locktick",
- "lru",
+ "lru 0.16.0",
  "parking_lot",
  "snarkvm",
  "tracing",
@@ -3965,7 +3974,7 @@ dependencies = [
  "indexmap 2.10.0",
  "itertools 0.14.0",
  "locktick",
- "lru",
+ "lru 0.16.0",
  "once_cell",
  "parking_lot",
  "snarkos-account",
@@ -4613,7 +4622,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.10.0",
  "locktick",
- "lru",
+ "lru 0.12.5",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -4779,7 +4788,7 @@ dependencies = [
  "bincode",
  "indexmap 2.10.0",
  "locktick",
- "lru",
+ "lru 0.12.5",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4799,7 +4808,7 @@ dependencies = [
  "colored 2.2.0",
  "indexmap 2.10.0",
  "locktick",
- "lru",
+ "lru 0.12.5",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4909,7 +4918,7 @@ dependencies = [
  "indexmap 2.10.0",
  "itertools 0.11.0",
  "locktick",
- "lru",
+ "lru 0.12.5",
  "parking_lot",
  "rand 0.8.5",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,7 +3963,7 @@ dependencies = [
  "anyhow",
  "colored 2.2.0",
  "indexmap 2.10.0",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "locktick",
  "lru",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,31 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 rev = "27538ccc6"
-#version = "=3.8.0"
+#version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]
 
 [workspace.dependencies.anyhow]
 version = "1.0"
 
+[workspace.dependencies.async-trait]
+version = "0.1"
+
+[workspace.dependencies.axum]
+version = "0.8"
+
+[workspace.dependencies.axum-extra]
+version = "0.10"
+
 [workspace.dependencies.built]
 version = "0.8"
 features = ["git2"]
+
+[workspace.dependencies.bytes]
+version = "1"
+
+[workspace.dependencies.base64]
+version = "0.22"
 
 [workspace.dependencies.clap]
 version = "4.4"
@@ -69,11 +84,26 @@ version = "0.29"
 [workspace.dependencies.futures]
 version = "0.3"
 
+[workspace.dependencies.futures-util]
+version = "0.3"
+
+[workspace.dependencies.locktick]
+version = "0.3"
+
+[workspace.dependencies.lru]
+version = "0.12.1"
+
+[workspace.dependencies.once_cell]
+version = "1"
+
 [workspace.dependencies.proptest]
 version = "=1.6.0" # Remove this once we upgrade to rand 0.9
 
-[workspace.dependencies.base64]
-version = "0.22"
+[workspace.dependencies.rayon]
+version = "1"
+
+[workspace.dependencies.time]
+version = "0.3"
 
 [workspace.dependencies.tokio]
 version = "1.28"
@@ -92,8 +122,22 @@ default-features = false
 version = "1"
 default-features = false
 
+[workspace.dependencies.serde_json]
+version = "1"
+
 [workspace.dependencies.parking_lot]
 version = "0.12"
+
+[workspace.dependencies.rand]
+version = "0.8"
+default-features = false
+
+[workspace.dependencies.rand_chacha]
+version = "0.3"
+default-features = false
+
+[workspace.dependencies.rand_distr]
+version = "0.4"
 
 [workspace.dependencies.tracing]
 version = "0.1"
@@ -108,6 +152,30 @@ version = "0.3"
 [workspace.dependencies.test-strategy]
 version = "0.4"
 
+[workspace.dependencies.snarkos-account]
+path = "account"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-cli]
+path = "cli"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-display]
+path = "display"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-node]
+path = "node"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-node-bft]
+path = "node/bft"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-node-bft-events]
+path = "node/bft/events"
+version = "=4.0.1"
+
 [workspace.dependencies.snarkos-node-bft-storage-service]
 path = "node/bft/storage-service"
 version = "=4.0.1"
@@ -115,6 +183,7 @@ version = "=4.0.1"
 [workspace.dependencies.snarkos-node-bft-ledger-service]
 path = "node/bft/ledger-service"
 version = "=4.0.1"
+default-features = false
 
 [workspace.dependencies.snarkos-node-consensus]
 path = "node/consensus"
@@ -124,8 +193,20 @@ version = "=4.0.1"
 path = "node/cdn"
 version = "=4.0.1"
 
+[workspace.dependencies.snarkos-node-metrics]
+path = "node/metrics"
+version = "=4.0.1"
+
 [workspace.dependencies.snarkos-node-router]
 path = "node/router"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-node-router-messages]
+path = "node/router/messages"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-node-rest]
+path = "node/rest"
 version = "=4.0.1"
 
 [workspace.dependencies.snarkos-node-sync]
@@ -138,6 +219,10 @@ version = "=4.0.1"
 
 [workspace.dependencies.snarkos-node-sync-locators]
 path = "node/sync/locators"
+version = "=4.0.1"
+
+[workspace.dependencies.snarkos-node-tcp]
+path = "node/tcp"
 version = "=4.0.1"
 
 [[bin]]
@@ -186,20 +271,16 @@ version = "0.3"
 optional = true
 
 [dependencies.snarkos-account]
-path = "./account"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-cli]
-path = "./cli"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node]
-path = "./node"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft]
-path = "./node/bft"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-cdn]
 workspace = true
@@ -208,23 +289,20 @@ workspace = true
 workspace = true
 
 [dependencies.snarkos-node-metrics]
-path = "./node/metrics"
-version = "=4.0.1"
+workspace = true
 optional = true
 
 [dependencies.snarkos-node-router]
 workspace = true
 
 [dependencies.snarkos-node-rest]
-path = "./node/rest"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-sync]
 workspace = true
 
 [dependencies.snarkos-node-tcp]
-path = "./node/tcp"
-version = "=4.0.1"
+workspace = true
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ version = "0.3"
 version = "0.3"
 
 [workspace.dependencies.lru]
-version = "0.12.1"
+version = "0.16"
 
 [workspace.dependencies.once_cell]
 version = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ locktick = [
   "snarkos-node-rest/locktick",
   "snarkvm/locktick"
 ]
-metrics = [ "dep:metrics", "snarkos-node/metrics" ]
+metrics = [ "dep:snarkos-node-metrics", "snarkos-node/metrics" ]
 cuda = [
   "snarkvm/cuda",
   "snarkos-account/cuda",
@@ -65,32 +65,28 @@ workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../node/metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.num_cpus]
 version = "1"
 
 [dependencies.parking_lot]
-version = "0.12"
+workspace = true
 
 [dependencies.rand]
-version = "0.8"
-default-features = false
+workspace = true
 
 [dependencies.rand_chacha]
-version = "0.3.0"
-default-features = false
+workspace = true
 
 [dependencies.rayon]
-version = "1"
+workspace = true
 
 [dependencies.self_update]
 version = "0.42"
@@ -100,28 +96,23 @@ features = [ "archive-zip", "compression-zip-deflate" ]
 workspace = true
 
 [dependencies.serde_json]
-version = "1"
+workspace = true
 features = [ "preserve_order" ]
 
 [dependencies.snarkos-account]
-path = "../account"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-display]
-path = "../display"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node]
-path = "../node"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-cdn]
-path = "../node/cdn"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-rest]
-path = "../node/rest"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
@@ -134,7 +125,7 @@ version = "0.9"
 version = "3"
 
 [dependencies.time]
-version = "0.3"
+workspace = true
 
 [dependencies.thiserror]
 version = "2.0.11"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -20,6 +20,9 @@
 #[macro_use]
 extern crate thiserror;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 pub mod commands;
 pub use commands::CLI;
 

--- a/display/Cargo.toml
+++ b/display/Cargo.toml
@@ -26,8 +26,7 @@ workspace = true
 version = "0.29"
 
 [dependencies.snarkos-node]
-path = "../node"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -64,71 +64,62 @@ version = "0.1"
 version = "2"
 
 [dependencies.futures-util]
-version = "0.3"
+workspace = true
 features = [ "sink" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
 [dependencies.lru]
-version = "0.12.1"
+workspace = true
 
 [dependencies.num_cpus]
 version = "1"
 
 [dependencies.once_cell]
-version = "1"
+workspace = true
 
 [dependencies.parking_lot]
 workspace = true
 
 [dependencies.rand]
-version = "0.8"
-default-features = false
+workspace = true
 
 [dependencies.serde_json]
-version = "1"
+workspace = true
 features = [ "preserve_order" ]
 
 [dependencies.snarkos-account]
-path = "../account"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft]
-path = "./bft"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-cdn]
-path = "./cdn"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-consensus]
-path = "./consensus"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-rest]
-path = "./rest"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-router]
-path = "./router"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-sync]
-path = "./sync"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-tcp]
-path = "./tcp"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
 
 [dependencies.time]
-version = "0.3"
+workspace = true
 
 [dependencies.tokio]
 workspace = true
@@ -153,7 +144,7 @@ version = "1"
 version = "0.49"
 
 [dev-dependencies.snarkos-node-router]
-path = "./router"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.tracing-subscriber]
@@ -161,7 +152,7 @@ workspace = true
 features = [ "env-filter", "fmt" ]
 
 [dev-dependencies.rand_chacha]
-version = "0.3.0"
+workspace = true
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -28,7 +28,7 @@ locktick = [
   "snarkvm/locktick"
 ]
 metrics = [
-  "dep:metrics",
+  "dep:snarkos-node-metrics",
   "snarkos-node-bft-events/metrics",
   "snarkos-node-bft-ledger-service/metrics"
 ]
@@ -56,10 +56,10 @@ workspace = true
 version = "1.0"
 
 [dependencies.async-trait]
-version = "0.1"
+workspace = true
 
 [dependencies.bytes]
-version = "1"
+workspace = true
 
 [dependencies.colored]
 version = "2"
@@ -73,39 +73,35 @@ workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot", "tokio" ]
 optional = true
 
 [dependencies.lru]
-version = "0.12.1"
+workspace = true
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.parking_lot]
 workspace = true
 
 [dependencies.rand]
-version = "0.8"
+workspace = true
 
 [dependencies.rayon]
-version = "1"
+workspace = true
 
 [dependencies.sha2]
 version = "0.10"
 default-features = false
 
 [dependencies.snarkos-account]
-path = "../../account"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft-events]
-path = "./events"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft-ledger-service]
 workspace = true
@@ -119,15 +115,14 @@ features = [ "memory" ]
 workspace = true
 
 [dependencies.snarkos-node-tcp]
-path = "../tcp"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
 features = [ "utilities" ]
 
 [dependencies.time]
-version = "0.3"
+workspace = true
 
 [dependencies.tokio]
 workspace = true
@@ -144,11 +139,10 @@ features = [ "codec" ]
 workspace = true
 
 [dev-dependencies.axum]
-version = "0.8"
+workspace = true
 
 [dev-dependencies.axum-extra]
-version = "0.10"
-default-features = false
+workspace = true
 features = [ "erased-json" ]
 
 [dev-dependencies.clap]
@@ -174,20 +168,20 @@ version = "0.49"
 workspace = true
 
 [dev-dependencies.rand_chacha]
-version = "0.3"
+workspace = true
 
 [dev-dependencies.rand_distr]
-version = "0.4"
+workspace = true
 
 [dev-dependencies.rayon]
-version = "1"
+workspace = true
 
 [dev-dependencies.snarkos-node-bft]
-path = "."
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkos-node-sync]
-path = "../sync"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.test-strategy]

--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -24,18 +24,17 @@ metrics = [ "snarkvm/metrics" ]
 workspace = true
 
 [dependencies.bytes]
-version = "1"
+workspace = true
 
 [dependencies.indexmap]
 workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.serde]
-version = "1"
+workspace = true
 
 [dependencies.snarkos-node-sync-locators]
-path = "../../sync/locators"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
@@ -59,8 +58,8 @@ features = [ "test-helpers" ]
 workspace = true
 
 [dev-dependencies.time]
-version = "0.3"
+workspace = true
 
 [dev-dependencies.snarkos-node-sync-locators]
-path = "../../sync/locators"
+workspace = true
 features = [ "test" ]

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -16,6 +16,9 @@
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 use aleo_std::StorageMode;
 use snarkos_account::Account;
 use snarkos_node_bft::{

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -21,7 +21,7 @@ default = [ ]
 ledger = [ "parking_lot", "rand", "rayon", "tokio", "tracing" ]
 ledger-write = [ ]
 locktick = [ "dep:locktick", "snarkvm/locktick" ]
-metrics = [ "dep:metrics", "snarkvm/metrics" ]
+metrics = [ "dep:snarkos-node-metrics", "snarkvm/metrics" ]
 mock = [ "parking_lot", "tracing" ]
 prover = [ ]
 cuda = [ "snarkvm/cuda" ]
@@ -40,26 +40,24 @@ workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../../metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.parking_lot]
-version = "0.12"
+workspace = true
 optional = true
 
 [dependencies.rand]
-version = "0.8"
+workspace = true
 optional = true
 
 [dependencies.rayon]
-version = "1"
+workspace = true
 optional = true
 
 [dependencies.snarkvm]

--- a/node/bft/ledger-service/src/lib.rs
+++ b/node/bft/ledger-service/src/lib.rs
@@ -19,6 +19,9 @@
 #[macro_use]
 extern crate async_trait;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 #[cfg(feature = "ledger")]
 pub mod ledger;
 #[cfg(feature = "ledger")]

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -22,6 +22,9 @@ extern crate async_trait;
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 pub use snarkos_node_bft_events as events;
 pub use snarkos_node_bft_ledger_service as ledger_service;
 pub use snarkos_node_bft_storage_service as storage_service;

--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -34,15 +34,15 @@ workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
 [dependencies.lru]
-version = "0.12.1"
+workspace = true
 
 [dependencies.parking_lot]
-version = "0.12"
+workspace = true
 optional = true
 
 [dependencies.snarkvm]

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -33,7 +33,7 @@ version = "1.0"
 version = "2"
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
@@ -41,13 +41,12 @@ optional = true
 version = "0.12"
 
 [dependencies.snarkos-node-metrics]
-path = "../metrics"
-version = "=4.0.1"
+workspace = true
 optional = true
 features = [ "metrics" ]
 
 [dependencies.rayon]
-version = "1"
+workspace = true
 optional = true
 
 [dependencies.reqwest]

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -25,7 +25,7 @@ locktick = [
   "snarkos-node-bft-storage-service/locktick",
   "snarkvm/locktick"
 ]
-metrics = [ "dep:metrics" ]
+metrics = [ "dep:snarkos-node-metrics" ]
 telemetry = [ "snarkos-node-bft/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda", "snarkos-node-bft-ledger-service/cuda" ]
 serial = [ "snarkos-node-bft-ledger-service/serial" ]
@@ -45,45 +45,36 @@ workspace = true
 features = [ "serde", "rayon" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
 [dependencies.lru]
-version = "0.12.1"
+workspace = true
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.parking_lot]
-version = "0.12"
+workspace = true
 
 [dependencies.snarkos-account]
-path = "../../account"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft]
-path = "../bft"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft-ledger-service]
-path = "../bft/ledger-service"
-version = "=4.0.1"
-default-features = false
+workspace = true
 features = [ "ledger", "ledger-write" ]
 
 [dependencies.snarkos-node-bft-storage-service]
-path = "../bft/storage-service"
-version = "=4.0.1"
-default-features = false
+workspace = true
 features = [ "persistent" ]
 
 [dependencies.snarkos-node-sync]
-path = "../sync"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
@@ -99,10 +90,10 @@ workspace = true
 workspace = true
 
 [dev-dependencies.itertools]
-version = "0.12"
+workspace = true
 
 [dev-dependencies.once_cell]
-version = "1.19"
+workspace = true
 
 [dev-dependencies.tracing-test]
 workspace = true

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -18,6 +18,9 @@
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 use snarkos_account::Account;
 use snarkos_node_bft::{
     BFT,

--- a/node/metrics/Cargo.toml
+++ b/node/metrics/Cargo.toml
@@ -23,7 +23,7 @@ metrics = [ "snarkvm/metrics" ]
 serial = [ ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
@@ -31,10 +31,10 @@ optional = true
 version = "0.13"
 
 [dependencies.parking_lot]
-version = "0.12"
+workspace = true
 
 [dependencies.rayon]
-version = "1"
+workspace = true
 optional = true
 
 [dependencies.snarkvm]
@@ -42,4 +42,4 @@ workspace = true
 features = [ "console", "ledger", "metrics" ]
 
 [dependencies.time]
-version = "0.3"
+workspace = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -36,10 +36,10 @@ serial = [
 workspace = true
 
 [dependencies.axum]
-version = "0.8"
+workspace = true
 
 [dependencies.axum-extra]
-version = "0.10"
+workspace = true
 features = [ "erased-json", "typed-header" ]
 
 [dependencies.http]
@@ -53,22 +53,22 @@ features = [ "serde", "rayon" ]
 version = "9.2"
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
 [dependencies.once_cell]
-version = "1.19"
+workspace = true
 
 [dependencies.parking_lot]
-version = "0.12"
+workspace = true
 
 [dependencies.serde]
 workspace = true 
 features = [ "derive" ]
 
 [dependencies.serde_json]
-version = "1"
+workspace = true
 features = [ "preserve_order" ]
 
 [dependencies.serde_with]
@@ -90,13 +90,13 @@ workspace = true
 workspace = true
 
 [dependencies.rand]
-version = "0.8"
+workspace = true
 
 [dependencies.rayon]
-version = "1"
+workspace = true
 
 [dependencies.time]
-version = "0.3"
+workspace = true
 
 [dependencies.tokio]
 workspace = true

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 [features]
 test = [ ]
 locktick = [ "dep:locktick", "snarkos-node-tcp/locktick", "snarkvm/locktick" ]
-metrics = [ "dep:metrics" ]
+metrics = [ "dep:snarkos-node-metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda" ]
 serial = [ "snarkos-node-bft-ledger-service/serial" ]
 
@@ -44,48 +44,40 @@ version = "0.3"
 features = [ "parking_lot" ]
 optional = true
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.parking_lot]
 workspace = true
 
 [dependencies.rand]
-version = "0.8"
+workspace = true
 
 [dependencies.rayon]
-version = "1.10"
+workspace = true
 
 [dependencies.snarkos-account]
-path = "../../account"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-bft-ledger-service]
-path = "../bft/ledger-service"
-version = "=4.0.1"
-default-features = false
+workspace = true
 features = [ "ledger", "prover" ]
 
 [dependencies.snarkos-node-sync-locators]
-path = "../sync/locators"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-router-messages]
-path = "messages"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-tcp]
-path = "../tcp"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
 
 [dependencies.time]
-version = "0.3"
+workspace = true
 
 [dependencies.tokio]
 workspace = true
@@ -120,19 +112,19 @@ features = [ "sink" ]
 version = "0.2"
 
 [dev-dependencies.snarkos-node-bft-ledger-service]
-path = "../bft/ledger-service"
+workspace = true
 features = [ "ledger-write", "test" ]
 
 [dev-dependencies.snarkos-node-sync]
-path = "../sync"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkos-node-router]
-path = "."
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkos-node-router-messages]
-path = "messages"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkvm]

--- a/node/router/messages/Cargo.toml
+++ b/node/router/messages/Cargo.toml
@@ -21,18 +21,16 @@ default = [ ]
 test = [ ]
 
 [dependencies.bytes]
-version = "1"
+workspace = true
 
 [dependencies.serde]
-version = "1"
+workspace = true
 
 [dependencies.snarkos-node-bft-events]
-path = "../../bft/events"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkos-node-sync-locators]
-path = "../../sync/locators"
-version = "=4.0.1"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
@@ -45,7 +43,7 @@ features = [ "codec" ]
 workspace = true
 
 [dev-dependencies.snarkos-node-sync-locators]
-path = "../../sync/locators"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkvm]

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -20,6 +20,9 @@ extern crate async_trait;
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 pub use snarkos_node_router_messages as messages;
 
 mod handshake;

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -24,8 +24,7 @@ locktick = [
   "snarkos-node-router/locktick",
 ]
 serial = ["snarkos-node-bft-ledger-service/serial"]
-
-metrics = [ "dep:metrics" ]
+metrics = [ "dep:snarkos-node-metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-bft-ledger-service/cuda", "snarkos-node-router/cuda" ]
 test = [ "snarkos-node-sync-locators/test" ]
 
@@ -43,7 +42,7 @@ workspace = true
 workspace = true
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
@@ -58,16 +57,14 @@ workspace = true
 features = [ "sync" ]
 
 [dependencies.rand]
-version = "0.8"
+workspace = true
 
 [dependencies.snarkos-node-bft-ledger-service]
 workspace = true
 features = [ "ledger-write" ]
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.snarkos-node-router]
@@ -77,7 +74,7 @@ workspace = true
 workspace = true
 
 [dependencies.snarkos-node-sync-locators]
-workspace =true
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true
@@ -86,11 +83,11 @@ workspace = true
 workspace = true
 
 [dev-dependencies.snarkos-node-bft-ledger-service]
-path = "../bft/ledger-service"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkos-node-sync-locators]
-path = "locators"
+workspace = true
 features = [ "test" ]
 
 [dev-dependencies.snarkos-node-sync-communication-service]

--- a/node/sync/src/lib.rs
+++ b/node/sync/src/lib.rs
@@ -18,6 +18,9 @@
 #[macro_use]
 extern crate tracing;
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 pub use snarkos_node_sync_communication_service as communication_service;
 pub use snarkos_node_sync_locators as locators;
 

--- a/node/tcp/Cargo.toml
+++ b/node/tcp/Cargo.toml
@@ -19,30 +19,32 @@ edition = "2024"
 [features]
 default = [ ]
 locktick = [ "dep:locktick" ]
-metrics = [ "dep:metrics" ]
+metrics = [ "dep:snarkos-node-metrics" ]
 
-[dependencies]
-async-trait = "0.1"
-bytes = "1"
-parking_lot = "0.12"
+[dependencies.async-trait]
+workspace = true
+
+[dependencies.bytes]
+workspace = true
+
+[dependencies.parking_lot]
+workspace = true
 
 [dependencies.futures-util]
-version = "0.3"
+workspace = true
 features = [ "sink" ]
 
 [dependencies.locktick]
-version = "0.3"
+workspace = true
 features = [ "parking_lot" ]
 optional = true
 
-[dependencies.metrics]
-package = "snarkos-node-metrics"
-path = "../metrics"
-version = "=4.0.1"
+[dependencies.snarkos-node-metrics]
+workspace = true
 optional = true
 
 [dependencies.once_cell]
-version = "1"
+workspace = true
 features = [ "parking_lot" ]
 
 [dependencies.tokio]

--- a/node/tcp/src/lib.rs
+++ b/node/tcp/src/lib.rs
@@ -18,6 +18,9 @@
 
 //! **Tcp** is a simple, low-level, and customizable implementation of a TCP stack.
 
+#[cfg(feature = "metrics")]
+extern crate snarkos_node_metrics as metrics;
+
 mod helpers;
 pub use helpers::*;
 


### PR DESCRIPTION
The PR also makes some commonly used third-party crates workspace dependencies, and updates `lru` to `0.16`.

### `extern crate`
One noticeable change is that I needed to explicitly rename the metrics dependency for the crates to use it so you see the following sometimes.
```rust
#[cfg(feature = "metrics")]
extern crate snarkos_node_metrics as metrics;
```

I could also have renamed the workspace dependency, but this way all local workspace dependencies are prefixed with `snarkos-`.
