### PR TITLE
[Feature] Show list of peers in terminal UI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ rustflags = [
     # See here: https://github.com/rust-lang/rust/issues/71515
     "-C", "link-arg=-fuse-ld=lld",
 ]
+
+[env]
+CXXFLAGS = "-include cstdint" #TODO: remove once RocksDB 0.24 is r

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@ rustflags = [
 ]
 
 [env]
-CXXFLAGS = "-include cstdint" #TODO: remove once RocksDB 0.24 is r
+CXXFLAGS = "-include cstdint" #TODO: remove once RocksDB 0.24 is released

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -634,8 +634,6 @@ impl Start {
             false => self.rest.or_else(|| Some("0.0.0.0:3030".parse().unwrap())),
         };
 
-        // If the display is not enabled, render the welcome message.
-        if self.nodisplay {
             // Print the Aleo address.
             println!("👛 Your Aleo address is {}.\n", account.address().to_string().bold());
             // Print the node type and network.
@@ -669,7 +667,6 @@ impl Start {
                     }
                 }
             }
-        }
 
         // If the node is a validator, check if the open files limit is lower than recommended.
         #[cfg(target_family = "unix")]
@@ -710,7 +707,12 @@ impl Start {
         match node_type {
             NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, self.allow_external_peers, dev_txs, self.dev, shutdown.clone()).await,
             NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, self.dev, shutdown.clone()).await,
-            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.rotate_external_peers, self.dev, shutdown).await,
+            NodeType::Client => {
+                if !self.nodisplay && !self.nocdn {
+                    println!("🪧 The terminal UI will not start until the client has finished syncing from the CDN. If this step takes too long, consider restarting with `--nodisplay`.");
+                }
+                Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.rotate_external_peers, self.dev, shutdown).await
+            }
         }
     }
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -703,16 +703,17 @@ impl Start {
             }
         };
 
+
+        // TODO(kaimast): start the display earlier and show sync progress.
+        if !self.nodisplay && !self.nocdn {
+            println!("🪧 The terminal UI will not start until the node has finished syncing from the CDN. If this step takes too long, consider restarting with `--nodisplay`.");
+        }
+
         // Initialize the node.
         match node_type {
             NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, self.allow_external_peers, dev_txs, self.dev, shutdown.clone()).await,
             NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, self.dev, shutdown.clone()).await,
-            NodeType::Client => {
-                if !self.nodisplay && !self.nocdn {
-                    println!("🪧 The terminal UI will not start until the client has finished syncing from the CDN. If this step takes too long, consider restarting with `--nodisplay`.");
-                }
-                Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.rotate_external_peers, self.dev, shutdown).await
-            }
+            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.rotate_external_peers, self.dev, shutdown).await
         }
     }
 

--- a/display/src/lib.rs
+++ b/display/src/lib.rs
@@ -57,6 +57,14 @@ pub struct Display<N: Network> {
     logs: Logs,
 }
 
+fn header_style() -> Style {
+    Style::default().fg(Color::Cyan)
+}
+
+fn content_style() -> Style {
+    Style::default().fg(Color::White)
+}
+
 impl<N: Network> Display<N> {
     /// Initializes a new display.
     pub fn start(node: Node<N>, log_receiver: Receiver<Vec<u8>>) -> Result<()> {
@@ -163,7 +171,7 @@ impl<N: Network> Display<N> {
                     .style(Style::default().add_modifier(Modifier::BOLD)),
             )
             .select(self.tabs.index)
-            .style(Style::default().fg(Color::Cyan))
+            .style(header_style())
             .highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(Color::White));
         f.render_widget(tabs, chunks[0]);
 

--- a/display/src/pages/logs.rs
+++ b/display/src/pages/logs.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{content_style, header_style};
+
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -65,7 +67,9 @@ impl Logs {
 
         let combined_logs = self.log_cache.iter().map(|s| s.as_str()).collect::<String>();
 
-        let combined_logs = Paragraph::new(combined_logs).block(Block::default().borders(Borders::ALL).title("Logs"));
+        let combined_logs = Paragraph::new(combined_logs)
+            .style(content_style())
+            .block(Block::default().borders(Borders::ALL).style(header_style()).title("Logs"));
         f.render_widget(combined_logs, chunks[0]);
     }
 }

--- a/display/src/pages/overview.rs
+++ b/display/src/pages/overview.rs
@@ -54,14 +54,10 @@ impl Overview {
             .into_iter()
             .filter(|peer| !peer.is_candidate()) // Too many candidate peers for overview.
             .map(|peer| {
-                let state = if peer.is_candidate() {
-                    "candidate"
-                } else if peer.is_connecting() {
-                    "connecting"
-                } else if peer.is_connected() {
-                    "connected"
-                } else {
-                    unreachable!("Unknown peer state");
+                let state = match peer {
+                    Peer::Candidate(_) => "candidate",
+                    Peer::Connecting(_) => "connecting",
+                    Peer::Connected(_) => "connected",
                 }.to_string();
 
                 let node_type = if let Some(node_type ) = peer.node_type() {

--- a/display/src/pages/overview.rs
+++ b/display/src/pages/overview.rs
@@ -13,15 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{content_style, header_style};
+
 use snarkos_node::{Node, router::Peer};
 use snarkvm::prelude::Network;
 
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
-    text::{Span, Text},
-    widgets::{Block, Borders, Paragraph, Row, Table, canvas::Canvas},
+    style::{Color, Modifier, Style},
+    text::Text,
+    widgets::{Block, Borders, Paragraph, Row, Table},
 };
 
 pub(crate) struct Overview;
@@ -35,7 +37,9 @@ impl Overview {
             Text::raw("N/A")
         };
 
-        let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::ALL).title("Latest Block"));
+        let paragraph = Paragraph::new(text)
+            .style(content_style())
+            .block(Block::default().borders(Borders::ALL).style(header_style()).title("Latest Block"));
         f.render_widget(&paragraph, area);
     }
 
@@ -72,13 +76,14 @@ impl Overview {
                     "N/A".to_string()
                 };
 
-                Row::new([format!("{:?}", peer.listener_addr()), state, node_type, last_seen])
+                Row::new([format!("{:?}", peer.listener_addr()), state, node_type, last_seen]).style(content_style())
             })
             .collect();
 
         let peer_table = Table::new(rows, constraints)
-            .header(Row::new(header))
-            .block(Block::default().borders(Borders::ALL).title("Peers"));
+            .style(content_style())
+            .header(Row::new(header).style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)))
+            .block(Block::default().borders(Borders::ALL).style(header_style()).title("Peers"));
 
         f.render_widget(peer_table, area);
     }
@@ -93,9 +98,9 @@ impl Overview {
         self.draw_latest_block(f, chunks[0], node);
         self.draw_peer_table(f, chunks[1], node);
 
-        let canvas = Canvas::default().block(Block::default().borders(Borders::ALL).title("Help")).paint(|ctx| {
-            ctx.print(0f64, 0f64, Span::styled("Press ESC to quit", Style::default().fg(Color::White)));
-        });
-        f.render_widget(canvas, chunks[2]);
+        let help = Paragraph::new("Press ESC to quit")
+            .style(content_style())
+            .block(Block::default().borders(Borders::ALL).title("Help").style(header_style()));
+        f.render_widget(help, chunks[2]);
     }
 }

--- a/display/src/pages/overview.rs
+++ b/display/src/pages/overview.rs
@@ -13,36 +13,85 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snarkos_node::Node;
+use snarkos_node::{Node, router::Peer};
 use snarkvm::prelude::Network;
 
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
-    text::Span,
-    widgets::{Block, Borders, canvas::Canvas},
+    text::{Span, Text},
+    widgets::{Block, Borders, Paragraph, Row, Table, canvas::Canvas},
 };
 
 pub(crate) struct Overview;
 
 impl Overview {
-    pub(crate) fn draw<N: Network>(&self, f: &mut Frame, area: Rect, _node: &Node<N>) {
+    fn draw_latest_block<N: Network>(&self, f: &mut Frame, area: Rect, node: &Node<N>) {
+        let text = if let Some(ledger) = node.ledger() {
+            let block = ledger.latest_block();
+            Text::raw(format!("Hash: {} | Height: {}", block.hash(), block.height()))
+        } else {
+            Text::raw("N/A")
+        };
+
+        let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::ALL).title("Latest Block"));
+        f.render_widget(&paragraph, area);
+    }
+
+    /// Draws a table containing all connected and connecting peers.
+    fn draw_peer_table<N: Network>(&self, f: &mut Frame, area: Rect, node: &Node<N>) {
+        let header = ["IP", "State", "Node Type"];
+        let constraints = [Constraint::Length(20), Constraint::Length(10), Constraint::Length(10)];
+
+        let rows: Vec<_> = node
+            .router()
+            .get_peers()
+            .into_iter()
+            .filter(|peer| !peer.is_candidate()) // Too many candidate peers for overview.
+            .map(|peer| {
+                let state = if peer.is_candidate() {
+                    "candidate"
+                } else if peer.is_connecting() {
+                    "connecting"
+                } else if peer.is_connected() {
+                    "connected"
+                } else {
+                    unreachable!("Unknown peer state");
+                }.to_string();
+
+                let node_type = if let Some(node_type ) = peer.node_type() {
+                    node_type.to_string()
+                } else {
+                    "unknown".to_string()
+                };
+
+                let last_seen = if let Peer::Connected(p) = &peer {
+                    format!("{:.2}s ago", p.last_seen.elapsed().as_secs_f64())
+                } else {
+                    "N/A".to_string()
+                };
+
+                Row::new([format!("{:?}", peer.listener_addr()), state, node_type, last_seen])
+            })
+            .collect();
+
+        let peer_table = Table::new(rows, constraints)
+            .header(Row::new(header))
+            .block(Block::default().borders(Borders::ALL).title("Peers"));
+
+        f.render_widget(peer_table, area);
+    }
+
+    pub(crate) fn draw<N: Network>(&self, f: &mut Frame, area: Rect, node: &Node<N>) {
         // Initialize the layout of the page.
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Percentage(10), Constraint::Percentage(70), Constraint::Max(2)].as_ref())
+            .constraints([Constraint::Length(3), Constraint::Min(10), Constraint::Length(3)]) // The box border adds a line on both sides.
             .split(area);
 
-        let canvas = Canvas::default().block(Block::default().borders(Borders::ALL).title("Block")).paint(|_ctx| {
-            // ctx.draw(&ball);
-        });
-        f.render_widget(canvas, chunks[0]);
-
-        let canvas = Canvas::default().block(Block::default().borders(Borders::ALL).title("Peers")).paint(|_ctx| {
-            // ctx.draw(&ball);
-        });
-        f.render_widget(canvas, chunks[1]);
+        self.draw_latest_block(f, chunks[0], node);
+        self.draw_peer_table(f, chunks[1], node);
 
         let canvas = Canvas::default().block(Block::default().borders(Borders::ALL).title("Help")).paint(|ctx| {
             ctx.print(0f64, 0f64, Span::styled("Press ESC to quit", Style::default().fg(Color::White)));

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -119,7 +119,7 @@ impl<N: Network> Router<N> {
     const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
     /// The maximum number of candidate peers permitted to be stored in the node.
     const MAXIMUM_CANDIDATE_PEERS: usize = 10_000;
-    /// The maximum amount of connection attempts withing a 10 second threshold
+    /// The maximum amount of connection attempts within a 10 second threshold
     #[cfg(not(test))]
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The duration in seconds after which a connected peer is considered inactive or
@@ -403,6 +403,11 @@ impl<N: Network> Router<N> {
     /// Returns the connected peer given the peer IP, if it exists.
     pub fn get_connected_peer(&self, ip: &SocketAddr) -> Option<ConnectedPeer<N>> {
         if let Some(Peer::Connected(peer)) = self.peer_pool.read().get(ip) { Some(peer.clone()) } else { None }
+    }
+
+    /// Returns the list of all peers (connected, connecting, and candidate).
+    pub fn get_peers(&self) -> Vec<Peer<N>> {
+        self.peer_pool.read().values().cloned().collect()
     }
 
     /// Returns the connected peers.

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -249,8 +249,14 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
     pub fn rest(&self) -> &Option<Rest<N, C, Self>> {
         &self.rest
     }
+
+    /// Returns the router.
+    pub fn router(&self) -> &Router<N> {
+        &self.router
+    }
 }
 
+/// Sync-specific code.
 impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
     const SYNC_INTERVAL: Duration = std::time::Duration::from_secs(5);
 

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -15,9 +15,10 @@
 
 use crate::{Client, Prover, Validator, traits::NodeInterface};
 use snarkos_account::Account;
-use snarkos_node_router::messages::NodeType;
+use snarkos_node_router::{Router, messages::NodeType};
 use snarkvm::prelude::{
     Address,
+    Ledger,
     Network,
     PrivateKey,
     ViewKey,
@@ -166,6 +167,24 @@ impl<N: Network> Node<N> {
             Self::Validator(node) => node.is_dev(),
             Self::Prover(node) => node.is_dev(),
             Self::Client(node) => node.is_dev(),
+        }
+    }
+
+    /// Get the router for P2P networking
+    pub fn router(&self) -> &Router<N> {
+        match self {
+            Self::Validator(node) => node.router(),
+            Self::Prover(node) => node.router(),
+            Self::Client(node) => node.router(),
+        }
+    }
+
+    /// Get the underlying ledger (if any).
+    pub fn ledger(&self) -> Option<&Ledger<N, ConsensusDB<N>>> {
+        match self {
+            Self::Validator(node) => Some(node.ledger()),
+            Self::Prover(_) => None,
+            Self::Client(node) => Some(node.ledger()),
         }
     }
 }

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -157,6 +157,10 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
         // Return the node.
         Ok(node)
     }
+
+    pub fn router(&self) -> &Router<N> {
+        &self.router
+    }
 }
 
 #[async_trait]

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -202,9 +202,12 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
     pub fn rest(&self) -> &Option<Rest<N, C, Self>> {
         &self.rest
     }
-}
 
-impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
+    /// Returns the router.
+    pub fn router(&self) -> &Router<N> {
+        &self.router
+    }
+
     // /// Initialize the transaction pool.
     // fn initialize_transaction_pool(&self, dev: Option<u16>) -> Result<()> {
     //     use snarkvm::{

--- a/node/tests/disconnect.rs
+++ b/node/tests/disconnect.rs
@@ -19,7 +19,6 @@
 mod common;
 use common::{node::*, test_peer::TestPeer};
 
-use snarkos_node_router::Outbound;
 use snarkos_node_tcp::P2P;
 
 use deadline::deadline;
@@ -38,7 +37,6 @@ macro_rules! test_disconnect {
         async fn $peer_type() {
             use deadline::deadline;
             use pea2pea::Pea2Pea;
-            use snarkos_node_router::Outbound;
             use snarkos_node_tcp::P2P;
             use std::time::Duration;
 

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -20,7 +20,6 @@ mod common;
 use common::{node::*, test_peer::TestPeer};
 
 use snarkos_node::{Client, Prover, Validator};
-use snarkos_node_router::Outbound;
 use snarkos_node_tcp::{ConnectError, P2P};
 use snarkvm::prelude::{MainnetV0 as CurrentNetwork, store::helpers::memory::ConsensusMemory};
 

--- a/node/tests/peering.rs
+++ b/node/tests/peering.rs
@@ -17,10 +17,7 @@
 mod common;
 use common::test_peer::TestPeer;
 
-use snarkos_node_router::{
-    Outbound,
-    messages::{Message, PeerResponse},
-};
+use snarkos_node_router::messages::{Message, PeerResponse};
 use snarkos_node_tcp::P2P;
 
 use deadline::deadline;


### PR DESCRIPTION
This PR makes the "Overview" page in the terminal UI (`display`) usable. It now shows the currently connected peers and information about the latest block.

### Screenshot
﻿<img width="932" height="663" alt="Screenshot of Overview Page" src="https://github.com/user-attachments/assets/fd06739d-2a76-4814-a807-79ef713e624d" />


