### PR TITLE
fix: CDN height rounding to previous bundle boundary

### DIFF
--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -452,8 +452,8 @@ async fn cdn_height<const BLOCKS_PER_FILE: u32>(client: &Client, base_url: &http
     };
     // Decrement the tip by a few blocks to ensure the CDN is caught up.
     let tip = tip.saturating_sub(10);
-    // Adjust the tip to the closest subsequent multiple of BLOCKS_PER_FILE.
-    Ok(tip - (tip % BLOCKS_PER_FILE) + BLOCKS_PER_FILE)
+    // Adjust the tip to the closest previous multiple of BLOCKS_PER_FILE.
+    Ok(tip - (tip % BLOCKS_PER_FILE))
 }
 
 /// Retrieves the objects from the CDN with the given URL.


### PR DESCRIPTION
Change: round down the tip to the nearest BLOCKS_PER_FILE multiple after subtracting the safety offset.
Rationale: prevents selecting a bundle that may not yet be available, reducing 404s and unnecessary retries while aligning with the function’s intent to avoid unstable tips.