### PR TITLE
[Chore] Bump snarkVM rev and update message version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "blst",
  "cc",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.14.0",
@@ -4259,12 +4259,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4326,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4396,7 +4396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4420,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4469,7 +4469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4515,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4555,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4577,7 +4577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4591,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4647,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4686,7 +4686,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4725,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4736,7 +4736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4751,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4764,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "metrics",
 ]
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4964,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4994,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=cc11039#cc11039db8681cedc64f7b3b9b355ee8ac41689a"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "cc11039"
+rev = "fc4951e"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -114,11 +114,12 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 impl<N: Network> Message<N> {
     /// The version of the network protocol; this is incremented for breaking changes between migration versions.
     // Note. This should be incremented for each new `ConsensusVersion` that is added.
-    pub const VERSIONS: [(ConsensusVersion, u32); 4] = [
+    pub const VERSIONS: [(ConsensusVersion, u32); 5] = [
         (ConsensusVersion::V5, 17),
         (ConsensusVersion::V7, 18),
         (ConsensusVersion::V8, 19),
         (ConsensusVersion::V9, 20),
+        (ConsensusVersion::V10, 21),
     ];
 
     /// Returns the latest message version.


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR bumps the snarkVM rev to the latest `staging` changes. These changes include a new consensus version, so `Message::VERSION` needed an update as well

## Related PRs

snarkVM sister PR here - https://github.com/ProvableHQ/snarkVM/pull/2828