### PR TITLE
[Fix] Disallow multiple conns per validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,6 +4073,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-router-messages",
  "snarkos-node-sync",
+ "snarkos-node-sync-communication-service",
  "snarkos-node-sync-locators",
  "snarkos-node-tcp",
  "snarkvm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync-communication-service",
  "snarkos-node-sync-locators",
+ "snarkos-node-tcp",
  "snarkvm",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4128,7 +4128,6 @@ name = "snarkos-node-sync-communication-service"
 version = "4.2.1"
 dependencies = [
  "async-trait",
- "parking_lot",
  "tokio",
 ]
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -311,17 +311,6 @@ impl<N: Network> CommunicationService for Gateway<N> {
     async fn send(&self, peer_ip: SocketAddr, message: Self::Message) -> Option<oneshot::Receiver<io::Result<()>>> {
         Transport::send(self, peer_ip, message).await
     }
-
-    fn ban_peer(&self, peer_ip: SocketAddr) {
-        trace!("Banning peer {peer_ip} for timing out on block requests");
-
-        let tcp = self.tcp().clone();
-        tcp.banned_peers().update_ip_ban(peer_ip.ip());
-
-        tokio::spawn(async move {
-            tcp.disconnect(peer_ip).await;
-        });
-    }
 }
 
 impl<N: Network> Gateway<N> {
@@ -906,20 +895,6 @@ impl<N: Network> Gateway<N> {
                 Ok(true)
             }
         }
-    }
-
-    /// Disconnects from the given peer IP, if the peer is connected. The returned boolean
-    /// indicates whether the peer was actually disconnected from, or if this was a noop.
-    pub fn disconnect(&self, peer_ip: SocketAddr) -> JoinHandle<bool> {
-        let gateway = self.clone();
-        tokio::spawn(async move {
-            if let Some(peer) = gateway.get_connected_peer(peer_ip) {
-                let connected_addr = peer.connected_addr;
-                gateway.tcp.disconnect(connected_addr).await
-            } else {
-                false
-            }
-        })
     }
 
     /// Initialize a new instance of the heartbeat.

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -400,7 +400,7 @@ impl<N: Network> Gateway<N> {
             return true;
         }
         // Retrieve the Aleo address of the peer IP.
-        match self.resolver.read().get_address(ip) {
+        match self.resolve_to_aleo_addr(ip) {
             // Determine if the peer IP is an authorized validator.
             Some(address) => self.is_authorized_validator_address(address),
             None => false,
@@ -557,8 +557,8 @@ impl<N: Network> Gateway<N> {
             });
         }
         if let Some(peer) = self.peer_pool.write().get_mut(&peer_ip) {
-            if matches!(peer, Peer::Connected(_)) {
-                self.resolver.write().remove_peer(peer_ip);
+            if let Peer::Connected(connected_peer) = peer {
+                self.resolver.write().remove_peer(peer_ip, connected_peer.aleo_addr);
             }
             peer.downgrade_to_candidate(peer_ip);
         }
@@ -573,7 +573,7 @@ impl<N: Network> Gateway<N> {
     /// which can be used to determine when and whether the event has been delivered.
     fn send_inner(&self, peer_ip: SocketAddr, event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
         // Resolve the listener IP to the (ambiguous) peer address.
-        let Some(peer_addr) = self.resolver.read().get_ambiguous(peer_ip) else {
+        let Some(peer_addr) = self.resolve_to_ambiguous(peer_ip) else {
             warn!("Unable to resolve the listener IP address '{peer_ip}'");
             return None;
         };
@@ -823,7 +823,7 @@ impl<N: Network> Gateway<N> {
                     // Iterate over the validators.
                     for validator_ip in connected_peers.into_iter().take(MAX_VALIDATORS_TO_SEND) {
                         // Retrieve the validator address.
-                        if let Some(validator_address) = self_.resolver.read().get_address(validator_ip) {
+                        if let Some(validator_address) = self_.resolve_to_aleo_addr(validator_ip) {
                             // Add the validator to the list of validators.
                             validators.insert(validator_ip, validator_address);
                         }
@@ -999,7 +999,7 @@ impl<N: Network> Gateway<N> {
         // Log the connected validators.
         info!("{connections_msg}");
         for peer_ip in &connected_validators {
-            let address = self.resolver.read().get_address(*peer_ip).map_or("Unknown".to_string(), |a| {
+            let address = self.resolve_to_aleo_addr(*peer_ip).map_or("Unknown".to_string(), |a| {
                 connected_validator_addresses.insert(a);
                 a.to_string()
             });

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -385,12 +385,8 @@ impl<N: Network> Gateway<N> {
 
     /// Returns `true` if the node is connected to the given Aleo address.
     pub fn is_connected_address(&self, address: Address<N>) -> bool {
-        // Retrieve the peer IP of the given address.
-        match self.resolver.read().get_peer_ip_for_address(address) {
-            // Determine if the peer IP is connected.
-            Some(peer_ip) => self.is_connected(peer_ip),
-            None => false,
-        }
+        // The resolver only contains data on connected peers.
+        self.resolver.read().get_peer_ip_for_address(address).is_some()
     }
 
     /// Returns `true` if the given peer IP is an authorized validator.

--- a/node/bft/src/helpers/resolver.rs
+++ b/node/bft/src/helpers/resolver.rs
@@ -17,6 +17,9 @@ use snarkvm::prelude::{Address, Network};
 
 use std::{collections::HashMap, net::SocketAddr};
 
+/// The resolver contains some reverse maps for peers which are not available
+/// by default to the implementors of PeerPoolHandling (who already contain
+/// maps from the peer's listening address to their various components).
 #[derive(Debug)]
 pub struct Resolver<N: Network> {
     /// The map of the (ambiguous) peer address to listener address.

--- a/node/bft/src/helpers/resolver.rs
+++ b/node/bft/src/helpers/resolver.rs
@@ -19,12 +19,8 @@ use std::{collections::HashMap, net::SocketAddr};
 
 #[derive(Debug)]
 pub struct Resolver<N: Network> {
-    /// The map of the listener address to (ambiguous) peer address.
-    from_listener: HashMap<SocketAddr, SocketAddr>,
     /// The map of the (ambiguous) peer address to listener address.
     to_listener: HashMap<SocketAddr, SocketAddr>,
-    /// A map of `peer IP` to `address`.
-    peer_addresses: HashMap<SocketAddr, Address<N>>,
     /// A map of `address` to `peer IP`.
     address_peers: HashMap<Address<N>, SocketAddr>,
 }
@@ -39,12 +35,7 @@ impl<N: Network> Default for Resolver<N> {
 impl<N: Network> Resolver<N> {
     /// Initializes a new instance of the resolver.
     pub fn new() -> Self {
-        Self {
-            from_listener: Default::default(),
-            to_listener: Default::default(),
-            peer_addresses: Default::default(),
-            address_peers: Default::default(),
-        }
+        Self { to_listener: Default::default(), address_peers: Default::default() }
     }
 }
 
@@ -54,39 +45,23 @@ impl<N: Network> Resolver<N> {
         self.to_listener.get(&peer_addr).copied()
     }
 
-    /// Returns the (ambiguous) peer address for the given listener address, if it exists.
-    pub fn get_ambiguous(&self, peer_ip: SocketAddr) -> Option<SocketAddr> {
-        self.from_listener.get(&peer_ip).copied()
-    }
-
-    /// Returns the address for the given peer IP.
-    pub fn get_address(&self, peer_ip: SocketAddr) -> Option<Address<N>> {
-        self.peer_addresses.get(&peer_ip).copied()
-    }
-
     /// Returns the peer IP for the given address.
     pub fn get_peer_ip_for_address(&self, address: Address<N>) -> Option<SocketAddr> {
         self.address_peers.get(&address).copied()
     }
 
-    /// Inserts a bidirectional mapping of the listener address and the (ambiguous) peer address,
-    /// alongside a bidirectional mapping of the listener address and the Aleo address.
+    /// Inserts a mapping of a peer's connected address to its listener address,
+    /// alongside a mapping of the Aleo address to the listener address.
     pub fn insert_peer(&mut self, listener_ip: SocketAddr, peer_addr: SocketAddr, address: Address<N>) {
-        self.from_listener.insert(listener_ip, peer_addr);
         self.to_listener.insert(peer_addr, listener_ip);
-        self.peer_addresses.insert(listener_ip, address);
         self.address_peers.insert(address, listener_ip);
     }
 
-    /// Removes the bidirectional mapping of the listener address and the (ambiguous) peer address,
-    /// alongside the bidirectional mapping of the listener address and the Aleo address.
-    pub fn remove_peer(&mut self, listener_ip: SocketAddr) {
-        if let Some(peer_addr) = self.from_listener.remove(&listener_ip) {
-            self.to_listener.remove(&peer_addr);
-        }
-        if let Some(address) = self.peer_addresses.remove(&listener_ip) {
-            self.address_peers.remove(&address);
-        }
+    /// Removes the mapping of a peer's connected address to its listener address,
+    /// alongside the mapping of the Aleo address to the listener address.
+    pub fn remove_peer(&mut self, connected_addr: SocketAddr, aleo_addr: Address<N>) {
+        self.to_listener.remove(&connected_addr);
+        self.address_peers.remove(&aleo_addr);
     }
 }
 
@@ -106,22 +81,16 @@ mod tests {
         let address = Address::<CurrentNetwork>::new(rng.r#gen());
 
         assert!(resolver.get_listener(peer_addr).is_none());
-        assert!(resolver.get_address(listener_ip).is_none());
-        assert!(resolver.get_ambiguous(listener_ip).is_none());
         assert!(resolver.get_peer_ip_for_address(address).is_none());
 
         resolver.insert_peer(listener_ip, peer_addr, address);
 
         assert_eq!(resolver.get_listener(peer_addr).unwrap(), listener_ip);
-        assert_eq!(resolver.get_address(listener_ip).unwrap(), address);
-        assert_eq!(resolver.get_ambiguous(listener_ip).unwrap(), peer_addr);
         assert_eq!(resolver.get_peer_ip_for_address(address).unwrap(), listener_ip);
 
-        resolver.remove_peer(listener_ip);
+        resolver.remove_peer(peer_addr, address);
 
         assert!(resolver.get_listener(peer_addr).is_none());
-        assert!(resolver.get_address(listener_ip).is_none());
-        assert!(resolver.get_ambiguous(listener_ip).is_none());
         assert!(resolver.get_peer_ip_for_address(address).is_none());
     }
 }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -44,6 +44,7 @@ use crate::{
 use snarkos_account::Account;
 use snarkos_node_bft_events::PrimaryPing;
 use snarkos_node_bft_ledger_service::LedgerService;
+use snarkos_node_router::PeerPoolHandling;
 use snarkos_node_sync::{BlockSync, DUMMY_SELF_IP, Ping};
 use snarkvm::{
     console::{
@@ -731,7 +732,7 @@ impl<N: Network> Primary<N> {
         let batch_author = batch_header.author();
 
         // Ensure the batch proposal is from the validator.
-        match self.gateway.resolver().read().get_address(peer_ip) {
+        match self.gateway.resolve_to_aleo_addr(peer_ip) {
             // If the peer is a validator, then ensure the batch proposal is from the validator.
             Some(address) => {
                 if address != batch_author {
@@ -1005,7 +1006,7 @@ impl<N: Network> Primary<N> {
         let signer = signature.to_address();
 
         // Ensure the batch signature is signed by the validator.
-        if self.gateway.resolver().read().get_address(peer_ip) != Some(signer) {
+        if self.gateway.resolve_to_aleo_addr(peer_ip) != Some(signer) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
             bail!("Malicious peer - batch signature is from a different validator ({signer})");
@@ -1044,7 +1045,7 @@ impl<N: Network> Primary<N> {
                     // Retrieve the committee lookback for the round.
                     let committee_lookback = self_.ledger.get_committee_lookback_for_round(proposal.round())?;
                     // Retrieve the address of the validator.
-                    let Some(signer) = self_.gateway.resolver().read().get_address(peer_ip) else {
+                    let Some(signer) = self_.gateway.resolve_to_aleo_addr(peer_ip) else {
                         bail!("Signature is from a disconnected validator");
                     };
                     // Add the signature to the batch.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -291,7 +291,7 @@ impl<N: Network> Sync<N> {
         // Check if any existing requests can be removed.
         // We should do this even if we cannot block sync, to ensure
         // there are no dangling block requests.
-        let new_requests = self.block_sync.handle_block_request_timeouts(Some(&self.gateway));
+        let new_requests = self.block_sync.handle_block_request_timeouts(&self.gateway);
         if let Some((sync_peers, requests)) = new_requests {
             self.send_block_requests(sync_peers, requests).await;
         }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -291,7 +291,7 @@ impl<N: Network> Sync<N> {
         // Check if any existing requests can be removed.
         // We should do this even if we cannot block sync, to ensure
         // there are no dangling block requests.
-        let new_requests = self.block_sync.handle_block_request_timeouts(&self.gateway);
+        let new_requests = self.block_sync.handle_block_request_timeouts(Some(&self.gateway));
         if let Some((sync_peers, requests)) = new_requests {
             self.send_block_requests(sync_peers, requests).await;
         }

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -67,6 +67,9 @@ workspace = true
 workspace = true
 features = [ "ledger", "prover" ]
 
+[dependencies.snarkos-node-sync-communication-service]
+workspace = true
+
 [dependencies.snarkos-node-sync-locators]
 workspace = true
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -45,10 +45,11 @@ pub use routing::*;
 mod writing;
 
 pub use crate::messages::NodeType;
-use crate::messages::{Message, MessageCodec};
+use crate::messages::{BlockRequest, Message, MessageCodec};
 
 use snarkos_account::Account;
 use snarkos_node_bft_ledger_service::LedgerService;
+use snarkos_node_sync_communication_service::CommunicationService;
 use snarkos_node_tcp::{Config, ConnectionSide, P2P, Tcp, is_bogon_ip, is_unspecified_or_broadcast_ip};
 
 use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey, error};
@@ -321,6 +322,28 @@ pub trait PeerPoolHandling<N: Network>: P2P {
         }
         Ok(())
     }
+
+    /// Disconnects from the given peer IP, if the peer is connected. The returned boolean
+    /// indicates whether the peer was actually disconnected from, or if this was a noop.
+    fn disconnect(&self, listener_addr: SocketAddr) -> JoinHandle<bool> {
+        let connected_addr = self.resolve_to_ambiguous(listener_addr);
+        let tcp = self.tcp().clone();
+        tokio::spawn(async move {
+            if let Some(connected_addr) = connected_addr { tcp.disconnect(connected_addr).await } else { false }
+        })
+    }
+
+    /// Temporarily IP-ban and disconnect from the peer with the given listener address and an
+    /// optional reason for the ban.
+    fn ip_ban_peer(&self, listener_addr: SocketAddr, reason: Option<&str>) {
+        let ip = listener_addr.ip();
+        debug!("IP-banning {ip}{}", reason.map(|r| format!(" reason: {r}")).unwrap_or_default());
+
+        let tcp = self.tcp().clone();
+        tcp.banned_peers().update_ip_ban(ip);
+
+        self.disconnect(listener_addr);
+    }
 }
 
 /// The router keeps track of connected and connecting peers.
@@ -493,20 +516,6 @@ impl<N: Network> Router<N> {
         Ok(false)
     }
 
-    /// Disconnects from the given peer IP, if the peer is connected. The returned boolean
-    /// indicates whether the peer was actually disconnected from, or if this was a noop.
-    pub fn disconnect(&self, peer_ip: SocketAddr) -> JoinHandle<bool> {
-        let router = self.clone();
-        tokio::spawn(async move {
-            if let Some(peer) = router.get_connected_peer(peer_ip) {
-                let connected_addr = peer.connected_addr;
-                router.tcp.disconnect(connected_addr).await
-            } else {
-                false
-            }
-        })
-    }
-
     /// Returns the IP address of this node.
     pub fn local_ip(&self) -> SocketAddr {
         self.tcp.listening_addr().expect("The TCP listener is not enabled")
@@ -672,6 +681,31 @@ impl<N: Network> Router<N> {
         self.handles.lock().iter().for_each(|handle| handle.abort());
         // Close the listener.
         self.tcp.shut_down().await;
+    }
+}
+
+#[async_trait]
+impl<N: Network> CommunicationService for Router<N> {
+    /// The message type.
+    type Message = Message<N>;
+
+    /// Prepares a block request to be sent.
+    fn prepare_block_request(start_height: u32, end_height: u32) -> Self::Message {
+        debug_assert!(start_height < end_height, "Invalid block request format");
+        Message::BlockRequest(BlockRequest { start_height, end_height })
+    }
+
+    /// Sends the given message to specified peer.
+    ///
+    /// This function returns as soon as the message is queued to be sent,
+    /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
+    /// which can be used to determine when and whether the message has been delivered.
+    async fn send(
+        &self,
+        peer_ip: SocketAddr,
+        message: Self::Message,
+    ) -> Option<tokio::sync::oneshot::Receiver<io::Result<()>>> {
+        self.send(peer_ip, message)
     }
 }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -93,6 +93,15 @@ pub trait PeerPoolHandling<N: Network>: P2P {
         }
     }
 
+    /// Returns the connected peer aleo address from the listener IP address.
+    fn resolve_to_aleo_addr(&self, listener_addr: SocketAddr) -> Option<Address<N>> {
+        if let Some(Peer::Connected(peer)) = self.peer_pool().read().get(&listener_addr) {
+            Some(peer.aleo_addr)
+        } else {
+            None
+        }
+    }
+
     /// Returns `true` if the node is connecting to the given peer's listener address.
     fn is_connecting(&self, listener_addr: SocketAddr) -> bool {
         self.peer_pool().read().get(&listener_addr).is_some_and(|peer| peer.is_connecting())

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -18,6 +18,7 @@ use snarkos_node_router::{
     Heartbeat,
     Inbound,
     Outbound,
+    PeerPoolHandling,
     Router,
     Routing,
     messages::{

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -294,7 +294,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         // (if the ledger height is lower or equal to the current sync height, this is a noop)
         self.sync.set_sync_height(self.ledger.latest_height());
 
-        let new_requests = self.sync.handle_block_request_timeouts(self);
+        let new_requests = self.sync.handle_block_request_timeouts(Some(self.router()));
         if let Some((block_requests, sync_peers)) = new_requests {
             self.send_block_requests(block_requests, sync_peers).await;
         }
@@ -354,7 +354,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
     ) {
         // Issues the block requests in batches.
         for requests in block_requests.chunks(DataBlocks::<N>::MAXIMUM_NUMBER_OF_BLOCKS as usize) {
-            if !self.sync.send_block_requests(self, &sync_peers, requests).await {
+            if !self.sync.send_block_requests(self.router(), &sync_peers, requests).await {
                 // Stop if we fail to process a batch of requests.
                 break;
             }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -294,7 +294,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         // (if the ledger height is lower or equal to the current sync height, this is a noop)
         self.sync.set_sync_height(self.ledger.latest_height());
 
-        let new_requests = self.sync.handle_block_request_timeouts(Some(self.router()));
+        let new_requests = self.sync.handle_block_request_timeouts(self.router());
         if let Some((block_requests, sync_peers)) = new_requests {
             self.send_block_requests(block_requests, sync_peers).await;
         }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -31,7 +31,6 @@ use snarkos_node_router::{
         UnconfirmedTransaction,
     },
 };
-use snarkos_node_sync::communication_service::CommunicationService;
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::{
     ledger::narwhal::Data,
@@ -131,42 +130,6 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                 self.router().disconnect(peer_ip);
             }
         }
-    }
-}
-
-#[async_trait]
-impl<N: Network, C: ConsensusStorage<N>> CommunicationService for Client<N, C> {
-    /// The message type.
-    type Message = Message<N>;
-
-    /// Prepares a block request to be sent.
-    fn prepare_block_request(start_height: u32, end_height: u32) -> Self::Message {
-        debug_assert!(start_height < end_height, "Invalid block request format");
-        Message::BlockRequest(BlockRequest { start_height, end_height })
-    }
-
-    /// Sends the given message to specified peer.
-    ///
-    /// This function returns as soon as the message is queued to be sent,
-    /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
-    /// which can be used to determine when and whether the message has been delivered.
-    async fn send(
-        &self,
-        peer_ip: SocketAddr,
-        message: Self::Message,
-    ) -> Option<tokio::sync::oneshot::Receiver<io::Result<()>>> {
-        self.router().send(peer_ip, message)
-    }
-
-    fn ban_peer(&self, peer_ip: SocketAddr) {
-        debug!("Banning peer {peer_ip} for timing out on block requests");
-
-        let tcp = self.router.tcp().clone();
-        tcp.banned_peers().update_ip_ban(peer_ip.ip());
-
-        tokio::spawn(async move {
-            tcp.disconnect(peer_ip).await;
-        });
     }
 }
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -14,16 +14,19 @@
 // limitations under the License.
 
 use super::*;
-use snarkos_node_router::messages::{
-    BlockRequest,
-    BlockResponse,
-    DataBlocks,
-    DisconnectReason,
-    Message,
-    MessageCodec,
-    Ping,
-    Pong,
-    UnconfirmedTransaction,
+use snarkos_node_router::{
+    PeerPoolHandling,
+    messages::{
+        BlockRequest,
+        BlockResponse,
+        DataBlocks,
+        DisconnectReason,
+        Message,
+        MessageCodec,
+        Ping,
+        Pong,
+        UnconfirmedTransaction,
+    },
 };
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::{

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -90,6 +90,9 @@ features = [ "test" ]
 workspace = true
 features = [ "test" ]
 
+[dev-dependencies.snarkos-node-tcp]
+workspace = true
+
 [dev-dependencies.snarkos-node-sync-communication-service]
 workspace = true
 features = [ "test-helpers" ]

--- a/node/sync/communication-service/Cargo.toml
+++ b/node/sync/communication-service/Cargo.toml
@@ -23,13 +23,6 @@ version = "0.1"
 workspace = true
 features = [ "sync" ]
 
-[dependencies.parking_lot]
-workspace = true
-optional = true
-
-[dev-dependencies.parking_lot]
-workspace = true
-
 [features]
 default = [ ]
-test-helpers = [ "dep:parking_lot" ]
+test-helpers = [ ]

--- a/node/sync/communication-service/src/lib.rs
+++ b/node/sync/communication-service/src/lib.rs
@@ -39,26 +39,18 @@ pub trait CommunicationService: Send + Sync {
     /// which can be used to determine when and whether the message has been delivered.
     /// If no peer with the given IP exists, this function returns None.
     async fn send(&self, peer_ip: SocketAddr, message: Self::Message) -> Option<oneshot::Receiver<io::Result<()>>>;
-
-    /// Mark a peer to be removed and (temporarily) banned.
-    fn ban_peer(&self, peer_ip: SocketAddr);
 }
 
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {
     use super::*;
 
-    use parking_lot::Mutex;
-
     #[derive(Clone)]
     pub struct DummyMessage {}
 
     /// A communication service that does not do anything (for testing).
     #[derive(Default)]
-    pub struct DummyCommunicationService {
-        // Any ban requests will be stored here.
-        pub peers_to_ban: Mutex<Vec<SocketAddr>>,
-    }
+    pub struct DummyCommunicationService;
 
     #[async_trait]
     impl CommunicationService for DummyCommunicationService {
@@ -74,10 +66,6 @@ pub mod test_helpers {
             _message: Self::Message,
         ) -> Option<oneshot::Receiver<io::Result<()>>> {
             None
-        }
-
-        fn ban_peer(&self, peer_ip: SocketAddr) {
-            self.peers_to_ban.lock().push(peer_ip);
         }
     }
 }

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -18,7 +18,7 @@ use crate::{
     locators::BlockLocators,
 };
 use snarkos_node_bft_ledger_service::LedgerService;
-use snarkos_node_router::messages::DataBlocks;
+use snarkos_node_router::{PeerPoolHandling, messages::DataBlocks};
 use snarkos_node_sync_communication_service::CommunicationService;
 use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, NUM_RECENT_BLOCKS};
 use snarkvm::prelude::{Network, block::Block};
@@ -936,12 +936,12 @@ impl<N: Network> BlockSync<N> {
     /// Removes block requests that have timed out, i.e, requests we sent that did not receive a response in time.
     ///
     /// This removes the corresponding block responses and returns the set of peers/addresses that timed out.
-    /// It will ask the communication service to ban any timed-out peers.
+    /// It will ask the peer pool handling service to ban any timed-out peers.
     ///
     /// Finally, it will return a set of new of block requests that replaced the timed-out requests (if needed).
-    pub fn handle_block_request_timeouts<C: CommunicationService>(
+    pub fn handle_block_request_timeouts<P: PeerPoolHandling<N>>(
         &self,
-        communication: &C,
+        peer_pool_handler: Option<&P>,
     ) -> Option<BlockRequestBatch<N>> {
         // Acquire the write lock on the requests map.
         let mut requests = self.requests.write();
@@ -1003,7 +1003,9 @@ impl<N: Network> BlockSync<N> {
         // Now remove and ban any unresponsive peers
         for peer_ip in peers_to_ban {
             self.remove_peer(&peer_ip);
-            communication.ban_peer(peer_ip);
+            if let Some(peer_pool_handler) = peer_pool_handler {
+                peer_pool_handler.ip_ban_peer(peer_ip, Some("timed out on block requests"));
+            }
         }
 
         // Re-issue any timed-out requests.
@@ -1290,7 +1292,7 @@ mod tests {
     };
 
     use snarkos_node_bft_ledger_service::MockLedgerService;
-    use snarkos_node_sync_communication_service::test_helpers::DummyCommunicationService;
+    use snarkos_node_router::Router;
     use snarkvm::{
         ledger::committee::Committee,
         prelude::{Field, TestRng},
@@ -1818,8 +1820,7 @@ mod tests {
         assert_eq!(new_sync.requests.read().len(), requests.len());
 
         // Remove timed out block requests.
-        let c = DummyCommunicationService::default();
-        new_sync.handle_block_request_timeouts(&c);
+        new_sync.handle_block_request_timeouts(None::<&Router<CurrentNetwork>>);
 
         // Check that the number of requests is reduced based on the ledger height.
         assert_eq!(new_sync.requests.read().len(), (locator_height - ledger_height) as usize);
@@ -1847,12 +1848,7 @@ mod tests {
         assert_eq!(sync.locators.read().len(), 1);
 
         // Remove timed out block requests.
-        let c = DummyCommunicationService::default();
-        sync.handle_block_request_timeouts(&c);
-
-        let ban_list = c.peers_to_ban.lock();
-        assert_eq!(ban_list.len(), 1);
-        assert_eq!(ban_list.iter().next(), Some(&peer_ip));
+        sync.handle_block_request_timeouts(None::<&Router<CurrentNetwork>>);
 
         assert!(sync.requests.read().is_empty());
         assert!(sync.locators.read().is_empty());
@@ -1894,12 +1890,7 @@ mod tests {
         assert_eq!(sync.requests.read().len(), 2);
 
         // Remove timed out block requests.
-        let c = DummyCommunicationService::default();
-        let re_requests = sync.handle_block_request_timeouts(&c);
-
-        let ban_list = c.peers_to_ban.lock();
-        assert_eq!(ban_list.len(), 1);
-        assert_eq!(ban_list.iter().next(), Some(&peer_ip1));
+        let re_requests = sync.handle_block_request_timeouts(None::<&Router<CurrentNetwork>>);
 
         assert_eq!(sync.requests.read().len(), 1);
         assert_eq!(sync.locators.read().len(), 2);

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1298,6 +1298,9 @@ mod tests {
     };
 
     use indexmap::{IndexSet, indexset};
+    #[cfg(feature = "locktick")]
+    use locktick::parking_lot::RwLock;
+    #[cfg(not(feature = "locktick"))]
     use parking_lot::RwLock;
     use rand::Rng;
     use std::net::{IpAddr, Ipv4Addr};

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -941,7 +941,7 @@ impl<N: Network> BlockSync<N> {
     /// Finally, it will return a set of new of block requests that replaced the timed-out requests (if needed).
     pub fn handle_block_request_timeouts<P: PeerPoolHandling<N>>(
         &self,
-        peer_pool_handler: Option<&P>,
+        peer_pool_handler: &P,
     ) -> Option<BlockRequestBatch<N>> {
         // Acquire the write lock on the requests map.
         let mut requests = self.requests.write();
@@ -1003,9 +1003,7 @@ impl<N: Network> BlockSync<N> {
         // Now remove and ban any unresponsive peers
         for peer_ip in peers_to_ban {
             self.remove_peer(&peer_ip);
-            if let Some(peer_pool_handler) = peer_pool_handler {
-                peer_pool_handler.ip_ban_peer(peer_ip, Some("timed out on block requests"));
-            }
+            peer_pool_handler.ip_ban_peer(peer_ip, Some("timed out on block requests"));
         }
 
         // Re-issue any timed-out requests.
@@ -1292,17 +1290,40 @@ mod tests {
     };
 
     use snarkos_node_bft_ledger_service::MockLedgerService;
-    use snarkos_node_router::Router;
+    use snarkos_node_router::Peer;
+    use snarkos_node_tcp::{P2P, Tcp};
     use snarkvm::{
         ledger::committee::Committee,
         prelude::{Field, TestRng},
     };
 
     use indexmap::{IndexSet, indexset};
+    use parking_lot::RwLock;
     use rand::Rng;
     use std::net::{IpAddr, Ipv4Addr};
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
+
+    #[derive(Default)]
+    struct DummyPeerPoolHandler {
+        peers_to_ban: RwLock<Vec<SocketAddr>>,
+    }
+
+    impl P2P for DummyPeerPoolHandler {
+        fn tcp(&self) -> &Tcp {
+            unreachable!();
+        }
+    }
+
+    impl<N: Network> PeerPoolHandling<N> for DummyPeerPoolHandler {
+        fn peer_pool(&self) -> &RwLock<HashMap<SocketAddr, Peer<N>>> {
+            unreachable!();
+        }
+
+        fn ip_ban_peer(&self, listener_addr: SocketAddr, _reason: Option<&str>) {
+            self.peers_to_ban.write().push(listener_addr);
+        }
+    }
 
     /// Returns the peer IP for the sync pool.
     fn sample_peer_ip(id: u16) -> SocketAddr {
@@ -1820,7 +1841,8 @@ mod tests {
         assert_eq!(new_sync.requests.read().len(), requests.len());
 
         // Remove timed out block requests.
-        new_sync.handle_block_request_timeouts(None::<&Router<CurrentNetwork>>);
+        let c = DummyPeerPoolHandler::default();
+        new_sync.handle_block_request_timeouts(&c);
 
         // Check that the number of requests is reduced based on the ledger height.
         assert_eq!(new_sync.requests.read().len(), (locator_height - ledger_height) as usize);
@@ -1848,7 +1870,12 @@ mod tests {
         assert_eq!(sync.locators.read().len(), 1);
 
         // Remove timed out block requests.
-        sync.handle_block_request_timeouts(None::<&Router<CurrentNetwork>>);
+        let c = DummyPeerPoolHandler::default();
+        sync.handle_block_request_timeouts(&c);
+
+        let ban_list = c.peers_to_ban.write();
+        assert_eq!(ban_list.len(), 1);
+        assert_eq!(ban_list.iter().next(), Some(&peer_ip));
 
         assert!(sync.requests.read().is_empty());
         assert!(sync.locators.read().is_empty());
@@ -1890,7 +1917,13 @@ mod tests {
         assert_eq!(sync.requests.read().len(), 2);
 
         // Remove timed out block requests.
-        let re_requests = sync.handle_block_request_timeouts(None::<&Router<CurrentNetwork>>);
+        let c = DummyPeerPoolHandler::default();
+
+        let re_requests = sync.handle_block_request_timeouts(&c);
+
+        let ban_list = c.peers_to_ban.write();
+        assert_eq!(ban_list.len(), 1);
+        assert_eq!(ban_list.iter().next(), Some(&peer_ip1));
 
         assert_eq!(sync.requests.read().len(), 1);
         assert_eq!(sync.locators.read().len(), 2);


### PR DESCRIPTION
This PR targets https://github.com/ProvableHQ/snarkOS/issues/3888.

It appears that we are already guarding the validators against connecting to those with an already-connected `Address` during the handshake (both sides, via `Gateway::verify_challenge_request`), but we're doing a bad job at it, as we're assuming that the multiple connections can only be attributed to a single listener address. This is trivially solved with https://github.com/ProvableHQ/snarkOS/commit/9258e342e6e97446087a81abcc91d421f54aaa88.

Next, I took a closer look at banning, and realized that the ones triggered by delayed block sync responses currently partially do not work, as the address used to disconnect is the listener address, which is the wrong one to use in case of connections we had accepted (as opposed to initiated). This is fixed with https://github.com/ProvableHQ/snarkOS/commit/ff2672c510dd98e858ff4106c4f82889cc18a1e7. A side bonus of this change is that banning peers and high-level disconnects have been moved to the `PeerPoolHandling` trait, deduplicating some code.

In addition, the `Gateway`'s `Resolver` [was shrunk](https://github.com/ProvableHQ/snarkOS/pull/3889/commits/378ea824a76af1020d809641640c6e621bff4c8c), as the peer pool is able to resolve listener addresses to connected addresses and Aleo addresses. It's a pure cleanup.

The linked issue requires further changes, but since the diff has grown quite a bit already, I decided to cut it short here and leave the rest to a follow-up.