### PR TITLE
Update maximum number of client peers for a validator

### DIFF
--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -129,10 +129,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Routing<N> for Validator<N, C> {}
 
-impl<N: Network, C: ConsensusStorage<N>> Heartbeat<N> for Validator<N, C> {
-    /// The maximum number of peers permitted to maintain connections with.
-    const MAXIMUM_NUMBER_OF_PEERS: usize = 200;
-}
+impl<N: Network, C: ConsensusStorage<N>> Heartbeat<N> for Validator<N, C> {}
 
 impl<N: Network, C: ConsensusStorage<N>> Outbound<N> for Validator<N, C> {
     /// Returns a reference to the router.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR updates the `MAXIMUM_NUMBER_OF_PEERS` for validator nodes from 200 to the default value of 21. 

Previously it was set to 200, with the intention that it was to limit the number of connected validators, however that was never the case, as that is guarded by a separate mechanism. This new change changes it back to the expected maximum number of connected **_clients_**.
