### PR TITLE
Propagate transactions even if global state root not found

### DIFF
--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -469,6 +469,21 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     let _node = node.clone();
                     // For each deployment, spawn a task to verify it.
                     tokio::task::spawn_blocking(move || {
+                        // First collect the state root.
+                        let Some(state_root) = transaction.fee_transition().map(|t| t.global_state_root()) else {
+                            debug!("Failed to access global state root for deployment from peer_ip {peer_ip}");
+                            _node.num_verifying_deploys.fetch_sub(1, Relaxed);
+                            return;
+                        };
+                        // Check if the state root is in the ledger.
+                        if !_node.ledger().contains_state_root(&state_root).unwrap_or(false) {
+                            debug!("Failed to find global state root for deployment from peer_ip {peer_ip}, propagating anyway");
+                            // Propagate the `UnconfirmedTransaction`.
+                            _node.propagate(Message::UnconfirmedTransaction(serialized), &[peer_ip]);
+                            _node.num_verifying_deploys.fetch_sub(1, Relaxed);
+                            return;
+                            // Also skip the `check_transaction_basic` call if it is already propagated.
+                        }
                         // Check the deployment.
                         match _node.ledger.check_transaction_basic(&transaction, None, &mut rand::thread_rng()) {
                             Ok(_) => {
@@ -522,6 +537,24 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     let _node = node.clone();
                     // For each execution, spawn a task to verify it.
                     tokio::task::spawn_blocking(move || {
+                        // First collect the state roots.
+                        let state_roots = [
+                            transaction.execution().map(|t| t.global_state_root()),
+                            transaction.fee_transition().map(|t| t.global_state_root()),
+                        ]
+                        .into_iter()
+                        .flatten();
+
+                        for state_root in state_roots {
+                            if !_node.ledger().contains_state_root(&state_root).unwrap_or(false) {
+                                debug!("Failed to find global state root for execution from peer_ip {peer_ip}, propagating anyway");
+                                // Propagate the `UnconfirmedTransaction`.
+                                _node.propagate(Message::UnconfirmedTransaction(serialized), &[peer_ip]);
+                                _node.num_verifying_executions.fetch_sub(1, Relaxed);
+                                return;
+                                // Also skip the `check_transaction_basic` call if it is already propagated.
+                            }
+                        }
                         // Check the execution.
                         match _node.ledger.check_transaction_basic(&transaction, None, &mut rand::thread_rng()) {
                             Ok(_) => {


### PR DESCRIPTION
## Motivation

While combing through mainnet logs, I noticed a non-trivial amount (1000 per client per hour) of "global state root not found" errors. In all likelihood, these are caused by nodes temporarily being behind. This PR should improve the network's UX by letting those transactions propagate anyway.

## Analysis
The performance impact under honest conditions should not be too bad, but may be offset by https://github.com/ProvableHQ/snarkOS/pull/3493

An attacker will have a somewhat easier time to get their transactions propagated to cause load on the network, but if they do so with an intentionally invalid state root, it will actually become cheaper for validators to reject it.

Because we don't use custom error types, we risk changing the underlying error message. So this should help: https://github.com/ProvableHQ/snarkVM/pull/2929

## Test Plan

Existing tests should suffice