### PR TITLE
Feat/add buildinfo to metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3974,7 +3974,9 @@ dependencies = [
 name = "snarkos-node-metrics"
 version = "4.2.1"
 dependencies = [
+ "built",
  "locktick",
+ "metrics",
  "metrics-exporter-prometheus",
  "parking_lot",
  "rayon",

--- a/node/metrics/Cargo.toml
+++ b/node/metrics/Cargo.toml
@@ -27,6 +27,9 @@ workspace = true
 features = [ "parking_lot" ]
 optional = true
 
+[dependencies.metrics]
+version = "0.22"
+
 [dependencies.metrics-exporter-prometheus]
 version = "0.13"
 
@@ -42,4 +45,7 @@ workspace = true
 features = [ "console", "ledger", "metrics" ]
 
 [dependencies.time]
+workspace = true
+
+[build-dependencies.built]
 workspace = true

--- a/node/metrics/build.rs
+++ b/node/metrics/build.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -42,7 +42,6 @@ use std::{
 };
 use time::OffsetDateTime;
 
-
 /// Initializes the metrics and returns a handle to the task running the metrics exporter.
 pub fn initialize_metrics(ip: Option<SocketAddr>) {
     // Build the Prometheus exporter.

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -63,6 +63,9 @@ pub fn initialize_metrics(ip: Option<SocketAddr>) {
     for name in crate::names::HISTOGRAM_NAMES {
         register_histogram(name);
     }
+
+    // Set the build information metric
+    set_build_info();
 }
 
 pub fn update_block_metrics<N: Network>(block: &Block<N>) {
@@ -153,4 +156,29 @@ pub fn add_transmission_latency_metric<N: Network>(
     for key in keys_to_remove {
         transmissions_tracker.remove(&key);
     }
+}
+
+/// Sets the build information metric with version details as labels.
+pub fn set_build_info() {
+    // Include the generated build information
+    mod built_info {
+        include!(concat!(env!("OUT_DIR"), "/built.rs"));
+    }
+    
+    let version = built_info::PKG_VERSION;
+    let git_commit = built_info::GIT_COMMIT_HASH.unwrap_or("unknown");
+    let git_branch = built_info::GIT_HEAD_REF.unwrap_or("unknown");
+    let features = built_info::FEATURES_LOWERCASE_STR.replace(' ', "");
+
+    // Set the build info metric to 1 with version information as labels
+    gauge_with_labels(
+        build::BUILD_INFO,
+        vec![
+            ("version".to_string(), version.to_string()),
+            ("git_commit".to_string(), git_commit.to_string()),
+            ("git_branch".to_string(), git_branch.to_string()),
+            ("features".to_string(), features),
+        ],
+        1.0,
+    );
 }

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod names;
+pub mod names;
 
 // Expose the names at the crate level for easy access.
 pub use names::*;
@@ -41,6 +41,7 @@ use std::{
     },
 };
 use time::OffsetDateTime;
+
 
 /// Initializes the metrics and returns a handle to the task running the metrics exporter.
 pub fn initialize_metrics(ip: Option<SocketAddr>) {
@@ -158,27 +159,22 @@ pub fn add_transmission_latency_metric<N: Network>(
     }
 }
 
+// Include the generated build information
+mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 /// Sets the build information metric with version details as labels.
+/// The resulting metric will show as:
+/// snarkos_build_info{version="4.2.1",git_commit="abc123",git_branch="main",features="cuda,metrics"} 1
 pub fn set_build_info() {
-    // Include the generated build information
-    mod built_info {
-        include!(concat!(env!("OUT_DIR"), "/built.rs"));
-    }
-    
     let version = built_info::PKG_VERSION;
     let git_commit = built_info::GIT_COMMIT_HASH.unwrap_or("unknown");
     let git_branch = built_info::GIT_HEAD_REF.unwrap_or("unknown");
     let features = built_info::FEATURES_LOWERCASE_STR.replace(' ', "");
 
-    // Set the build info metric to 1 with version information as labels
-    gauge_with_labels(
-        build::BUILD_INFO,
-        vec![
-            ("version".to_string(), version.to_string()),
-            ("git_commit".to_string(), git_commit.to_string()),
-            ("git_branch".to_string(), git_branch.to_string()),
-            ("features".to_string(), features),
-        ],
-        1.0,
-    );
+    ::metrics::gauge!(build::BUILD_INFO, "version" => version.to_string()).set(1.0);
+    ::metrics::gauge!(build::BUILD_INFO, "git_commit" => git_commit.to_string()).set(1.0);
+    ::metrics::gauge!(build::BUILD_INFO, "git_branch" => git_branch.to_string()).set(1.0);
+    ::metrics::gauge!(build::BUILD_INFO, "features" => features).set(1.0);
 }

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -15,7 +15,7 @@
 
 pub(super) const COUNTER_NAMES: [&str; 2] = [bft::LEADERS_ELECTED, consensus::STALE_UNCONFIRMED_TRANSMISSIONS];
 
-pub(super) const GAUGE_NAMES: [&str; 27] = [
+pub(super) const GAUGE_NAMES: [&str; 26] = [
     bft::CONNECTED,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
@@ -42,7 +42,6 @@ pub(super) const GAUGE_NAMES: [&str; 27] = [
     router::CANDIDATE,
     router::RESTRICTED,
     tcp::TCP_TASKS,
-    build::BUILD_INFO,
 ];
 
 pub(super) const HISTOGRAM_NAMES: [&str; 3] =

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -15,7 +15,7 @@
 
 pub(super) const COUNTER_NAMES: [&str; 2] = [bft::LEADERS_ELECTED, consensus::STALE_UNCONFIRMED_TRANSMISSIONS];
 
-pub(super) const GAUGE_NAMES: [&str; 26] = [
+pub(super) const GAUGE_NAMES: [&str; 27] = [
     bft::CONNECTED,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
@@ -42,6 +42,7 @@ pub(super) const GAUGE_NAMES: [&str; 26] = [
     router::CANDIDATE,
     router::RESTRICTED,
     tcp::TCP_TASKS,
+    build::BUILD_INFO,
 ];
 
 pub(super) const HISTOGRAM_NAMES: [&str; 3] =
@@ -93,4 +94,8 @@ pub mod router {
 
 pub mod tcp {
     pub const TCP_TASKS: &str = "snarkos_tcp_tasks_total";
+}
+
+pub mod build {
+    pub const BUILD_INFO: &str = "snarkos_build_info";
 }


### PR DESCRIPTION
# Add Build Info as Labeled Prometheus Gauge Metrics

Exposes snarkOS build information as Prometheus gauge metrics with labels, following the "info" metric best practices.

## Implementation

Creates labeled gauge metrics for:
- **Version**: `built_info::PKG_VERSION` 
- **Git Commit**: `built_info::GIT_COMMIT_HASH`
- **Git Branch**: `built_info::GIT_HEAD_REF`  
- **Features**: `built_info::FEATURES_LOWERCASE_STR`

## Metrics Output

```prometheus
# TYPE snarkos_build_info gauge
snarkos_build_info{version="4.2.1"} 1
snarkos_build_info{git_commit="f2e3c3fa3708d527d1f20ddd418c08db81a1620a"} 1  
snarkos_build_info{git_branch="feat/add_buildinfo_to_metrics"} 1
snarkos_build_info{features="default,rayon"} 1
```

## Technical Details

- Uses native `::metrics::gauge!` macro with labels
- Follows same pattern as snarkVM's `histogram_label` 
- Automatically initialized when metrics are enabled
- Static build info set once at startup

## Changes

- Added build script (`build.rs`) for compile-time build information
- Added `metrics` dependency (v0.22) for labeled gauge support
- Updated metric names in `names.rs` 
- Implemented gauge metrics with labels in `lib.rs`

## Benefits

- Track version distribution across deployments
- Correlate metrics with specific code changes
- Verify deployments via metrics scraping
