### PR TITLE
Use a process with loaded imports for deploymeny cost determination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "blst",
  "cc",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "indexmap 2.11.0",
  "itertools 0.14.0",
@@ -4256,12 +4256,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4272,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4286,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4357,7 +4357,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4380,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4448,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4486,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4552,7 +4552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4588,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4644,7 +4644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -4683,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4709,7 +4709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4722,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4733,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4748,7 +4748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4790,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4813,7 +4813,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4857,7 +4857,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "metrics",
 ]
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4962,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "indexmap 2.11.0",
  "paste",
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4993,7 +4993,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=0da94881fe6794659835d0616c070ac2a742148e#0da94881fe6794659835d0616c070ac2a742148e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ version = "1.0.1"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-#path = "../snarkVM"
+# path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "0da94881fe6794659835d0616c070ac2a742148e"
+rev = "8c0524f46209db1dd87d840376292f95406f1df7"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]


### PR DESCRIPTION
## Motivation

Deployment of programs with imports was recently broken, because the deployment_cost function assumes the process contains all of the imports. This PR ensures we pass in a Process with the loaded imports.

## Test Plan

Manually tested success of nested deployments. In the future we'll have regression tests in CI on all known types of programs.

## Related PRs

https://github.com/ProvableHQ/snarkVM/pull/2910
