### PR TITLE
By default don't generate txs in devnet

### DIFF
--- a/devnet.sh
+++ b/devnet.sh
@@ -114,7 +114,7 @@ for validator_index in "${validator_indices[@]}"; do
   fi
 
   # Send the command to start the validator to the new window and capture output to the log file
-  tmux send-keys -t "devnet:$window_index" "snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity --metrics --metrics-ip=0.0.0.0:$metrics_port" C-m
+  tmux send-keys -t "devnet:$window_index" "snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity --metrics --metrics-ip=0.0.0.0:$metrics_port --no-dev-txs" C-m
 done
 
 if [ "$total_clients" -ne 0 ]; then


### PR DESCRIPTION
## Motivation

Because this eats up resources and most people don't use it. This is a remnant from early snarkOS where this was needed for advancing.

CC @Roee-87

