### PR TITLE
[Feat] Persistent peer cache for clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,7 @@ dependencies = [
 name = "snarkos-node-router"
 version = "4.1.0"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "async-trait",
  "colored 3.0.0",

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -721,7 +721,7 @@ impl Start {
         // Initialize the node.
         match node_type {
             NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, self.allow_external_peers, dev_txs, self.dev, shutdown.clone()).await,
-            NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, self.dev, shutdown.clone()).await,
+            NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, storage_mode, self.dev, shutdown.clone()).await,
             NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.rotate_external_peers, self.dev, shutdown).await
         }
     }

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -23,6 +23,9 @@ metrics = [ "dep:snarkos-node-metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda" ]
 serial = [ "snarkos-node-bft-ledger-service/serial" ]
 
+[dependencies.aleo-std]
+workspace = true
+
 [dependencies.anyhow]
 workspace = true
 

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -40,7 +40,7 @@ use std::net::SocketAddr;
 use tokio::task::spawn_blocking;
 
 /// The max number of peers to send in a `PeerResponse` message.
-const MAX_PEERS_TO_SEND: usize = u8::MAX as usize;
+pub(crate) const MAX_PEERS_TO_SEND: usize = u8::MAX as usize;
 
 #[async_trait]
 pub trait Inbound<N: Network>: Reading + Outbound<N> {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -52,6 +52,7 @@ use snarkos_node_tcp::{Config, ConnectionSide, P2P, Tcp, is_bogon_ip, is_unspeci
 
 use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 
+use aleo_std::{StorageMode, aleo_ledger_dir};
 use anyhow::{Result, bail};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::{Mutex, RwLock};
@@ -61,7 +62,9 @@ use parking_lot::{Mutex, RwLock};
 use std::net::IpAddr;
 use std::{
     collections::{HashMap, HashSet},
+    fs,
     future::Future,
+    io::Write,
     net::SocketAddr,
     ops::Deref,
     str::FromStr,
@@ -72,6 +75,9 @@ use tokio::task::JoinHandle;
 
 /// The default port used by the router.
 pub const DEFAULT_NODE_PORT: u16 = 4130;
+
+/// The name of the file containing cached peers.
+const PEER_CACHE_FILENAME: &str = "cached_router_peers";
 
 /// The router keeps track of connected and connecting peers.
 /// The actual network communication happens in Inbound/Outbound,
@@ -108,6 +114,8 @@ pub struct InnerRouter<N: Network> {
     rotate_external_peers: bool,
     /// If the flag is set, the node will engage in P2P gossip to request more peers.
     allow_external_peers: bool,
+    /// The storage mode.
+    storage_mode: StorageMode,
     /// The boolean flag for the development mode.
     is_dev: bool,
 }
@@ -138,16 +146,27 @@ impl<N: Network> Router<N> {
         max_peers: u16,
         rotate_external_peers: bool,
         allow_external_peers: bool,
+        storage_mode: StorageMode,
         is_dev: bool,
     ) -> Result<Self> {
         // Initialize the TCP stack.
         let tcp = Tcp::new(Config::new(node_ip, max_peers));
 
-        let trusted_peers = trusted_peers
+        let mut initial_peers = trusted_peers
             .iter()
             .copied()
             .map(|addr| (addr, Peer::new_candidate(addr, true)))
             .collect::<HashMap<_, _>>();
+
+        let mut peer_cache_path = aleo_ledger_dir(N::ID, &storage_mode);
+        peer_cache_path.push(PEER_CACHE_FILENAME);
+        if let Ok(cached_peers_str) = fs::read_to_string(&peer_cache_path) {
+            for peer_addr_str in cached_peers_str.lines() {
+                if let Ok(addr) = SocketAddr::from_str(peer_addr_str) {
+                    initial_peers.insert(addr, Peer::new_candidate(addr, false));
+                }
+            }
+        }
 
         // Initialize the router.
         Ok(Self(Arc::new(InnerRouter {
@@ -157,10 +176,11 @@ impl<N: Network> Router<N> {
             ledger,
             cache: Default::default(),
             resolver: Default::default(),
-            peer_pool: RwLock::new(trusted_peers),
+            peer_pool: RwLock::new(initial_peers),
             handles: Default::default(),
             rotate_external_peers,
             allow_external_peers,
+            storage_mode,
             is_dev,
         })))
     }
@@ -528,9 +548,51 @@ impl<N: Network> Router<N> {
         self.handles.lock().push(tokio::spawn(future));
     }
 
+    // Save the best peers to disk.
+    fn save_best_peers(&self) -> Result<()> {
+        // Collect all prospect peers.
+        let mut peers = self.get_peers();
+
+        // Get the average values to gauge peer quality.
+        let known_peers = self.tcp().known_peers().snapshot();
+        let sent_msgs = known_peers.values().map(|stats| stats.sent().0).sum::<u64>();
+        let recv_msgs = known_peers.values().map(|stats| stats.received().0).sum::<u64>();
+        let failures = known_peers.values().map(|stats| stats.failures()).sum::<u64>();
+        let avg_sent_msgs = (sent_msgs as f64) / (known_peers.len() as f64);
+        let avg_recv_msgs = (recv_msgs as f64) / (known_peers.len() as f64);
+        let avg_failures = (failures as f64) / (known_peers.len() as f64);
+
+        // Keep the peers that aren't outliers.
+        peers.retain(|peer| {
+            let peer_ip = peer.listener_addr().ip();
+            if let Some(peer_stats) = known_peers.get(&peer_ip) {
+                (peer_stats.sent().0 as f64) > avg_sent_msgs * 0.75
+                    && (peer_stats.received().0 as f64) > avg_recv_msgs * 0.75
+                    && (peer_stats.failures() as f64) <= avg_failures
+            } else {
+                false
+            }
+        });
+        peers.truncate(MAX_PEERS_TO_SEND);
+
+        // Dump the connected peers to a file.
+        let mut path = aleo_ledger_dir(N::ID, &self.storage_mode);
+        path.push(PEER_CACHE_FILENAME);
+        let mut file = fs::File::create(path)?;
+        for peer in peers {
+            writeln!(file, "{}", peer.listener_addr())?;
+        }
+
+        Ok(())
+    }
+
     /// Shuts down the router.
     pub async fn shut_down(&self) {
         info!("Shutting down the router...");
+        // Save the best peers for future use.
+        if let Err(e) = self.save_best_peers() {
+            warn!("Failed to persist best peers to disk: {e}");
+        }
         // Abort the tasks.
         self.handles.lock().iter().for_each(|handle| handle.abort());
         // Close the listener.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -573,6 +573,14 @@ impl<N: Network> Router<N> {
                 false
             }
         });
+        // Prioritize peers with the lowest failure count.
+        peers.sort_unstable_by_key(|peer| {
+            if let Some(peer_stats) = known_peers.get(&peer.listener_addr().ip()) {
+                peer_stats.failures()
+            } else {
+                0 // A dummy value - this is unreachable.
+            }
+        });
         peers.truncate(MAX_PEERS_TO_SEND);
 
         // Dump the connected peers to a file.

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -23,6 +23,7 @@ use std::{
     sync::Arc,
 };
 
+use aleo_std::StorageMode;
 use snarkos_account::Account;
 use snarkos_node_bft_ledger_service::MockLedgerService;
 use snarkos_node_router::{Router, messages::NodeType};
@@ -67,6 +68,7 @@ pub async fn client(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
         max_peers,
         false,
         true,
+        StorageMode::Test(None),
         true,
     )
     .await
@@ -88,6 +90,7 @@ pub async fn prover(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
         max_peers,
         false,
         true,
+        StorageMode::Test(None),
         true,
     )
     .await
@@ -114,6 +117,7 @@ pub async fn validator(
         max_peers,
         false,
         allow_external_peers,
+        StorageMode::Test(None),
         true,
     )
     .await

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -68,7 +68,7 @@ pub async fn client(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
         max_peers,
         false,
         true,
-        StorageMode::Test(None),
+        StorageMode::new_test(None),
         true,
     )
     .await
@@ -90,7 +90,7 @@ pub async fn prover(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
         max_peers,
         false,
         true,
-        StorageMode::Test(None),
+        StorageMode::new_test(None),
         true,
     )
     .await
@@ -117,7 +117,7 @@ pub async fn validator(
         max_peers,
         false,
         allow_external_peers,
-        StorageMode::Test(None),
+        StorageMode::new_test(None),
         true,
     )
     .await

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -163,6 +163,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
             rotate_external_peers,
             allow_external_peers,
+            storage_mode.clone(),
             dev.is_some(),
         )
         .await?;

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -88,10 +88,13 @@ impl<N: Network> Node<N> {
         account: Account<N>,
         trusted_peers: &[SocketAddr],
         genesis: Block<N>,
+        storage_mode: StorageMode,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
     ) -> Result<Self> {
-        Ok(Self::Prover(Arc::new(Prover::new(node_ip, account, trusted_peers, genesis, dev, shutdown).await?)))
+        Ok(Self::Prover(Arc::new(
+            Prover::new(node_ip, account, trusted_peers, genesis, storage_mode, dev, shutdown).await?,
+        )))
     }
 
     /// Initializes a new client node.

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -42,6 +42,7 @@ use snarkvm::{
     synthesizer::VM,
 };
 
+use aleo_std::StorageMode;
 use anyhow::Result;
 use colored::Colorize;
 use core::{marker::PhantomData, time::Duration};
@@ -96,6 +97,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
         account: Account<N>,
         trusted_peers: &[SocketAddr],
         genesis: Block<N>,
+        storage_mode: StorageMode,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
     ) -> Result<Self> {
@@ -119,6 +121,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
             rotate_external_peers,
             allow_external_peers,
+            storage_mode,
             dev.is_some(),
         )
         .await?;

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -118,6 +118,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
             rotate_external_peers,
             allow_external_peers,
+            storage_mode.clone(),
             dev.is_some(),
         )
         .await?;

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -45,6 +45,7 @@ pub async fn prover() -> Prover<CurrentNetwork, ConsensusMemory<CurrentNetwork>>
         Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
         &[],
         sample_genesis_block(),
+        StorageMode::Test(None),
         None,
         Default::default(),
     )

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -45,7 +45,7 @@ pub async fn prover() -> Prover<CurrentNetwork, ConsensusMemory<CurrentNetwork>>
         Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap(),
         &[],
         sample_genesis_block(),
-        StorageMode::Test(None),
+        StorageMode::new_test(None),
         None,
         Default::default(),
     )


### PR DESCRIPTION
This PR introduces a simple, persistent peer cache, which saves high-quality peers on shutdown, and introduces them to the peer pool as candidate peers on startup. The scoring metrics are basically "free", as we already keep track of them.

This was tested locally as follows:
1. 4 `--dev` validators with `--allow-external-peers`, plus one `--dev` client, were started
2. the client was promptly shut down
3. the client had the addresses of all the validators saved at the expected location
4. one of the aforementioned addresses was manually changed
5. the client was restarted
6. the client's logs were inspected for the changed address (it was there)

CC https://github.com/ProvableHQ/snarkOS/issues/3580