### PR TITLE
added test_network to default feature list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [features]
-default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics" ]
+default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics", "snarkos-cli/test_network" ]
 history = [ "snarkos-node/history" ]
 telemetry = [ "snarkos-node/telemetry" ]
 cuda = [
@@ -172,7 +172,6 @@ locktick = [
   "snarkos-node-tcp/locktick"
 ]
 serial = [ "snarkos-cli/serial" ]
-test_network = [ "snarkos-cli/test_network" ]
 
 [dependencies.anyhow]
 workspace = true


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->
## Motivation

This PR includes the `test_network` to the list of default features that are automatically included in the default installation of SnarkOS.  
Previously, users would have to specify the `test_network` as an added feature flag during installation.  This would be easy to miss (and was missed) by some teams who routinely use local test networks for development.
