### PR TITLE
[CI] Sync benchmarks

### DIFF
--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 network_id=1
-min_height=240
+min_height=250
 
 # The number of validators that are syncing
 num_nodes=1
@@ -16,6 +16,10 @@ poll_interval=1 # Check block heights every second
 
 network_name=$(get_network_name $network_id)
 echo "Using network: $network_name (ID: $network_id)"
+
+info.txt > snapshot_info
+echo "Snapshot_info:"
+echo ${snapshot_info}
 
 # Create log directory
 log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
@@ -75,7 +79,7 @@ while (( total_wait < max_wait )); do
     echo "🎉 Test passed!. Waited $total_wait for $min_height blocks. Throughput was $throughput blocks/s."
 
     # Append data to results file.
-    printf "{ \"name\": \"bft-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is\" },\n" \
+    printf "{ \"name\": \"bft-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is, target_height=${min_height}, ${snapshot_info}\" },\n" \
        "$throughput" "$total_wait" | tee -a results.json
     exit 0
   fi

--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+network_id=1
+min_height=240
+
+# The number of validators that are syncing
+num_nodes=1
+
+# Adjust this to show more/less log messages
+log_filter="warn,snarkos_node_sync=debug"
+
+max_wait=1800 # Wait for up to 30 minutes
+poll_interval=1 # Check block heights every second
+
+. ./.ci/utils.sh
+
+network_name=$(get_network_name $network_id)
+echo "Using network: $network_name (ID: $network_id)"
+
+# Create log directory
+log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
+mkdir -p "$log_dir"
+
+# Array to store PIDs of all processes
+declare -a PIDS
+
+# Define a trap handler that cleans up all processes on exit.
+function exit_handler() {
+  shutdown "${PIDS[@]}"
+}
+trap exit_handler EXIT
+
+# Define a trap handler that prints a message when an error occurs 
+trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+
+# Shared flags betwen all nodes
+common_flags=" --nodisplay --network $network_id --nocdn --dev-num-validators=40 \
+  --no-dev-txs --log-filter=$log_filter"
+
+# The client that has the ledger
+taskset -c 0,1 snarkos start --dev 0 --validator ${common_flags} \
+  --logfile="$log_dir/validator-0.log" &
+PIDS[0]=$!
+
+# Stores the list of all validators.
+validators="127.0.0.1:5000"
+
+# Spawn the clients that will sync the ledger
+for ((node_index = 1; node_index <= num_nodes; node_index++)); do
+  # Ensure there are no old ledger files and the node syncs from scratch
+  snarkos clean --dev $node_index --network $network_id || true
+  
+  taskset -c 2,3 snarkos start --dev $node_index --validator ${common_flags} \
+          --logfile "$log_dir/validator-$node_index.log" \
+          --validators=$validators &
+  PIDS[node_index]=$!
+
+  # Add the validators BFT address to the validators list.
+  bft_port=$((5000 + node_index))
+  validators="$validators,127.0.0.1:$bft_port"
+
+  # Add 1-second delay between starting nodes to avoid hitting rate limits
+  sleep 1
+done
+
+wait_for_nodes 0 $((num_nodes+1))
+
+# Check heights periodically with a timeout
+total_wait=0
+while (( total_wait < max_wait )); do
+  if check_heights $((num_nodes+1)) 0 $min_height "$network_name"; then
+    # Use floating point division
+    throughput=$(bc <<< "scale=2; $min_height/$total_wait")
+
+    echo "🎉 Test passed!. Waited $total_wait for $min_height blocks. Throughput was $throughput blocks/s."
+
+    # Append data to results file.
+    printf "{ \"name\": \"bft-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is\" },\n" \
+       "$throughput" "$total_wait" | tee -a results.json
+    exit 0
+  fi
+  
+  # Continue waiting
+  sleep $poll_interval
+  total_wait=$((total_wait+poll_interval))
+  echo "Waited $total_wait seconds so far..."
+done
+
+echo "❌ Test failed! Validators did not sync within 30 minutes."
+
+# Print logs for debugging
+echo "Last 20 lines of validators logs:"
+for ((node_index = 0; node_index <= num_nodes; node_index++)); do
+  echo "=== Node $node_index logs ==="
+  tail -n 20 "$log_dir/validator-$node_index.log"
+done
+
+shutdown "${PIDS[@]}"
+exit 1

--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -25,14 +25,12 @@ echo ${snapshot_info}
 log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
 mkdir -p "$log_dir"
 
-# Array to store PIDs of all processes
-declare -a PIDS
-
 # Define a trap handler that cleans up all processes on exit.
 function exit_handler() {
-  shutdown "${PIDS[@]}"
+  stop_nodes
 }
 trap exit_handler EXIT
+trap child_exit_handler CHLD
 
 # Define a trap handler that prints a message when an error occurs 
 trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
@@ -99,5 +97,4 @@ for ((node_index = 0; node_index <= num_nodes; node_index++)); do
   tail -n 20 "$log_dir/validator-$node_index.log"
 done
 
-shutdown "${PIDS[@]}"
 exit 1

--- a/.ci/bench_cdn_sync.sh
+++ b/.ci/bench_cdn_sync.sh
@@ -55,7 +55,7 @@ while (( total_wait < max_wait )); do
     echo "🎉 Test passed!. Waited $total_wait for $min_height blocks. Throughput was $throughput blocks/s."
 
     # Append data to results file.
-    printf "{ \"name\": \"cdn-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is\" }\n" \
+    printf "{ \"name\": \"cdn-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is, target_height=${min_height}\" }\n" \
        "$throughput" "$total_wait" | tee -a results.json
     shutdown "${PIDS[@]}"
     exit 0

--- a/.ci/bench_cdn_sync.sh
+++ b/.ci/bench_cdn_sync.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+####################################################
+# Measures a client syncing 1000 blocks from the CDN
+####################################################
+
+network_id=0 # CDN sync is tested for mainnet
+min_height=250
+
+# Adjust this to show more/less log messages
+log_filter="info"
+
+max_wait=600 # Wait for up to ten minutes
+poll_interval=1 # Check block heights every second
+
+. ./.ci/utils.sh
+
+network_name=$(get_network_name $network_id)
+echo "Using network: $network_name (ID: $network_id)"
+
+# Create log directory
+log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
+mkdir -p "$log_dir"
+
+# Array to store PIDs of all processes
+declare -a PIDS
+
+# Define a trap handler that cleans up all processes on exit.
+function exit_handler() {
+  shutdown "${PIDS[@]}"
+}
+trap exit_handler EXIT
+
+# Define a trap handler that prints a message when an error occurs 
+trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+
+# Ensure there are no old ledger files and the node syncs from scratch
+snarkos clean --network $network_id || true
+
+# Spawn the client that will sync the ledger.
+# Use the same CPU cores as in the other benchmarks, so the numbers are comparable.
+taskset -c 1,2 snarkos start --nodisplay --network $network_id \
+  --client  --log-filter=$log_filter &
+PIDS[client_index]=$!
+
+wait_for_nodes 0 1
+
+# Check heights periodically with a timeout
+total_wait=0
+while (( total_wait < max_wait )); do
+  if check_heights 0 1 $min_height "$network_name"; then
+    # Use floating point division
+    throughput=$(bc <<< "scale=2; $min_height/$total_wait")
+
+    echo "🎉 Test passed!. Waited $total_wait for $min_height blocks. Throughput was $throughput blocks/s."
+
+    # Append data to results file.
+    printf "{ \"name\": \"cdn-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is\" }\n" \
+       "$throughput" "$total_wait" | tee -a results.json
+    shutdown "${PIDS[@]}"
+    exit 0
+  fi
+  
+  # Continue waiting
+  sleep $poll_interval
+  total_wait=$((total_wait+poll_interval))
+  echo "Waited $total_wait seconds so far..."
+done
+
+echo "❌ Test failed! Client did not sync within 5 minutes."
+
+shutdown "${PIDS[@]}"
+exit 1

--- a/.ci/bench_p2p_sync.sh
+++ b/.ci/bench_p2p_sync.sh
@@ -5,7 +5,7 @@
 ###########################################################
 
 network_id=1
-min_height=240
+min_height=250
 
 # The number of clients that are syncing
 num_clients=1
@@ -20,6 +20,10 @@ poll_interval=1 # Check block heights every second
 
 network_name=$(get_network_name $network_id)
 echo "Using network: $network_name (ID: $network_id)"
+
+snapshot_info=$(<info.txt)
+echo "Snapshot_info:"
+echo "${snapshot_info}"
 
 # Create log directory
 log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
@@ -76,8 +80,8 @@ while (( total_wait < max_wait )); do
     echo "🎉 Test passed!. Waited $total_wait for $min_height blocks. Throughput was $throughput blocks/s."
 
     # Append data to results file.
-    printf "{ \"name\": \"p2p-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is\" },\n" \
-       "$throughput" "$total_wait" | tee -a results.json
+    printf "{ \"name\": \"p2p-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is, target_height=%i, %s\" },\n" \
+       "$throughput" "$total_wait" "$min_height" "$snapshot_info" | tee -a results.json
     shutdown "${PIDS[@]}"
     exit 0
   fi

--- a/.ci/bench_p2p_sync.sh
+++ b/.ci/bench_p2p_sync.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+###########################################################
+# Measures a client syncing 1000 blocks from another client
+###########################################################
+
+network_id=1
+min_height=240
+
+# The number of clients that are syncing
+num_clients=1
+
+# Adjust this to show more/less log messages
+log_filter="warn,snarkos_node_sync=debug"
+
+max_wait=1800 # Wait for up to 30 minutes
+poll_interval=1 # Check block heights every second
+
+. ./.ci/utils.sh
+
+network_name=$(get_network_name $network_id)
+echo "Using network: $network_name (ID: $network_id)"
+
+# Create log directory
+log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
+mkdir -p "$log_dir"
+
+# Array to store PIDs of all processes
+declare -a PIDS
+
+# Define a trap handler that cleans up all processes on exit.
+function exit_handler() {
+  shutdown "${PIDS[@]}"
+}
+trap exit_handler EXIT
+
+# Define a trap handler that prints a message when an error occurs 
+trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+
+# Shared flags betwen all nodes
+common_flags=" --nodisplay --network $network_id --nocdn --dev-num-validators=40 \
+  --no-dev-txs --log-filter=$log_filter"
+
+# The client that has the ledger
+# (runs on the first two cores)
+taskset -c 0,1 snarkos start --dev 0 --client ${common_flags} \
+  --logfile="$log_dir/client-0.log" &
+PIDS[0]=$!
+ 
+# Spawn the clients that will sync the ledger
+# (running on the other two cores)
+for ((client_index = 1; client_index <= num_clients; client_index++)); do
+  prev_port=$((4130+client_index-1))
+
+  # Ensure there are no old ledger files and the node syncs from scratch
+  snarkos clean --dev $client_index --network $network_id || true
+
+  taskset -c 2,3 snarkos start --dev $client_index --client ${common_flags} \
+    --logfile="$log_dir/client-$client_index.log" \
+    --peers=127.0.0.1:$prev_port &
+  PIDS[client_index]=$!
+
+  # Add 1-second delay between starting nodes to avoid hitting rate limits
+  sleep 1
+done
+
+wait_for_nodes 0 $((num_clients+1))
+
+# Check heights periodically with a timeout
+total_wait=0
+while (( total_wait < max_wait )); do
+  if check_heights 0 $((num_clients+1)) $min_height "$network_name"; then
+    # Use floating point division
+    throughput=$(bc <<< "scale=2; $min_height/$total_wait")
+
+    echo "🎉 Test passed!. Waited $total_wait for $min_height blocks. Throughput was $throughput blocks/s."
+
+    # Append data to results file.
+    printf "{ \"name\": \"p2p-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is\" },\n" \
+       "$throughput" "$total_wait" | tee -a results.json
+    shutdown "${PIDS[@]}"
+    exit 0
+  fi
+  
+  # Continue waiting
+  sleep $poll_interval
+  total_wait=$((total_wait+poll_interval))
+  echo "Waited $total_wait seconds so far..."
+done
+
+echo "❌ Test failed! Clients did not sync within 30 minutes."
+
+# Print logs for debugging
+echo "Last 20 lines of client logs:"
+for ((client_index = 0; client_index < num_clients; client_index++)); do
+  echo "=== Client $client_index logs ==="
+  tail -n 20 "$log_dir/client-$client_index.log"
+done
+
+shutdown "${PIDS[@]}"
+exit 1

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+####################################################
+# Runs and tests a development network
+####################################################
+
 set -eo pipefail # error on any command failure
 
 # Uncomment this to print commands before executing them for easier debugging.
@@ -52,7 +57,7 @@ common_flags="--nodisplay --nobanner --noupdater --network=$network_id \
 
 # Start all validator nodes in the background
 for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
-  snarkos clean --dev $validator_index
+  snarkos clean --dev $validator_index --network=$network_id
 
   log_file="$log_dir/validator-$validator_index.log"
   if [ $validator_index -eq 0 ]; then
@@ -64,6 +69,7 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
   fi
   PIDS[validator_index]=$!
   echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
+
   # Add 1-second delay between starting nodes to avoid hitting rate limits
   sleep 1
 done

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -32,14 +32,9 @@ log_dir="$PWD/.logs-$(date +"%Y%m%d%H%M%S")"
 mkdir -p "$log_dir"
 chmod 755 "$log_dir"
 
-# Array to store PIDs of all processes
-declare -a PIDS
-
 # Define a trap handler that cleans up all processes on exit.
 function exit_handler() {
-  shutdown "${PIDS[@]}"
-  rm program/main.aleo || true
-  rm program/program.json || true
+  stop_nodes
 
   # Remove all temporary files and folders
   rm program/program.json program/main.aleo || true
@@ -47,6 +42,7 @@ function exit_handler() {
   rmdir program || true
 }
 trap exit_handler EXIT
+trap child_exit_handler CHLD
 
 # Define a trap handler that prints a message when an error occurs 
 trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR

--- a/.ci/generate_ledger.sh
+++ b/.ci/generate_ledger.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+####################################################
+# Runs a network up to a certain height andi stores
+# the first node's ledger in a zipfile.
+####################################################
+
+set -eo pipefail # error on any command failure
+
+# Uncomment this to print commands before executing them for easier debugging.
+#set -x
+
+# Change this to increase/decrease logging
+log_filter="info,snarkos_node_rest=warn,snarkos_node_bft::primary=error,snarkos_node_router=error,snarkos_node_tcp=off"
+
+# Set parameters directly
+total_validators=$1
+min_height=$2
+network_id=$3
+
+# How often to poll the network height (in seconds)
+poll_interval=10
+
+# Default values if not provided
+: "${total_validators:=40}"
+: "${min_height:=250}"
+: "${network_id:=1}"
+
+. ./.ci/utils.sh
+
+git_commit=$(git rev-parse --short=10 HEAD)
+echo "On git commit ${git_commit}"
+
+network_name=$(get_network_name "$network_id")
+echo "Network set $network_name with $total_validators validators"
+
+# Create log directory
+log_dir="$PWD/.logs-$(date +"%Y%m%d%H%M%S")"
+mkdir -p "$log_dir"
+chmod 755 "$log_dir"
+
+# Array to store PIDs of all processes
+declare -a PIDS
+
+# Define a trap handler that cleans up all processes on exit.
+function exit_handler() {
+  shutdown "${PIDS[@]}"
+}
+trap exit_handler EXIT
+
+# Define a trap handler that prints a message when an error occurs 
+trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+
+# Flags used by all ndoes
+common_flags="--nodisplay --nobanner --noupdater --network=$network_id \
+  --log-filter=$log_filter --allow-external-peers --dev-num-validators=$total_validators"
+
+# Start all validator nodes in the background
+for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
+  snarkos clean --dev $validator_index --network=$network_id
+
+  log_file="$log_dir/validator-$validator_index.log"
+  if [ $validator_index -eq 0 ]; then
+    snarkos start ${common_flags} --dev "$validator_index" \
+      --validator --logfile "$log_file" --metrics --no-dev-txs &
+  else
+    snarkos start ${common_flags} --dev "$validator_index" \
+      --validator --logfile "$log_file" &
+  fi
+  PIDS[validator_index]=$!
+  echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
+
+  # Add 1-second delay between starting nodes to avoid hitting rate limits
+  sleep 1
+done
+
+# Ensure all nodes are up and running.
+wait_for_nodes "$total_validators" 0
+
+# Wait until all nodes reached the given height.
+total_wait=0
+while ! check_heights "$total_validators" 0 "$min_height" "$network_name"; do
+  # Continue waiting
+  sleep $poll_interval
+  total_wait=$((total_wait + $poll_interval))
+  echo "Waited $total_wait seconds so far..."
+done
+
+printf "num_validators=${total_validators}, git_commit=${git_commit}, snapshot_height=${min_height}" > info.txt
+
+zipname="sync-ledger-val${num_validators}-${min_height}.zip"
+echo "Done! Generating zipfile \"$zipname\""
+zip $zipname ".ledger-${network_id}-0" info.txt

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+######################################
+# Utility functions for devnet scripts
+######################################
+
+# Function checking that each node reached a sufficient block height.
+function check_heights() {
+  echo "Checking block heights on all nodes..."
+
+  local total_validators=$1
+  local total_clients=$2
+  local min_height=$3
+  local network_name=$4
+
+  local all_reached=true
+  local highest_height=0
+
+  for ((node_index = 0; node_index < total_validators + total_clients; node_index++)); do
+    port=$((3030 + node_index))
+    height=$(curl -s "http://127.0.0.1:$port/v2/$network_name/block/height/latest" || echo "0")
+    echo "Node $node_index block height: $height"
+    
+    # Track highest height for reporting
+    if [[ "$height" =~ ^[0-9]+$ ]] && (( height > highest_height )); then
+      highest_height=$height
+    fi
+    
+    if ! [[ "$height" =~ ^[0-9]+$ ]] || (( height < min_height )); then
+      all_reached=false
+    fi
+  done
+  
+  if $all_reached; then
+    echo "✅ SUCCESS: All nodes reached minimum height of $min_height"
+    return 0
+  else
+    echo "⏳ WAITING: Not all nodes reached minimum height of $min_height (highest so far: $highest_height)"
+    return 1
+  fi
+}
+
+# Function checking that nodes created logs on disk.
+function check_logs() {
+  echo "Checking logs exist for all nodes..."
+  local log_dir=$1
+  local total_validators=$2
+  local total_clients=$3
+  
+  local all_reached=true
+  local highest_height=0
+
+  for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
+    if [ ! -s "$log_dir/validator-${validator_index}.log" ]; then
+      echo "❌ Test failed! Validator #${validator_index} did not create any logs in \"$log_dir\"."
+      return 1
+    fi
+  done
+  for ((client_index = 0; client_index < total_clients; client_index++)); do
+    if [ ! -s "$log_dir/client-${client_index}.log" ]; then
+      echo "❌ Test failed! Client #${client_index} did not create any logs in \"$log_dir\"."
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+# Determine network name based on network_id
+function get_network_name() {
+  local network_id=$1
+
+  case $network_id in
+    0)
+      echo "mainnet"
+      ;;
+    1)
+      echo "testnet"
+      ;;
+    2)
+      echo "canary"
+      ;;
+    *)
+      >&2 echo "Unknown network ID: $network_id, defaulting to mainnet"
+      echo "mainnet"
+      ;;
+  esac
+}
+
+# Stops all running processe in the given list.
+function shutdown() {
+  pids=("$@")
+  echo "🚨 Cleaning up ${#pids[@]} process(es)…"
+  for pid in "${pids[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+# succeeds if all nodes are available.
+function check_nodes() {
+  local total_validators=$1
+  local total_clients=$2
+
+  for ((node_index = 0; node_index < total_validators + total_clients; node_index++)); do
+    port=$((3030 + node_index))
+    status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v2/$network_name/version")
+    # Fail if the HTTP response is not 2XX.
+    if (( status < 200 || status > 300 )); then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+# Blocks until the network is ready.
+function wait_for_nodes() {
+  echo "Waiting for nodes to become ready"
+  
+  local total_validators=$1
+  local total_clients=$2
+
+  while true; do
+    if check_nodes "$total_validators" "$total_clients"; then
+      echo "All nodes are ready!"
+      return 0
+    fi
+  done
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,12 +181,12 @@ commands:
           name: "Run DB backup test"
           timeout: 10m  # Allow 10 minutes total
           command: |
-            ./.circleci/db_backup_ci.sh # run the db checkpoint test script first, and clean the dev ledgers afterwards
+            ./.ci/db_backup_ci.sh # run the db checkpoint test script first, and clean the dev ledgers afterwards
       - run:
           name: "Run block advancement test"
           timeout: 20m  # Allow 20 minutes total
           command: |
-            ./.circleci/devnet_ci.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>
+            ./.ci/devnet_ci.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>
       - clear_environment:
           cache_key: << parameters.cache_key >>
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,101 @@
+name: Run snarkOS Benchmarks
+
+on:
+  push:
+    branches:
+      - 'staging'
+      - 'ci/sync-benchmark'
+  workflow_dispatch:
+
+jobs:
+  # Run benchmarks and stores the output to a file
+  benchmark:
+    name: Benchmark
+    runs-on:
+      labels: ubuntu-latest-m
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.88 # Update this when the MSRV changes.
+
+      - name: Install required Debian pacakges
+        run: sudo apt install -y lld
+
+      - name: Set up Rust build chaching
+        uses: Swatinem/rust-cache@v2
+
+      - name: "Setup GCP"
+        env:
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+        run: |
+            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+            sudo apt-get update
+            sudo apt-get install google-cloud-cli -y
+            echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-key.json
+            gcloud auth activate-service-account --key-file=${HOME}/gcloud-key.json
+
+      - name: "Fetch Ledger Data"
+        run: |
+            gcloud config set project protocol-development-sandbox
+            gcloud storage cp gs://ci_testdata/sync-ledger-val40-250.zip ledger.zip
+            unzip ledger.zip
+ 
+      - name: Install snarkOS (test_network)
+        run:
+          cargo install --path=. --locked --features=test_network
+
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      - name: Create results file
+        run: printf "[\n" | tee -a results.json
+
+      - name: Run P2P sync benchmark
+        run:
+          ./.ci/bench_p2p_sync.sh
+
+      #- name: Run BFT sync benchmark
+      #  run:
+      #    ./.ci/bench_bft_sync.sh
+
+      - name: Install snarkOS (production)
+        run:
+          cargo install --path=. --locked
+
+      - name: Run CDN sync benchmark
+        run:
+          ./.ci/bench_cdn_sync.sh
+
+      - name: Finish results file
+        run: printf "]\n" | tee -a results.json
+
+      - name: Generate benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: snarkOS Benchmarks
+          tool: 'customSmallerIsBetter'
+          output-file-path: results.json
+          auto-push: false
+          alert-threshold: '150%'
+          comment-on-alert: true
+          summary-always: true
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-comment-cc-users: '@kaimast'
+
+      - name: Push benchmark result
+        # Avoid pushing results on pull requests or experimental branches, to reduce noise in the data.
+        # The results for all other runs are still accessible through the workflow summary.
+        if: github.ref_name == 'staging' || github.ref_name == 'ci/sync-benchmark'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin gh-pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,6 +42,7 @@ jobs:
       - name: "Fetch Ledger Data"
         run: |
             gcloud config set project protocol-development-sandbox
+            # Created with `.ci/generate_ledger.sh 40 250 1`
             gcloud storage cp gs://ci_testdata/sync-ledger-val40-250.zip ledger.zip
             unzip ledger.zip
  


### PR DESCRIPTION
This PR adds a benchmark workflow using Github Actions (similar to the one in snarkVM). It measures sync performance. The benchmarks only run for commits on staging and when manually triggered. 

## Graphs
Results for benchmark runs can be found on the [Dashboard](https://provablehq.github.io/snarkOS/dev/bench/). The dashboard will only contain runs from this PR's branch and staging. See a screenshot of the current graph for p2p sync below.

<img width="80%" alt="Picture of the p2p sync graph" src="https://github.com/user-attachments/assets/4eca5539-15fd-4bfb-a1bf-2b4cb9c54cda" />

The graph also contains additional information for each run, such as the git commit used to create the snapshot, in the tooltip.
<img width="80%" alt="Picture of the tooltip with extra data" src="https://github.com/user-attachments/assets/cc84f6e9-6005-43a1-afa9-7bfd442a282c" />

## Workflow Summaries
Alternatively, you can go to the workflow summary to see results. That is useful when manually triggering runs of the benchmarks. See [here](https://github.com/ProvableHQ/snarkOS/actions/runs/17249923552/attempts/1#summary-48949336576) for an example of such a summary.

