### PR TITLE
[Fix] CLI endpoint response handling

### DIFF
--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -205,7 +205,7 @@ impl Developer {
     fn handle_ureq_result(result: Result<http::Response<ureq::Body>>) -> Result<Option<ureq::Body>> {
         let response = result?;
 
-        if response.status() == http::StatusCode::OK {
+        if response.status().is_success() {
             Ok(Some(response.into_body()))
         } else if response.status() == http::StatusCode::NOT_FOUND {
             Ok(None)


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR expands the handling of successful query responses to be any response code within 200 and 300. The current implementation was fixed to 200s specifically. 
