### PR TITLE
feat: Add support for both ip and hostname for peers

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -49,7 +49,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use serde::{Deserialize, Serialize};
 use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     path::PathBuf,
     sync::{Arc, atomic::AtomicBool},
 };
@@ -313,20 +313,24 @@ impl Start {
     fn parse_trusted_peers(&self) -> Result<Vec<SocketAddr>> {
         let Some(peers) = &self.peers else { return Ok(vec![]) };
 
-        // Split on an empty string returns an empty string.
-        if peers.is_empty() {
-            return Ok(vec![]);
+        match peers.is_empty() {
+            // Split on an empty string returns an empty string.
+            true => Ok(vec![]),
+            false => Ok(peers
+                .split(',')
+                .flat_map(|ip_or_hostname| {
+                    let trimmed = ip_or_hostname.trim();
+                    match trimmed.to_socket_addrs() {
+                        Ok(mut ip_iter) => {
+                            // A hostname might resolve to multiple IP addresses. We will use only the first one,
+                            // assuming this aligns with the user's expectations.
+                            ip_iter.next()
+                        }
+                        Err(e) => panic!("The hostname or IP supplied to --peers ('{trimmed}') is malformed: {e}"),
+                    }
+                })
+                .collect()),
         }
-
-        let mut result = vec![];
-        for ip in peers.split(',') {
-            match ip.parse::<SocketAddr>() {
-                Ok(ip) => result.push(ip),
-                Err(err) => bail!("An address supplied to --peers ('{ip}') is malformed: {err}"),
-            }
-        }
-
-        Ok(result)
     }
 
     /// Returns the initial validator(s) to connect to, from the given configurations.
@@ -1150,6 +1154,59 @@ mod tests {
             assert_eq!(start.validators, Some("IP1,IP2,IP3".to_string()));
         } else {
             panic!("Unexpected result of clap parsing!");
+        }
+    }
+
+    #[test]
+    fn parse_peers_when_ips() {
+        let arg_vec = vec!["snarkos", "start", "--peers", "127.0.0.1:3030,127.0.0.2:3030"];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Start(start) = cli.command {
+            let peers = start.parse_trusted_peers();
+            assert!(peers.is_ok());
+            assert_eq!(peers.unwrap().len(), 2, "Expected two peers");
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
+    }
+
+    #[test]
+    fn parse_peers_when_hostnames() {
+        let arg_vec = vec!["snarkos", "start", "--peers", "www.example.com:4130,www.google.com:4130"];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Start(start) = cli.command {
+            let peers = start.parse_trusted_peers();
+            assert!(peers.is_ok());
+            assert_eq!(peers.unwrap().len(), 2, "Expected two peers");
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
+    }
+
+    #[test]
+    fn parse_peers_when_mixed_and_with_whitespaces() {
+        let arg_vec = vec!["snarkos", "start", "--peers", "  127.0.0.1:3030,  www.google.com:4130 "];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Start(start) = cli.command {
+            let peers = start.parse_trusted_peers();
+            assert!(peers.is_ok());
+            assert_eq!(peers.unwrap().len(), 2, "Expected two peers");
+        } else {
+            panic!("Unexpected result of clap parsing!");
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn parse_peers_when_unknown_hostname_gracefully() {
+        let arg_vec = vec!["snarkos", "start", "--peers", "banana.cake.eafafdaeefasdfasd.com"];
+        let cli = CLI::parse_from(arg_vec);
+
+        if let Command::Start(start) = cli.command {
+            start.parse_trusted_peers();
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ProvableHQ/snarkOS/issues/378

It is convinent to be able to specify both IPs and hostnames as peers. Especially, when you are building ephemeral testnets and want to specify peers as

```
./snarkos start --peers "validator0:4130,client0:4130"
```

Where you can populate the `/etc/hosts` file with subnet hostnames.

<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Related PRs

Supersedes: https://github.com/ProvableHQ/snarkOS/pull/3432
