### PR TITLE
Enable devprintln on test_network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "envmnt"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4146,6 +4152,8 @@ dependencies = [
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
+ "snarkvm-curves",
+ "snarkvm-fields",
  "snarkvm-ledger",
  "snarkvm-metrics",
  "snarkvm-parameters",
@@ -4158,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4186,18 +4194,18 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "blst",
  "cc",
  "sppark",
- "which",
+ "which 8.0.0",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4211,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4221,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4231,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4241,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.14.0",
@@ -4259,12 +4267,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4275,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4289,7 +4297,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4304,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4317,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4326,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4336,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4348,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4360,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4371,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4383,7 +4391,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4396,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4407,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4420,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4431,7 +4439,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4451,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4469,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4489,7 +4497,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4504,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4515,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4523,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4533,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4544,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4555,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4566,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4577,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4591,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4608,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4635,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4647,7 +4655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4667,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4686,7 +4694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4699,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4712,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4725,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4736,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4751,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4764,7 +4772,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4773,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4793,7 +4801,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4816,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4832,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4859,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4875,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "metrics",
 ]
@@ -4883,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4906,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4939,7 +4947,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4964,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4982,19 +4990,20 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "bincode",
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-utilities"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5015,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.0.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fc4951e#fc4951e24d1c2bbae71104b4bfce29d13a3c6289"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=13229cae2#13229cae2ee2899d78bb0db23ee682b2e1848c39"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -5068,7 +5077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdc4f02f557e3037bbe2a379cac8be6e014a67beb7bf0996b536979392f6361"
 dependencies = [
  "cc",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -6086,6 +6095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.0.8",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6350,6 +6370,12 @@ checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "e72d6f600"
+rev = "13229cae2"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "fc4951e"
+rev = "e72d6f600"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,8 @@ cuda = [
 ]
 test_network = [ 
   "snarkvm/test_targets", 
-  "snarkvm/test_consensus_heights" 
+  "snarkvm/test_consensus_heights",
+  "snarkvm/dev-print"
 ]
 serial = [ ]
 


### PR DESCRIPTION
## Motivation

The `test_network` feature is for integration testing, offering custom consensus heights and low proof targets. It is now available through a Leo command as well.

I think it would be useful for as much low level logging information to be offered to users by default, by enabling dev_println.

## Test Plan

- [x] Run a network to see if the logs are appetizable.
  - It can be quite spammy, but most users will only test a few transactions, and for them it may be super useful to actually see the low level reason for transactions failing to verify. We can revert this PR if we get some bug reports of people asking about the new logs.

## Related PRs / issues

https://github.com/ProvableHQ/snarkVM/issues/2875