### PR TITLE
[Fix] Don't panic if peer upgrade fails

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,4 +3,6 @@ ignore = [
   # As the rust community considers the paste crate 'done', we can safely ignore this warning.
   # see https://users.rust-lang.org/t/paste-alternatives/126787/2
   "RUSTSEC-2024-0436",
+  # TODO find a suitable replacement for fxhash.
+  "RUSTSEC-2025-0057",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2899,7 +2899,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2936,7 +2936,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4123,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4148,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4176,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "blst",
  "cc",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4201,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "indexmap 2.11.1",
  "itertools 0.14.0",
@@ -4249,12 +4249,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4326,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4373,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4441,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4513,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4534,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "anyhow",
  "indexmap 2.11.1",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4689,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4726,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4763,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4823,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "metrics",
 ]
@@ -4874,7 +4874,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4955,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "indexmap 2.11.1",
  "paste",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,7 +1783,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2899,7 +2899,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2936,7 +2936,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4123,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4148,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4176,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "blst",
  "cc",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4201,7 +4201,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "indexmap 2.11.1",
  "itertools 0.14.0",
@@ -4249,12 +4249,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4326,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4373,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4441,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4494,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4513,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4534,7 +4534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4545,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "anyhow",
  "indexmap 2.11.1",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4689,7 +4689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4702,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4726,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "indexmap 2.11.1",
  "rayon",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4763,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4823,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "snarkvm-algorithms",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "metrics",
 ]
@@ -4874,7 +4874,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4955,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "indexmap 2.11.1",
  "paste",
@@ -4973,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.1.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=94110b5302cab7d0b4f145d739892b2ba08aa567#94110b5302cab7d0b4f145d739892b2ba08aa567"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=47d313f15#47d313f1511e9cce424b943034fe146734f8a91f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2fd9bf7b4949480ce03d1f4dfce6e2956bde268808a05ac8e667f0e1ed9907"
+checksum = "869be259eeb00852087ad36e9a68c67959c2811dc8fc6c680fcac98948c4f172"
 dependencies = [
  "aleo-std-cpu",
  "aleo-std-profiler",
@@ -55,21 +55,21 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-cpu"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b957faa45f9be4488020abcb689dfe91a4bcd9993bed454b55df5c1f4beb19"
+checksum = "9881417111e9266cf47bb2fec0e7ef32454fa2ac05763a48f25c1d50f260e1b9"
 
 [[package]]
 name = "aleo-std-profiler"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3437b42d4334bfcabdec55a5fb5f423ba21de9d7a8dec3cf7857f01a46d50afc"
+checksum = "0d53500befe6ecd23f8fc11ccf510b680516b3a6aff08d60f12e1dda00b77787"
 
 [[package]]
 name = "aleo-std-storage"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd8973bd8bc50f7b1110ca51a00b57a4f4dd61d5cfc2d7a3f5ad0f98418726a"
+checksum = "46f6571ae16ee20c1e9a95b6ba685ca7156d519400f597c5e59f53b641637225"
 dependencies = [
  "dirs",
  "tempfile",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-time"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8127eaa610f323cb882c78b625fab0d7752cee741faa3e0b9d50b5c71c6f2d8d"
+checksum = "a9ebd144c81671193ed85aa2db9bb5e183421843e0485de8fffc07e5cf50e18a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-timed"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a410927dec807eef79e31718bbc7f506356b8bdcbed210f670d91a09a629041"
+checksum = "68f6ff9e4c36858fa2c29e5284b77527b5a7466743976e1ba1f5824e16683545"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-timer"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14edf4007a98323f763701688bcbe3bc6ecf33e20c3a81b3eb8d6661ff01b217"
+checksum = "12aca1021aef2c476bad30d2f681e891b2be4f07dbc230a96df09cb693bfb3cb"
 dependencies = [
  "colored 2.2.0",
 ]
@@ -111,12 +111,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -431,9 +425,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blake2"
@@ -539,10 +533,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -571,15 +566,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -604,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -614,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -626,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -735,7 +729,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "log",
  "serde",
  "serde_derive",
@@ -809,7 +803,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -825,13 +819,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -989,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1158,18 +1152,18 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -1216,12 +1210,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1235,6 +1229,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "flate2"
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width 0.2.0",
 ]
@@ -1451,7 +1451,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1467,7 +1467,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "libc",
  "libgit2-sys",
  "log",
@@ -1515,7 +1515,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1941,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1989,7 +1989,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2155,7 +2155,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -2200,9 +2200,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2240,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -2255,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
 dependencies = [
  "hashbrown 0.15.5",
 ]
@@ -2280,11 +2280,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2318,7 +2318,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2442,7 +2442,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2478,12 +2478,11 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2599,7 +2598,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2636,12 +2635,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -2776,9 +2769,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -2851,13 +2844,13 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.6",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2895,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2906,7 +2899,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2915,9 +2908,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -2936,16 +2929,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3053,7 +3046,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -3070,11 +3063,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.5.0"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3103,7 +3096,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3145,17 +3138,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3166,14 +3150,8 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3284,7 +3262,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3293,15 +3271,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3396,11 +3374,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3439,7 +3417,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3448,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3520,7 +3498,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3568,7 +3546,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -3741,6 +3719,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
+ "snarkvm",
  "tikv-jemallocator",
  "toml 0.9.5",
  "tracing",
@@ -3766,7 +3745,7 @@ dependencies = [
  "clap",
  "colored 3.0.0",
  "crossterm 0.29.0",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
  "nix",
  "num_cpus",
@@ -3818,9 +3797,9 @@ dependencies = [
  "deadline",
  "futures-util",
  "http 1.3.1",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -3860,10 +3839,10 @@ dependencies = [
  "colored 3.0.0",
  "deadline",
  "futures",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.12.1",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "mockall",
  "open",
  "parking_lot",
@@ -3901,7 +3880,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "proptest",
  "serde",
  "snarkos-node-sync-locators",
@@ -3918,7 +3897,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -3935,9 +3914,9 @@ version = "4.1.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "parking_lot",
  "snarkvm",
  "tracing",
@@ -3971,10 +3950,10 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "once_cell",
  "parking_lot",
  "snarkos-account",
@@ -4011,7 +3990,7 @@ dependencies = [
  "base64 0.22.1",
  "built",
  "http 1.3.1",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "jsonwebtoken",
  "locktick",
  "once_cell",
@@ -4088,7 +4067,7 @@ version = "4.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
@@ -4119,7 +4098,7 @@ name = "snarkos-node-sync-locators"
 version = "4.1.0"
 dependencies = [
  "anyhow",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "snarkvm",
  "tracing",
@@ -4179,7 +4158,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -4255,7 +4234,7 @@ name = "snarkvm-circuit-environment"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -4447,7 +4426,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "lazy_static",
  "paste",
  "serde",
@@ -4486,7 +4465,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "num-derive",
  "num-traits",
  "serde_json",
@@ -4624,9 +4603,9 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -4661,7 +4640,7 @@ name = "snarkvm-ledger-block"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4682,7 +4661,7 @@ version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
  "anyhow",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4713,7 +4692,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4726,7 +4705,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4750,7 +4729,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -4790,9 +4769,9 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4810,9 +4789,9 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4850,7 +4829,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
  "parking_lot",
  "rayon",
@@ -4923,10 +4902,10 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "locktick",
- "lru 0.16.0",
+ "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -4956,7 +4935,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -4979,7 +4958,7 @@ name = "snarkvm-synthesizer-program"
 version = "4.1.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e035becf3#e035becf33e99f43a6f373595e106204c587fad8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5077,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "sppark"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdc4f02f557e3037bbe2a379cac8be6e014a67beb7bf0996b536979392f6361"
+checksum = "d9c900139f3f6fdc8db217881a946adf00e935102fdd82b0e1bc19bacbffa311"
 dependencies = [
  "cc",
  "which 4.4.2",
@@ -5255,7 +5234,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -5272,15 +5251,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5394,12 +5373,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -5409,15 +5387,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5560,7 +5538,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5630,7 +5608,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.9.4",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5726,14 +5704,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -5846,9 +5824,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00432f493971db5d8e47a65aeb3b02f8226b9b11f1450ff86bb772776ebadd70"
+checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -5867,9 +5845,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b6cabebbecc4c45189ab06b52f956206cea7d8c8a20851c35a85cb169224cc"
+checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
 dependencies = [
  "base64 0.22.1",
  "http 1.3.1",
@@ -5967,30 +5945,31 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -6002,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6015,9 +5994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote 1.0.40",
  "wasm-bindgen-macro-support",
@@ -6025,9 +6004,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -6038,18 +6017,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6093,7 +6072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "winsafe",
 ]
 
@@ -6115,11 +6094,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6136,7 +6115,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6170,12 +6149,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6186,7 +6171,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6195,7 +6180,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6226,6 +6211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6247,7 +6241,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -6367,13 +6361,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.3",
-]
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -6407,18 +6398,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",
@@ -6510,7 +6501,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "memchr",
  "thiserror 2.0.16",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,7 +3719,6 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkos-node-tcp",
- "snarkvm",
  "tikv-jemallocator",
  "toml 0.9.5",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,6 @@ cuda = [
 ]
 locktick = [
   "dep:locktick",
-  "dep:tracing",
   "snarkos-node/locktick",
   "snarkos-node-bft/locktick",
   "snarkos-node-consensus/locktick",
@@ -319,12 +318,14 @@ workspace = true
 [dependencies.snarkos-node-tcp]
 workspace = true
 
+[dependencies.snarkvm]
+workspace = true
+
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 [dependencies.tracing]
 workspace = true
-optional = true
 
 [dev-dependencies.rusty-hook]
 version = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,9 +318,6 @@ workspace = true
 [dependencies.snarkos-node-tcp]
 workspace = true
 
-[dependencies.snarkvm]
-workspace = true
-
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 tikv-jemallocator = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "94110b5302cab7d0b4f145d739892b2ba08aa567"
+rev = "47d313f15"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "e035becf3"
+rev = "94110b5302cab7d0b4f145d739892b2ba08aa567"
 #version = "=4.0.1"
 default-features = false
 #features = [ "circuit", "console", "rocks" ]

--- a/cli/src/helpers/updater.rs
+++ b/cli/src/helpers/updater.rs
@@ -79,15 +79,15 @@ impl Updater {
         }
     }
 
-    /// Display the CLI message.
-    pub fn print_cli() -> String {
+    /// Returns the message to be printed to the CLI (if any).
+    pub fn print_cli() -> Option<String> {
         if let Ok(latest_version) = Self::update_available() {
             let mut output = "🟢 A new version is available! Run".bold().green().to_string();
             output += &" `snarkos update` ".bold().white();
             output += &format!("to update to v{latest_version}.").bold().green();
-            output
+            Some(output)
         } else {
-            String::new()
+            None
         }
     }
 }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -16,6 +16,7 @@
 use crate::{
     MAX_LEADER_CERTIFICATE_DELAY_IN_SECS,
     Primary,
+    errors::log_warning,
     helpers::{
         BFTReceiver,
         ConsensusSender,
@@ -269,8 +270,10 @@ impl<N: Network> BFT<N> {
         // If the BFT is ready, then update to the next round.
         if is_ready {
             // Update to the next round in storage.
-            if let Err(e) = self.storage().increment_to_next_round(current_round) {
-                warn!("BFT failed to increment to the next round from round {current_round} - {e}");
+            if let Err(err) = self.storage().increment_to_next_round(current_round) {
+                log_warning(
+                    err.context(format!("BFT failed to increment to the next round from round {current_round}")),
+                );
                 return false;
             }
             // Update the timer for the leader certificate.

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -20,6 +20,7 @@ use crate::{
     MAX_BATCH_DELAY_IN_MS,
     MEMORY_POOL_PORT,
     Worker,
+    errors::log_warning,
     events::{EventCodec, PrimaryPing},
     helpers::{Cache, PrimarySender, Resolver, Storage, SyncSender, WorkerSender, assign_to_worker},
     spawn_blocking,
@@ -583,7 +584,7 @@ impl<N: Network> Gateway<N> {
         let result = self.unicast(peer_addr, event);
         // If the event was unable to be sent, disconnect.
         if let Err(e) = &result {
-            warn!("{CONTEXT} Failed to send '{name}' to '{peer_ip}': {e}");
+            warn!("{CONTEXT} Failed to send '{name}' to '{peer_ip}' - {e}");
             debug!("{CONTEXT} Disconnecting from '{peer_ip}' (unable to send)");
             self.disconnect(peer_ip);
         }
@@ -719,8 +720,8 @@ impl<N: Network> Gateway<N> {
                     // Ensure the block response is well-formed.
                     blocks.ensure_response_is_well_formed(peer_ip, request.start_height, request.end_height)?;
                     // Send the blocks to the sync module.
-                    if let Err(e) = sync_sender.advance_with_sync_blocks(peer_ip, blocks.0).await {
-                        warn!("Unable to process block response from '{peer_ip}' - {e}");
+                    if let Err(err) = sync_sender.advance_with_sync_blocks(peer_ip, blocks.0).await {
+                        log_warning(err.context(format!("Unable to process block response from '{peer_ip}'")));
                     }
                 }
                 Ok(())
@@ -1086,7 +1087,7 @@ impl<N: Network> Gateway<N> {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
             if let Some(peer_ip) = self.resolver.get_listener(peer_addr) {
-                warn!("{CONTEXT} Disconnecting from '{peer_ip}' - {error}");
+                log_warning(error.context(format!("{CONTEXT} Disconnecting from '{peer_ip}'")));
                 let self_ = self.clone();
                 tokio::spawn(async move {
                     Transport::send(&self_, peer_ip, DisconnectReason::ProtocolViolation.into()).await;

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -97,3 +97,41 @@ macro_rules! spawn_blocking {
         $crate::execute_blocking(move || $expr).await
     };
 }
+
+pub mod errors {
+    use colored::Colorize;
+
+    /// Prints an anyhow::Error
+    /// Helper function for `log_error` and `log_warning`.
+    /// TODO(kaimast): replace with similar logic in snarkvm
+    #[inline]
+    fn flatten_anyhow_error<E: std::borrow::Borrow<anyhow::Error>>(error: E) -> String {
+        let error = error.borrow();
+        let chain = error.chain().skip(1).map(|next| next.to_string()).collect::<Vec<String>>().join(" — ");
+        format!("{error} — {}", chain.dimmed())
+    }
+
+    /// Logs `anyhow::Error`'s its error chain using the `ERROR` log level.
+    ///
+    /// This follows the existing convention in the codebase that joins errors using em dashes.
+    /// For example, an error "Invalid transaction" with a cause "Proof failed"would be logged
+    /// as "Invalid transaction — Proof failed".
+    /// TODO(kaimast): replace with similar logic in snarkvm
+    pub fn log_error<E: std::borrow::Borrow<anyhow::Error>>(error: E) {
+        tracing::error!("{}", flatten_anyhow_error(error));
+    }
+
+    /// Logs `anyhow::Error`'s its error chain using the `WARN` log level.
+    ///
+    /// This follows the existing convention in the codebase that joins errors using em dashes.
+    /// For example, an error "Invalid transaction" with a cause "Proof failed"would be logged
+    /// as "Invalid transaction — Proof failed".
+    pub fn log_warning<E: std::borrow::Borrow<anyhow::Error>>(error: E) {
+        tracing::warn!("{}", flatten_anyhow_error(error));
+    }
+
+    /// Logs `anyhow::Error`'s its error chain using the `DEBUG` log level.
+    pub fn log_debug<E: std::borrow::Borrow<anyhow::Error>>(error: E) {
+        tracing::debug!("{}", flatten_anyhow_error(error));
+    }
+}

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -70,13 +70,30 @@ pub const PRIMARY_PING_IN_MS: u64 = 2 * MAX_BATCH_DELAY_IN_MS; // ms
 /// The interval at which each worker broadcasts a ping to every other node.
 pub const WORKER_PING_IN_MS: u64 = 4 * MAX_BATCH_DELAY_IN_MS; // ms
 
+/// Wrapper around `tokio::spawn_blocking` that awaits the future and propagates panics.
+pub async fn execute_blocking<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(inner) => inner,
+        Err(err) => {
+            if err.is_panic() {
+                // Resume the panic on the main task
+                std::panic::resume_unwind(err.into_panic());
+            } else {
+                panic!("Got unexpected tokio error: {err}");
+            }
+        }
+    }
+}
+
 /// A helper macro to spawn a blocking task.
+/// It is cleaner to use `execute_blocking` directly.
 #[macro_export]
 macro_rules! spawn_blocking {
     ($expr:expr) => {
-        match tokio::task::spawn_blocking(move || $expr).await {
-            Ok(value) => value,
-            Err(error) => Err(anyhow::anyhow!("[tokio::spawn_blocking] {error}")),
-        }
+        $crate::execute_blocking(move || $expr).await
     };
 }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -24,6 +24,7 @@ use crate::{
     WORKER_PING_IN_MS,
     Worker,
     events::{BatchPropose, BatchSignature, Event},
+    execute_blocking,
     helpers::{
         BFTSender,
         PrimaryReceiver,
@@ -571,14 +572,13 @@ impl<N: Network> Primary<N> {
                         }
 
                         // Deserialize the transaction. If the transaction exceeds the maximum size, then return an error.
-                        let transaction = spawn_blocking!({
-                            match transaction {
-                                Data::Object(transaction) => Ok(transaction),
-                                Data::Buffer(bytes) => {
-                                    Ok(Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64))?)
-                                }
+                        let transaction = execute_blocking(|| match transaction {
+                            Data::Object(transaction) => Ok(transaction),
+                            Data::Buffer(bytes) => {
+                                Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64))
                             }
-                        })?;
+                        })
+                        .await?;
 
                         // TODO (raychu86): Record Commitment - Remove this logic after the next migration height is reached.
                         // ConsensusVersion V8 Migration logic -
@@ -874,14 +874,13 @@ impl<N: Network> Primary<N> {
                     (transmission_id, transmission)
                 {
                     // Deserialize the transaction. If the transaction exceeds the maximum size, then return an error.
-                    let transaction = spawn_blocking!({
-                        match transaction {
-                            Data::Object(transaction) => Ok(transaction),
-                            Data::Buffer(bytes) => {
-                                Ok(Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64))?)
-                            }
+                    let transaction = execute_blocking(|| match transaction {
+                        Data::Object(transaction) => Ok(transaction),
+                        Data::Buffer(bytes) => {
+                            Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64))
                         }
-                    })?;
+                    })
+                    .await?;
 
                     // TODO (raychu86): Record Commitment - Remove this logic after the next migration height is reached.
                     // ConsensusVersion V8 Migration logic -

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -23,6 +23,7 @@ use crate::{
     Transport,
     WORKER_PING_IN_MS,
     Worker,
+    errors::{log_debug, log_error, log_warning},
     events::{BatchPropose, BatchSignature, Event},
     execute_blocking,
     helpers::{
@@ -60,6 +61,7 @@ use snarkvm::{
 };
 
 use aleo_std::StorageMode;
+use anyhow::Context;
 use colored::Colorize;
 use futures::stream::{FuturesUnordered, StreamExt};
 use indexmap::{IndexMap, IndexSet};
@@ -133,7 +135,8 @@ impl<N: Network> Primary<N> {
         dev: Option<u16>,
     ) -> Result<Self> {
         // Initialize the gateway.
-        let gateway = Gateway::new(account, storage.clone(), ledger.clone(), ip, trusted_validators, dev)?;
+        let gateway = Gateway::new(account, storage.clone(), ledger.clone(), ip, trusted_validators, dev)
+            .with_context(|| "Failed to initialize gateway")?;
         // Initialize the sync module.
         let sync = Sync::new(gateway.clone(), storage.clone(), ledger.clone(), block_sync);
 
@@ -180,7 +183,10 @@ impl<N: Network> Primary<N> {
                         // skip the certificate.
                         if let Err(err) = self.sync_with_certificate_from_peer::<true>(DUMMY_SELF_IP, certificate).await
                         {
-                            warn!("Failed to load stored certificate {} from proposal cache - {err}", fmt_id(batch_id));
+                            log_warning(err.context(format!(
+                                "Failed to load stored certificate {} from proposal cache",
+                                fmt_id(batch_id)
+                            )));
                         }
                     }
                     Ok(())
@@ -225,7 +231,8 @@ impl<N: Network> Primary<N> {
                 self.storage.clone(),
                 self.ledger.clone(),
                 self.proposed_batch.clone(),
-            )?;
+            )
+            .with_context(|| "Failed to initialize worker")?;
             // Run the worker instance.
             worker.run(rx_worker);
             // Add the worker to the list of workers.
@@ -239,7 +246,7 @@ impl<N: Network> Primary<N> {
         // First, initialize the sync channels.
         let (sync_sender, sync_receiver) = init_sync_channels();
         // Next, initialize the sync module and sync the storage from ledger.
-        self.sync.initialize(bft_sender).await?;
+        self.sync.initialize(bft_sender).await.with_context(|| "Failed to initialize sync")?;
         // Next, load and process the proposal cache before running the sync module.
         self.load_proposal_cache().await?;
         // Next, run the sync module.
@@ -358,8 +365,8 @@ impl<N: Network> Primary<N> {
         let mut lock_guard = self.propose_lock.lock().await;
 
         // Check if the proposed batch has expired, and clear it if it has expired.
-        if let Err(e) = self.check_proposed_batch_for_expiration().await {
-            warn!("Failed to check the proposed batch for expiration - {e}");
+        if let Err(err) = self.check_proposed_batch_for_expiration().await {
+            log_warning(err.context("Failed to check the proposed batch for expiration"));
             return Ok(());
         }
 
@@ -425,8 +432,8 @@ impl<N: Network> Primary<N> {
         metrics::gauge(metrics::bft::PROPOSAL_ROUND, round as f64);
 
         // Ensure that the primary does not create a new proposal too quickly.
-        if let Err(e) = self.check_proposal_timestamp(previous_round, self.gateway.account().address(), now()) {
-            debug!("Primary is safely skipping a batch proposal for round {round} - {}", format!("{e}").dimmed());
+        if let Err(err) = self.check_proposal_timestamp(previous_round, self.gateway.account().address(), now()) {
+            log_debug(err.context(format!("Primary is safely skipping a batch proposal for round {round}")));
             return Ok(());
         }
 
@@ -461,7 +468,10 @@ impl<N: Network> Primary<N> {
         }
 
         // Retrieve the committee to check against.
-        let committee_lookback = self.ledger.get_committee_lookback_for_round(round)?;
+        let committee_lookback = self
+            .ledger
+            .get_committee_lookback_for_round(round)
+            .with_context(|| format!("Failed to get committee lookback for round {round}"))?;
         // Check if the primary is connected to enough validators to reach quorum threshold.
         {
             // Retrieve the connected validator addresses.
@@ -578,7 +588,8 @@ impl<N: Network> Primary<N> {
                                 Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64))
                             }
                         })
-                        .await?;
+                        .await
+                        .with_context(|| "Failed to deserialize transaction")?;
 
                         // TODO (raychu86): Record Commitment - Remove this logic after the next migration height is reached.
                         // ConsensusVersion V8 Migration logic -
@@ -692,8 +703,8 @@ impl<N: Network> Primary<N> {
         })
         .inspect_err(|_| {
             // On error, reinsert the transmissions and then propagate the error.
-            if let Err(e) = self.reinsert_transmissions_into_workers(transmissions) {
-                error!("Failed to reinsert transmissions: {e:?}");
+            if let Err(err) = self.reinsert_transmissions_into_workers(transmissions) {
+                log_error(err.context("Failed to reinsert transmissions"));
             }
         })?;
         // Broadcast the batch to all validators for signing.
@@ -833,16 +844,18 @@ impl<N: Network> Primary<N> {
             // If the transmission is not well-formed, then return early.
             self.ledger.ensure_transmission_is_well_formed(*transmission_id, transmission)
         }) {
-            debug!("Batch propose at round {batch_round} from '{peer_ip}' contains an invalid transmission - {err}",);
+            log_debug(err.context(format!(
+                "Batch propose at round {batch_round} from '{peer_ip}' contains an invalid transmission"
+            )));
             return Ok(());
         }
 
         // Ensure the batch is for the current round.
         // This method must be called after fetching previous certificates (above),
         // and prior to checking the batch header (below).
-        if let Err(e) = self.ensure_is_signing_round(batch_round) {
+        if let Err(err) = self.ensure_is_signing_round(batch_round) {
             // If the primary is not signing for the peer's round, then return early.
-            debug!("{e} from '{peer_ip}'");
+            log_debug(err);
             return Ok(());
         }
 
@@ -1077,7 +1090,8 @@ impl<N: Network> Primary<N> {
         // If there was an error storing the certificate, reinsert the transmissions back into the ready queue.
         if let Err(e) = self.store_and_broadcast_certificate(&proposal, &committee_lookback).await {
             // Reinsert the transmissions back into the ready queue for the next proposal.
-            self.reinsert_transmissions_into_workers(proposal.into_transmissions())?;
+            self.reinsert_transmissions_into_workers(proposal.into_transmissions())
+                .with_context(|| "Failed to reinsert transmission to into workers after store_and_broadcast failed")?;
             return Err(e);
         }
 
@@ -1280,8 +1294,8 @@ impl<N: Network> Primary<N> {
                         // Process the primary certificate.
                         let id = fmt_id(primary_certificate.id());
                         let round = primary_certificate.round();
-                        if let Err(e) = self_.process_batch_certificate_from_peer(peer_ip, primary_certificate).await {
-                            warn!("Cannot process a primary certificate '{id}' at round {round} in a 'PrimaryPing' from '{peer_ip}' - {e}");
+                        if let Err(err) = self_.process_batch_certificate_from_peer(peer_ip, primary_certificate).await {
+                            log_warning(err.context(format!("Cannot process a primary certificate '{id}' at round {round} in a 'PrimaryPing' from '{peer_ip}'")));
                         }
                     });
                 }
@@ -1371,8 +1385,8 @@ impl<N: Network> Primary<N> {
                 // In addition, spawning a task can cause concurrent processing of signatures (even with a lock),
                 // which means the RwLock for the proposed batch must become a 'tokio::sync' to be safe.
                 let id = fmt_id(batch_signature.batch_id);
-                if let Err(e) = self_.process_batch_signature_from_peer(peer_ip, batch_signature).await {
-                    warn!("Cannot store a signature for batch '{id}' from '{peer_ip}' - {e}");
+                if let Err(err) = self_.process_batch_signature_from_peer(peer_ip, batch_signature).await {
+                    log_warning(err.context(format!("Cannot store a signature for batch '{id}' from '{peer_ip}'")));
                 }
             }
         });
@@ -1397,8 +1411,12 @@ impl<N: Network> Primary<N> {
                     // Process the batch certificate.
                     let id = fmt_id(batch_certificate.id());
                     let round = batch_certificate.round();
-                    if let Err(e) = self_.process_batch_certificate_from_peer(peer_ip, batch_certificate).await {
-                        warn!("Cannot store a certificate '{id}' for round {round} from '{peer_ip}' - {e}");
+                    if let Err(err) = self_.process_batch_certificate_from_peer(peer_ip, batch_certificate).await {
+                        log_warning(
+                            err.context(format!(
+                                "Cannot store a certificate '{id}' for round {round} from '{peer_ip}'"
+                            )),
+                        );
                     }
                 });
             }
@@ -1440,8 +1458,8 @@ impl<N: Network> Primary<N> {
                 // Attempt to increment to the next round if the quorum threshold is reached.
                 if is_quorum_threshold_reached {
                     debug!("Quorum threshold reached for round {}", current_round);
-                    if let Err(e) = self_.try_increment_to_the_next_round(next_round).await {
-                        warn!("Failed to increment to the next round - {e}");
+                    if let Err(err) = self_.try_increment_to_the_next_round(next_round).await {
+                        log_warning(err.context("Failed to increment to the next round"));
                     }
                 }
             }
@@ -1635,9 +1653,10 @@ impl<N: Network> Primary<N> {
         // If a BFT sender was provided, send the certificate to the BFT.
         if let Some(bft_sender) = self.bft_sender.get() {
             // Await the callback to continue.
-            if let Err(e) = bft_sender.send_primary_certificate_to_bft(certificate.clone()).await {
-                warn!("Failed to update the BFT DAG from primary - {e}");
-                return Err(e);
+            if let Err(err) = bft_sender.send_primary_certificate_to_bft(certificate.clone()).await {
+                let err = err.context("Failed to update the BFT DAG from primary");
+                log_warning(&err);
+                return Err(err);
             };
         }
         // Broadcast the certified batch to all validators.
@@ -1722,9 +1741,10 @@ impl<N: Network> Primary<N> {
             // If a BFT sender was provided, send the round and certificate to the BFT.
             if let Some(bft_sender) = self.bft_sender.get() {
                 // Send the certificate to the BFT.
-                if let Err(e) = bft_sender.send_primary_certificate_to_bft(certificate).await {
-                    warn!("Failed to update the BFT DAG from sync: {e}");
-                    return Err(e);
+                if let Err(err) = bft_sender.send_primary_certificate_to_bft(certificate).await {
+                    let err = err.context("Failed to update the BFT DAG from sync");
+                    log_warning(&err);
+                    return Err(err);
                 };
             }
         }
@@ -1841,7 +1861,7 @@ impl<N: Network> Primary<N> {
         // Wait for all of the transmissions to be fetched.
         while let Some(result) = fetch_transmissions.next().await {
             // Retrieve the transmission.
-            let (transmission_id, transmission) = result?;
+            let (transmission_id, transmission) = result.with_context(|| "Failed to fetch missing transmission")?;
             // Insert the transmission into the set.
             transmissions.insert(transmission_id, transmission);
         }
@@ -1863,8 +1883,10 @@ impl<N: Network> Primary<N> {
         }
 
         // Fetch the missing previous certificates.
-        let missing_previous_certificates =
-            self.fetch_missing_certificates(peer_ip, round, batch_header.previous_certificate_ids()).await?;
+        let missing_previous_certificates = self
+            .fetch_missing_certificates(peer_ip, round, batch_header.previous_certificate_ids())
+            .await
+            .with_context(|| "Failed to fetch missing certificates")?;
         if !missing_previous_certificates.is_empty() {
             debug!(
                 "Fetched {} missing previous certificates for round {round} from '{peer_ip}'",
@@ -1920,7 +1942,7 @@ impl<N: Network> Primary<N> {
         // Wait for all of the missing certificates to be fetched.
         while let Some(result) = fetch_certificates.next().await {
             // Insert the missing certificate into the set.
-            missing_certificates.insert(result?);
+            missing_certificates.insert(result.with_context(|| "Failed to fetch missing certificate")?);
         }
         // Return the missing certificates.
         Ok(missing_certificates)
@@ -1949,7 +1971,7 @@ impl<N: Network> Primary<N> {
             ProposalCache::new(latest_round, proposal, signed_proposals, pending_certificates)
         };
         if let Err(err) = proposal_cache.store(&self.storage_mode) {
-            error!("Failed to store the current proposal cache: {err}");
+            log_error(err.context("Failed to store the current proposal cache"));
         }
         // Close the gateway.
         self.gateway.shut_down().await;

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     MAX_FETCH_TIMEOUT_IN_MS,
     PRIMARY_PING_IN_MS,
     Transport,
+    errors::log_error,
     events::DataBlocks,
     execute_blocking,
     helpers::{BFTSender, Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
@@ -31,7 +32,7 @@ use snarkvm::{
     prelude::{cfg_into_iter, cfg_iter},
 };
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
 use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
@@ -228,7 +229,7 @@ impl<N: Network> Sync<N> {
                 let res = callback.send(self_.advance_with_sync_blocks(peer_ip, blocks).await);
 
                 if let Err(err) = res {
-                    warn!("Failed to send response to callbac: {err:?}");
+                    warn!("Failed to send response to callback: {err:?}");
                 }
             }
 
@@ -259,7 +260,7 @@ impl<N: Network> Sync<N> {
                     let res = callback.send(self_clone.update_peer_locators(peer_ip, locators));
 
                     if let Err(err) = res {
-                        warn!("Failed to send response to callbac: {err:?}");
+                        warn!("Failed to send response to callback: {err:?}");
                     }
                 });
             }
@@ -450,9 +451,11 @@ impl<N: Network> Sync<N> {
         // If a BFT sender was provided, send the certificates to the BFT.
         if let Some(bft_sender) = self.bft_sender.get() {
             // Await the callback to continue.
-            if let Err(e) = bft_sender.tx_sync_bft_dag_at_bootup.send(certificates).await {
-                bail!("Failed to update the BFT DAG from sync: {e}");
-            }
+            bft_sender
+                .tx_sync_bft_dag_at_bootup
+                .send(certificates)
+                .await
+                .with_context(|| "Failed to update the BFT DAG from sync")?;
         }
 
         self.block_sync.set_sync_height(block_height);
@@ -599,7 +602,7 @@ impl<N: Network> Sync<N> {
             if within_gc {
                 info!("Finished catching up with the network. Switching back to BFT sync.");
                 if let Err(err) = self.sync_storage_with_ledger_at_bootup().await {
-                    error!("BFT sync (with bootup routine) failed - {err}");
+                    log_error(err.context("BFT sync (with bootup routine) failed"));
                 }
             }
 
@@ -687,9 +690,7 @@ impl<N: Network> Sync<N> {
                     // For validators, BFT spawns a receiver task in `BFT::start_handlers`.
                     if let Some(bft_sender) = self.bft_sender.get() {
                         // Await the callback to continue.
-                        if let Err(err) = bft_sender.send_sync_bft(certificate).await {
-                            bail!("Failed to sync certificate - {err}");
-                        };
+                        bft_sender.send_sync_bft(certificate).await.with_context(|| "Failed to sync certificate")?;
                     }
                 }
             }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -19,8 +19,8 @@ use crate::{
     PRIMARY_PING_IN_MS,
     Transport,
     events::DataBlocks,
+    execute_blocking,
     helpers::{BFTSender, Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
-    spawn_blocking,
 };
 use snarkos_node_bft_events::{CertificateRequest, CertificateResponse, Event};
 use snarkos_node_bft_ledger_service::LedgerService;
@@ -198,10 +198,10 @@ impl<N: Network> Sync<N> {
 
                 // Remove the expired pending transmission requests.
                 let self__ = self_.clone();
-                let _ = spawn_blocking!({
+                execute_blocking(move || {
                     self__.pending.clear_expired_callbacks();
-                    Ok(())
-                });
+                })
+                .await;
             }
         });
 
@@ -597,7 +597,7 @@ impl<N: Network> Sync<N> {
         let _lock = self.sync_lock.lock().await;
 
         let self_ = self.clone();
-        tokio::task::spawn_blocking(move || {
+        execute_blocking(move || {
             // Check the next block.
             self_.ledger.check_next_block(&block)?;
             // Attempt to advance to the next block.
@@ -612,7 +612,7 @@ impl<N: Network> Sync<N> {
 
             Ok(())
         })
-        .await?
+        .await
     }
 
     /// Advances the ledger by the given block and updates the storage accordingly.
@@ -770,7 +770,7 @@ impl<N: Network> Sync<N> {
                     let block_authority = block.authority().clone();
 
                     let self_ = self.clone();
-                    tokio::task::spawn_blocking(move || {
+                    execute_blocking(move || {
                         // Check the next block.
                         self_.ledger.check_next_block(&block)?;
                         // Attempt to advance to the next block.
@@ -783,7 +783,7 @@ impl<N: Network> Sync<N> {
 
                         Ok::<(), anyhow::Error>(())
                     })
-                    .await??;
+                    .await?;
                     // Remove the block height from the latest block responses.
                     latest_block_responses.remove(&block_height);
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -225,8 +225,14 @@ impl<N: Network> Sync<N> {
         let self_ = self.clone();
         self.spawn(async move {
             while let Some((peer_ip, blocks, callback)) = rx_block_sync_advance_with_sync_blocks.recv().await {
-                callback.send(self_.advance_with_sync_blocks(peer_ip, blocks).await).ok();
+                let res = callback.send(self_.advance_with_sync_blocks(peer_ip, blocks).await);
+
+                if let Err(err) = res {
+                    warn!("Failed to send response to callbac: {err:?}");
+                }
             }
+
+            debug!("Handler for block_sync_advance_with_sync_blocks stopped");
         });
 
         // Process the block sync request to remove the peer.
@@ -235,6 +241,8 @@ impl<N: Network> Sync<N> {
             while let Some(peer_ip) = rx_block_sync_remove_peer.recv().await {
                 self_.remove_peer(peer_ip);
             }
+
+            debug!("Handler for block_sync_remove_peer stopped");
         });
 
         // Process each block sync request to update peer locators.
@@ -248,9 +256,15 @@ impl<N: Network> Sync<N> {
             while let Some((peer_ip, locators, callback)) = rx_block_sync_update_peer_locators.recv().await {
                 let self_clone = self_.clone();
                 tokio::spawn(async move {
-                    callback.send(self_clone.update_peer_locators(peer_ip, locators)).ok();
+                    let res = callback.send(self_clone.update_peer_locators(peer_ip, locators));
+
+                    if let Err(err) = res {
+                        warn!("Failed to send response to callbac: {err:?}");
+                    }
                 });
             }
+
+            debug!("Handler for block_sync_remove_peer stopped");
         });
 
         // Process each certificate request.
@@ -263,6 +277,8 @@ impl<N: Network> Sync<N> {
             while let Some((peer_ip, certificate_request)) = rx_certificate_request.recv().await {
                 self_.send_certificate_response(peer_ip, certificate_request);
             }
+
+            debug!("Handler for certificate_request stopped");
         });
 
         // Process each certificate response.
@@ -275,6 +291,8 @@ impl<N: Network> Sync<N> {
             while let Some((peer_ip, certificate_response)) = rx_certificate_response.recv().await {
                 self_.finish_certificate_request(peer_ip, certificate_response);
             }
+
+            debug!("Handler for certificate_response stopped");
         });
 
         Ok(())

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -19,6 +19,7 @@ use crate::{
     ProposedBatch,
     Transport,
     events::{Event, TransmissionRequest, TransmissionResponse},
+    execute_blocking,
     helpers::{Pending, Ready, Storage, WorkerReceiver, fmt_id, max_redundant_requests},
     spawn_blocking,
 };
@@ -390,12 +391,11 @@ impl<N: Network> Worker<N> {
             bail!("Transaction '{}.{}' already exists.", fmt_id(transaction_id), fmt_id(checksum).dimmed());
         }
         // Deserialize the transaction. If the transaction exceeds the maximum size, then return an error.
-        let transaction = spawn_blocking!({
-            match transaction {
-                Data::Object(transaction) => Ok(transaction),
-                Data::Buffer(bytes) => Ok(Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64))?),
-            }
-        })?;
+        let transaction = execute_blocking(|| match transaction {
+            Data::Object(transaction) => Ok(transaction),
+            Data::Buffer(bytes) => Transaction::<N>::read_le(&mut bytes.take(N::MAX_TRANSACTION_SIZE as u64)),
+        })
+        .await?;
 
         // Check that the transaction is well-formed and unique.
         self.ledger.check_transaction_basic(transaction_id, transaction).await?;
@@ -426,9 +426,8 @@ impl<N: Network> Worker<N> {
 
                 // Remove the expired pending certificate requests.
                 let self__ = self_.clone();
-                let _ = spawn_blocking!({
+                spawn_blocking!({
                     self__.pending.clear_expired_callbacks();
-                    Ok(())
                 });
             }
         });
@@ -455,9 +454,8 @@ impl<N: Network> Worker<N> {
             while let Some((peer_ip, transmission_response)) = rx_transmission_response.recv().await {
                 // Process the transmission response.
                 let self__ = self_.clone();
-                let _ = spawn_blocking!({
+                spawn_blocking!({
                     self__.finish_transmission_request(peer_ip, transmission_response);
-                    Ok(())
                 });
             }
         });

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -33,6 +33,7 @@ use snarkvm::{
     },
 };
 
+use anyhow::Context;
 use colored::Colorize;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
@@ -496,12 +497,12 @@ impl<N: Network> Worker<N> {
             );
         }
         // Wait for the transmission to be fetched.
-        match timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver).await {
-            // If the transmission was fetched, return it.
-            Ok(result) => Ok((transmission_id, result?)),
-            // If the transmission was not fetched, return an error.
-            Err(e) => bail!("Unable to fetch transmission - (timeout) {e}"),
-        }
+        let transmission = timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver)
+            .await
+            .with_context(|| "Unable to fetch transmission from peer - (timeout)")?
+            .with_context(|| "Unable to fetch transmission from peer")?;
+
+        Ok((transmission_id, transmission))
     }
 
     /// Handles the incoming transmission response.

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -131,7 +131,9 @@ impl<N: Network> Router<N> {
         if let Some(addr) = listener_addr {
             if let Ok(ref challenge_request) = handshake_result {
                 if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                    peer.upgrade_to_connected(peer_addr, challenge_request, self.clone());
+                    if let Err(err) = peer.upgrade_to_connected(peer_addr, challenge_request, self.clone()) {
+                        warn!("Failed to upgrade peer to `connected`: {err}");
+                    }
                 }
                 #[cfg(feature = "metrics")]
                 self.update_metrics();

--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -16,6 +16,7 @@
 use crate::{NodeType, Router, messages::ChallengeRequest};
 use snarkvm::prelude::{Address, Network};
 
+use anyhow::{Result, ensure};
 use std::{net::SocketAddr, time::Instant};
 
 /// A peer of any connection status.
@@ -82,9 +83,14 @@ impl<N: Network> Peer<N> {
     }
 
     /// Promote a connecting peer to a fully connected one.
-    pub fn upgrade_to_connected(&mut self, connected_addr: SocketAddr, cr: &ChallengeRequest<N>, router: Router<N>) {
+    pub fn upgrade_to_connected(
+        &mut self,
+        connected_addr: SocketAddr,
+        cr: &ChallengeRequest<N>,
+        router: Router<N>,
+    ) -> Result<()> {
         // Logic check: this can only happen during the handshake.
-        assert!(matches!(self, Self::Connecting(_)));
+        ensure!(matches!(self, Self::Connecting(_)), "Peer is not in `connecting` state");
 
         let timestamp = Instant::now();
         let listener_addr = SocketAddr::from((connected_addr.ip(), cr.listener_port));
@@ -103,6 +109,8 @@ impl<N: Network> Peer<N> {
             last_seen: timestamp,
             router,
         });
+
+        Ok(())
     }
 
     /// Demote a peer to candidate status, marking it as disconnected.

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -20,7 +20,8 @@ use clap::Parser;
 use locktick::lock_snapshots;
 #[cfg(feature = "locktick")]
 use std::time::Instant;
-use std::{env, process::exit};
+use std::{backtrace::Backtrace, env, panic::catch_unwind};
+use tracing::log::logger;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use tikv_jemallocator::Jemalloc;
@@ -32,7 +33,35 @@ static GLOBAL: Jemalloc = Jemalloc;
 // Obtain information on the build.
 include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
-fn main() -> anyhow::Result<()> {
+/// Prints a message using `tracing::error` if logging is enabled, otherwise uses `eprintln`.
+macro_rules! print_error {
+    ($($arg:tt)*) => {
+        if tracing::log::log_enabled!(tracing::log::Level::Error) {
+            tracing::error!($($arg)*);
+        } else {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
+/// Stops the process with the given exit code.
+fn exit(exitcode: i32) -> ! {
+    tracing::debug!("Stopping process with exitcode {exitcode}");
+
+    // Ensure all log messages are written before the process terminates.
+    logger().flush();
+
+    // Perform the system call to exit the process.
+    std::process::exit(exitcode);
+}
+
+/// Prints an anyhow::Error
+pub fn display_error(error: &anyhow::Error) {
+    eprintln!("⚠️ {error}");
+    error.chain().skip(1).for_each(|cause| eprintln!("     ↳ {cause}"));
+}
+
+fn main() {
     // A hack to avoid having to go through clap to display advanced version information.
     check_for_version();
 
@@ -68,27 +97,74 @@ fn main() -> anyhow::Result<()> {
         }
     });
 
-    // Parse the given arguments.
-    let cli = CLI::parse();
-    if !cli.noupdater {
-        // Run the updater.
-        println!("{}", Updater::print_cli());
-    }
+    // Set a custom hook here to show "pretty" errors when panicking.
+    std::panic::set_hook(Box::new(|err| {
+        print_error!("⚠️ {}\n", err.to_string().replace("panicked at", "snarkOS encountered an unexpected error at"));
+
+        // Always show backtraces.
+        let backtrace = Backtrace::force_capture().to_string();
+
+        let mut msg = "Backtrace:\n".to_string();
+        msg.push_str("      [...]\n");
+
+        // Remove all the low level frames.
+        // This can be done more cleanly once the `backtrace_frames` feature is stabilized.
+        let lines = backtrace.lines().skip_while(|line| !line.contains("core::panicking"));
+
+        for line in lines {
+            // Stop printing once we hit the panic handler.
+            if line.contains("snarkos::main") {
+                break;
+            }
+
+            msg.push_str(&format!("{line}\n"));
+        }
+
+        // Print the entire backtrace as a single log message.
+        print_error!("{msg}");
+    }));
 
     // Run the CLI.
-    match cli.command.parse() {
-        Ok(output) => println!("{output}\n"),
-        Err(error) => {
-            // Print the top level error and then any additional context.
-            println!("⚠️  {error}");
-            for entry in error.chain().skip(1) {
-                println!("     ↳ {entry}");
-            }
-            println!();
+    // We use `catch_unwind` here to ensure a panic stops execution and not just a single thread.
+    // Note: `catch_unwind` can be nested without problems.
+    let result = catch_unwind(|| {
+        // Parse the given arguments.
+        let cli = CLI::parse();
+
+        // Run the updater.
+        if !cli.noupdater
+            && let Some(msg) = Updater::print_cli()
+        {
+            println!("{msg}");
+        }
+
+        // Run the CLI.
+        cli.command.parse()
+    });
+
+    // Process any errors (including panics).
+    match result {
+        Ok(Ok(output)) => {
+            println!("{output}\n");
+            exit(0);
+        }
+        Ok(Err(err)) => {
+            // A regular error occurred.
+            display_error(&err);
+            eprintln!();
+            eprintln!("Use `--help` for instructions on how to use this command");
+
+            exit(1);
+        }
+        Err(_) => {
+            print_error!(
+                "This is most likely a bug!\n\
+                Please report it to the snarkOS developers: https://github.com/ProvableHQ/snarkOS/issues/new?template=bug.md"
+            );
+
             exit(1);
         }
     }
-    Ok(())
 }
 
 /// Checks whether the version information was requested and - if so - display it and exit.


### PR DESCRIPTION
 There seem to some cases where a peer's gets downgraded to candidate, while the handshake is still in progress. In that case, a node should not panic but simply throw an error message.

(Includes changes from #3835)