### PR TITLE
[Perf] Use snarkVM's block caching

### DIFF
--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -47,7 +47,7 @@ trap child_exit_handler CHLD
 # Define a trap handler that prints a message when an error occurs 
 trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
-# Flags used by all ndoes
+# Flags used by all nodes.
 common_flags=(
   --nodisplay --nobanner --noupdater "--network=$network_id" --verbosity=1
   "--dev-num-validators=$total_validators"
@@ -81,11 +81,12 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
   sleep 1
 done
 
-# Start all client nodes in the background
+# Start all client nodes in the background.
 for ((client_index = 0; client_index < total_clients; client_index++)); do
+  # compute the absolute index for this node.
   node_index=$((client_index + total_validators))
 
-  snarkos clean --dev $node_index
+  snarkos clean "--dev=$node_index" "--network=$network_id"
 
   log_file="$log_dir/client-$client_index.log"
   snarkos start "${common_flags[@]}" "--dev=$node_index" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,22 +153,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -297,7 +297,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -393,7 +393,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1974,7 +1974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1990,7 +1990,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2018,7 +2018,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2039,7 +2039,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2392,7 +2392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2910,7 +2910,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3476,7 +3476,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -3787,7 +3787,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
 dependencies = [
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "indicatif",
  "log",
  "quick-xml",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "blst",
  "cc",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "indexmap 2.12.0",
  "itertools 0.14.0",
@@ -4630,12 +4630,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4907,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4940,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5012,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5024,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5091,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5115,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5143,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5195,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5212,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "metrics",
 ]
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5323,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "enum-iterator",
  "indexmap 2.12.0",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5980,7 +5980,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6529,9 +6529,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6558,34 +6558,19 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6594,16 +6579,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6612,7 +6588,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6648,7 +6624,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6673,7 +6649,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "6bec0e0e"
+rev = "fbd99608f"
 #version = "=4.3.0"
 default-features = false
 

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -191,7 +191,7 @@ impl Scan {
     ) -> Result<Vec<Record<N, Plaintext<N>>>> {
         // Check the bounds of the request.
         if start_height > end_height {
-            bail!("Invalid block range");
+            bail!("Invalid block range. Start height ({start_height}) is not smaller than end height ({end_height}).");
         }
 
         // Derive the x-coordinate of the address corresponding to the given view key.
@@ -259,7 +259,8 @@ impl Scan {
             let blocks_endpoint =
                 Developer::build_endpoint::<N>(endpoint, &format!("blocks?start={request_start}&end={request_end}"))?;
             // Fetch blocks
-            let blocks: Vec<Block<N>> = ureq::get(&blocks_endpoint).call()?.into_body().read_json()?;
+            let blocks: Vec<Block<N>> = (|| ureq::get(&blocks_endpoint).call()?.into_body().read_json())()
+                .with_context(|| format!("Failed to fetch blocks range {request_start}..{request_end}"))?;
 
             // Scan the blocks for owned records.
             for block in &blocks {

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -50,7 +50,6 @@ use parking_lot::RwLock;
 use rayon::prelude::*;
 
 use std::{
-    collections::BTreeMap,
     fmt,
     io::Read,
     ops::Range,
@@ -60,14 +59,10 @@ use std::{
     },
 };
 
-/// The capacity of the cache holding the highest blocks.
-const BLOCK_CACHE_SIZE: usize = 10;
-
 /// A core ledger service.
 #[allow(clippy::type_complexity)]
 pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     ledger: Ledger<N, C>,
-    block_cache: Arc<RwLock<BTreeMap<u32, Block<N>>>>,
     latest_leader: Arc<RwLock<Option<(u64, Address<N>)>>>,
     shutdown: Arc<AtomicBool>,
 }
@@ -75,8 +70,7 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
 impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     /// Initializes a new core ledger service.
     pub fn new(ledger: Ledger<N, C>, shutdown: Arc<AtomicBool>) -> Self {
-        let block_cache = Arc::new(RwLock::new(BTreeMap::new()));
-        Self { ledger, block_cache, latest_leader: Default::default(), shutdown }
+        Self { ledger, latest_leader: Default::default(), shutdown }
     }
 }
 
@@ -141,14 +135,6 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     /// Returns the block for the given block height.
     fn get_block(&self, height: u32) -> Result<Block<N>> {
-        // First, check if the block is in the block cache.
-        // Using `try_read` to avoid blocking the thread: https://github.com/rayon-rs/rayon/issues/1205
-        if let Some(block_cache) = self.block_cache.try_read() {
-            if let Some(block) = block_cache.get(&height) {
-                return Ok(block.clone());
-            }
-        }
-        // If no block is found in the cache, then retrieve the block from the ledger.
         self.ledger.get_block(height)
     }
 
@@ -379,15 +365,6 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         }
         // Advance to the next block.
         self.ledger.advance_to_next_block(block)?;
-        // Add the block to the block cache.
-        {
-            let mut block_cache = self.block_cache.write();
-            block_cache.insert(block.height(), block.clone());
-            // Prune the block cache if it exceeds the maximum size.
-            if block_cache.len() > BLOCK_CACHE_SIZE {
-                block_cache.pop_first();
-            }
-        }
         // Update BFT metrics.
         #[cfg(feature = "metrics")]
         {

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -23,11 +23,7 @@ use snarkos_node_cdn::CdnBlockSync;
 use snarkos_node_network::NodeType;
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
-    Heartbeat,
-    Inbound,
-    Outbound,
-    Router,
-    Routing,
+    Heartbeat, Inbound, Outbound, Router, Routing,
     messages::{Message, UnconfirmedSolution, UnconfirmedTransaction},
 };
 use snarkos_node_sync::{BLOCK_REQUEST_BATCH_DELAY, BlockSync, Ping, PrepareSyncRequest, locators::BlockLocators};
@@ -48,7 +44,7 @@ use snarkvm::{
 };
 
 use aleo_std::StorageMode;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use core::future::Future;
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
@@ -62,8 +58,7 @@ use std::{
     sync::{
         Arc,
         atomic::{
-            AtomicBool,
-            AtomicUsize,
+            AtomicBool, AtomicUsize,
             Ordering::{Acquire, Relaxed},
         },
     },
@@ -148,9 +143,13 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         let signal_node = Self::handle_signals(shutdown.clone());
 
         // Initialize the ledger.
-        let genesis_clone = genesis.clone();
-        let mode = storage_mode.clone();
-        let ledger = spawn_blocking!(Ledger::<N, C>::load(genesis_clone, mode))?;
+        let ledger = {
+            let storage_mode = storage_mode.clone();
+            let genesis = genesis.clone();
+
+            spawn_blocking!(Ledger::<N, C>::load(genesis, storage_mode))
+        }
+        .with_context(|| "Failed to initialize the ledger")?;
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone(), shutdown.clone()));

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -24,11 +24,7 @@ use snarkos_node_consensus::Consensus;
 use snarkos_node_network::{NodeType, PeerPoolHandling};
 use snarkos_node_rest::Rest;
 use snarkos_node_router::{
-    Heartbeat,
-    Inbound,
-    Outbound,
-    Router,
-    Routing,
+    Heartbeat, Inbound, Outbound, Router, Routing,
     messages::{PuzzleResponse, UnconfirmedSolution, UnconfirmedTransaction},
 };
 use snarkos_node_sync::{BlockSync, Ping};
@@ -37,15 +33,14 @@ use snarkos_node_tcp::{
     protocols::{Disconnect, Handshake, OnConnect, Reading},
 };
 use snarkvm::prelude::{
-    Ledger,
-    Network,
+    Ledger, Network,
     block::{Block, Header},
     puzzle::Solution,
     store::ConsensusStorage,
 };
 
 use aleo_std::StorageMode;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use core::future::Future;
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::Mutex;
@@ -101,8 +96,13 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         let signal_node = Self::handle_signals(shutdown.clone());
 
         // Initialize the ledger.
-        let mode = storage_mode.clone();
-        let ledger = spawn_blocking!(Ledger::load(genesis, mode))?;
+        let ledger = {
+            let storage_mode = storage_mode.clone();
+            let genesis = genesis.clone();
+
+            spawn_blocking!(Ledger::<N, C>::load(genesis, storage_mode))
+        }
+        .with_context(|| "Failed to initialize the ledger")?;
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), shutdown.clone()));
@@ -483,8 +483,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
 mod tests {
     use super::*;
     use snarkvm::prelude::{
-        MainnetV0,
-        VM,
+        MainnetV0, VM,
         store::{ConsensusStore, helpers::memory::ConsensusMemory},
     };
 


### PR DESCRIPTION
This is a companion PR for [snarkVM #2971](https://github.com/ProvableHQ/snarkVM/pull/2971).

It removes the cache in `snarkos-node-bft-ledger-service` and instead uses the native mechanism in snarkVM. This allows cached blocks to be available for components that use the `Ledger` object directly and not through `LedgerService`.

This PR also fixes an issue with the `devnet_ci.sh` script, where the wrong `network_id` might be used for cleanup.