### PR TITLE
[Fix] Return proper JSON from REST APIs

### DIFF
--- a/node/rest/src/helpers/json.rs
+++ b/node/rest/src/helpers/json.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snarkvm::prelude::{Network, Plaintext, Value};
+
+use anyhow::Result;
+
+/// Convert a `Value` to JSON.
+/// `Value` implements Serialize by just calling `to_string()` on the value, which leads to Display
+/// output which (sometimes) looks like JSON but isn't.
+/// We produce actual JSON by calling `serde_json::to_value` on the inner object.
+pub(crate) fn value_to_json<N: Network>(mapping_value: Option<&Value<N>>) -> Result<serde_json::Value> {
+    let json_value = if let Some(mapping_value) = mapping_value {
+        match mapping_value {
+            Value::Plaintext(plaintext) => match plaintext {
+                Plaintext::Array(array, _) => serde_json::to_value(array)?,
+                Plaintext::Struct(map, _) => serde_json::to_value(map)?,
+                Plaintext::Literal(literal, _) => serde_json::to_value(literal)?,
+            },
+            Value::Record(record) => serde_json::to_value(record)?,
+            Value::Future(future) => serde_json::to_value(future)?,
+        }
+    } else {
+        serde_json::Value::Object(Default::default())
+    };
+
+    Ok(json_value)
+}
+
+pub(crate) fn mapping_to_json<N: Network>(mapping_values: &[(Plaintext<N>, Value<N>)]) -> Result<serde_json::Value> {
+    let mut json = serde_json::Map::new();
+    for (key, value) in mapping_values {
+        let key = match key {
+            // TODO: not sure if keys can be anything other than literals
+            Plaintext::Array(array, _) => serde_json::to_string(&array)?,
+            Plaintext::Struct(map, _) => serde_json::to_string(&map)?,
+            // We can not use json here as it would cause the key to be escaped
+            Plaintext::Literal(literal, _) => literal.to_string(),
+        };
+        json.insert(key, value_to_json(Some(value))?);
+    }
+
+    Ok(serde_json::Value::Object(json))
+}

--- a/node/rest/src/helpers/mod.rs
+++ b/node/rest/src/helpers/mod.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 mod auth;
+
+/// This is used by CLI and needs to be public.
 pub use auth::*;
 
 mod error;

--- a/node/rest/src/helpers/mod.rs
+++ b/node/rest/src/helpers/mod.rs
@@ -21,3 +21,6 @@ pub(crate) use error::*;
 
 mod path;
 pub(crate) use path::Path;
+
+mod json;
+pub(crate) use json::*;

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 use super::*;
+use crate::helpers::{mapping_to_json, value_to_json};
+
 use snarkos_node_router::messages::UnconfirmedSolution;
 use snarkvm::{
     ledger::puzzle::Solution,
@@ -419,15 +421,16 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let mapping_value = rest.ledger.vm().finalize_store().get_value_confirmed(id, name, &key)?;
 
         // Check if metadata is requested and return the value with metadata if so.
-        if metadata.metadata.unwrap_or(false) {
-            return Ok(ErasedJson::pretty(json!({
-                "data": mapping_value,
+        let json_value = if metadata.metadata.is_some() {
+            json!({
+                "data": value_to_json(mapping_value.as_ref())?,
                 "height": rest.ledger.latest_height(),
-            })));
-        }
+            })
+        } else {
+            value_to_json(mapping_value.as_ref())?
+        };
 
-        // Return the value without metadata.
-        Ok(ErasedJson::pretty(mapping_value))
+        Ok(ErasedJson::pretty(json_value))
     }
 
     /// GET /<network>/program/{programID}/mapping/{mappingName}?all={true}&metadata={true}
@@ -452,15 +455,17 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         {
             Ok(Ok(mapping_values)) => {
                 // Check if metadata is requested and return the mapping with metadata if so.
-                if metadata.metadata.unwrap_or(false) {
-                    return Ok(ErasedJson::pretty(json!({
-                        "data": mapping_values,
+                let json_value = if metadata.metadata.is_some() {
+                    json!({
+                        "data": mapping_to_json(&mapping_values)?,
                         "height": height,
-                    })));
-                }
+                    })
+                } else {
+                    // Return the full mapping without metadata.
+                    mapping_to_json(&mapping_values)?
+                };
 
-                // Return the full mapping without metadata.
-                Ok(ErasedJson::pretty(mapping_values))
+                Ok(ErasedJson::pretty(json_value))
             }
             Ok(Err(err)) => Err(RestError::internal_server_error(err.context("Unable to read mapping"))),
             Err(err) => Err(RestError::internal_server_error(anyhow!("Tokio error: {err}"))),

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -421,7 +421,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let mapping_value = rest.ledger.vm().finalize_store().get_value_confirmed(id, name, &key)?;
 
         // Check if metadata is requested and return the value with metadata if so.
-        let json_value = if metadata.metadata.is_some() {
+        let json_value = if metadata.metadata.unwrap_or(false) {
             json!({
                 "data": value_to_json(mapping_value.as_ref())?,
                 "height": rest.ledger.latest_height(),
@@ -455,7 +455,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         {
             Ok(Ok(mapping_values)) => {
                 // Check if metadata is requested and return the mapping with metadata if so.
-                let json_value = if metadata.metadata.is_some() {
+                let json_value = if metadata.metadata.unwrap_or(false) {
                     json!({
                         "data": mapping_to_json(&mapping_values)?,
                         "height": height,


### PR DESCRIPTION
Replaces PR #3606 and fixes issue #3361.

### Reproducing the Bug
On `staging`, run test network using `./devnet.sh`. When you query the bonded validator mapping, it should give you the incorrectly formatted output.

```
~> curl http://localhost:3030/testnet/program/credits.aleo/mapping/bonded/$VALIDATOR_ADDR
"{\n  validator: $VALIDATOR_ADDR ,\n  microcredits: 187500058346732u64\n}"
```
(here $VALIDATOR_ADDR is a bonded address, that can be retrieved from the logs)

### Testing
On the PR branch (`fix/value-json`) run another test network and execute the above command again. Now you will get an output with the correct formatting.

```
~> curl http://localhost:3030/testnet/program/credits.aleo/mapping/bonded/$VALIDATOR_ADDR
{
  "validator": "$VALIDATOR_ADDR",
  "microcredits": "187500297811718u64"
}
```