### PR TITLE
[Logs] Improve the broken handshake log message

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1342,8 +1342,7 @@ macro_rules! expect_event {
             // Received nothing.
             None => {
                 return Err(error(format!(
-                    "{CONTEXT} '{}' disconnected before sending {:?}",
-                    $peer_addr,
+                    "{CONTEXT} the peer disconnected before sending {:?}, likely due to peer saturation or shutdown",
                     stringify!($event_ty)
                 )))
             }

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -65,7 +65,10 @@ macro_rules! expect_message {
             }
             // Received nothing.
             None => {
-                return Err(error(format!("'{}' disconnected before sending {:?}", $peer_addr, stringify!($msg_ty),)))
+                return Err(error(format!(
+                    "the peer disconnected before sending {:?}, likely due to peer saturation or shutdown",
+                    stringify!($msg_ty),
+                )))
             }
         }
     };


### PR DESCRIPTION
This PR clarifies why the high-level handshake may be broken in the appropriate log message; in addition, the IP address is deduplicated from it (it's already present in the corresponding call to `warn`).

Closes https://github.com/ProvableHQ/snarkOS/issues/3646.