### PR TITLE
[Feat] Track peer height for cache purposes

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -336,7 +336,7 @@ impl<N: Network> Sync<N> {
 
     /// We received new peer locators during a Ping.
     fn update_peer_locators(&self, peer_ip: SocketAddr, locators: BlockLocators<N>) -> Result<()> {
-        self.block_sync.update_peer_locators(peer_ip, locators)
+        self.block_sync.update_peer_locators(peer_ip, &locators)
     }
 
     /// A peer disconnected.

--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -62,6 +62,8 @@ pub struct ConnectedPeer<N: Network> {
     pub node_type: NodeType,
     /// The message version of the peer.
     pub version: u32,
+    /// The latest block height known to be associated with the peer.
+    pub last_height_seen: Option<u32>,
     /// The timestamp of the first message received from the peer.
     pub first_seen: Instant,
     /// The timestamp of the last message received from this peer.
@@ -99,6 +101,7 @@ impl<N: Network> Peer<N> {
             node_type: cr.node_type,
             trusted: self.is_trusted(),
             version: cr.version,
+            last_height_seen: None,
             first_seen: timestamp,
             last_seen: timestamp,
             router,
@@ -131,6 +134,15 @@ impl<N: Network> Peer<N> {
             Self::Candidate(p) => &p.listener_addr,
             Self::Connecting(p) => &p.listener_addr,
             Self::Connected(p) => &p.listener_addr,
+        }
+    }
+
+    /// The listener (public) address of this peer.
+    pub fn last_height_seen(&self) -> Option<u32> {
+        match self {
+            Self::Candidate(_) => None,
+            Self::Connecting(_) => None,
+            Self::Connected(peer) => peer.last_height_seen,
         }
     }
 

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -196,7 +196,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 }
                 // If the peer is a prover, ensure there are no block locators.
                 else if message.node_type.is_prover() && message.block_locators.is_some() {
-                    bail!("Peer '{peer_ip}' is a prover or client, but block locators were provided");
+                    bail!("Peer '{peer_ip}' is a prover, but block locators were provided");
                 }
 
                 // Process the ping message.

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -36,7 +36,7 @@ use snarkvm::prelude::{
 
 use anyhow::{Result, anyhow, bail};
 use snarkos_node_tcp::is_bogon_ip;
-use std::net::SocketAddr;
+use std::{cmp, net::SocketAddr};
 use tokio::task::spawn_blocking;
 
 /// The max number of peers to send in a `PeerResponse` message.
@@ -314,21 +314,34 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
 
     /// Handles a `PeerRequest` message.
     fn peer_request(&self, peer_ip: SocketAddr) -> bool {
-        // Retrieve the connected peers.
-        let peers = self.router().connected_peers();
-        // Filter out invalid addresses.
-        let peers = match self.router().is_dev() {
-            // In development mode, relax the validity requirements to make operating devnets more flexible.
-            true => {
-                peers.into_iter().filter(|ip| *ip != peer_ip && !is_bogon_ip(ip.ip())).take(MAX_PEERS_TO_SEND).collect()
+        // Retrieve the connected peers, filtering out invalid addresses.
+        let mut peers = self.router().filter_connected_peers(|peer| {
+            let ip = peer.listener_addr;
+            match self.router().is_dev() {
+                // In development mode, relax the validity requirements to make operating devnets more flexible.
+                true => ip != peer_ip && !is_bogon_ip(ip.ip()),
+                // In production mode, ensure the peer IPs are valid.
+                false => ip != peer_ip && self.router().is_valid_peer_ip(&ip),
             }
-            // In production mode, ensure the peer IPs are valid.
-            false => peers
-                .into_iter()
-                .filter(|ip| *ip != peer_ip && self.router().is_valid_peer_ip(ip))
-                .take(MAX_PEERS_TO_SEND)
-                .collect(),
-        };
+        });
+        // Get the low-level peer stats.
+        let known_peers = self.tcp().known_peers().snapshot();
+
+        // Sort the prospect peers.
+        peers.sort_unstable_by_key(|peer| {
+            if let Some(peer_stats) = known_peers.get(&peer.listener_addr.ip()) {
+                // Prioritize greatest height, then lowest failure count.
+                (cmp::Reverse(peer.last_height_seen), peer_stats.failures())
+            } else {
+                // Unreachable; use an else-compatible dummy.
+                (cmp::Reverse(peer.last_height_seen), 0)
+            }
+        });
+
+        // Truncate and convert to socket addrs.
+        peers.truncate(MAX_PEERS_TO_SEND);
+        let peers = peers.into_iter().map(|peer| peer.listener_addr).collect();
+
         // Send a `PeerResponse` message to the peer.
         self.router().send(peer_ip, Message::PeerResponse(PeerResponse { peers }));
         true

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -61,6 +61,7 @@ use parking_lot::{Mutex, RwLock};
 #[cfg(not(any(test)))]
 use std::net::IpAddr;
 use std::{
+    cmp,
     collections::{HashMap, HashSet},
     fs,
     future::Future,
@@ -381,6 +382,21 @@ impl<N: Network> Router<N> {
         }
     }
 
+    /// Updates the connected peer - if it exists -  given the peer IP and a closure.
+    /// The returned status indicates whether the update was successful, i.e. the peer had existed.
+    pub fn update_connected_peer<F: FnMut(&mut ConnectedPeer<N>)>(
+        &self,
+        listener_addr: &SocketAddr,
+        mut update_fn: F,
+    ) -> bool {
+        if let Some(Peer::Connected(peer)) = self.peer_pool.write().get_mut(listener_addr) {
+            update_fn(peer);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Returns the list of all peers (connected, connecting, and candidate).
     pub fn get_peers(&self) -> Vec<Peer<N>> {
         self.peer_pool.read().values().cloned().collect()
@@ -553,15 +569,17 @@ impl<N: Network> Router<N> {
         // Collect all prospect peers.
         let mut peers = self.get_peers();
 
-        // Get the average values to gauge peer quality.
+        // Get the low-level peer stats.
         let known_peers = self.tcp().known_peers().snapshot();
 
-        // Prioritize peers with the lowest failure count.
+        // Sort the list of peers.
         peers.sort_unstable_by_key(|peer| {
             if let Some(peer_stats) = known_peers.get(&peer.listener_addr().ip()) {
-                peer_stats.failures()
+                // Prioritize greatest height, then lowest failure count.
+                (cmp::Reverse(peer.last_height_seen()), peer_stats.failures())
             } else {
-                0 // A dummy value - this is unreachable.
+                // Unreachable; use an else-compatible dummy.
+                (cmp::Reverse(peer.last_height_seen()), 0)
             }
         });
         peers.truncate(MAX_PEERS_TO_SEND);

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -236,10 +236,13 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         // If block locators were provided, then update the peer in the sync pool.
         if let Some(block_locators) = message.block_locators {
             // Check the block locators are valid, and update the peer in the sync pool.
-            if let Err(error) = self.sync.update_peer_locators(peer_ip, block_locators) {
+            if let Err(error) = self.sync.update_peer_locators(peer_ip, &block_locators) {
                 warn!("Peer '{peer_ip}' sent invalid block locators: {error}");
                 return false;
             }
+
+            let last_peer_height = Some(block_locators.latest_locator_height());
+            self.router().update_connected_peer(&peer_ip, |peer| peer.last_height_seen = last_peer_height);
         }
 
         // Send a `Pong` message to the peer.

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -168,7 +168,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Prover<N, C> {
         // If block locators were provided, then update the peer in the sync pool.
         if let Some(block_locators) = message.block_locators {
             // Check the block locators are valid, and update the peer in the sync pool.
-            if let Err(error) = self.sync.update_peer_locators(peer_ip, block_locators) {
+            if let Err(error) = self.sync.update_peer_locators(peer_ip, &block_locators) {
                 warn!("Peer '{peer_ip}' sent invalid block locators: {error}");
                 return false;
             }

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1446,7 +1446,7 @@ mod tests {
 
             for peer_id in 1..=num_peers {
                 // Add a peer.
-                sync.update_peer_locators(sample_peer_ip(peer_id), sample_block_locators(10)).unwrap();
+                sync.update_peer_locators(sample_peer_ip(peer_id), &sample_block_locators(10)).unwrap();
                 // Add the peer to the set of peers.
                 peers.insert(sample_peer_ip(peer_id));
             }
@@ -1471,15 +1471,15 @@ mod tests {
 
         // Add a peer (fork).
         let peer_1 = sample_peer_ip(1);
-        sync.update_peer_locators(peer_1, sample_block_locators_with_fork(20, 11)).unwrap();
+        sync.update_peer_locators(peer_1, &sample_block_locators_with_fork(20, 11)).unwrap();
 
         // Add a peer.
         let peer_2 = sample_peer_ip(2);
-        sync.update_peer_locators(peer_2, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_2, &sample_block_locators(10)).unwrap();
 
         // Add a peer.
         let peer_3 = sample_peer_ip(3);
-        sync.update_peer_locators(peer_3, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_3, &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, _) = sync.prepare_block_requests();
@@ -1514,15 +1514,15 @@ mod tests {
 
         // Add a peer (fork).
         let peer_1 = sample_peer_ip(1);
-        sync.update_peer_locators(peer_1, sample_block_locators_with_fork(20, 10)).unwrap();
+        sync.update_peer_locators(peer_1, &sample_block_locators_with_fork(20, 10)).unwrap();
 
         // Add a peer.
         let peer_2 = sample_peer_ip(2);
-        sync.update_peer_locators(peer_2, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_2, &sample_block_locators(10)).unwrap();
 
         // Add a peer.
         let peer_3 = sample_peer_ip(3);
-        sync.update_peer_locators(peer_3, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_3, &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, _) = sync.prepare_block_requests();
@@ -1532,7 +1532,7 @@ mod tests {
 
         // Add a peer.
         let peer_4 = sample_peer_ip(4);
-        sync.update_peer_locators(peer_4, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_4, &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, sync_peers) = sync.prepare_block_requests();
@@ -1562,15 +1562,15 @@ mod tests {
 
         // Add a peer (fork).
         let peer_1 = sample_peer_ip(1);
-        sync.update_peer_locators(peer_1, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_1, &sample_block_locators(10)).unwrap();
 
         // Add a peer.
         let peer_2 = sample_peer_ip(2);
-        sync.update_peer_locators(peer_2, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_2, &sample_block_locators(10)).unwrap();
 
         // Add a peer.
         let peer_3 = sample_peer_ip(3);
-        sync.update_peer_locators(peer_3, sample_block_locators_with_fork(20, 10)).unwrap();
+        sync.update_peer_locators(peer_3, &sample_block_locators_with_fork(20, 10)).unwrap();
 
         // Prepare the block requests.
         let (requests, _) = sync.prepare_block_requests();
@@ -1580,7 +1580,7 @@ mod tests {
 
         // Add a peer.
         let peer_4 = sample_peer_ip(4);
-        sync.update_peer_locators(peer_4, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_4, &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, sync_peers) = sync.prepare_block_requests();
@@ -1605,7 +1605,7 @@ mod tests {
         let sync = sample_sync_at_height(0);
 
         // Add a peer.
-        sync.update_peer_locators(sample_peer_ip(1), sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, sync_peers) = sync.prepare_block_requests();
@@ -1648,7 +1648,7 @@ mod tests {
         let sync = sample_sync_at_height(9);
 
         // Add a peer.
-        sync.update_peer_locators(sample_peer_ip(1), sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(10)).unwrap();
 
         // Inserting a block height that is already in the ledger should fail.
         sync.insert_block_request(9, (None, None, indexset![sample_peer_ip(1)])).unwrap_err();
@@ -1663,14 +1663,14 @@ mod tests {
         // Test 2 peers.
         let peer1_ip = sample_peer_ip(1);
         for peer1_height in 0..500u32 {
-            sync.update_peer_locators(peer1_ip, sample_block_locators(peer1_height)).unwrap();
+            sync.update_peer_locators(peer1_ip, &sample_block_locators(peer1_height)).unwrap();
             assert_eq!(sync.get_peer_height(&peer1_ip), Some(peer1_height));
 
             let peer2_ip = sample_peer_ip(2);
             for peer2_height in 0..500u32 {
                 println!("Testing peer 1 height at {peer1_height} and peer 2 height at {peer2_height}");
 
-                sync.update_peer_locators(peer2_ip, sample_block_locators(peer2_height)).unwrap();
+                sync.update_peer_locators(peer2_ip, &sample_block_locators(peer2_height)).unwrap();
                 assert_eq!(sync.get_peer_height(&peer2_ip), Some(peer2_height));
 
                 // Compute the distance between the peers.
@@ -1697,13 +1697,13 @@ mod tests {
         let sync = sample_sync_at_height(0);
 
         let peer_ip = sample_peer_ip(1);
-        sync.update_peer_locators(peer_ip, sample_block_locators(100)).unwrap();
+        sync.update_peer_locators(peer_ip, &sample_block_locators(100)).unwrap();
         assert_eq!(sync.get_peer_height(&peer_ip), Some(100));
 
         sync.remove_peer(&peer_ip);
         assert_eq!(sync.get_peer_height(&peer_ip), None);
 
-        sync.update_peer_locators(peer_ip, sample_block_locators(200)).unwrap();
+        sync.update_peer_locators(peer_ip, &sample_block_locators(200)).unwrap();
         assert_eq!(sync.get_peer_height(&peer_ip), Some(200));
 
         sync.remove_peer(&peer_ip);
@@ -1715,13 +1715,13 @@ mod tests {
         let sync = sample_sync_at_height(0);
 
         let peer_ip = sample_peer_ip(1);
-        sync.update_peer_locators(peer_ip, sample_block_locators(100)).unwrap();
+        sync.update_peer_locators(peer_ip, &sample_block_locators(100)).unwrap();
         assert_eq!(sync.get_peer_height(&peer_ip), Some(100));
 
         sync.remove_peer(&peer_ip);
         assert_eq!(sync.get_peer_height(&peer_ip), None);
 
-        sync.update_peer_locators(peer_ip, sample_block_locators(200)).unwrap();
+        sync.update_peer_locators(peer_ip, &sample_block_locators(200)).unwrap();
         assert_eq!(sync.get_peer_height(&peer_ip), Some(200));
     }
 
@@ -1732,7 +1732,7 @@ mod tests {
 
         // Add a peer.
         let peer_ip = sample_peer_ip(1);
-        sync.update_peer_locators(peer_ip, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_ip, &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, sync_peers) = sync.prepare_block_requests();
@@ -1763,7 +1763,7 @@ mod tests {
         assert_eq!(requests.len(), 0);
 
         // Add the peer again.
-        sync.update_peer_locators(peer_ip, sample_block_locators(10)).unwrap();
+        sync.update_peer_locators(peer_ip, &sample_block_locators(10)).unwrap();
 
         // Prepare the block requests.
         let (requests, _) = sync.prepare_block_requests();
@@ -1790,7 +1790,7 @@ mod tests {
 
         // Add a peer.
         let locators = sample_block_locators(locator_height);
-        sync.update_peer_locators(sample_peer_ip(1), locators.clone()).unwrap();
+        sync.update_peer_locators(sample_peer_ip(1), &locators).unwrap();
 
         // Construct block requests
         let (requests, sync_peers) = sync.prepare_block_requests();
@@ -1832,7 +1832,7 @@ mod tests {
         let locators = sample_block_locators(10);
         let block_hash = locators.get_hash(1);
 
-        sync.update_peer_locators(peer_ip, locators.clone()).unwrap();
+        sync.update_peer_locators(peer_ip, &locators).unwrap();
 
         let timestamp = Instant::now() - BLOCK_REQUEST_TIMEOUT - Duration::from_secs(1);
 
@@ -1869,9 +1869,9 @@ mod tests {
         let block_hash1 = locators.get_hash(1);
         let block_hash2 = locators.get_hash(2);
 
-        sync.update_peer_locators(peer_ip1, locators.clone()).unwrap();
-        sync.update_peer_locators(peer_ip2, locators.clone()).unwrap();
-        sync.update_peer_locators(peer_ip3, locators.clone()).unwrap();
+        sync.update_peer_locators(peer_ip1, &locators).unwrap();
+        sync.update_peer_locators(peer_ip2, &locators).unwrap();
+        sync.update_peer_locators(peer_ip3, &locators).unwrap();
 
         assert_eq!(sync.locators.read().len(), 3);
 

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -584,13 +584,13 @@ impl<N: Network> BlockSync<N> {
     ///
     /// This function does **not** check
     /// that the block locators are consistent with the peer's previous block locators or other peers' block locators.
-    pub fn update_peer_locators(&self, peer_ip: SocketAddr, locators: BlockLocators<N>) -> Result<()> {
+    pub fn update_peer_locators(&self, peer_ip: SocketAddr, locators: &BlockLocators<N>) -> Result<()> {
         // Update the locators entry for the given peer IP.
         // We perform this update atomically, and drop the lock as soon as we are done with the update.
         match self.locators.write().entry(peer_ip) {
             hash_map::Entry::Occupied(mut e) => {
                 // Return early if the block locators did not change.
-                if e.get() == &locators {
+                if e.get() == locators {
                     return Ok(());
                 }
 


### PR DESCRIPTION
This PR extends the `ConnectedPeer` object with a new member representing its last known block height, as informed by its `BlockLocators`, and uses it to sort the entries in the persistent peer cache, and those sent in response to `PeerRequest` messages.

For now I've omitted the last part of the proposed implementation, as I think it was intended to be related to the `PeerRequest` messages we _receive_, not provide. That being said, this is something that could be considered a hardening feature separate from these changes, and as such, it could be introduced in another PR.

CC https://github.com/ProvableHQ/snarkOS/issues/3844
CC https://github.com/ProvableHQ/snarkOS/issues/3580