### PR TITLE
[Feature] Add flamegraph generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
  "darling 0.20.11",
  "indoc",
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3651,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3912,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3931,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -4114,6 +4114,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "base64 0.22.1",
+ "cfg-if",
  "clap",
  "colored 3.0.0",
  "console-subscriber",
@@ -4143,6 +4144,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-flame",
  "tracing-subscriber",
  "ureq",
  "zeroize",
@@ -4263,7 +4265,6 @@ dependencies = [
  "indexmap 2.12.1",
  "proptest",
  "serde",
- "snarkos-node-network",
  "snarkos-node-sync-locators",
  "snarkvm",
  "test-strategy 0.4.3",
@@ -4527,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -4550,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4578,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "blst",
  "cc",
@@ -4589,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4603,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4613,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4623,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4633,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "indexmap 2.12.1",
  "itertools 0.14.0",
@@ -4651,12 +4652,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4667,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4681,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4696,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4709,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4718,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4728,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4740,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4752,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4763,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4775,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4788,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4799,7 +4800,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -4814,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4825,7 +4826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4845,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4863,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4884,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4899,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4910,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4918,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4928,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4939,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4950,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4961,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4972,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4986,7 +4987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5003,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5033,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5045,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "indexmap 2.12.1",
@@ -5062,12 +5063,13 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tracing",
 ]
 
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "indexmap 2.12.1",
@@ -5086,7 +5088,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5099,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "indexmap 2.12.1",
  "rayon",
@@ -5112,7 +5114,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "indexmap 2.12.1",
  "rayon",
@@ -5125,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5136,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "indexmap 2.12.1",
  "rayon",
@@ -5151,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5164,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5173,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5193,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5216,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5233,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5261,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5279,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "metrics",
 ]
@@ -5287,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5310,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5344,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -5369,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "enum-iterator",
  "indexmap 2.12.1",
@@ -5383,12 +5385,13 @@ dependencies = [
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
  "tiny-keccak",
+ "tracing",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5401,7 +5404,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5424,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=b176b1409#b176b14095a58bbcba6b31f975015c4293ad18d4"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=feat%2Ftracing-instrument#0ba29ef203765a0fd41ea424e92fb72bb6eb7450"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5697,9 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -6132,9 +6135,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -6161,6 +6164,17 @@ checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6425,9 +6439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6438,9 +6452,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6451,9 +6465,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote 1.0.42",
  "wasm-bindgen-macro-support",
@@ -6461,9 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6474,18 +6488,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6848,18 +6862,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,10 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "b176b1409"
+#rev = "b176b1409"
 #version = "=4.4.0"
+branch = "feat/tracing-instrument"
+#version = "=4.2.1"
 default-features = false
 
 [workspace.dependencies.anyhow]
@@ -295,6 +297,13 @@ test_targets = [ "snarkos-cli/test_targets" ]
 test_consensus_heights = [ "snarkos-cli/test_consensus_heights" ]
 test_network = [ "snarkos-cli/test_network" ]
 tokio_console = [ "snarkos-cli/tokio_console" ]
+instrumentation  = [
+  "snarkos-node/instrumentation",
+  "snarkos-node-router/instrumentation",
+  "snarkos-node-sync/instrumentation",
+  "snarkos-node-cdn/instrumentation"
+]
+flamegraph = [ "instrumentation", "snarkos-cli/flamegraph" ]
 
 [dependencies.clap]
 workspace = true

--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ By default, the metrics feature is turned on for some internal crates.
   This feature turns on code for detecting deadlocks.
 * **test_targets** -
   This feature allows the lowering of coinbase and proof targets for testing.
+* **flamegraph** -
+  Enables generation of flamegraphs (using the [tracing-flame crate](https://docs.rs/tracing-flame/latest/tracing_flame/index.html)). This feature should only be used for profiling.
 
 ## 6.5 Local backups
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,12 @@ test_network = [
   "test_consensus_heights",
   "snarkvm/dev-print"
 ]
-serial = [ ]
+flamegraph = [ "dep:tracing-flame" ]
+serial = [
+  "snarkvm/serial",
+  "snarkos-node-metrics/serial",
+  "snarkos-node/serial"
+]
 tokio_console = [ "dep:console-subscriber", "tokio/tracing" ]
 
 [dependencies.aleo-std]
@@ -54,6 +59,9 @@ workspace = true
 
 [dependencies.base64]
 workspace = true
+
+[dependencies.cfg-if]
+version = "1"
 
 [dependencies.clap]
 workspace = true
@@ -72,6 +80,10 @@ workspace = true
 [dependencies.indexmap]
 workspace = true
 features = [ "serde", "rayon" ]
+
+[dependencies.tracing-flame]
+version = "0.2"
+optional = true
 
 [dependencies.locktick]
 workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -150,6 +150,7 @@ version = "3"
 
 [dependencies.time]
 workspace = true
+features = [ "std", "formatting" ]
 
 [dependencies.thiserror]
 workspace = true

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -273,9 +273,9 @@ impl Start {
         let shutdown: Arc<AtomicBool> = Default::default();
 
         // Initialize the logger.
-        let log_receiver = crate::helpers::initialize_logger(
+        let (log_receiver, _log_guard) = crate::helpers::initialize_logger(
             self.verbosity,
-            &self.log_filter,
+            self.log_filter.clone(),
             self.nodisplay,
             self.logfile.clone(),
             shutdown.clone(),

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -243,6 +243,10 @@ pub struct Start {
     #[clap(long)]
     pub nocdn: bool,
 
+    #[clap(long, hide = true)]
+    /// Generate a flamegraph using `tracing`. Only works if the `flamegraph` feature is enabled.
+    pub enable_flamegraph: bool,
+
     /// Enables development mode used to set up test networks.
     ///
     /// The purpose of this flag is to run multiple nodes on the same machine and in the same working directory.
@@ -278,6 +282,7 @@ impl Start {
             self.log_filter.clone(),
             self.nodisplay,
             self.logfile.clone(),
+            self.enable_flamegraph,
             shutdown.clone(),
         )
         .with_context(|| "Failed to set up logger")?;

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -26,6 +26,7 @@ use std::{
     str::FromStr,
     sync::{Arc, atomic::AtomicBool},
 };
+use time::{UtcDateTime, macros::format_description};
 use tokio::sync::mpsc;
 use tracing_subscriber::{
     EnvFilter,
@@ -195,7 +196,10 @@ pub fn initialize_logger<P: AsRef<Path>>(
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "flamegraph")] {
-            let (flame_layer, log_guard) = FlameLayer::with_file("./snarkos-trace.folded").with_context(|| "Failed to create flamegraph file")?;
+            // Add a timestamp to the trace file name, so we do not overwrite an existing one.
+            let timestamp = UtcDateTime::now().format(format_description!("[year][month][day]-[hour][minute][second]")).with_context(|| "Failed to format timestamp")?;
+            let trace_file_name = format!("snarkos-trace-{timestamp}.folded");
+            let (flame_layer, log_guard) = FlameLayer::with_file(trace_file_name.clone()).with_context(|| format!("Failed to create flamegraph file at {trace_file_name}"))?;
             let _ = registry.with(flame_layer).try_init();
 
             Ok((log_receiver, log_guard))

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -17,6 +17,7 @@ use crate::helpers::{DynamicFormatter, LogWriter};
 
 use anyhow::{Result, bail};
 
+use anyhow::Context;
 use crossterm::tty::IsTty;
 use std::{
     fs::File,
@@ -31,6 +32,9 @@ use tracing_subscriber::{
     layer::{Layer, SubscriberExt},
     util::SubscriberInitExt,
 };
+
+#[cfg(feature = "flamegraph")]
+use tracing_flame::FlameLayer;
 
 fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
     // First, set default log verbosity.
@@ -105,7 +109,15 @@ fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
 }
 
 fn parse_log_filter(filter_str: &str) -> Result<EnvFilter> {
-    EnvFilter::from_str(filter_str).map_err(|err| err.into())
+    EnvFilter::from_str(filter_str).with_context(|| "Failed to set up log filter")
+}
+
+#[cfg(not(feature = "flamegraph"))]
+pub struct EmptyLogGuard {}
+
+#[cfg(not(feature = "flamegraph"))]
+impl Drop for EmptyLogGuard {
+    fn drop(&mut self) {}
 }
 
 /// Sets the log filter based on the given verbosity level.
@@ -120,15 +132,17 @@ fn parse_log_filter(filter_str: &str) -> Result<EnvFilter> {
 /// 5 => info, debug, trace, snarkos_node_router=trace
 /// 6 => info, debug, trace, snarkos_node_tcp=trace
 /// ```
+///
+/// Do not drop the returned log guard until shutdown.
 pub fn initialize_logger<P: AsRef<Path>>(
     verbosity: u8,
-    log_filter: &Option<String>,
+    log_filter: Option<String>,
     nodisplay: bool,
     logfile: P,
     shutdown: Arc<AtomicBool>,
-) -> Result<mpsc::Receiver<Vec<u8>>> {
+) -> Result<(mpsc::Receiver<Vec<u8>>, impl Drop)> {
     let [stdout_filter, logfile_filter] = std::array::from_fn(|_| {
-        if let Some(filter) = log_filter { parse_log_filter(filter) } else { parse_log_verbosity(verbosity) }
+        if let Some(filter) = &log_filter { parse_log_filter(filter) } else { parse_log_verbosity(verbosity) }
     });
 
     // Create the directories tree for a logfile if it doesn't exist.
@@ -159,8 +173,8 @@ pub fn initialize_logger<P: AsRef<Path>>(
     // of the log event, i.e., the file/module where the log message was created.
     let show_target = verbosity > 2 || log_filter.is_some();
 
-    // Attach tracing-subscriber.
-    let layered = tracing_subscriber::registry()
+    // Initialize tracing.
+    let registry = tracing_subscriber::registry()
         .with(
             // Add layer using LogWriter for stdout / terminal
             tracing_subscriber::fmt::Layer::default()
@@ -179,14 +193,17 @@ pub fn initialize_logger<P: AsRef<Path>>(
                 .with_filter(logfile_filter?),
         );
 
-    // Attach console-subscriber, if enabled.
-    #[cfg(feature = "tokio_console")]
-    let layered = layered.with(console_subscriber::spawn());
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "flamegraph")] {
+            let (flame_layer, log_guard) = FlameLayer::with_file("./snarkos-trace.folded").with_context(|| "Failed to create flamegraph file")?;
+            let _ = registry.with(flame_layer).try_init();
 
-    // Initialize tracing.
-    let _ = layered.try_init();
-
-    Ok(log_receiver)
+            Ok((log_receiver, log_guard))
+        } else {
+            let _ = registry.try_init();
+            Ok((log_receiver, EmptyLogGuard{}))
+        }
+    }
 }
 
 /// Set up only terminal logging

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -113,12 +113,27 @@ fn parse_log_filter(filter_str: &str) -> Result<EnvFilter> {
     EnvFilter::from_str(filter_str).with_context(|| "Failed to set up log filter")
 }
 
-#[cfg(not(feature = "flamegraph"))]
-pub struct EmptyLogGuard {}
+/// Holds any logging state that needs to be kept alive during the nodes execution.
+/// Dropping this guard will flush the logs and close the flamegraph file (if any).
+#[derive(Default)]
+pub struct LogGuard {
+    #[cfg(feature = "flamegraph")]
+    flame_guard: Option<(String, tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>)>,
+}
 
-#[cfg(not(feature = "flamegraph"))]
-impl Drop for EmptyLogGuard {
-    fn drop(&mut self) {}
+impl Drop for LogGuard {
+    fn drop(&mut self) {
+        #[cfg(feature = "flamegraph")]
+        if let Some((filename, flame_guard)) = &mut self.flame_guard {
+            // Flush the flamegraph file and a message on what to do with it.
+            match flame_guard.flush() {
+                Ok(()) => println!(
+                    "Written folded tracing data to disk. Run `inferno-flamegraph {filename} > flamegraph.svg` to generate a graph from it."
+                ),
+                Err(err) => eprintln!("Failed to flush flamegraph file at {filename}: {err}"),
+            }
+        }
+    }
 }
 
 /// Sets the log filter based on the given verbosity level.
@@ -140,8 +155,9 @@ pub fn initialize_logger<P: AsRef<Path>>(
     log_filter: Option<String>,
     nodisplay: bool,
     logfile: P,
+    enable_flamegraph: bool,
     shutdown: Arc<AtomicBool>,
-) -> Result<(mpsc::Receiver<Vec<u8>>, impl Drop)> {
+) -> Result<(mpsc::Receiver<Vec<u8>>, LogGuard)> {
     let [stdout_filter, logfile_filter] = std::array::from_fn(|_| {
         if let Some(filter) = &log_filter { parse_log_filter(filter) } else { parse_log_verbosity(verbosity) }
     });
@@ -194,19 +210,23 @@ pub fn initialize_logger<P: AsRef<Path>>(
                 .with_filter(logfile_filter?),
         );
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "flamegraph")] {
-            // Add a timestamp to the trace file name, so we do not overwrite an existing one.
-            let timestamp = UtcDateTime::now().format(format_description!("[year][month][day]-[hour][minute][second]")).with_context(|| "Failed to format timestamp")?;
-            let trace_file_name = format!("snarkos-trace-{timestamp}.folded");
-            let (flame_layer, log_guard) = FlameLayer::with_file(trace_file_name.clone()).with_context(|| format!("Failed to create flamegraph file at {trace_file_name}"))?;
-            let _ = registry.with(flame_layer).try_init();
+    if enable_flamegraph {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "flamegraph")] {
+                // Add a timestamp to the trace file name, so we do not overwrite an existing one.
+                let timestamp = UtcDateTime::now().format(format_description!("[year][month][day]-[hour][minute][second]")).with_context(|| "Failed to format timestamp")?;
+                let trace_file_name = format!("snarkos-trace-{timestamp}.folded");
+                let (flame_layer, log_guard) = FlameLayer::with_file(trace_file_name.clone()).with_context(|| format!("Failed to create flamegraph file at {trace_file_name}"))?;
+                let _ = registry.with(flame_layer).try_init();
 
-            Ok((log_receiver, log_guard))
-        } else {
-            let _ = registry.try_init();
-            Ok((log_receiver, EmptyLogGuard{}))
+                Ok((log_receiver, LogGuard { flame_guard: Some((trace_file_name, log_guard)) }))
+            } else {
+                bail!("Cannot enable flamegraph. Disabled at compile time.");
+            }
         }
+    } else {
+        let _ = registry.try_init();
+        Ok((log_receiver, LogGuard::default()))
     }
 }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -50,6 +50,11 @@ cuda = [
   "snarkos-node-router/cuda",
   "snarkos-node-sync/cuda"
 ]
+instrumentation = [
+  "snarkvm/instrumentation",
+  "snarkos-node-router/instrumentation",
+  "snarkos-node-bft/instrumentation"
+]
 serial = [ "snarkos-node-bft/serial" ]
 test = []
 

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -44,6 +44,7 @@ test = [
   "snarkos-node-bft-ledger-service/test",
   "snarkos-node-bft-storage-service/test"
 ]
+instrumentation = [ ]
 serial = [ "snarkos-node-bft-ledger-service/serial" ]
 
 [dependencies.aleo-std]

--- a/node/bft/events/src/challenge_request.rs
+++ b/node/bft/events/src/challenge_request.rs
@@ -60,10 +60,18 @@ impl<N: Network> FromBytes for ChallengeRequest<N> {
         let listener_port = u16::read_le(&mut reader)?;
         let address = Address::<N>::read_le(&mut reader)?;
         let nonce = u64::read_le(&mut reader)?;
-        let snarkos_sha = {
-            let bytes =
-                <[u8; 40]>::read_le(&mut reader).map_err(|err| io_error(format!("Invalid snarkOS SHA - {err}")))?;
-            if bytes == Self::UNKNOWN_COMMIT_HASH { None } else { Some(bytes) }
+        let snarkos_sha = match <[u8; 40]>::read_le(&mut reader) {
+            Ok(bytes) => {
+                if bytes == Self::UNKNOWN_COMMIT_HASH {
+                    None
+                } else {
+                    Some(bytes)
+                }
+            }
+            Err(err) => {
+                tracing::warn!("Invalid snarkOS SHA - {err}");
+                None
+            }
         };
 
         Ok(Self { version, listener_port, address, nonce, snarkos_sha })

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1014,6 +1014,7 @@ impl<N: Network> Primary<N> {
     /// 3. Store the signature.
     /// 4. Certify the batch if enough signatures have been received.
     /// 5. Broadcast the batch certificate to all validators.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self, batch_signature), fields(batch_id = %batch_signature.batch_id)))]
     async fn process_batch_signature_from_peer(
         &self,
         peer_ip: SocketAddr,
@@ -1664,6 +1665,7 @@ impl<N: Network> Primary<N> {
     }
 
     /// Stores the certified batch and broadcasts it to all validators, returning the certificate.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self, proposal, committee), fields(round = proposal.round())))]
     async fn store_and_broadcast_certificate(&self, proposal: &Proposal<N>, committee: &Committee<N>) -> Result<()> {
         // Create the batch certificate and transmissions.
         let (certificate, transmissions) = tokio::task::block_in_place(|| proposal.to_certificate(committee))?;

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -22,6 +22,7 @@ locktick = [ "dep:locktick", "snarkvm/locktick" ]
 parallel = [ "rayon" ]
 cuda = [ "snarkvm/cuda" ]
 metrics = [ "dep:snarkos-node-metrics" ]
+instrumentation = [ ]
 
 [dependencies.anyhow]
 workspace = true

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -22,6 +22,7 @@ locktick = [ "dep:locktick", "snarkos-node-tcp/locktick", "snarkvm/locktick" ]
 metrics = [ "dep:snarkos-node-metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda" ]
 serial = [ "snarkos-node-bft-ledger-service/serial" ]
+instrumentation = [ ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/router/messages/src/challenge_request.rs
+++ b/node/router/messages/src/challenge_request.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 use snarkos_node_network::NodeType;
-use snarkvm::prelude::{FromBytes, ToBytes, io_error};
+use snarkvm::prelude::{FromBytes, ToBytes};
 
 use std::borrow::Cow;
 
@@ -59,10 +59,18 @@ impl<N: Network> FromBytes for ChallengeRequest<N> {
         let address = Address::<N>::read_le(&mut reader)?;
         let nonce = u64::read_le(&mut reader)?;
 
-        let snarkos_sha = {
-            let bytes =
-                <[u8; 40]>::read_le(&mut reader).map_err(|err| io_error(format!("Invalid snarkOS SHA - {err}")))?;
-            if bytes == Self::UNKNOWN_COMMIT_HASH { None } else { Some(bytes) }
+        let snarkos_sha = match <[u8; 40]>::read_le(&mut reader) {
+            Ok(bytes) => {
+                if bytes == Self::UNKNOWN_COMMIT_HASH {
+                    None
+                } else {
+                    Some(bytes)
+                }
+            }
+            Err(err) => {
+                tracing::warn!("Invalid snarkOS SHA - {err}");
+                None
+            }
         };
 
         Ok(Self { version, listener_port, node_type, address, nonce, snarkos_sha })

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -76,6 +76,7 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
     /// Handles the inbound message from the peer. The returned value indicates whether
     /// the connection is still active, and errors cause a disconnect once they are
     /// propagated to the caller.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self, message)))]
     async fn inbound(&self, peer_addr: SocketAddr, message: Message<N>) -> Result<bool> {
         // Retrieve the listener IP for the peer.
         let peer_ip = match self.router().resolve_to_listener(peer_addr) {

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -298,6 +298,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
     }
 
     /// Client-side version of [`snarkvm_node_bft::Sync::try_advancing_block_synchronization`].
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     async fn try_advancing_block_synchronization(&self) {
         let has_new_blocks = match self.sync.try_advancing_block_synchronization().await {
             Ok(val) => val,
@@ -317,6 +318,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
     }
 
     /// Client-side version of `snarkvm_node_bft::Sync::try_block_sync()`.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     async fn try_issuing_block_requests(&self) {
         // Wait for peer updates or timeout
         let _ = timeout(Self::MAX_SYNC_INTERVAL, self.sync.wait_for_peer_update()).await;
@@ -371,6 +373,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         }
     }
 
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     async fn send_block_requests(
         &self,
         block_requests: Vec<(u32, PrepareSyncRequest<N>)>,
@@ -419,6 +422,11 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     let _node = node.clone();
                     // For each solution, spawn a task to verify it.
                     tokio::task::spawn_blocking(move || {
+                        #[cfg(feature = "instrumentation")]
+                        let _span =
+                            tracing::span!(tracing::Level::TRACE, "solution_verification", solution_id = %solution.id())
+                                .entered();
+
                         // Retrieve the latest epoch hash.
                         if let Ok(epoch_hash) = _node.ledger.latest_epoch_hash() {
                             // Check if the prover has reached their solution limit.
@@ -426,12 +434,19 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                             // here prevents the to-be aborted solutions from propagating through the network.
                             let prover_address = solution.address();
                             if _node.ledger.is_solution_limit_reached(&prover_address, 0) {
-                                debug!("Invalid Solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch", fmt_id(solution.id()));
+                                debug!(
+                                    "Invalid Solution '{}' - Prover '{prover_address}' has reached their solution limit for the current epoch",
+                                    fmt_id(solution.id())
+                                );
                             }
                             // Retrieve the latest proof target.
                             let proof_target = _node.ledger.latest_block().header().proof_target();
                             // Ensure that the solution is valid for the given epoch.
+                            #[cfg(feature = "instrumentation")]
+                            let _check_span = tracing::span!(tracing::Level::INFO, "puzzle_check_solution").entered();
                             let is_valid = _node.puzzle.check_solution(&solution, epoch_hash, proof_target);
+                            #[cfg(feature = "instrumentation")]
+                            drop(_check_span);
 
                             match is_valid {
                                 // If the solution is valid, propagate the `UnconfirmedSolution`.
@@ -501,7 +516,9 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                         };
                         // Check if the state root is in the ledger.
                         if !_node.ledger().contains_state_root(&state_root).unwrap_or(false) {
-                            debug!("Failed to find global state root for deployment from peer_ip {peer_ip}, propagating anyway");
+                            debug!(
+                                "Failed to find global state root for deployment from peer_ip {peer_ip}, propagating anyway"
+                            );
                             // Propagate the `UnconfirmedTransaction`.
                             _node.propagate(Message::UnconfirmedTransaction(serialized), &[peer_ip]);
                             _node.num_verifying_deploys.fetch_sub(1, Relaxed);
@@ -541,7 +558,6 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
                     info!("Shutting down execution verification");
                     break;
                 }
-
                 // Determine if the queue contains txs to verify.
                 let queue_is_empty = node.execute_queue.lock().is_empty();
                 // Determine if our verification counter has space to verify new txs.

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -249,6 +249,7 @@ impl<N: Network> Node<N> {
     /// Returns the number of blocks this node is behind the greatest peer height,
     /// or `None` if not connected to peers yet.
     pub fn num_blocks_behind(&self) -> Option<u32> {
+        use snarkos_node_router::Outbound;
         match self {
             Self::Validator(node) => node.num_blocks_behind(),
             Self::Prover(node) => node.num_blocks_behind(),

--- a/node/sync/Cargo.toml
+++ b/node/sync/Cargo.toml
@@ -23,6 +23,7 @@ locktick = [
   "snarkos-node-bft-ledger-service/locktick",
   "snarkos-node-router/locktick",
 ]
+instrumentation = [ ]
 serial = ["snarkos-node-bft-ledger-service/serial"]
 metrics = [ "dep:snarkos-node-metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-bft-ledger-service/cuda", "snarkos-node-router/cuda" ]

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -359,6 +359,7 @@ impl<N: Network> BlockSync<N> {
     }
 
     /// Send a batch of block requests.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip_all))]
     pub async fn send_block_requests<C: CommunicationService>(
         &self,
         communication: &C,
@@ -453,6 +454,7 @@ impl<N: Network> BlockSync<N> {
     /// Note, that this only queues the response. After this, you most likely want to call `Self::try_advancing_block_synchronization`.
     ///
     #[inline]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self, blocks)))]
     pub fn insert_block_responses(
         &self,
         peer_ip: SocketAddr,
@@ -520,6 +522,7 @@ impl<N: Network> BlockSync<N> {
     /// Validators do not call this function, and instead invoke
     /// [`snarkos_node_bft::Sync::try_advancing_block_synchronization`] which also updates the BFT state.
     #[inline]
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self)))]
     pub async fn try_advancing_block_synchronization(&self) -> Result<bool> {
         // Acquire the lock to ensure this function is called only once at a time.
         // If the lock is already acquired, return early.
@@ -556,18 +559,24 @@ impl<N: Network> BlockSync<N> {
             let ledger = self.ledger.clone();
             let advanced = tokio::task::spawn_blocking(move || {
                 // Try to check the next block and advance to it.
-                match ledger.check_next_block(&block) {
-                    Ok(_) => match ledger.advance_to_next_block(&block) {
-                        Ok(_) => true,
-                        Err(err) => {
-                            warn!(
-                                "Failed to advance to next block (height: {}, hash: '{}'): {err}",
-                                block.height(),
-                                block.hash()
-                            );
-                            false
+                let check_result = ledger.check_next_block(&block);
+
+                match check_result {
+                    Ok(_) => {
+                        let result = ledger.advance_to_next_block(&block);
+
+                        match result {
+                            Ok(_) => true,
+                            Err(err) => {
+                                warn!(
+                                    "Failed to advance to next block (height: {}, hash: '{}'): {err}",
+                                    block.height(),
+                                    block.hash()
+                                );
+                                false
+                            }
                         }
-                    },
+                    }
                     Err(err) => {
                         warn!(
                             "The next block (height: {}, hash: '{}') is invalid - {err}",
@@ -635,6 +644,7 @@ impl<N: Network> BlockSync<N> {
     ///
     /// This function does **not** check
     /// that the block locators are consistent with the peer's previous block locators or other peers' block locators.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self, locators)))]
     pub fn update_peer_locators(&self, peer_ip: SocketAddr, locators: &BlockLocators<N>) -> Result<()> {
         // Update the locators entry for the given peer IP.
         // We perform this update atomically, and drop the lock as soon as we are done with the update.
@@ -886,6 +896,7 @@ impl<N: Network> BlockSync<N> {
 
     /// Inserts the given block response, after checking that the request exists and the response is well-formed.
     /// On success, this function removes the peer IP from the request sync peers and inserts the response.
+    #[cfg_attr(feature = "instrumentation", tracing::instrument(skip(self, block), fields(height = block.height(), peer_ip = %peer_ip)))]
     fn insert_block_response(&self, peer_ip: SocketAddr, block: Block<N>) -> Result<()> {
         // Retrieve the block height.
         let height = block.height();


### PR DESCRIPTION
With this PR, nodes create a `snarkos-trace.folded` file on shutdown if the `flamegraph` feature is enabled.

One can then create a flame graph from the file. For example, to generate an SVG of the flame graph using the `inferno` crate, run the following command:
```inferno-flamegraph snarkos-trace.folded > flamegraph.svg```