### PR TITLE
Handle errors in the REST API better

### DIFF
--- a/.circleci/devnet_ci.sh
+++ b/.circleci/devnet_ci.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail # error on any command failure
-set -x # print commands before executing them for easier debugging
+
+# Uncomment this to print commands before executing them for easier debugging.
+#set -x
 
 # Set parameters directly
 total_validators=$1
@@ -13,6 +15,9 @@ min_height=$4
 : "${total_clients:=2}"
 : "${network_id:=0}"
 : "${min_height:=60}" # To likely go past the 100 round garbage collection limit.
+
+# Change this to increase/decrease log messages
+log_filter="info,snarkos_node_router=error,snarkos_node_tcp=error"
 
 # Determine network name based on network_id
 case $network_id in
@@ -34,7 +39,7 @@ esac
 echo "Using network: $network_name (ID: $network_id)"
 
 # Create log directory
-log_dir=${PWD}".logs-$(date +"%Y%m%d%H%M%S")"
+log_dir="$PWD/.logs-$(date +"%Y%m%d%H%M%S")"
 mkdir -p "$log_dir"
 chmod 755 "$log_dir"
 
@@ -49,9 +54,19 @@ function cleanup() {
       kill -9 "$pid" 2>/dev/null || true
     fi
   done
+
+  # Remove all temporary files and folders
+  rm program/program.json program/main.aleo || true
+  rm program/txn_data.json program/invalid_txn_data.json || true
+  rmdir program || true
 }
 trap cleanup EXIT
 trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+
+# Flags used by all ndoes
+common_flags="--nodisplay --nobanner --noupdater --network=$network_id \
+  --log-filter=$log_filter \
+  --dev-num-validators=$total_validators"
 
 # Start all validator nodes in the background
 for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
@@ -59,11 +74,12 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
 
   log_file="$log_dir/validator-$validator_index.log"
   if [ $validator_index -eq 0 ]; then
-    snarkos start --nodisplay --network "$network_id" --dev "$validator_index" --allow-external-peers \
-      --dev-num-validators "$total_validators" --validator --logfile "$log_file" --metrics --no-dev-txs &
+    snarkos start ${common_flags} --dev "$validator_index" --allow-external-peers \
+      --validator --logfile "$log_file" \
+      --metrics --no-dev-txs &
   else
-    snarkos start --nodisplay --network "$network_id" --dev "$validator_index" --allow-external-peers \
-      --dev-num-validators "$total_validators" --validator --logfile "$log_file" &
+    snarkos start ${common_flags} --dev "$validator_index" --allow-external-peers \
+      --validator --logfile "$log_file" &
   fi
   PIDS[validator_index]=$!
   echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
@@ -78,12 +94,12 @@ for ((client_index = 0; client_index < total_clients; client_index++)); do
   snarkos clean --dev $node_index
 
   log_file="$log_dir/client-$client_index.log"
-  snarkos start --nodisplay --network "$network_id" --dev $node_index --dev-num-validators "$total_validators" \
-      --client --logfile "$log_file" &
+  snarkos start ${common_flags} --dev $node_index \
+    --client --logfile "$log_file" &
   PIDS[node_index]=$!
   echo "Started client $client_index with PID ${PIDS[$node_index]}"
   # Add 1-second delay between starting nodes to avoid hitting rate limits
-  if [ $client_index -lt $((total_clients - 1)) ]; then
+  if (( client_index < total_clients-1)); then
     sleep 1
   fi
 done
@@ -99,11 +115,11 @@ check_heights() {
     echo "Node $node_index block height: $height"
     
     # Track highest height for reporting
-    if [[ "$height" =~ ^[0-9]+$ ]] && [ "$height" -gt "$highest_height" ]; then
+    if [[ "$height" =~ ^[0-9]+$ ]] && (( height > highest_height )); then
       highest_height=$height
     fi
     
-    if ! [[ "$height" =~ ^[0-9]+$ ]] || [ "$height" -lt "$min_height" ]; then
+    if ! [[ "$height" =~ ^[0-9]+$ ]] || (( height < min_height )); then
       all_reached=false
     fi
   done
@@ -125,11 +141,11 @@ consensus_version_stable() {
   height=$(curl -s "http://localhost:3030/$network_name/block/height/latest")
   if [[ "$consensus_version" =~ ^[0-9]+$ ]] && [[ "$height" =~ ^[0-9]+$ ]]; then
     # If the consensus version is greater than the last seen, we update it.
-    if [[ "$consensus_version" -gt "$last_seen_consensus_version" ]]; then
+    if (( consensus_version > last_seen_consensus_version)); then
       echo "✅ Consensus version updated to $consensus_version"
     # If the consensus version is the same whereas the block height is different and at least 10, we can assume that the consensus version is stable
     else
-      if [[ "$height" -ne "$last_seen_height" ]] && [[ "$height" -ge 10 ]]; then
+      if (( (height != last_seen_height) && (height >= 10) )); then
         echo "✅ Consensus version is stable at $consensus_version with height $height"
         return 0
       fi
@@ -145,11 +161,11 @@ consensus_version_stable() {
 
 # Check consensus versions periodically with a timeout
 total_wait=0
-while [ $total_wait -lt 300 ]; do  # 5 minutes max
+while (( total_wait < 300 )); do  # 5 minutes max
   if consensus_version_stable; then
-    break    
+    break
   fi
-  
+
   # Continue waiting
   sleep 30
   total_wait=$((total_wait + 30))
@@ -159,7 +175,6 @@ done
 # Function checking that nodes created logs on disk.
 function check_logs() {
   echo "Checking logs for all nodes..."
-  all_reached=true
   for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
     if [ ! -s "$log_dir/validator-${validator_index}.log" ]; then
       echo "❌ Test failed! Validator #${validator_index} did not create any logs."
@@ -177,6 +192,8 @@ function check_logs() {
 
   return 0
 }
+
+echo "ℹ️Testing Program Deployment and Execution"
 
 # Creates a test program.
 mkdir -p program
@@ -200,41 +217,144 @@ echo """{
   \"editions\": {}
 }
 """ > program/program.json
-cd program
 
 # Deploy the test program and wait for the deployment to be processed.
-deploy_result=$(snarkos developer deploy --dev-key 0 --network "$network_id" --endpoint=localhost:3030 --broadcast  --wait --timeout 10 test_program.aleo)
+_deploy_result=$(cd program && snarkos developer deploy --dev-key 0 --network "$network_id" --endpoint=localhost:3030 --broadcast  --wait --timeout 10 test_program.aleo)
 
 # Execute a function in the deployed program and wait for the execution to be processed.
 # Use the old flags here `--query` and `--broadcast=URL` to test they still work.
-execute_result=$(snarkos developer execute --dev-key 0 --network "$network_id" --query=localhost:3030 --broadcast=http://localhost:3030/$network_name/transaction/broadcast test_program.aleo main 1u32 1u32 --wait --timeout 10)
+execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --query=localhost:3030 --broadcast=http://localhost:3030/$network_name/transaction/broadcast test_program.aleo main 1u32 1u32 --wait --timeout 10)
 
 # Fail if the execution transaction does not exist.
 tx=$(echo "$execute_result" | tail -n 1)
 found=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/$network_name/transaction/$tx")
 # Fail if the HTTP response is not 2XX.
-if [[ "$found" -lt 200 || "$found" -ge 300 ]]; then
-  printf "❌ Test failed! Transaction does not exist or contains an error: \ndeploy_result: %s\n\execute_result: %s\nfound: %s\n" \
-    "$deploy_result" "$execute_result" "$found"
+if (( found < 200 || found >= 300 )); then
+  printf "❌ Test failed! Transaction does not exist or contains an error: \nexecute_result: %s\nfound: %s\n" \
+    "$execute_result" "$found"
   exit 1
 else
   echo "✅ Transaction executed successfully: $execute_result"
 fi
 
+echo "ℹ️Testing REST API and REST Error Handling"
+
+# Test invalid transaction data (JsonDataError) returns 422 Unprocessable Content
+echo "Testing invalid transaction data returns 422 status code..."
+(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --endpoint=localhost:3030 \
+  --store txn_data.json --store-format=string \
+  test_program.aleo main 1u32 1u32)
+
+# Modify the proof data
+# This changes the last three characters in the hash but keeps the correct length.
+# `printf %s` avoids a newline at the end.
+(cd program && printf %s "$(jq -c '.id = (.id[0:-3] + "qpz")' txn_data.json)" > invalid_txn_data.json)
+
+invalid_tx_status=$(curl -s -w "%{http_code}" -X POST \
+  -H "Content-Type: application/json" \
+  -d "$(< ./program/invalid_txn_data.json)" \
+  "http://localhost:3030/$network_name/transaction/broadcast" \
+  -o /dev/null)
+
+if (( invalid_tx_status == 422 )); then
+  echo "✅ Invalid transaction correctly returned 422 Unprocessable Content"
+else
+  echo "❌ Test failed! Invalid transaction returned $invalid_tx_status instead of 422"
+  exit 1
+fi
+
+# Test that the returned error is valid JSON
+json_error=$(curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d "$(< ./program/invalid_txn_data.json)" \
+  "http://localhost:3030/$network_name/transaction/broadcast")
+
+# Ensure the top-level error message is "Invalid transaction"
+if ! jq -e '.message | test("Invalid transaction")' <<< "$json_error" > /dev/null ; then 
+  echo "❌ Test failed! Invalid JSON returned: \"$json_error\""
+  exit 1
+fi
+
+echo "✅ Invalid transaction return valid JSON error"
+
+# Test malformed JSON syntax (JsonSyntaxError) returns 400 Bad Request
+malformed_json_response=$(curl -s -w "%{http_code}" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"malformed": json}' \
+  "http://localhost:3030/$network_name/transaction/broadcast" \
+  -o /dev/null)
+
+if (( malformed_json_response == 400 )); then
+  echo "✅ Malformed JSON correctly returned 400 Bad Request"
+else
+  echo "❌ Test failed! Malformed JSON returned $malformed_json_response instead of 400"
+  exit 1
+fi
+
+# Test that malformed JSON returns a properly formatted RestError
+malformed_json_error=$(curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"malformed": json}' \
+  "http://localhost:3030/$network_name/transaction/broadcast")
+
+# Verify the message contains JSON-related error text
+if ! jq -e '.message | test("Invalid JSON")' <<< "$malformed_json_error" > /dev/null; then
+  echo "❌ Test failed! Malformed JSON response message doesn't contain expected JSON error text: \"$malformed_json_error\""
+  exit 1
+fi
+
+echo "✅ Malformed JSON returns properly formatted RestError with JSON syntax error message"
+
+# Test invalid Content-Type header returns 400 Bad Request
+echo "Testing missing Content-Type header returns 400 status code..."
+missing_content_type_response=$(curl -s -w "%{http_code}" -X POST \
+  -d '{"valid": "json"}' \
+  "http://localhost:3030/$network_name/transaction/broadcast" \
+  -o /dev/null)
+
+if (( missing_content_type_response == 400 )); then
+  echo "✅ Missing Content-Type correctly returned 400 Bad Request"
+else
+  echo "❌ Test failed! Missing Content-Type returned $missing_content_type_response instead of 400"
+  exit 1
+fi
+
+# Test that missing Content-Type returns a properly formatted RestError
+echo "Testing missing Content-Type returns valid RestError format..."
+missing_content_type_error=$(curl -s -X POST \
+  -d '{"valid": "json"}' \
+  "http://localhost:3030/$network_name/transaction/broadcast")
+
+# Verify the response is valid JSON
+if ! jq . <<< "$missing_content_type_error" > /dev/null 2>&1; then
+  echo "❌ Test failed! Missing Content-Type response is not valid JSON: \"$missing_content_type_error\""
+  exit 1
+fi
+
+# Verify the message contains Content-Type related error text
+if ! jq -e '.message | test("Content-Type|application/json")' <<< "$missing_content_type_error" > /dev/null; then
+  echo "❌ Test failed! Missing Content-Type response message doesn't contain expected error text: \"$missing_content_type_error\""
+  exit 1
+fi
+
+echo "✅ Missing Content-Type returns properly formatted RestError with Content-Type error message"
+
 # Scan the network for records.
 scan_result=$(snarkos developer scan --dev-key 0 --network "$network_id" --start 0 --endpoint=localhost:3030)
 num_records=$(echo "$scan_result" | grep -c "owner")
 # Fail if the scan did not return 4 records.
-if [[ "$num_records" -ne 4 ]]; then
+if (( num_records != 4 )); then
   echo "❌ Test failed! Expected 4 records, but found $num_records: $scan_result"
   exit 1
 else
   echo "✅ Scan returned 4 records correctly: $scan_result"
 fi
 
+echo "ℹ️Testing network progress"
+
 # Check heights periodically with a timeout
 total_wait=0
-while [ $total_wait -lt 600 ]; do  # 10 minutes max
+while (( total_wait < 600 )); do  # 10 minutes max
   if check_heights; then
     echo "🎉 Test passed! All nodes reached minimum height."
     

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -333,7 +333,7 @@ dependencies = [
  "rustversion",
  "serde",
  "serde_json",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "typed-json",
@@ -3217,7 +3217,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -4028,6 +4028,7 @@ dependencies = [
  "snarkvm",
  "time",
  "tokio",
+ "tower 0.4.13",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -5594,6 +5595,21 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -5630,7 +5646,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5660,7 +5676,7 @@ dependencies = [
  "http 1.3.1",
  "pin-project",
  "thiserror 2.0.16",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -82,14 +82,15 @@ pub struct Developer {
     verbosity: Option<u8>,
 }
 
-/// Format for serialized errors returned by the REST API.
-#[derive(serde::Deserialize)]
+/// The serialized REST error sent over the network.
+#[derive(Debug, Deserialize)]
 struct RestError {
     /// The type of error (corresponding to the HTTP status code).
     error_type: String,
     /// The top-level error message.
     message: String,
     /// The chain of errors that led to the top-level error.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     chain: Vec<String>,
 }
 

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -237,7 +237,7 @@ impl Developer {
 
         while start_time.elapsed() < timeout_duration {
             // Check if transaction exists in a confirmed block
-            let tx_endpoint = format!("{endpoint}{}/transaction/{transaction_id}", N::SHORT_NAME);
+            let tx_endpoint = format!("{endpoint}v2/{}/transaction/{transaction_id}", N::SHORT_NAME);
             let result = Self::http_get(&tx_endpoint).with_context(|| "Failed to check transaction status")?;
 
             match result {
@@ -255,7 +255,7 @@ impl Developer {
 
     /// Gets the latest eidtion of an Aleo program.
     fn get_latest_edition<N: Network>(endpoint: &Uri, program_id: &ProgramID<N>) -> Result<u16> {
-        match Self::http_get_json(&format!("{endpoint}{}/program/{program_id}/latest_edition", N::SHORT_NAME,))? {
+        match Self::http_get_json(&format!("{endpoint}v2/{}/program/{program_id}/latest_edition", N::SHORT_NAME,))? {
             Some(edition) => Ok(edition),
             None => bail!("Got unexpected 404 response"),
         }
@@ -269,7 +269,7 @@ impl Developer {
 
         // Send a request to the query node.
         let result: Option<Value<N>> = Self::http_get_json(&format!(
-            "{endpoint}{}/program/{credits}/mapping/{account_mapping}/{address}",
+            "{endpoint}v2/{}/program/{credits}/mapping/{account_mapping}/{address}",
             N::SHORT_NAME,
         ))?;
 
@@ -337,7 +337,7 @@ impl Developer {
             let broadcast_endpoint = if let Some(url) = broadcast_value {
                 url.to_string()
             } else {
-                format!("{endpoint}{}/transaction/broadcast", N::SHORT_NAME)
+                format!("{endpoint}v2/{}/transaction/broadcast", N::SHORT_NAME)
             };
 
             let result: Result<String> = match Self::http_post_json(&broadcast_endpoint, &transaction) {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -54,6 +54,10 @@ pub struct CLI {
     /// Specify a subcommand.
     #[clap(subcommand)]
     pub command: Command,
+
+    /// Disable checking for new versions at startup.
+    #[clap(long, global = true)]
+    pub noupdater: bool,
 }
 
 /// The subcommand passed after `snarkos`, e.g. `Start` corresponds to `snarkos start`.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -179,7 +179,7 @@ pub struct Start {
     /// Write log message to stdout instead of showing a terminal UI.
     ///
     /// This is useful, for example, for running a node as a service instead of in the foreground or to pipe its output into a file.
-    #[clap(long, verbatim_doc_comment, hide = true)]
+    #[clap(long, verbatim_doc_comment)]
     pub nodisplay: bool,
 
     /// Do not show the Aleo banner and information about the node on startup.

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -54,6 +54,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
+
 use axum_extra::response::ErasedJson;
 use clap::{Parser, ValueEnum};
 use indexmap::IndexMap;
@@ -459,12 +460,6 @@ impl IntoResponse for RestError {
     }
 }
 
-impl From<anyhow::Error> for RestError {
-    fn from(err: anyhow::Error) -> Self {
-        Self(err.to_string())
-    }
-}
-
 #[derive(Clone)]
 struct NodeState {
     bft: Option<BFT<CurrentNetwork>>,
@@ -475,7 +470,7 @@ struct NodeState {
 async fn get_leader(State(node): State<NodeState>) -> Result<ErasedJson, RestError> {
     match &node.bft {
         Some(bft) => Ok(ErasedJson::pretty(bft.leader())),
-        None => Err(RestError::from(anyhow!("BFT is not enabled"))),
+        None => Err(RestError("BFT is not enabled".into())),
     }
 }
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -114,5 +114,9 @@ workspace = true
 [dev-dependencies.base64]
 workspace = true
 
+[dev-dependencies.tower]
+version = "0.4"
+features = ["util"]
+
 [build-dependencies.built]
 workspace = true

--- a/node/rest/src/helpers/error.rs
+++ b/node/rest/src/helpers/error.rs
@@ -13,22 +13,149 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::{Error as AnyhowError, anyhow};
 use axum::{
-    http::StatusCode,
+    extract::rejection::JsonRejection,
+    http::{StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
 };
+use serde_json::json;
 
 /// An enum of error handlers for the REST API server.
-pub struct RestError(pub String);
+#[derive(Debug)]
+pub enum RestError {
+    /// 400 Bad Request - Invalid input, malformed parameters, validation errors
+    BadRequest(AnyhowError),
+    /// 404 Not Found - Resource not found
+    NotFound(AnyhowError),
+    /// 422 Unprocessable Entity - Business logic validation errors
+    UnprocessableEntity(AnyhowError),
+    /// 429 Too Many Requests - Rate limiting
+    TooManyRequests(AnyhowError),
+    /// 503 Service Unavailable - Temporary service issues (node syncing, feature unavailable)
+    ServiceUnavailable(AnyhowError),
+    /// 500 Internal Server Error - Actual server errors, unexpected failures
+    InternalServerError(AnyhowError),
+}
+
+impl RestError {
+    /// Create a BadRequest error
+    pub fn bad_request(inner: anyhow::Error) -> Self {
+        Self::BadRequest(inner)
+    }
+
+    /// Create a NotFound error
+    pub fn not_found(inner: anyhow::Error) -> Self {
+        Self::NotFound(inner)
+    }
+
+    /// Create an UnprocessableEntity error
+    pub fn unprocessable_entity(inner: anyhow::Error) -> Self {
+        Self::UnprocessableEntity(inner)
+    }
+
+    /// Create a TooManyRequests error
+    pub fn too_many_requests(inner: anyhow::Error) -> Self {
+        Self::TooManyRequests(inner)
+    }
+
+    /// Create a ServiceUnavailable error
+    pub fn service_unavailable(inner: anyhow::Error) -> Self {
+        Self::ServiceUnavailable(inner)
+    }
+
+    /// Create an InternalServerError error
+    pub fn internal_server_error(inner: anyhow::Error) -> Self {
+        Self::InternalServerError(inner)
+    }
+
+    /// Extract the full chain of errors from the `anyhow::Error`.
+    /// (excludes the top-level error)
+    fn error_chain(error: &AnyhowError) -> Vec<String> {
+        let mut chain = vec![];
+        let mut source = error.source();
+        while let Some(err) = source {
+            chain.push(err.to_string());
+            source = err.source();
+        }
+        chain
+    }
+}
 
 impl IntoResponse for RestError {
     fn into_response(self) -> Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, format!("Something went wrong: {}", self.0)).into_response()
+        let (status, error_type, error) = match self {
+            RestError::BadRequest(err) => (StatusCode::BAD_REQUEST, "bad_request", err),
+            RestError::NotFound(err) => (StatusCode::NOT_FOUND, "not_found", err),
+            RestError::UnprocessableEntity(err) => (StatusCode::UNPROCESSABLE_ENTITY, "unprocessable_entity", err),
+            RestError::TooManyRequests(err) => (StatusCode::TOO_MANY_REQUESTS, "too_many_requests", err),
+            RestError::ServiceUnavailable(err) => (StatusCode::SERVICE_UNAVAILABLE, "service_unavailable", err),
+            RestError::InternalServerError(err) => (StatusCode::INTERNAL_SERVER_ERROR, "internal_server_error", err),
+        };
+
+        // Convert to JSON and include the chain of causes (if any).
+        let error_chain = Self::error_chain(&error);
+        let json_body = if error_chain.is_empty() {
+            json!({
+                "message": error.to_string(),
+                "error_type": error_type,
+            })
+        } else {
+            json!({
+                "message": error.to_string(),
+                "error_type": error_type,
+                "chain": error_chain,
+            })
+        }
+        .to_string();
+
+        info!("Returning REST error: {json_body}");
+
+        let mut response = Response::new(json_body.into());
+        *response.status_mut() = status;
+        response.headers_mut().insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        response
     }
 }
 
 impl From<anyhow::Error> for RestError {
     fn from(err: anyhow::Error) -> Self {
-        Self(err.to_string())
+        // Default to 500 Internal Server Error
+        Self::InternalServerError(err)
+    }
+}
+
+impl From<String> for RestError {
+    fn from(msg: String) -> Self {
+        // Default to 500 Internal Server Error
+        Self::InternalServerError(anyhow::anyhow!(msg))
+    }
+}
+
+impl From<&str> for RestError {
+    fn from(msg: &str) -> Self {
+        // Default to 500 Internal Server Error
+        Self::InternalServerError(anyhow::anyhow!(msg.to_string()))
+    }
+}
+
+/// Implement `From<JsonRejection>` for `RestError` to enable automatic conversion
+impl From<JsonRejection> for RestError {
+    fn from(rejection: JsonRejection) -> Self {
+        match rejection {
+            JsonRejection::JsonDataError(err) => {
+                RestError::bad_request(anyhow!(err).context("Invalid JSON data in request body"))
+            }
+            JsonRejection::JsonSyntaxError(err) => {
+                RestError::bad_request(anyhow!(err).context("Invalid JSON syntax in request body"))
+            }
+            JsonRejection::MissingJsonContentType(_) => {
+                RestError::bad_request(anyhow!("Content-Type must be `application/json`"))
+            }
+            JsonRejection::BytesRejection(err) => {
+                RestError::bad_request(anyhow!(err).context("Failed to read request body"))
+            }
+            _ => RestError::bad_request(anyhow!("Invalid JSON request")),
+        }
     }
 }

--- a/node/rest/src/helpers/mod.rs
+++ b/node/rest/src/helpers/mod.rs
@@ -17,4 +17,4 @@ mod auth;
 pub use auth::*;
 
 mod error;
-pub use error::*;
+pub(crate) use error::*;

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -40,7 +40,6 @@ use snarkvm::{
 
 use anyhow::{Context, Result};
 use axum::{
-    Json,
     body::Body,
     extract::{ConnectInfo, DefaultBodyLimit, Path, Query, State},
     http::{Method, Request, StatusCode, header::CONTENT_TYPE},

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -154,92 +154,88 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 .expect("Couldn't set up rate limiting for the REST server!"),
         );
 
-        let network = N::SHORT_NAME;
         let routes = axum::Router::new()
 
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
-            .route(&format!("/{network}/node/address"), get(Self::get_node_address))
-            .route(&format!("/{network}/program/{{id}}/mapping/{{name}}"), get(Self::get_mapping_values))
-            .route(&format!("/{network}/db_backup"), post(Self::db_backup))
+            .route("/node/address", get(Self::get_node_address))
+            .route("/program/{id}/mapping/{name}", get(Self::get_mapping_values))
+            .route("/db_backup", post(Self::db_backup))
             .route_layer(middleware::from_fn(auth_middleware))
 
              // Get ../consensus_version
-            .route(&format!("/{network}/consensus_version"), get(Self::get_consensus_version))
+            .route("/consensus_version", get(Self::get_consensus_version))
 
             // GET ../block/..
-            .route(&format!("/{network}/block/height/latest"), get(Self::get_block_height_latest))
-            .route(&format!("/{network}/block/hash/latest"), get(Self::get_block_hash_latest))
-            .route(&format!("/{network}/block/latest"), get(Self::get_block_latest))
-            .route(&format!("/{network}/block/{{height_or_hash}}"), get(Self::get_block))
+            .route("/block/height/latest", get(Self::get_block_height_latest))
+            .route("/block/hash/latest", get(Self::get_block_hash_latest))
+            .route("/block/latest", get(Self::get_block_latest))
+            .route("/block/{height_or_hash}", get(Self::get_block))
             // The path param here is actually only the height, but the name must match the route
             // above, otherwise there'll be a conflict at runtime.
-            .route(&format!("/{network}/block/{{height_or_hash}}/header"), get(Self::get_block_header))
-            .route(&format!("/{network}/block/{{height_or_hash}}/transactions"), get(Self::get_block_transactions))
+            .route("/block/{height_or_hash}/header", get(Self::get_block_header))
+            .route("/block/{height_or_hash}/transactions", get(Self::get_block_transactions))
 
             // GET and POST ../transaction/..
-            .route(&format!("/{network}/transaction/{{id}}"), get(Self::get_transaction))
-            .route(&format!("/{network}/transaction/confirmed/{{id}}"), get(Self::get_confirmed_transaction))
-            .route(&format!("/{network}/transaction/unconfirmed/{{id}}"), get(Self::get_unconfirmed_transaction))
-            .route(&format!("/{network}/transaction/broadcast"), post(Self::transaction_broadcast))
+            .route("/transaction/{id}", get(Self::get_transaction))
+            .route("/transaction/confirmed/{id}", get(Self::get_confirmed_transaction))
+            .route("/transaction/unconfirmed/{id}", get(Self::get_unconfirmed_transaction))
+            .route("/transaction/broadcast", post(Self::transaction_broadcast))
 
             // POST ../solution/broadcast
-            .route(&format!("/{network}/solution/broadcast"), post(Self::solution_broadcast))
-
+            .route("/solution/broadcast", post(Self::solution_broadcast))
 
             // GET ../find/..
-            .route(&format!("/{network}/find/blockHash/{{tx_id}}"), get(Self::find_block_hash))
-            .route(&format!("/{network}/find/blockHeight/{{state_root}}"), get(Self::find_block_height_from_state_root))
-            .route(&format!("/{network}/find/transactionID/deployment/{{program_id}}"), get(Self::find_latest_transaction_id_from_program_id))
-            .route(&format!("/{network}/find/transactionID/deployment/{{program_id}}/{{edition}}"), get(Self::find_transaction_id_from_program_id_and_edition))
-            .route(&format!("/{network}/find/transactionID/{{transition_id}}"), get(Self::find_transaction_id_from_transition_id))
-            .route(&format!("/{network}/find/transitionID/{{input_or_output_id}}"), get(Self::find_transition_id))
+            .route("/find/blockHash/{tx_id}", get(Self::find_block_hash))
+            .route("/find/blockHeight/{state_root}", get(Self::find_block_height_from_state_root))
+            .route("/find/transactionID/deployment/{program_id}", get(Self::find_latest_transaction_id_from_program_id))
+            .route("/find/transactionID/deployment/{program_id}/{edition}", get(Self::find_transaction_id_from_program_id_and_edition))
+            .route("/find/transactionID/{transition_id}", get(Self::find_transaction_id_from_transition_id))
+            .route("/find/transitionID/{input_or_output_id}", get(Self::find_transition_id))
 
             // GET ../peers/..
-            .route(&format!("/{network}/peers/count"), get(Self::get_peers_count))
-            .route(&format!("/{network}/peers/all"), get(Self::get_peers_all))
-            .route(&format!("/{network}/peers/all/metrics"), get(Self::get_peers_all_metrics))
+            .route("/peers/count", get(Self::get_peers_count))
+            .route("/peers/all", get(Self::get_peers_all))
+            .route("/peers/all/metrics", get(Self::get_peers_all_metrics))
 
             // GET ../program/..
-            .route(&format!("/{network}/program/{{id}}"), get(Self::get_program))
-            .route(&format!("/{network}/program/{{id}}/latest_edition"), get(Self::get_latest_program_edition))
-            .route(&format!("/{network}/program/{{id}}/{{edition}}"), get(Self::get_program_for_edition))
-            .route(&format!("/{network}/program/{{id}}/mappings"), get(Self::get_mapping_names))
-            .route(&format!("/{network}/program/{{id}}/mapping/{{name}}/{{key}}"), get(Self::get_mapping_value))
+            .route("/program/{id}", get(Self::get_program))
+            .route("/program/{id}/latest_edition", get(Self::get_latest_program_edition))
+            .route("/program/{id}/{edition}", get(Self::get_program_for_edition))
+            .route("/program/{id}/mappings", get(Self::get_mapping_names))
+            .route("/program/{id}/mapping/{name}/{key}", get(Self::get_mapping_value))
 
             // GET ../sync/..
             // Note: keeping ../sync_status for compatibility
-            .route(&format!("/{network}/sync_status"), get(Self::get_sync_status))
-            .route(&format!("/{network}/sync/status"), get(Self::get_sync_status))
-            .route(&format!("/{network}/sync/peers"), get(Self::get_sync_peers))
-            .route(&format!("/{network}/sync/requests"), get(Self::get_sync_requests_summary))
-            .route(&format!("/{network}/sync/requests/list"), get(Self::get_sync_requests_list))
+            .route("/sync_status", get(Self::get_sync_status))
+            .route("/sync/status", get(Self::get_sync_status))
+            .route("/sync/peers", get(Self::get_sync_peers))
+            .route("/sync/requests", get(Self::get_sync_requests_summary))
+            .route("/sync/requests/list", get(Self::get_sync_requests_list))
 
             // GET misc endpoints.
-            .route(&format!("/{network}/version"), get(Self::get_version))
-            .route(&format!("/{network}/blocks"), get(Self::get_blocks))
-            .route(&format!("/{network}/height/{{hash}}"), get(Self::get_height))
-            .route(&format!("/{network}/memoryPool/transmissions"), get(Self::get_memory_pool_transmissions))
-            .route(&format!("/{network}/memoryPool/solutions"), get(Self::get_memory_pool_solutions))
-            .route(&format!("/{network}/memoryPool/transactions"), get(Self::get_memory_pool_transactions))
-            .route(&format!("/{network}/statePath/{{commitment}}"), get(Self::get_state_path_for_commitment))
-            .route(&format!("/{network}/stateRoot/latest"), get(Self::get_state_root_latest))
-            .route(&format!("/{network}/stateRoot/{{height}}"), get(Self::get_state_root))
-            .route(&format!("/{network}/committee/latest"), get(Self::get_committee_latest))
-            .route(&format!("/{network}/committee/{{height}}"), get(Self::get_committee))
-            .route(&format!("/{network}/delegators/{{validator}}"), get(Self::get_delegators_for_validator));
+            .route("/version", get(Self::get_version))
+            .route("/blocks", get(Self::get_blocks))
+            .route("/height/{hash}", get(Self::get_height))
+            .route("/memoryPool/transmissions", get(Self::get_memory_pool_transmissions))
+            .route("/memoryPool/solutions", get(Self::get_memory_pool_solutions))
+            .route("/memoryPool/transactions", get(Self::get_memory_pool_transactions))
+            .route("/statePath/{commitment}", get(Self::get_state_path_for_commitment))
+            .route("/stateRoot/latest", get(Self::get_state_root_latest))
+            .route("/stateRoot/{height}", get(Self::get_state_root))
+            .route("/committee/latest", get(Self::get_committee_latest))
+            .route("/committee/{height}", get(Self::get_committee))
+            .route("/delegators/{validator}", get(Self::get_delegators_for_validator));
 
         // If the node is a validator and `telemetry` features is enabled, enable the additional endpoint.
         #[cfg(feature = "telemetry")]
         let routes = match self.consensus {
-            Some(_) => routes
-                .route(&format!("/{network}/validators/participation"), get(Self::get_validator_participation_scores)),
+            Some(_) => routes.route("/validators/participation", get(Self::get_validator_participation_scores)),
             None => routes,
         };
 
         // If the `history` feature is enabled, enable the additional endpoint.
         #[cfg(feature = "history")]
-        let routes =
-            routes.route(&format!("/{network}/block/{{blockHeight}}/history/{{mapping}}"), get(Self::get_history));
+        let routes = routes.route("/block/{blockHeight}/history/{mapping}", get(Self::get_history));
 
         routes
             // Pass in `Rest` to make things convenient.
@@ -261,9 +257,21 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // Log the REST rate limit per IP.
         debug!("REST rate limit per IP - {rest_rps} RPS");
 
-        let v1_router = self.build_routes(rest_rps).layer(middleware::map_response(v1_error_middleware));
-        let v2_router = axum::Router::new().nest("/v2", self.build_routes(rest_rps));
-        let router = v1_router.merge(v2_router);
+        // Add the v1 API as default and under "/v1".
+        let default_router = axum::Router::new().nest(
+            &format!("/{}", N::SHORT_NAME),
+            self.build_routes(rest_rps).layer(middleware::map_response(v1_error_middleware)),
+        );
+        let v1_router = axum::Router::new().nest(
+            &format!("/v1/{}", N::SHORT_NAME),
+            self.build_routes(rest_rps).layer(middleware::map_response(v1_error_middleware)),
+        );
+
+        // Add the v2 API under "/v2".
+        let v2_router = axum::Router::new().nest(&format!("/v2/{}", N::SHORT_NAME), self.build_routes(rest_rps));
+
+        // Combine all routes.
+        let router = default_router.merge(v1_router).merge(v2_router);
 
         let rest_listener =
             TcpListener::bind(rest_ip).await.with_context(|| "Failed to bind TCP port for REST endpoints")?;
@@ -295,7 +303,7 @@ async fn v1_error_middleware(response: Response) -> Response {
         return response;
     }
 
-    // Return opaque error instead of panicking
+    // Returns a opaque error instead of panicking.
     let fallback = || {
         let mut response = Response::new(Body::from("Failed to convert error"));
         *response.status_mut() = V1_STATUS_CODE;

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -20,6 +20,9 @@ use snarkvm::{
     prelude::{Address, Identifier, LimitedWriter, Plaintext, Program, ToBytes, VM, block::Transaction},
 };
 
+use axum::{Json, extract::rejection::JsonRejection};
+
+use anyhow::{Context, anyhow};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -112,13 +115,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // Manually parse the height or the height of the hash, axum doesn't support different types
         // for the same path param.
         let block = if let Ok(height) = height_or_hash.parse::<u32>() {
-            rest.ledger.get_block(height)?
+            rest.ledger.get_block(height).with_context(|| "Failed to get block by height")?
+        } else if let Ok(hash) = height_or_hash.parse::<N::BlockHash>() {
+            rest.ledger.get_block_by_hash(&hash).with_context(|| "Failed to get block by hash")?
         } else {
-            let hash = height_or_hash
-                .parse::<N::BlockHash>()
-                .map_err(|_| RestError("invalid input, it is neither a block height nor a block hash".to_string()))?;
-
-            rest.ledger.get_block_by_hash(&hash)?
+            return Err(RestError::bad_request(anyhow!(
+                "invalid input, it is neither a block height nor a block hash"
+            )));
         };
 
         Ok(ErasedJson::pretty(block))
@@ -136,12 +139,12 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
         // Ensure the end height is greater than the start height.
         if start_height > end_height {
-            return Err(RestError("Invalid block range".to_string()));
+            return Err(RestError::bad_request(anyhow!("Invalid block range")));
         }
 
         // Ensure the block range is bounded.
         if end_height - start_height > MAX_BLOCK_RANGE {
-            return Err(RestError(format!(
+            return Err(RestError::bad_request(anyhow!(
                 "Cannot request more than {MAX_BLOCK_RANGE} blocks per call (requested {})",
                 end_height - start_height
             )));
@@ -159,7 +162,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // Fetch the blocks from ledger and serialize to json.
         match tokio::task::spawn_blocking(get_json_blocks).await {
             Ok(json) => json,
-            Err(err) => Err(RestError(format!("Failed to get blocks '{start_height}..{end_height}' - {err}"))),
+            Err(err) => {
+                let err: anyhow::Error = err.into();
+
+                Err(RestError::internal_server_error(
+                    err.context(format!("Failed to get blocks '{start_height}..{end_height}'")),
+                ))
+            }
         }
     }
 
@@ -239,7 +248,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id)?))
+        // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
+        Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id).map_err(|err| {
+            if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
+        })?))
     }
 
     // GET /<network>/transaction/confirmed/{transactionID}
@@ -247,7 +259,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_confirmed_transaction(tx_id)?))
+        // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
+        Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id).map_err(|err| {
+            if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
+        })?))
     }
 
     // GET /<network>/transaction/unconfirmed/{transactionID}
@@ -255,7 +270,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_unconfirmed_transaction(&tx_id)?))
+        // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
+        Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id).map_err(|err| {
+            if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
+        })?))
     }
 
     // GET /<network>/memoryPool/transmissions
@@ -264,7 +282,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             Some(consensus) => {
                 Ok(ErasedJson::pretty(consensus.unconfirmed_transmissions().collect::<IndexMap<_, _>>()))
             }
-            None => Err(RestError("Route isn't available for this node type".to_string())),
+            None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
         }
     }
 
@@ -272,7 +290,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     pub(crate) async fn get_memory_pool_solutions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
             Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_solutions().collect::<IndexMap<_, _>>())),
-            None => Err(RestError("Route isn't available for this node type".to_string())),
+            None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
         }
     }
 
@@ -280,7 +298,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     pub(crate) async fn get_memory_pool_transactions(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
         match rest.consensus {
             Some(consensus) => Ok(ErasedJson::pretty(consensus.unconfirmed_transactions().collect::<IndexMap<_, _>>())),
-            None => Err(RestError("Route isn't available for this node type".to_string())),
+            None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
         }
     }
 
@@ -392,7 +410,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<ErasedJson, RestError> {
         // Return an error if the `all` query parameter is not set to `true`.
         if metadata.all != Some(true) {
-            return Err(RestError("Invalid query parameter. At this time, 'all=true' must be included".to_string()));
+            return Err(RestError::bad_request(anyhow!(
+                "Invalid query parameter. At this time, 'all=true' must be included"
+            )));
         }
 
         // Retrieve the latest height.
@@ -414,8 +434,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 // Return the full mapping without metadata.
                 Ok(ErasedJson::pretty(mapping_values))
             }
-            Ok(Err(err)) => Err(RestError(format!("Unable to read mapping - {err}"))),
-            Err(err) => Err(RestError(format!("Unable to read mapping - {err}"))),
+            Ok(Err(err)) => Err(RestError::internal_server_error(err.context("Unable to read mapping"))),
+            Err(err) => Err(RestError::internal_server_error(anyhow!("Tokio error: {err}"))),
         }
     }
 
@@ -460,14 +480,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<ErasedJson, RestError> {
         // Do not process the request if the node is too far behind to avoid sending outdated data.
         if !rest.routing.is_within_sync_leniency() {
-            return Err(RestError("Unable to  request delegators (node is syncing)".to_string()));
+            return Err(RestError::service_unavailable(anyhow!("Unable to request delegators (node is syncing)")));
         }
 
         // Return the delegators for the given validator.
         match tokio::task::spawn_blocking(move || rest.ledger.get_delegators_for_validator(&validator)).await {
             Ok(Ok(delegators)) => Ok(ErasedJson::pretty(delegators)),
-            Ok(Err(err)) => Err(RestError(format!("Unable to request delegators - {err}"))),
-            Err(err) => Err(RestError(format!("Unable to request delegators - {err}"))),
+            Ok(Err(err)) => Err(RestError::internal_server_error(err.context("Unable to request delegators"))),
+            Err(err) => Err(RestError::internal_server_error(anyhow!(err).context("Tokio error"))),
         }
     }
 
@@ -544,11 +564,22 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     pub(crate) async fn transaction_broadcast(
         State(rest): State<Self>,
         check_transaction: Query<CheckTransaction>,
-        Json(tx): Json<Transaction<N>>,
+        json_result: Result<Json<Transaction<N>>, JsonRejection>,
     ) -> Result<ErasedJson, RestError> {
+        let Json(tx) = match json_result {
+            Ok(json) => json,
+            Err(JsonRejection::JsonDataError(err)) => {
+                // For JsonDataError, return 422 to let transaction validation handle it
+                return Err(RestError::unprocessable_entity(anyhow!("Invalid transaction data: {}", err)));
+            }
+            Err(other_rejection) => return Err(other_rejection.into()),
+        };
         // Do not process the transaction if the node is too far behind.
         if !rest.routing.is_within_sync_leniency() {
-            return Err(RestError(format!("Unable to broadcast transaction '{}' (node is syncing)", fmt_id(tx.id()))));
+            return Err(RestError::service_unavailable(anyhow!(
+                "Unable to broadcast transaction '{}' (node is syncing)",
+                fmt_id(tx.id())
+            )));
         }
 
         // If the transaction exceeds the transaction size limit, return an error.
@@ -557,7 +588,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // TODO: Should this be a blocking task?
         let buffer = Vec::with_capacity(3000);
         if tx.write_le(LimitedWriter::new(buffer, N::MAX_TRANSACTION_SIZE)).is_err() {
-            return Err(RestError("Transaction size exceeds the byte limit".to_string()));
+            return Err(RestError::bad_request(anyhow!("Transaction size exceeds the byte limit")));
         }
 
         if check_transaction.check_transaction.unwrap_or(false) {
@@ -577,17 +608,26 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                     "Too many deploy verifications in progress",
                 )
             };
+
             // Try to acquire a slot.
-            let prev = counter.fetch_add(1, Ordering::Relaxed);
-            if prev >= limit {
-                counter.fetch_sub(1, Ordering::Relaxed);
-                return Err(RestError(err_msg.to_string()));
+            if counter
+                .fetch_update(
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                    |val| {
+                        if val < limit { Some(val + 1) } else { None }
+                    },
+                )
+                .is_err()
+            {
+                return Err(RestError::too_many_requests(anyhow!("{}", err_msg)));
             }
+
             // Perform the check.
             let res = rest
                 .ledger
                 .check_transaction_basic(&tx, None, &mut rand::thread_rng())
-                .map_err(|e| RestError(format!("Invalid transaction: {e}")));
+                .map_err(|err| RestError::unprocessable_entity(err.context("Invalid transaction")));
             // Release the slot.
             counter.fetch_sub(1, Ordering::Relaxed);
             // Propagate error if any.
@@ -620,7 +660,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<ErasedJson, RestError> {
         // Do not process the solution if the node is too far behind.
         if !rest.routing.is_within_sync_leniency() {
-            return Err(RestError(format!(
+            return Err(RestError::service_unavailable(anyhow!(
                 "Unable to broadcast solution '{}' (node is syncing)",
                 fmt_id(solution.id())
             )));
@@ -644,7 +684,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 // here prevents the to-be aborted solutions from propagating through the network.
                 let prover_address = solution.address();
                 if rest.ledger.is_solution_limit_reached(&prover_address, 0) {
-                    return Err(RestError(format!(
+                    return Err(RestError::unprocessable_entity(anyhow!(
                         "Invalid solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch",
                         fmt_id(solution.id())
                     )));
@@ -655,9 +695,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 {
                     Ok(Ok(())) => {}
                     Ok(Err(err)) => {
-                        return Err(RestError(format!("Invalid solution '{}' - {err}", fmt_id(solution.id()))));
+                        return Err(RestError::unprocessable_entity(
+                            err.context(format!("Invalid solution '{}'", fmt_id(solution.id()))),
+                        ));
                     }
-                    Err(err) => return Err(RestError(format!("Invalid solution '{}' - {err}", fmt_id(solution.id())))),
+                    Err(err) => {
+                        return Err(RestError::internal_server_error(anyhow!("Tokio error: {err}")));
+                    }
                 }
             }
         }
@@ -678,7 +722,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         backup_path: Query<BackupPath>,
     ) -> Result<ErasedJson, RestError> {
-        rest.ledger.backup_database(&backup_path.path).map_err(RestError::from)?;
+        rest.ledger.backup_database(&backup_path.path)?;
 
         Ok(ErasedJson::pretty(()))
     }
@@ -691,9 +735,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<impl axum::response::IntoResponse, RestError> {
         // Retrieve the history for the given block height and variant.
         let history = snarkvm::synthesizer::History::new(N::ID, rest.ledger.vm().finalize_store().storage_mode());
-        let result = history
-            .load_mapping(height, mapping)
-            .map_err(|_| RestError(format!("Could not load mapping '{mapping}' from block '{height}'")))?;
+        let result = history.load_mapping(height, mapping).map_err(|err| {
+            RestError::not_found(err.context(format!("Could not load mapping '{mapping}' from block '{height}'")))
+        })?;
 
         Ok((StatusCode::OK, [(CONTENT_TYPE, "application/json")], result))
     }
@@ -727,7 +771,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
                 Ok(ErasedJson::pretty(participation_scores))
             }
-            None => Err(RestError("Route isn't available for this node type".to_string())),
+            None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
         }
     }
 }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -70,8 +70,11 @@ fn main() -> anyhow::Result<()> {
 
     // Parse the given arguments.
     let cli = CLI::parse();
-    // Run the updater.
-    println!("{}", Updater::print_cli());
+    if !cli.noupdater {
+        // Run the updater.
+        println!("{}", Updater::print_cli());
+    }
+
     // Run the CLI.
     match cli.command.parse() {
         Ok(output) => println!("{output}\n"),


### PR DESCRIPTION
This PR uses #3759 as its base. I will change this PR's base to `staging` after the other PR is merged.

* The REST API now returns the error chain as JSON
* It will (try to) set the HTTP status code correctly
* CLI can now parse the returned error
* This PR also adds a few new command line flags (to help remove noise from the devnet CI logs)
     - `--nobanner` hides the Aleo banner at startup
     - `--noupdater` does not check for updates