### PR TITLE
[Fix] Improve endpoint handling in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,9 +431,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "blake2"
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -735,7 +735,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "log",
  "serde",
  "serde_derive",
@@ -809,7 +809,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -825,7 +825,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1467,7 +1467,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
  "libgit2-sys",
  "log",
@@ -1515,7 +1515,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1985,11 +1985,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -2070,9 +2070,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -2155,7 +2155,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
 ]
 
@@ -2318,7 +2318,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2442,7 +2442,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2599,7 +2599,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2851,13 +2851,13 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3053,7 +3053,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -3074,7 +3074,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3103,7 +3103,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3139,14 +3139,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -3160,13 +3160,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -3177,9 +3177,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -3284,7 +3284,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3297,7 +3297,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3439,7 +3439,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3520,7 +3520,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3568,7 +3568,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -3766,7 +3766,7 @@ dependencies = [
  "clap",
  "colored 3.0.0",
  "crossterm 0.29.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "nix",
  "num_cpus",
@@ -3818,7 +3818,7 @@ dependencies = [
  "deadline",
  "futures-util",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru 0.16.0",
  "num_cpus",
@@ -3860,7 +3860,7 @@ dependencies = [
  "colored 3.0.0",
  "deadline",
  "futures",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.12.1",
  "locktick",
  "lru 0.16.0",
@@ -3901,7 +3901,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "proptest",
  "serde",
  "snarkos-node-sync-locators",
@@ -3918,7 +3918,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3935,7 +3935,7 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru 0.16.0",
  "parking_lot",
@@ -3971,7 +3971,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.0",
@@ -4011,7 +4011,7 @@ dependencies = [
  "base64 0.22.1",
  "built",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "jsonwebtoken",
  "locktick",
  "once_cell",
@@ -4088,7 +4088,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
@@ -4119,7 +4119,7 @@ name = "snarkos-node-sync-locators"
 version = "4.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "snarkvm",
  "tracing",
@@ -4179,7 +4179,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -4255,7 +4255,7 @@ name = "snarkvm-circuit-environment"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -4447,7 +4447,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "lazy_static",
  "paste",
  "serde",
@@ -4486,7 +4486,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "num-derive",
  "num-traits",
  "serde_json",
@@ -4624,7 +4624,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru 0.16.0",
  "parking_lot",
@@ -4661,7 +4661,7 @@ name = "snarkvm-ledger-block"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4682,7 +4682,7 @@ version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4713,7 +4713,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4726,7 +4726,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4750,7 +4750,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4790,7 +4790,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru 0.16.0",
  "parking_lot",
@@ -4810,7 +4810,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "lru 0.16.0",
  "parking_lot",
@@ -4850,7 +4850,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -4923,7 +4923,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.0",
@@ -4956,7 +4956,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -4979,7 +4979,7 @@ name = "snarkvm-synthesizer-program"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b2e05284e#b2e05284ef08a23fb1f5d0c95a428a6999ac55fa"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5255,7 +5255,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -5560,7 +5560,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5630,7 +5630,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5879,13 +5879,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6355,9 +6356,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "winsafe"
@@ -6371,7 +6372,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -6509,7 +6510,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "memchr",
  "thiserror 2.0.16",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "b2e05284e"
+rev = "7bc4c28"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/node/rest/src/helpers/error.rs
+++ b/node/rest/src/helpers/error.rs
@@ -43,7 +43,8 @@ pub enum RestError {
 pub struct SerializedRestError {
     pub message: String,
     pub error_type: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    /// Does not include error chain in message if it is empty, and generates an empty error chain if none is given.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub chain: Vec<String>,
 }
 

--- a/node/rest/src/helpers/mod.rs
+++ b/node/rest/src/helpers/mod.rs
@@ -18,3 +18,6 @@ pub use auth::*;
 
 mod error;
 pub(crate) use error::*;
+
+mod path;
+pub(crate) use path::Path;

--- a/node/rest/src/helpers/path.rs
+++ b/node/rest/src/helpers/path.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::RestError;
+
+use axum::{
+    extract::{FromRequestParts, path::ErrorKind, rejection::PathRejection},
+    http::request::Parts,
+};
+use serde::de::DeserializeOwned;
+
+struct PathError {
+    message: String,
+    path: String,
+    cause: anyhow::Error,
+    location: Option<String>,
+}
+
+/// Convert Path errors into the unified REST error type.
+impl From<PathError> for RestError {
+    fn from(val: PathError) -> Self {
+        let err = if let Some(loc) = val.location {
+            val.cause.context(format!("Invalid argument \"{loc}\" in path \"{}\": {}", val.path, val.message))
+        } else {
+            val.cause.context(format!("Invalid path \"{}\": {}", val.path, val.message))
+        };
+
+        RestError::bad_request(err)
+    }
+}
+
+/// Custom Path extractor to improve errors in invalid URLs.
+/// Adapted from axum's [customize-path-rejection](https://github.com/tokio-rs/axum/blob/main/examples/customize-path-rejection/src/main.rs)
+pub struct Path<T>(pub T);
+
+impl<S, T> FromRequestParts<S> for Path<T>
+where
+    T: DeserializeOwned + Send,
+    S: Send + Sync,
+{
+    type Rejection = RestError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
+            Ok(value) => Ok(Self(value.0)),
+            Err(rejection) => {
+                let err = match rejection {
+                    PathRejection::FailedToDeserializePathParams(inner) => {
+                        let kind = inner.kind();
+
+                        let (message, location) = match &kind {
+                            ErrorKind::WrongNumberOfParameters { .. } => {
+                                ("wrong number of parameters".to_string(), None)
+                            }
+                            ErrorKind::ParseErrorAtKey { key, value, expected_type } => (
+                                format!("value `{value}` is not of expected type `{expected_type}`"),
+                                Some(key.clone()),
+                            ),
+                            ErrorKind::ParseErrorAtIndex { index, value, expected_type } => (
+                                format!("value `{value}` at index {index} is not of expected type `{expected_type}`"),
+                                None,
+                            ),
+                            ErrorKind::ParseError { value, expected_type } => {
+                                (format!("value `{value}` is not of expected type `{expected_type}`"), None)
+                            }
+                            ErrorKind::InvalidUtf8InPathParam { key } => {
+                                ("invalid UTF-8 in parameter".to_string(), Some(key.clone()))
+                            }
+                            ErrorKind::Message(msg) => (format!("unknown error: {msg}"), None),
+                            _ => ("unknown error".to_string(), None),
+                        };
+
+                        PathError { message, path: parts.uri.path().to_string(), location, cause: inner.into() }
+                    }
+                    PathRejection::MissingPathParams(error) => PathError {
+                        message: "missing path parameter".to_string(),
+                        path: parts.uri.path().to_string(),
+                        location: None,
+                        cause: error.into(),
+                    },
+                    _ => PathError {
+                        message: "unknown path error".to_string(),
+                        path: parts.uri.path().to_string(),
+                        location: None,
+                        cause: rejection.into(),
+                    },
+                };
+
+                Err(err.into())
+            }
+        }
+    }
+}

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -19,6 +19,7 @@
 extern crate tracing;
 
 mod helpers;
+// Imports custom `Path` type, to be used instead of `axum`'s.
 pub use helpers::*;
 
 mod routes;
@@ -41,7 +42,7 @@ use snarkvm::{
 use anyhow::{Context, Result};
 use axum::{
     body::Body,
-    extract::{ConnectInfo, DefaultBodyLimit, Path, Query, State},
+    extract::{ConnectInfo, DefaultBodyLimit, Query, State},
     http::{Method, Request, StatusCode, header::CONTENT_TYPE},
     middleware,
     response::Response,

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -326,7 +326,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         metadata: Query<Metadata>,
     ) -> Result<ErasedJson, RestError> {
         // Get the program from the ledger.
-        let program = rest.ledger.get_program(id)?;
+        let program = rest.ledger.get_program(id).with_context(|| format!("Failed to find program `{id}`"))?;
         // Check if metadata is requested and return the program with metadata if so.
         if metadata.metadata.unwrap_or(false) {
             // Get the edition of the program.
@@ -345,7 +345,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         metadata: Query<Metadata>,
     ) -> Result<ErasedJson, RestError> {
         // Get the program from the ledger.
-        let program = rest.ledger.get_program_for_edition(id, edition)?;
+        let program = rest
+            .ledger
+            .get_program_for_edition(id, edition)
+            .with_context(|| format!("Failed to find program `{id}` for edition {edition}"))?;
         // Check if metadata is requested and return the program with metadata if so.
         if metadata.metadata.unwrap_or(false) {
             return rest.return_program_with_metadata(program, edition);


### PR DESCRIPTION
This PR mirrors fixes from [snarkOS #2895](github.com/ProvableHQ/snarkVM/pull/2895). In particular, to ensure endpoint URLs are valid for a variety of supported hostnames/prefixes.

The PR also ensure the error formatting in REST module is correct when there are issues with the given endpoint path. The resulting errors are not perfect yet, e.g., an invalid program ID still returns this rather cryptic error below, but improved error handling can be tackled in a future PR.

```
~> curl http://localhost:3030/v2/testnet/program/foobar
{"message":"Invalid path \"/program/foobar\": unknown error: Failed to parse string. Parsing Error: VerboseError { errors: [(\"\", Nom(Tag))] }","error_type":"bad_request","chain":["Failed to parse string. Parsing Error: VerboseError { errors: [(\"\", Nom(Tag))] }"]}⏎

```