### PR TITLE
[Tests] Add IP-banning test cases

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -70,8 +70,6 @@ use locktick::parking_lot::{Mutex, RwLock};
 #[cfg(not(feature = "locktick"))]
 use parking_lot::{Mutex, RwLock};
 use rand::seq::{IteratorRandom, SliceRandom};
-#[cfg(not(any(test)))]
-use std::net::IpAddr;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
@@ -434,18 +432,6 @@ impl<N: Network> Gateway<N> {
         }
 
         self.add_peer_on_handshake_resp(listener_addr)
-    }
-
-    /// Check whether the given IP address is currently banned.
-    #[cfg(not(any(test)))]
-    fn is_ip_banned(&self, ip: IpAddr) -> bool {
-        self.tcp.banned_peers().is_ip_banned(&ip)
-    }
-
-    /// Insert or update a banned IP.
-    #[cfg(not(any(test)))]
-    fn update_ip_ban(&self, ip: IpAddr) {
-        self.tcp.banned_peers().update_ip_ban(ip);
     }
 
     #[cfg(feature = "metrics")]

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -105,7 +105,7 @@ impl<N: Network> Router<N> {
         };
 
         // Check (or impose) IP-level bans.
-        #[cfg(not(any(test)))]
+        #[cfg(not(feature = "test"))]
         if !self.is_dev() && peer_side == ConnectionSide::Initiator {
             // If the IP is already banned reject the connection.
             if self.is_ip_banned(peer_addr.ip()) {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -60,15 +60,13 @@ use anyhow::{Result, bail};
 use locktick::parking_lot::{Mutex, RwLock};
 #[cfg(not(feature = "locktick"))]
 use parking_lot::{Mutex, RwLock};
-#[cfg(not(any(test)))]
-use std::net::IpAddr;
 use std::{
     cmp,
     collections::{HashMap, HashSet, hash_map::Entry},
     fs,
     future::Future,
     io::{self, Write},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     ops::Deref,
     str::FromStr,
     sync::Arc,
@@ -487,12 +485,12 @@ pub struct InnerRouter<N: Network> {
 
 impl<N: Network> Router<N> {
     /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
-    #[cfg(not(test))]
+    #[cfg(not(feature = "test"))]
     const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
     /// The maximum number of candidate peers permitted to be stored in the node.
     const MAXIMUM_CANDIDATE_PEERS: usize = 10_000;
     /// The maximum amount of connection attempts within a 10 second threshold
-    #[cfg(not(test))]
+    #[cfg(not(feature = "test"))]
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The duration after which a connected peer is considered inactive or
     /// disconnected if no message has been received in the meantime.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -432,6 +432,16 @@ pub trait PeerPoolHandling<N: Network>: P2P {
 
         self.disconnect(listener_addr);
     }
+
+    /// Check whether the given IP address is currently banned.
+    fn is_ip_banned(&self, ip: IpAddr) -> bool {
+        self.tcp().banned_peers().is_ip_banned(&ip)
+    }
+
+    /// Insert or update a banned IP.
+    fn update_ip_ban(&self, ip: IpAddr) {
+        self.tcp().banned_peers().update_ip_ban(ip);
+    }
 }
 
 /// The router keeps track of connected and connecting peers.
@@ -603,18 +613,6 @@ impl<N: Network> Router<N> {
     /// Returns the listener IP address from the (ambiguous) peer address.
     pub fn resolve_to_listener(&self, connected_addr: &SocketAddr) -> Option<SocketAddr> {
         self.resolver.read().get_listener(connected_addr)
-    }
-
-    /// Check whether the given IP address is currently banned.
-    #[cfg(not(any(test)))]
-    fn is_ip_banned(&self, ip: IpAddr) -> bool {
-        self.tcp.banned_peers().is_ip_banned(&ip)
-    }
-
-    /// Insert or update a banned IP.
-    #[cfg(not(any(test)))]
-    fn update_ip_ban(&self, ip: IpAddr) {
-        self.tcp.banned_peers().update_ip_ban(ip);
     }
 
     /// Returns the list of metrics for the connected peers.

--- a/node/router/tests/banning.rs
+++ b/node/router/tests/banning.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2019-2025 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+use common::*;
+
+use snarkos_node_router::PeerPoolHandling;
+use snarkos_node_tcp::{
+    P2P,
+    protocols::{Disconnect, Handshake},
+};
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn ban_connection_responder() {
+    // Create 2 client routers.
+    let node0 = client(0, 1).await;
+    let node1 = client(0, 1).await;
+
+    // Start listening on both sides.
+    node0.tcp().enable_listener().await.unwrap();
+    node1.tcp().enable_listener().await.unwrap();
+    // Enable handshake protocol in order to populate the peer pool.
+    node0.enable_handshake().await;
+    node1.enable_handshake().await;
+    // Enable disconnect protocol in order for the ban to update the peer pool.
+    node0.enable_disconnect().await;
+
+    // Connect node0 to node1.
+    let _ = node0.connect(node1.local_ip()).unwrap().await;
+    // Wait a moment to ensure that node1 has fully registered the connection too.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Ensure that everyone is fully connected.
+    assert_eq!(node0.tcp().num_connected(), 1);
+    assert_eq!(node1.tcp().num_connected(), 1);
+    assert_eq!(node0.connected_peers().len(), 1);
+    assert_eq!(node1.connected_peers().len(), 1);
+
+    // Make node0 ban node1.
+    let node1_addr = node1.tcp().listening_addr().unwrap();
+    node0.ip_ban_peer(node1_addr, None);
+    // Wait a moment to ensure that the associated disconnect has concluded.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Ensure that node0 is fully disconnected from node1; node1 may not be aware
+    // of it yet, so don't check it.
+    assert!(node0.is_ip_banned(node1_addr.ip()));
+    assert_eq!(node0.tcp().num_connected(), 0);
+    assert_eq!(node0.connected_peers().len(), 0);
+}
+
+#[tokio::test]
+async fn ban_connection_initiator() {
+    // Create 2 client routers.
+    let node0 = client(0, 1).await;
+    let node1 = client(0, 1).await;
+
+    // Start listening on both sides.
+    node0.tcp().enable_listener().await.unwrap();
+    node1.tcp().enable_listener().await.unwrap();
+    // Enable handshake protocol in order to populate the peer pool.
+    node0.enable_handshake().await;
+    node1.enable_handshake().await;
+    // Enable disconnect protocol in order for the ban to update the peer pool.
+    node0.enable_disconnect().await;
+
+    // Connect node1 to node0.
+    let _ = node1.connect(node0.local_ip()).unwrap().await;
+    // Wait a moment to ensure that node1 has fully registered the connection too.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Ensure that everyone is fully connected.
+    assert_eq!(node0.tcp().num_connected(), 1);
+    assert_eq!(node1.tcp().num_connected(), 1);
+    assert_eq!(node0.connected_peers().len(), 1);
+    assert_eq!(node1.connected_peers().len(), 1);
+
+    // Make node0 ban node1.
+    let node1_addr = node1.tcp().listening_addr().unwrap();
+    node0.ip_ban_peer(node1_addr, None);
+    // Wait a moment to ensure that the associated disconnect has concluded.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Ensure that node0 is fully disconnected from node1; node1 may not be aware
+    // of it yet, so don't check it.
+    assert!(node0.is_ip_banned(node1_addr.ip()));
+    assert_eq!(node0.tcp().num_connected(), 0);
+    assert_eq!(node0.connected_peers().len(), 0);
+}

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -18,6 +18,7 @@ use snarkos_node_router::{
     Heartbeat,
     Inbound,
     Outbound,
+    Peer,
     PeerPoolHandling,
     Router,
     Routing,
@@ -47,7 +48,11 @@ use snarkvm::prelude::{
 };
 
 use async_trait::async_trait;
-use std::{io, net::SocketAddr, str::FromStr};
+#[cfg(feature = "locktick")]
+use locktick::parking_lot::RwLock;
+#[cfg(not(feature = "locktick"))]
+use parking_lot::RwLock;
+use std::{collections::HashMap, io, net::SocketAddr, str::FromStr};
 use tracing::*;
 
 #[derive(Clone)]
@@ -71,6 +76,14 @@ impl<N: Network> P2P for TestRouter<N> {
     /// Returns a reference to the TCP instance.
     fn tcp(&self) -> &Tcp {
         self.router().tcp()
+    }
+}
+
+impl<N: Network> PeerPoolHandling<N> for TestRouter<N> {
+    const OWNER: &str = "[TestRouter]";
+
+    fn peer_pool(&self) -> &RwLock<HashMap<SocketAddr, Peer<N>>> {
+        self.router().peer_pool()
     }
 }
 


### PR DESCRIPTION
This PR adds 2 straightforward tests that ensure that IP-banning works for both possible sides of the connection.

Closes https://github.com/ProvableHQ/snarkOS/issues/3895.