### PR TITLE
Feature/add v2 api routes with error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -333,7 +333,7 @@ dependencies = [
  "rustversion",
  "serde",
  "serde_json",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "typed-json",
@@ -3215,7 +3215,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -4025,6 +4025,7 @@ dependencies = [
  "snarkvm",
  "time",
  "tokio",
+ "tower 0.4.13",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -5592,6 +5593,21 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -5628,7 +5644,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5658,7 +5674,7 @@ dependencies = [
  "http 1.3.1",
  "pin-project",
  "thiserror 2.0.14",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -114,5 +114,9 @@ workspace = true
 [dev-dependencies.base64]
 workspace = true
 
+[dev-dependencies.tower]
+version = "0.4"
+features = ["util"]
+
 [build-dependencies.built]
 workspace = true

--- a/node/rest/src/helpers/error.rs
+++ b/node/rest/src/helpers/error.rs
@@ -28,27 +28,27 @@ pub struct RestError {
 
 impl RestError {
     /// Creates a new internal server error.
-    pub fn new(message: impl Into<String>) -> Self {
-        Self { status: StatusCode::INTERNAL_SERVER_ERROR, message: message.into() }
+    pub fn new(message: String) -> Self {
+        Self { status: StatusCode::INTERNAL_SERVER_ERROR, message }
     }
 
     /// Creates a new error with a specific status code.
-    pub fn with_status(message: impl Into<String>, status: StatusCode) -> Self {
-        Self { status, message: message.into() }
+    pub fn with_status(message: String, status: StatusCode) -> Self {
+        Self { status, message }
     }
 
     /// Creates a 400 Bad Request error.
-    pub fn bad_request(message: impl Into<String>) -> Self {
+    pub fn bad_request(message: String) -> Self {
         Self::with_status(message, StatusCode::BAD_REQUEST)
     }
 
     /// Creates a 404 Not Found error.
-    pub fn not_found(message: impl Into<String>) -> Self {
+    pub fn not_found(message: String) -> Self {
         Self::with_status(message, StatusCode::NOT_FOUND)
     }
 
     /// Creates a 503 Service Unavailable error.
-    pub fn service_unavailable(message: impl Into<String>) -> Self {
+    pub fn service_unavailable(message: String) -> Self {
         Self::with_status(message, StatusCode::SERVICE_UNAVAILABLE)
     }
 }

--- a/node/rest/src/helpers/error.rs
+++ b/node/rest/src/helpers/error.rs
@@ -18,17 +18,49 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-/// An enum of error handlers for the REST API server.
-pub struct RestError(pub String);
+/// A generic error for the REST API server.
+pub struct RestError {
+    /// The HTTP status code to return.
+    pub status: StatusCode,
+    /// The error message.
+    pub message: String,
+}
+
+impl RestError {
+    /// Creates a new internal server error.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self { status: StatusCode::INTERNAL_SERVER_ERROR, message: message.into() }
+    }
+
+    /// Creates a new error with a specific status code.
+    pub fn with_status(message: impl Into<String>, status: StatusCode) -> Self {
+        Self { status, message: message.into() }
+    }
+
+    /// Creates a 400 Bad Request error.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::with_status(message, StatusCode::BAD_REQUEST)
+    }
+
+    /// Creates a 404 Not Found error.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::with_status(message, StatusCode::NOT_FOUND)
+    }
+
+    /// Creates a 503 Service Unavailable error.
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self::with_status(message, StatusCode::SERVICE_UNAVAILABLE)
+    }
+}
 
 impl IntoResponse for RestError {
     fn into_response(self) -> Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, format!("Something went wrong: {}", self.0)).into_response()
+        (self.status, format!("Something went wrong: {}", self.message)).into_response()
     }
 }
 
 impl From<anyhow::Error> for RestError {
     fn from(err: anyhow::Error) -> Self {
-        Self(err.to_string())
+        Self::new(err.to_string())
     }
 }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -486,7 +486,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<ErasedJson, RestError> {
         // Do not process the request if the node is too far behind to avoid sending outdated data.
         if !rest.routing.is_within_sync_leniency() {
-            return Err(RestError::service_unavailable("Unable to  request delegators (node is syncing)".to_string()));
+            return Err(RestError::service_unavailable("Unable to request delegators (node is syncing)".to_string()));
         }
 
         // Return the delegators for the given validator.


### PR DESCRIPTION
## Motivation

The current REST API returns 500 status code for all errors/unsuccessful calls, even for calls that are successful but aren't functionally sufficient for intended results (i.e., blocks not found, but the query was appropriate).  This effectively inhibits clients from knowing the nature of the error/failure.  Sometimes those errors are not really errors.  The REST API should return meaningful status codes.

For example, block range requests for ranges that the client node does not yet contain currently returns a 500 instead of a 404.  Also, a 500 is returned for when the node is currently syncing instead of a service unavailable status code.  In each of these cases, if callers had better status codes they could choose alternate paths to fulfill the requirements of their application needs.

The current version of the API does not include a version indicator in the URL (i.e., `/v1/*`).  Any change to the response codes is a breaking change for all clients/projects who have built on the existing API.  A new version of the API needs to be implemented using a coherent version scheme that is industry standard while at the same time keeping the old API in place, allowing gradual migration for dependent projects.   This PR proposes a `/v2/*` implementation with enhanced HTTP StatusCode implementations.  This would allow the API to change over time with a new version being released for breaking changes.

This PR only addresses the following two concerns:

1.  The addition of a `/v2/*` API to the existing API which will still be available for use.
2.  The addition of the appropriate `StatusCode::` for all `/v2` API calls.

## Test Plan

Tests were added to `rest/src/lib.rs` to show routes continue to return `StatusCode::INTERNAL_SERVER_ERROR` for `Response<Body>`.    Also tests were added to verify routes return the new appropriate status codes for the `/v2` api.

Additional perf and CI tests should be added, I'm assuming.  Looking for feedback here and any help ushering this in as appropriate for the project.

## Related PRs

This PR also addresses status codes:  https://github.com/ProvableHQ/snarkOS/pull/3789

That PR also includes a lot of other changes that are unrelated to just the status codes.  It does not include the addition of a `/v2` API while also allowing the existing functionality to continue to exist, effectively allowing a sane migration path without breaking dependent projects and infrastructure.

I propose that we make the changes proposed here first.  This will pave the way for the changes in the other PR with a potential `/v3` possible.   Also, the other PR introduces more JSON into responses in clients that are already overloaded with abundant JSON overhead.  Simply returning a status code does not add bloat while at the same time enables developers of applications interacting with snarkOS clients dramatically enhanced/meaningful responses.
