### PR TITLE
Ensure txs are broadcast either if not in sync, or when processed

### DIFF
--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -629,9 +629,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             }
             Err(other_rejection) => return Err(other_rejection.into()),
         };
-
-        // Determine transaction type.
-        let is_exec = tx.is_execute();
+        let tx_id = tx.id();
 
         // If the transaction exceeds the transaction size limit, return an error.
         // The buffer is initially roughly sized to hold a `transfer_public`,
@@ -643,17 +641,16 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
 
         // Prepare the unconfirmed transaction message.
-        let tx_id = tx.id();
         let message = Message::UnconfirmedTransaction(UnconfirmedTransaction {
             transaction_id: tx_id,
             transaction: Data::Object(tx.clone()),
         });
 
-        // Broadcast the transaction.
-        rest.routing.propagate(message, &[]);
-
         // Do not process the transaction if the node is too far behind.
         if !rest.routing.is_within_sync_leniency() {
+            // Broadcast the transaction to allow other nodes to process it.
+            rest.routing.propagate(message, &[]);
+
             return Err(RestError::service_unavailable(anyhow!(
                 "Broadcasted transaction '{}', but will not process it (node is syncing)",
                 fmt_id(tx_id)
@@ -662,7 +659,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
         if check_transaction.check_transaction.unwrap_or(false) {
             // Select counter and limit based on transaction type.
-            let (counter, limit, err_msg) = if is_exec {
+            let (counter, limit, err_msg) = if tx.is_execute() {
                 (
                     &rest.num_verifying_executions,
                     VM::<N, C>::MAX_PARALLEL_EXECUTE_VERIFICATIONS,
@@ -706,6 +703,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // Add the unconfirmed transaction to the memory pool.
             consensus.add_unconfirmed_transaction(tx.clone()).await?;
         }
+
+        // Broadcast the transaction after it has been processed.
+        rest.routing.propagate(message, &[]);
 
         Ok(ErasedJson::pretty(tx_id))
     }


### PR DESCRIPTION
## Motivation

Previous behaviour before https://github.com/ProvableHQ/snarkOS/pull/3825 meant transactions were not broadcast when not synced, a very common occurance and bad UX.

This PR ensures txs are broadcast either if not in sync, or when processed.

Open question: should being out of sync return a 503 `service_unavailable` or a 202 `accepted`?

## Test Plan

non-trivial broadcast success rates in automated stress tests should suffice.
