### PR TITLE
[Refactor] More high-level network cleanups

### DIFF
--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -137,7 +137,7 @@ impl<N: Network> Router<N> {
                 self.update_metrics();
                 debug!("Completed the handshake with '{peer_addr}'");
             } else if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                peer.downgrade_to_candidate(addr, false);
+                peer.downgrade_to_candidate(addr);
             }
         }
 
@@ -323,14 +323,6 @@ impl<N: Network> Router<N> {
                 entry.insert(Peer::Connecting);
             }
             Entry::Occupied(mut entry) => match entry.get_mut() {
-                Peer::Candidate(peer)
-                    if peer
-                        .restricted
-                        .map(|ts| ts.elapsed().as_secs() < Self::RADIO_SILENCE_IN_SECS)
-                        .unwrap_or(false) =>
-                {
-                    bail!("Dropping connection request from '{listener_addr}' (restricted)");
-                }
                 peer @ Peer::Candidate(_) => {
                     let _ = mem::replace(peer, Peer::Connecting);
                 }

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -100,7 +100,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         for peer in self.router().get_connected_peers() {
             // Disconnect if the peer has not communicated back within the predefined time.
             let elapsed = peer.last_seen.elapsed().as_secs();
-            if elapsed > Router::<N>::RADIO_SILENCE_IN_SECS {
+            if elapsed > Router::<N>::MAX_RADIO_SILENCE_SECS {
                 warn!("Peer {} has not communicated in {elapsed} seconds", peer.listener_addr);
                 // Disconnect from this peer.
                 self.router().disconnect(peer.listener_addr);

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -100,7 +100,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         for peer in self.router().get_connected_peers() {
             // Disconnect if the peer has not communicated back within the predefined time.
             let elapsed = peer.last_seen.elapsed();
-            if elapsed > Router::<N>::MAX_RADIO_SILENCE_SECS {
+            if elapsed > Router::<N>::MAX_RADIO_SILENCE {
                 warn!("Peer {} has not communicated in {elapsed:?}", peer.listener_addr);
                 // Disconnect from this peer.
                 self.router().disconnect(peer.listener_addr);

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -99,9 +99,9 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         // Check if any connected peer is stale.
         for peer in self.router().get_connected_peers() {
             // Disconnect if the peer has not communicated back within the predefined time.
-            let elapsed = peer.last_seen.elapsed().as_secs();
+            let elapsed = peer.last_seen.elapsed();
             if elapsed > Router::<N>::MAX_RADIO_SILENCE_SECS {
-                warn!("Peer {} has not communicated in {elapsed} seconds", peer.listener_addr);
+                warn!("Peer {} has not communicated in {elapsed:?}", peer.listener_addr);
                 // Disconnect from this peer.
                 self.router().disconnect(peer.listener_addr);
             }

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -300,14 +300,13 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         // Ensure that the trusted nodes are connected.
         let handles: Vec<_> = self
             .router()
-            .filter_connected_peers(|peer| peer.trusted)
+            .unconnected_trusted_peers()
             .iter()
-            .filter_map(|peer| {
-                let peer_addr = peer.listener_addr;
-                debug!("Attempting to (re-)connect to trusted peer `{peer_addr}`");
-                let hdl = self.router().connect(peer_addr);
+            .filter_map(|listener_addr| {
+                debug!("Attempting to (re-)connect to trusted peer `{listener_addr}`");
+                let hdl = self.router().connect(*listener_addr);
                 if hdl.is_none() {
-                    warn!("Could not initiate connection to trusted peer at `{peer_addr}`");
+                    warn!("Could not initiate connection to trusted peer at `{listener_addr}`");
                 }
                 hdl
             })

--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -147,11 +147,4 @@ impl<N: Network> Peer<N> {
             *last_seen = Instant::now();
         }
     }
-
-    /// Updates the peer's version.
-    pub fn update_version(&mut self, new_version: u32) {
-        if let Self::Connected(ConnectedPeer { version, .. }) = self {
-            *version = new_version;
-        }
-    }
 }

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -15,7 +15,6 @@
 
 use crate::{
     Outbound,
-    Peer,
     messages::{
         BlockRequest,
         BlockResponse,
@@ -198,15 +197,6 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 // If the peer is a prover, ensure there are no block locators.
                 else if message.node_type.is_prover() && message.block_locators.is_some() {
                     bail!("Peer '{peer_ip}' is a prover or client, but block locators were provided");
-                }
-
-                // Update the connected peer.
-                if let Err(error) =
-                    self.router().update_connected_peer(peer_ip, message.node_type, |conn: &mut Peer<N>| {
-                        conn.update_version(message.version);
-                    })
-                {
-                    bail!("[Ping] {error}");
                 }
 
                 // Process the ping message.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -118,9 +118,9 @@ impl<N: Network> Router<N> {
     /// The maximum amount of connection attempts withing a 10 second threshold
     #[cfg(not(test))]
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
-    /// The duration in seconds after which a connected peer is considered inactive or
+    /// The duration after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
-    const MAX_RADIO_SILENCE_SECS: Duration = Duration::from_secs(150); // 2.5 minutes
+    const MAX_RADIO_SILENCE: Duration = Duration::from_secs(150); // 2.5 minutes
 }
 
 impl<N: Network> Router<N> {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -121,7 +121,7 @@ impl<N: Network> Router<N> {
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The duration in seconds after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.
-    const RADIO_SILENCE_IN_SECS: u64 = 150; // 2.5 minutes
+    const MAX_RADIO_SILENCE_SECS: u64 = 150; // 2.5 minutes
 }
 
 impl<N: Network> Router<N> {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -469,25 +469,6 @@ impl<N: Network> Router<N> {
         self.update_metrics();
     }
 
-    /// Updates the connected peer with the given function.
-    pub fn update_connected_peer<Fn: FnMut(&mut Peer<N>)>(
-        &self,
-        peer_ip: SocketAddr,
-        node_type: NodeType,
-        mut write_fn: Fn,
-    ) -> Result<()> {
-        // Retrieve the peer.
-        if let Some(peer) = self.peer_pool.write().get_mut(&peer_ip) {
-            // Ensure the node type has not changed.
-            if peer.node_type() != Some(node_type) {
-                bail!("Peer '{peer_ip}' has changed node types");
-            }
-            // Lastly, update the peer with the given function.
-            write_fn(peer);
-        }
-        Ok(())
-    }
-
     pub fn update_last_seen_for_connected_peer(&self, peer_ip: SocketAddr) {
         if let Some(peer) = self.peer_pool.write().get_mut(&peer_ip) {
             peer.update_last_seen();


### PR DESCRIPTION
This PR is a direct follow-up to https://github.com/ProvableHQ/snarkOS/pull/3713, continuing with a refactoring sweep of the higher-level network layer around the `Router`.

A summary of the changes:
- remove the notion of a restricted peer in favor of the banning feature, which is targeting the same issue (connection spam), but is faster to trigger and has a wider reach
- `RADIO_SILENCE_IN_SECS` is renamed to `MAX_RADIO_SILENCE_SECS`
- the collection of trusted peers is removed in favor of enhancing the `Peer` object with a `trusted` flag
- several `heartbeat` and `outbound` methods are refactored for brevity and improved performance
- a few peer-related `Router` methods are removed
- peers can no longer have their node type or version updated without reconnecting (this may have been considered, but has never been possible - the node must be restarted in order for either to change)

Note: I currently only removed the updates to the `RESTRICTED` metric; should the metric be removed altogether, or perhaps show the number of banned peers instead?