### PR TITLE
Store the generated JWT secret to a file

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -649,6 +649,8 @@ impl Start {
 
                     if let Ok(jwt_token) = snarkos_node_rest::Claims::new(account.address(), jwt_secret, self.jwt_timestamp).to_jwt_string() {
                         println!("🔑 Your one-time JWT token is {}\n", jwt_token.dimmed());
+                        // Store the JWT secret to a file.
+                        std::fs::write(format!("jwt_secret_{}.txt", account.address()), jwt_token)?;
                     }
                 }
             }


### PR DESCRIPTION
## Motivation

Validators should be able to figure out what their node's JWT is (for calling the important `/db_backup` endpoint) without having to comb through the node's stdout output.

## Test Plan

Ran a node locally and the file is created as expected. Restarted the node and the file is overwritten.