### PR TITLE
[hotfix] Use correct cost determination for transactions after V10

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -416,18 +416,36 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             Transaction::Deploy(_, _, _, deployment, _) => {
                 let (_, (storage_cost, synthesis_cost, constructor_cost, _)) =
                     deployment_cost(&self.ledger.vm().process().read(), deployment, consensus_version)?;
-                storage_cost
-                    .checked_add(synthesis_cost)
-                    .and_then(|synthesis_cost| synthesis_cost.checked_add(constructor_cost))
-                    .ok_or(anyhow!(
-                        "The storage, synthesis, and constructor cost computation overflowed for a deployment"
-                    ))
+                let cost_to_check = if consensus_version >= ConsensusVersion::V10 {
+                    // From V10, only include the constructor compute cost for
+                    // deployments.
+                    //
+                    // If any individual function's finalize compute costs are
+                    // above the tranasction spend limit, the deployment will be
+                    // aborted in the block via Stack::initialize_and_check.
+                    constructor_cost
+                } else {
+                    // Include the storage, synthesis, and constructor cost for deployments.
+                    storage_cost
+                        .checked_add(synthesis_cost)
+                        .and_then(|synthesis_cost| synthesis_cost.checked_add(constructor_cost))
+                        .ok_or(anyhow!(
+                            "The storage, synthesis, and constructor cost computation overflowed for a deployment"
+                        ))?
+                };
+                Ok(cost_to_check)
             }
-            // Include the finalize cost and storage cost for executions.
             Transaction::Execute(_, _, execution, _) => {
-                let (total_cost, (_, _)) =
+                let (total_cost, (_, finalize_cost)) =
                     execution_cost(&self.ledger.vm().process().read(), execution, consensus_version)?;
-                Ok(total_cost)
+                let cost_to_check = if consensus_version >= ConsensusVersion::V10 {
+                    // From V10, only include the finalize compute cost for executions.
+                    finalize_cost
+                } else {
+                    // Include the finalize cost and storage cost for executions.
+                    total_cost
+                };
+                Ok(cost_to_check)
             }
             // Fee transactions are internal to the VM, they do not have a compute cost.
             Transaction::Fee(..) => Ok(0),

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -632,7 +632,7 @@ impl<N: Network> Primary<N> {
                         // Check if the next proposal cost exceeds the batch proposal spend limit.
                         let batch_spend_limit = BatchHeader::<N>::batch_spend_limit(current_block_height);
                         if next_proposal_cost > batch_spend_limit {
-                            trace!(
+                            debug!(
                                 "Proposing - Skipping transaction '{}' - Batch spend limit surpassed ({next_proposal_cost} > {})",
                                 fmt_id(transaction_id),
                                 batch_spend_limit


### PR DESCRIPTION
## Motivation

There was a bug in the adaptation to https://github.com/ProvableHQ/snarkVM/pull/2890

As noted in that issue:
- for deployments we care about the constructor limit: https://github.com/ProvableHQ/snarkVM/pull/2890/files#diff-7d50c9d8aeb6ed044ebd7996abf9afcccfc58a6277737f85f78a15152f4a02e5R341
  - We also care about the individual function finalize costs, but AFAIK those may be expensive to calculate here as we have to construct a Stack, so we defer it until Stack creation. 
- for executions we care about the finalize cost limit: https://github.com/ProvableHQ/snarkVM/pull/2890/files#diff-897e9a9f59d4fc522348f00c936a1fd07ee9c654858dc846a658d6a02f05810aR420

All of this logic is still unnecessarily hard to track, as noted in this issue to clean up in the future: https://github.com/provableHQ/snarkVM/issues/2892

## Test Plan

- [x] deployments and transactions have a higher success rate in automated devnet
