### PR TITLE
Fix CLI developer execute transfers logic

### DIFF
--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -24,6 +24,7 @@ use snarkvm::{
     ledger::{query::QueryTrait, store::helpers::memory::BlockMemory},
     prelude::{
         Address,
+        ConsensusVersion,
         Identifier,
         Locator,
         Process,
@@ -162,10 +163,14 @@ impl Execute {
                 let height = query.current_block_height()?;
                 let version = N::CONSENSUS_VERSION(height)?;
                 debug!("At block height {height} and consensus {version:?}");
+                let edition = if program_id == ProgramID::from_str("credits.aleo")? {
+                    if version < ConsensusVersion::V8 { 0 } else { 1 }
+                } else {
+                    Developer::get_latest_edition(&endpoint, &program_id)
+                        .with_context(|| format!("Failed to get latest edition for program {program_id}"))?
+                };
 
                 // Load the program and it's imports into the process.
-                let edition = Developer::get_latest_edition(&endpoint, &program_id)
-                    .with_context(|| format!("Failed to get latest edition for program {program_id}"))?;
                 load_program(&query, &mut vm.process().write(), &program_id, edition)?;
             }
 

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -24,7 +24,6 @@ use snarkvm::{
     ledger::{query::QueryTrait, store::helpers::memory::BlockMemory},
     prelude::{
         Address,
-        ConsensusVersion,
         Identifier,
         Locator,
         Process,
@@ -159,16 +158,12 @@ impl Execute {
             // Initialize the VM.
             let vm = VM::from(store)?;
 
-            if !is_static_query {
+            if !is_static_query && program_id != ProgramID::from_str("credits.aleo")? {
                 let height = query.current_block_height()?;
                 let version = N::CONSENSUS_VERSION(height)?;
                 debug!("At block height {height} and consensus {version:?}");
-                let edition = if program_id == ProgramID::from_str("credits.aleo")? {
-                    if version < ConsensusVersion::V8 { 0 } else { 1 }
-                } else {
-                    Developer::get_latest_edition(&endpoint, &program_id)
-                        .with_context(|| format!("Failed to get latest edition for program {program_id}"))?
-                };
+                let edition = Developer::get_latest_edition(&endpoint, &program_id)
+                    .with_context(|| format!("Failed to get latest edition for program {program_id}"))?;
 
                 // Load the program and it's imports into the process.
                 load_program(&query, &mut vm.process().write(), &program_id, edition)?;


### PR DESCRIPTION
## Motivation

With one recent change in the `developer execute` logic transfers via the CLI stopped working.
I noticed that while running the latest stress tests, which do a lot of transfers in the background.

Basically with the version before my change this command doesn't work:

```
        snarkos developer execute \
          --private-key <sender_pk> \
          --query <query_url> \
          --broadcast <broadcast_url> \
          credits.aleo transfer_public receiver_address <amount> \
          --network <network>
```

It always results in:

```
[20250825T064916284727] [snarkos stdout] 📦 Creating execution transaction for 'credits.aleo/transfer_public'...
[20250825T064916284727] [snarkos stdout] ⚠️  Failed to get latest edition for program credits.aleo
[20250825T064916284727] [snarkos stdout] ↳ HTTP GET request failed
[20250825T064916284727] [snarkos stdout] ↳ http status: 500
```

I checked it specifically for `credits.aleo ` and:

```
curl http://localhost:3030/testnet/program/credits.aleo/latest_edition -v

*   Trying 127.0.0.1:3030...
* Connected to localhost (127.0.0.1) port 3030 (#0)
> GET /testnet/program/credits.aleo/latest_edition HTTP/1.1
> Host: localhost:3030
> User-Agent: curl/7.81.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< content-type: text/plain; charset=utf-8
< vary: origin, access-control-request-method, access-control-request-headers
< access-control-allow-origin: *
< content-length: 72
< date: Mon, 25 Aug 2025 06:51:43 GMT
<
* Connection #0 to host localhost left intact

Something went wrong: Missing latest edition for program ID credits.aleo
```

I checked the code and saw that in `ledger/store/src/transaction/deployment.rs` we have:

```
    fn get_latest_edition_for_program(&self, program_id: &ProgramID<N>) -> Result<Option<u16>> {
        // Check if the program ID is for 'credits.aleo'.
        // This case is handled separately, as it is a default program of the VM.
        // TODO (howardwu): After we update 'fee' rules and 'Ratify' in genesis, we can remove this.
        if program_id == &ProgramID::from_str("credits.aleo")? {
            return Ok(None);
        }

        Ok(self.edition_map().get_confirmed(program_id)?.map(|x| *x))
    }
```

And in `ledger/src/get.rs`:

```
    pub fn get_latest_edition_for_program(&self, program_id: &ProgramID<N>) -> Result<u16> {
        match self.vm.block_store().get_latest_edition_for_program(program_id)? {
            Some(edition) => Ok(edition),
            None => bail!("Missing latest edition for program ID {program_id}"),
        }
    }
```

So with the latest change in the CLI this blocks any calls to the `credits.aleo` program, which means no transfers possible.

This PR fixes that by returning the old logic specifically for calls to `credits.aleo`.

This fix changes some logic introduced by https://github.com/ProvableHQ/snarkOS/pull/3759

## Test Plan

I am testing the 4.2.0 prerelease with the latest version of the stress tests right now. The latest version reports stats like how many execution transactions were send and how many landed. Withe the version before this PR the sent transactions will be close to `0`. Also the tx_runner logs can be checked, specifically the "tx_runner_transfers.log" and the "Failed to get latest edition for program credits.aleo" from above will be present on every attempt.

With the new version they should be at least over `100`. The error in the logs should be gone.
With the version of this PR we can see a lot of "Created execution transaction for 'credits.aleo/transfer_public'" in the "tx_runner_transfers.log" file. If we check the stats we will see them landing on blocks too.

## Related PRs

https://github.com/ProvableHQ/snarkOS/pull/3759
