### PR TITLE
Dynamic batch spend limits based on block height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "blst",
  "cc",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4243,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.14.0",
@@ -4271,12 +4271,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4408,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4481,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4578,7 +4578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4647,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4659,7 +4659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4698,7 +4698,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4737,7 +4737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4748,7 +4748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4763,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4776,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4785,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4828,7 +4828,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "metrics",
 ]
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5029,7 +5029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "blst",
  "cc",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4243,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "indexmap 2.10.0",
  "itertools 0.14.0",
@@ -4271,12 +4271,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4408,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4432,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4481,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4578,7 +4578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4647,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4659,7 +4659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4679,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -4698,7 +4698,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4737,7 +4737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4748,7 +4748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "indexmap 2.10.0",
  "rayon",
@@ -4763,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4776,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4785,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4828,7 +4828,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4888,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "metrics",
 ]
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "indexmap 2.10.0",
  "paste",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5029,7 +5029,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6707f49#6707f49c913451ce5003b90d48effe730c02c498"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2c7352c58#2c7352c585f6de40c6d7743f475fe2ac30c76fe9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "6707f49"
+rev = "2c7352c58"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "2c7352c58"
+rev = "b2e05284e"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/cli/src/commands/developer/deploy.rs
+++ b/cli/src/commands/developer/deploy.rs
@@ -183,7 +183,8 @@ impl Deploy {
             let vm = VM::from(store).with_context(|| "Failed to initialize the virtual machine")?;
 
             // Compute the minimum deployment cost.
-            let (minimum_deployment_cost, (_, _, _, _)) = deployment_cost(&vm.process().read(), &deployment)?;
+            let (minimum_deployment_cost, (_, _, _, _)) =
+                deployment_cost(&vm.process().read(), &deployment, consensus_version)?;
 
             // Prepare the fees.
             let fee = match &self.record {

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -23,7 +23,18 @@ use snarkvm::{
         puzzle::{Solution, SolutionID},
         store::ConsensusStorage,
     },
-    prelude::{Address, Field, FromBytes, Network, Result, bail, cfg_into_iter, deployment_cost, execution_cost_v2},
+    prelude::{
+        Address,
+        ConsensusVersion,
+        Field,
+        FromBytes,
+        Network,
+        Result,
+        bail,
+        cfg_into_iter,
+        deployment_cost,
+        execution_cost,
+    },
 };
 
 use anyhow::anyhow;
@@ -398,12 +409,13 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         &self,
         _transaction_id: N::TransactionID,
         transaction: Transaction<N>,
+        consensus_version: ConsensusVersion,
     ) -> Result<u64> {
         match &transaction {
             // Include the synthesis cost and storage cost for deployments.
             Transaction::Deploy(_, _, _, deployment, _) => {
                 let (_, (storage_cost, synthesis_cost, constructor_cost, _)) =
-                    deployment_cost(&self.ledger.vm().process().read(), deployment)?;
+                    deployment_cost(&self.ledger.vm().process().read(), deployment, consensus_version)?;
                 storage_cost
                     .checked_add(synthesis_cost)
                     .and_then(|synthesis_cost| synthesis_cost.checked_add(constructor_cost))
@@ -413,7 +425,8 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             }
             // Include the finalize cost and storage cost for executions.
             Transaction::Execute(_, _, execution, _) => {
-                let (total_cost, (_, _)) = execution_cost_v2(&self.ledger.vm().process().read(), execution)?;
+                let (total_cost, (_, _)) =
+                    execution_cost(&self.ledger.vm().process().read(), execution, consensus_version)?;
                 Ok(total_cost)
             }
             // Fee transactions are internal to the VM, they do not have a compute cost.

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -21,7 +21,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{Address, ConsensusVersion, Field, Network, Result, Zero, bail, ensure},
+    prelude::{Address, ConsensusVersion, Field, Network, Result, Zero, bail, ensure, consensus_config_value},
 };
 
 use indexmap::IndexMap;
@@ -244,8 +244,9 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         &self,
         _transaction_id: N::TransactionID,
         _transaction: Transaction<N>,
-        _consensus_version: ConsensusVersion,
+        consensus_version: ConsensusVersion,
     ) -> Result<u64> {
-        Ok(N::TRANSACTION_SPEND_LIMIT.last().unwrap().1)
+        let height = N::CONSENSUS_HEIGHT(consensus_version).unwrap();
+        Ok(consensus_config_value!(N, TRANSACTION_SPEND_LIMIT, height).unwrap())
     }
 }

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -21,7 +21,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{Address, ConsensusVersion, Field, Network, Result, Zero, bail, ensure, consensus_config_value},
+    prelude::{Address, ConsensusVersion, Field, Network, Result, Zero, bail, consensus_config_value, ensure},
 };
 
 use indexmap::IndexMap;

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -21,7 +21,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{Address, Field, Network, Result, Zero, bail, ensure},
+    prelude::{Address, ConsensusVersion, Field, Network, Result, Zero, bail, ensure},
 };
 
 use indexmap::IndexMap;
@@ -244,7 +244,8 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         &self,
         _transaction_id: N::TransactionID,
         _transaction: Transaction<N>,
+        _consensus_version: ConsensusVersion,
     ) -> Result<u64> {
-        Ok(N::TRANSACTION_SPEND_LIMIT)
+        Ok(N::TRANSACTION_SPEND_LIMIT.last().unwrap().1)
     }
 }

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -21,7 +21,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{Address, Field, Network, Result, Zero, bail},
+    prelude::{Address, ConsensusVersion, Field, Network, Result, Zero, bail},
 };
 
 use indexmap::IndexMap;
@@ -192,6 +192,7 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         &self,
         transaction_id: N::TransactionID,
         _transaction: Transaction<N>,
+        _consensus_version: ConsensusVersion,
     ) -> Result<u64> {
         bail!("Transaction '{transaction_id}' doesn't exist in prover")
     }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -20,7 +20,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{Address, Field, Network, Result},
+    prelude::{Address, ConsensusVersion, Field, Network, Result},
 };
 
 use indexmap::IndexMap;
@@ -126,5 +126,6 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
         &self,
         transaction_id: N::TransactionID,
         transaction: Transaction<N>,
+        consensus_version: ConsensusVersion,
     ) -> Result<u64>;
 }

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -25,7 +25,7 @@ use snarkvm::{
         puzzle::{Solution, SolutionID},
         store::ConsensusStorage,
     },
-    prelude::{Address, Field, Network, Result, narwhal::BatchCertificate},
+    prelude::{Address, ConsensusVersion, Field, Network, Result, narwhal::BatchCertificate},
 };
 use std::{
     fmt,
@@ -201,7 +201,8 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         &self,
         transaction_id: N::TransactionID,
         transaction: Transaction<N>,
+        consensus_version: ConsensusVersion,
     ) -> Result<u64> {
-        self.inner.transaction_spent_cost_in_microcredits(transaction_id, transaction)
+        self.inner.transaction_spent_cost_in_microcredits(transaction_id, transaction, consensus_version)
     }
 }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2382,7 +2382,7 @@ mod tests {
         // Check the workers are empty.
         primary.workers().iter().for_each(|worker| assert!(worker.transmissions().is_empty()));
 
-        // Generate a solution and a transaction.
+        // Generate a solution and transactions.
         let (solution_id, solution) = sample_unconfirmed_solution(&mut rng);
         primary.workers[0].process_unconfirmed_solution(solution_id, solution).await.unwrap();
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -586,6 +586,7 @@ impl<N: Network> Primary<N> {
                         let current_block_height = self.ledger.latest_block_height();
                         let consensus_version_v7_height = N::CONSENSUS_HEIGHT(ConsensusVersion::V7)?;
                         let consensus_version_v8_height = N::CONSENSUS_HEIGHT(ConsensusVersion::V8)?;
+                        let consensus_version = N::CONSENSUS_VERSION(current_block_height)?;
                         if current_block_height > consensus_version_v7_height
                             && current_block_height <= consensus_version_v8_height
                             && transaction.is_deploy()
@@ -606,8 +607,11 @@ impl<N: Network> Primary<N> {
 
                         // Compute the transaction spent cost (in microcredits).
                         // Note: We purposefully discard this transaction if we are unable to compute the spent cost.
-                        let Ok(cost) = self.ledger.transaction_spent_cost_in_microcredits(transaction_id, transaction)
-                        else {
+                        let Ok(cost) = self.ledger.transaction_spent_cost_in_microcredits(
+                            transaction_id,
+                            transaction,
+                            consensus_version,
+                        ) else {
                             debug!(
                                 "Proposing - Skipping and discarding transaction '{}' - Unable to compute transaction spent cost",
                                 fmt_id(transaction_id)
@@ -626,11 +630,12 @@ impl<N: Network> Primary<N> {
                         };
 
                         // Check if the next proposal cost exceeds the batch proposal spend limit.
-                        if next_proposal_cost > BatchHeader::<N>::BATCH_SPEND_LIMIT {
+                        let batch_spend_limit = BatchHeader::<N>::batch_spend_limit(current_block_height);
+                        if next_proposal_cost > batch_spend_limit {
                             trace!(
                                 "Proposing - Skipping transaction '{}' - Batch spend limit surpassed ({next_proposal_cost} > {})",
                                 fmt_id(transaction_id),
-                                BatchHeader::<N>::BATCH_SPEND_LIMIT
+                                batch_spend_limit
                             );
 
                             // Reinsert the transmission into the worker.
@@ -883,6 +888,7 @@ impl<N: Network> Primary<N> {
                     // Do not include deployments in a batch proposal.
                     let consensus_version_v7_height = N::CONSENSUS_HEIGHT(ConsensusVersion::V7)?;
                     let consensus_version_v8_height = N::CONSENSUS_HEIGHT(ConsensusVersion::V8)?;
+                    let consensus_version = N::CONSENSUS_VERSION(block_height)?;
                     if block_height > consensus_version_v7_height
                         && block_height <= consensus_version_v8_height
                         && transaction.is_deploy()
@@ -894,8 +900,11 @@ impl<N: Network> Primary<N> {
 
                     // Compute the transaction spent cost (in microcredits).
                     // Note: We purposefully discard this transaction if we are unable to compute the spent cost.
-                    let Ok(cost) = self.ledger.transaction_spent_cost_in_microcredits(*transaction_id, transaction)
-                    else {
+                    let Ok(cost) = self.ledger.transaction_spent_cost_in_microcredits(
+                        *transaction_id,
+                        transaction,
+                        consensus_version,
+                    ) else {
                         bail!(
                             "Invalid batch proposal - Unable to compute transaction spent cost on transaction '{}'",
                             fmt_id(transaction_id)
@@ -912,11 +921,12 @@ impl<N: Network> Primary<N> {
                     };
 
                     // Check if the next proposal cost exceeds the batch proposal spend limit.
-                    if next_proposal_cost > BatchHeader::<N>::BATCH_SPEND_LIMIT {
+                    let batch_spend_limit = BatchHeader::<N>::batch_spend_limit(block_height);
+                    if next_proposal_cost > batch_spend_limit {
                         bail!(
                             "Malicious peer - Batch proposal from '{peer_ip}' exceeds the spend limit on transaction '{}' ({next_proposal_cost} > {})",
                             fmt_id(transaction_id),
-                            BatchHeader::<N>::BATCH_SPEND_LIMIT
+                            batch_spend_limit
                         );
                     }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -633,7 +633,7 @@ mod tests {
                 transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
             ) -> Result<Block<N>>;
             fn advance_to_next_block(&self, block: &Block<N>) -> Result<()>;
-            fn transaction_spent_cost_in_microcredits(&self, transaction_id: N::TransactionID, transaction: Transaction<N>) -> Result<u64>;
+            fn transaction_spent_cost_in_microcredits(&self, transaction_id: N::TransactionID, transaction: Transaction<N>, consensus_version: ConsensusVersion) -> Result<u64>;
         }
     }
 


### PR DESCRIPTION
## Motivation

Adds in support for using batch spend limits based on the consensus version / block height.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2890