### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  target-branch: "mainnet"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
## Motivation

Removing this to stop the dependabot spam. We have `cargo audit`, and I'm exploring a workflow for fully automated dependency updates (for simple updates).

As to why this suddenly started happening: this file seems to have been untouched since 4 years, and I don't see any relevant PR merge before this, perhaps the Rust update to edition: 2024... https://github.com/ProvableHQ/snarkVM/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2870