### PR TITLE
[Feature] Ensure the process exits and produces a log message on panics

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,6 @@ ignore = [
   # As the rust community considers the paste crate 'done', we can safely ignore this warning.
   # see https://users.rust-lang.org/t/paste-alternatives/126787/2
   "RUSTSEC-2024-0436",
+  # TODO find a suitable replacement for fxhash.
+  "RUSTSEC-2025-0057",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,7 +3713,6 @@ dependencies = [
 name = "snarkos"
 version = "4.2.0"
 dependencies = [
- "anyhow",
  "built",
  "clap",
  "locktick",
@@ -4134,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4159,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4187,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "blst",
  "cc",
@@ -4198,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4212,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4222,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4232,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4242,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "indexmap 2.11.0",
  "itertools 0.14.0",
@@ -4260,12 +4259,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4276,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4290,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4305,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4318,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4327,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4337,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4349,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4361,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4372,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4384,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4397,7 +4396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4408,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4421,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4432,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4452,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4470,7 +4469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4490,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4505,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4516,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4524,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4534,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4545,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4556,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4567,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4578,7 +4577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4592,7 +4591,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4609,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4636,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4648,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -4670,7 +4669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -4689,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4702,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4715,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4728,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4739,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4754,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4767,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4776,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4796,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4819,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4836,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4863,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4881,7 +4880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "metrics",
 ]
@@ -4889,7 +4888,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4912,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4945,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4970,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "indexmap 2.11.0",
  "paste",
@@ -4988,7 +4987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5001,7 +5000,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5023,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=595af97169519#595af971695196fe7587341c8e347122422acb04"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2fd9bf7b4949480ce03d1f4dfce6e2956bde268808a05ac8e667f0e1ed9907"
+checksum = "869be259eeb00852087ad36e9a68c67959c2811dc8fc6c680fcac98948c4f172"
 dependencies = [
  "aleo-std-cpu",
  "aleo-std-profiler",
@@ -55,21 +55,21 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-cpu"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b957faa45f9be4488020abcb689dfe91a4bcd9993bed454b55df5c1f4beb19"
+checksum = "9881417111e9266cf47bb2fec0e7ef32454fa2ac05763a48f25c1d50f260e1b9"
 
 [[package]]
 name = "aleo-std-profiler"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3437b42d4334bfcabdec55a5fb5f423ba21de9d7a8dec3cf7857f01a46d50afc"
+checksum = "0d53500befe6ecd23f8fc11ccf510b680516b3a6aff08d60f12e1dda00b77787"
 
 [[package]]
 name = "aleo-std-storage"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd8973bd8bc50f7b1110ca51a00b57a4f4dd61d5cfc2d7a3f5ad0f98418726a"
+checksum = "46f6571ae16ee20c1e9a95b6ba685ca7156d519400f597c5e59f53b641637225"
 dependencies = [
  "dirs",
  "tempfile",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-time"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8127eaa610f323cb882c78b625fab0d7752cee741faa3e0b9d50b5c71c6f2d8d"
+checksum = "a9ebd144c81671193ed85aa2db9bb5e183421843e0485de8fffc07e5cf50e18a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-timed"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a410927dec807eef79e31718bbc7f506356b8bdcbed210f670d91a09a629041"
+checksum = "68f6ff9e4c36858fa2c29e5284b77527b5a7466743976e1ba1f5824e16683545"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-timer"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14edf4007a98323f763701688bcbe3bc6ecf33e20c3a81b3eb8d6661ff01b217"
+checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 dependencies = [
  "colored 2.2.0",
 ]
@@ -434,9 +434,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blake2"
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -813,7 +813,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -829,7 +829,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1225,7 +1225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1242,9 +1242,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "flate2"
@@ -1461,7 +1461,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1477,7 +1477,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "libc",
  "libgit2-sys",
  "log",
@@ -1999,7 +1999,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2150,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2165,7 +2165,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -2250,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -2452,7 +2452,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2608,7 +2608,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2854,7 +2854,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -2948,7 +2948,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -3073,11 +3073,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.5.0"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3106,7 +3106,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3272,7 +3272,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3285,11 +3285,11 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3427,7 +3427,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3739,7 +3739,7 @@ dependencies = [
 name = "snarkos-account"
 version = "4.1.0"
 dependencies = [
- "colored 2.2.0",
+ "colored 3.0.0",
  "snarkvm",
 ]
 
@@ -5070,9 +5070,9 @@ dependencies = [
 
 [[package]]
 name = "sppark"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdc4f02f557e3037bbe2a379cac8be6e014a67beb7bf0996b536979392f6361"
+checksum = "c86bee44b93b7937434ba031a51ac147687df230be3318cd6f2233834ac92292"
 dependencies = [
  "cc",
  "which 4.4.2",
@@ -5248,7 +5248,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -5273,7 +5273,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5387,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5401,15 +5401,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5622,7 +5622,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5959,30 +5959,31 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -5994,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6007,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote 1.0.40",
  "wasm-bindgen-macro-support",
@@ -6017,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -6030,18 +6031,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6111,7 +6112,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6360,9 +6361,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,9 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"
@@ -3726,6 +3729,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
+ "snarkvm",
  "tikv-jemallocator",
  "toml 0.9.5",
  "tracing",
@@ -4130,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4155,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4183,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "blst",
  "cc",
@@ -4194,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4208,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4218,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4228,7 +4232,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4238,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "indexmap 2.11.0",
  "itertools 0.14.0",
@@ -4256,12 +4260,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4272,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4286,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4301,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4314,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4323,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4333,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4345,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4357,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4368,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4380,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4393,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4404,7 +4408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4417,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4428,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4448,7 +4452,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4466,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4486,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4501,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4512,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4520,7 +4524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4530,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4541,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4552,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4563,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4574,7 +4578,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4588,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4605,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4632,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4644,8 +4648,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
+ "anyhow",
  "indexmap 2.11.0",
  "rayon",
  "serde_json",
@@ -4659,12 +4664,13 @@ dependencies = [
  "snarkvm-ledger-puzzle",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -4683,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4696,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4709,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4722,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4733,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "indexmap 2.11.0",
  "rayon",
@@ -4748,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4761,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4770,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4790,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4813,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4830,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4857,9 +4863,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
+ "anyhow",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4868,12 +4875,13 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-synthesizer-process",
  "snarkvm-synthesizer-program",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "metrics",
 ]
@@ -4881,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4904,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4937,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4962,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "indexmap 2.11.0",
  "paste",
@@ -4980,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4993,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5008,13 +5016,14 @@ dependencies = [
  "smol_str",
  "snarkvm-utilities-derives",
  "thiserror 2.0.16",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c0524f46209db1dd87d840376292f95406f1df7#8c0524f46209db1dd87d840376292f95406f1df7"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Fbetter-errors#44253639420a1658eea8834334ee7820cf7c8742"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,10 @@ version = "1.0.1"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-# path = "../snarkVM"
+#path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "8c0524f46209db1dd87d840376292f95406f1df7"
+branch = "feat/better-errors"
+#rev = "8c0524f46209db1dd87d840376292f95406f1df7"
 #version = "=4.0.1"
 default-features = false
 
@@ -260,7 +261,6 @@ cuda = [
 ]
 locktick = [
   "dep:locktick",
-  "dep:tracing",
   "snarkos-node/locktick",
   "snarkos-node-bft/locktick",
   "snarkos-node-consensus/locktick",
@@ -320,12 +320,14 @@ workspace = true
 [dependencies.snarkos-node-tcp]
 workspace = true
 
+[dependencies.snarkvm]
+workspace = true
+
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.6"
 
 [dependencies.tracing]
 workspace = true
-optional = true
 
 [dev-dependencies.rusty-hook]
 version = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-branch = "feat/better-errors"
-#rev = "8c0524f46209db1dd87d840376292f95406f1df7"
+rev = "595af97169519"
 #version = "=4.0.1"
 default-features = false
 
@@ -274,9 +273,6 @@ serial = [ "snarkos-cli/serial" ]
 test_targets = [ "snarkos-cli/test_targets" ]
 test_consensus_heights = [ "snarkos-cli/test_consensus_heights" ]
 test_network = [ "snarkos-cli/test_network" ]
-
-[dependencies.anyhow]
-workspace = true
 
 [dependencies.clap]
 workspace = true

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -21,7 +21,7 @@ cuda = [ "snarkvm/cuda" ]
 test_targets = [ "snarkvm/test_targets" ]
 
 [dependencies.colored]
-version = "2"
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true

--- a/cli/src/helpers/updater.rs
+++ b/cli/src/helpers/updater.rs
@@ -79,15 +79,15 @@ impl Updater {
         }
     }
 
-    /// Display the CLI message.
-    pub fn print_cli() -> String {
+    /// Returns the message to be printed to the CLI (if any).
+    pub fn print_cli() -> Option<String> {
         if let Ok(latest_version) = Self::update_available() {
             let mut output = "🟢 A new version is available! Run".bold().green().to_string();
             output += &" `snarkos update` ".bold().white();
             output += &format!("to update to v{latest_version}.").bold().green();
-            output
+            Some(output)
         } else {
-            String::new()
+            None
         }
     }
 }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -14,13 +14,15 @@
 // limitations under the License.
 
 use snarkos_cli::{commands::CLI, helpers::Updater};
+use snarkvm::utilities::display_error;
 
 use clap::Parser;
 #[cfg(feature = "locktick")]
 use locktick::lock_snapshots;
 #[cfg(feature = "locktick")]
 use std::time::Instant;
-use std::{env, process::exit};
+use std::{backtrace::Backtrace, env, panic::catch_unwind};
+use tracing::log::logger;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use tikv_jemallocator::Jemalloc;
@@ -32,7 +34,29 @@ static GLOBAL: Jemalloc = Jemalloc;
 // Obtain information on the build.
 include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
-fn main() -> anyhow::Result<()> {
+/// Prints a message using `tracing::error` if logging is enabled, otherwise uses `eprintln`.
+macro_rules! print_error {
+    ($($arg:tt)*) => {
+        if tracing::log::log_enabled!(tracing::log::Level::Error) {
+            tracing::error!($($arg)*);
+        } else {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
+/// Stops the process with the given exit code.
+fn exit(exitcode: i32) -> ! {
+    tracing::debug!("Stopping process with exitcode {exitcode}");
+
+    // Ensure all log messages are written before the process terminates.
+    logger().flush();
+
+    // Perform the system call to exit the process.
+    std::process::exit(exitcode);
+}
+
+fn main() {
     // A hack to avoid having to go through clap to display advanced version information.
     check_for_version();
 
@@ -68,27 +92,74 @@ fn main() -> anyhow::Result<()> {
         }
     });
 
-    // Parse the given arguments.
-    let cli = CLI::parse();
-    if !cli.noupdater {
-        // Run the updater.
-        println!("{}", Updater::print_cli());
-    }
+    // Set a custom hook here to show "pretty" errors when panicking.
+    std::panic::set_hook(Box::new(|err| {
+        print_error!("⚠️ {}\n", err.to_string().replace("panicked at", "snarkOS encountered an unexpected error at"));
+
+        // Always show backtraces.
+        let backtrace = Backtrace::force_capture().to_string();
+
+        let mut msg = "Backtrace:\n".to_string();
+        msg.push_str("      [...]\n");
+
+        // Remove all the low level frames.
+        // This can be done more cleanly once the `backtrace_frames` feature is stabilized.
+        let lines = backtrace.lines().skip_while(|line| !line.contains("core::panicking"));
+
+        for line in lines {
+            // Stop printing once we hit the panic handler.
+            if line.contains("snarkos::main") {
+                break;
+            }
+
+            msg.push_str(&format!("{line}\n"));
+        }
+
+        // Print the entire backtrace as a single log message.
+        print_error!("{msg}");
+    }));
 
     // Run the CLI.
-    match cli.command.parse() {
-        Ok(output) => println!("{output}\n"),
-        Err(error) => {
-            // Print the top level error and then any additional context.
-            println!("⚠️  {error}");
-            for entry in error.chain().skip(1) {
-                println!("     ↳ {entry}");
-            }
-            println!();
+    // We use `catch_unwind` here to ensure a panic stops execution and not just a single thread.
+    // Note: `catch_unwind` can be nested without problems.
+    let result = catch_unwind(|| {
+        // Parse the given arguments.
+        let cli = CLI::parse();
+
+        // Run the updater.
+        if !cli.noupdater
+            && let Some(msg) = Updater::print_cli()
+        {
+            println!("{msg}");
+        }
+
+        // Run the CLI.
+        cli.command.parse()
+    });
+
+    // Process any errors (including panics).
+    match result {
+        Ok(Ok(output)) => {
+            println!("{output}\n");
+            exit(0);
+        }
+        Ok(Err(err)) => {
+            // A regular error occurred.
+            display_error(&err);
+            eprintln!();
+            eprintln!("Use `--help` for instructions on how to use this command");
+
+            exit(1);
+        }
+        Err(_) => {
+            print_error!(
+                "This is most likely a bug!\n\
+                Please report it to the snarkOS developers: https://github.com/ProvableHQ/snarkOS/issues/new?template=bug.md"
+            );
+
             exit(1);
         }
     }
-    Ok(())
 }
 
 /// Checks whether the version information was requested and - if so - display it and exit.


### PR DESCRIPTION
Companion PR for [snarkVM #2813](https://github.com/ProvableHQ/snarkVM/pull/2813)

Nodes will now shut down when a panic occurs and log something like the following:
```
2025-09-05T01:46:29.904002Z ERROR snarkos: ⚠️ snarkOS encountered an unexpected error at /Users/kaimast/dev/snarkOS2/node/src/client/mod.rs:170:9:
<Panic Message>

2025-09-05T01:46:29.911964Z ERROR snarkos: Backtrace:
      [...]
   6: core::panicking::panic_fmt
   7: snarkos_cli::commands::start::Start::parse_node::{{closure}}
   8: snarkos_cli::commands::start::Start::parse::{{closure}}
   9: tokio::runtime::park::CachedParkThread::block_on
  10: tokio::runtime::context::runtime::enter_runtime
  11: tokio::runtime::runtime::Runtime::block_on
  12: snarkos_cli::commands::start::Start::parse
  13: snarkos_cli::commands::Command::parse
  14: std::panic::catch_unwind

2025-09-05T01:46:29.914254Z ERROR snarkos: This is most likely a bug!
Please report it to the snarkOS developers: https://github.com/ProvableHQ/snarkOS/issues/new?template=bug.md
2025-09-05T01:46:29.914275Z DEBUG snarkos: Stopping process with exitcode 1
```

This PR also updates the snarkVM rev and make sure snarkOS compiles with the latest changes.
