### PR TITLE
Reduce superfluous failed workflow spam

### DIFF
--- a/.github/workflows/update-snarkvm.yml
+++ b/.github/workflows/update-snarkvm.yml
@@ -119,6 +119,7 @@ jobs:
           
           This update was performed automatically by the snarkVM update workflow."
           git push --force-with-lease origin update-snarkvm-staging
+        continue-on-error: true
 
       - name: Create or update PR
         if: steps.snarkvm-commit.outputs.update_needed == 'true'


### PR DESCRIPTION
## Motivation

I am getting an email every single hour because of intended behaviour: this workflow is meant to only update the snarkVM rev on the `update-snarkvm-staging` branch if the branch wasn't already created by someone else or a previous run: https://github.com/ProvableHQ/snarkOS/pull/3918

I think it's likely `--force-with-lease` is probably superfluous, but it doesn't hurt either, so leaving that as is for now.
