### PR TITLE
[Chore] Update tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,17 +2027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2258,16 @@ dependencies = [
  "parking_lot",
  "simple_moving_average",
  "tokio",
+]
+
+[[package]]
+name = "locktick"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4a7c4b9459e549968abf200cb77c6faf0bdedc87df5065f73ca95031795050"
+dependencies = [
+ "backtrace",
+ "simple_moving_average",
 ]
 
 [[package]]
@@ -3760,7 +3759,7 @@ version = "4.2.2"
 dependencies = [
  "built",
  "clap",
- "locktick",
+ "locktick 0.4.0",
  "rusty-hook",
  "snarkos-account",
  "snarkos-cli",
@@ -3800,7 +3799,7 @@ dependencies = [
  "colored 3.0.0",
  "crossterm 0.29.0",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "nix",
  "num_cpus",
  "parking_lot",
@@ -3854,7 +3853,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "num_cpus",
  "once_cell",
@@ -3899,7 +3898,7 @@ dependencies = [
  "futures",
  "indexmap 2.11.4",
  "itertools 0.14.0",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "mockall",
  "open",
@@ -3957,7 +3956,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -3974,7 +3973,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "parking_lot",
  "snarkvm",
@@ -3989,7 +3988,7 @@ dependencies = [
  "bincode",
  "colored 3.0.0",
  "http 1.3.1",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "rayon",
  "reqwest",
@@ -4011,7 +4010,7 @@ dependencies = [
  "colored 3.0.0",
  "indexmap 2.11.4",
  "itertools 0.14.0",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "once_cell",
  "parking_lot",
@@ -4031,7 +4030,7 @@ dependencies = [
 name = "snarkos-node-metrics"
 version = "4.2.2"
 dependencies = [
- "locktick",
+ "locktick 0.3.0",
  "metrics-exporter-prometheus",
  "parking_lot",
  "rayon",
@@ -4051,7 +4050,7 @@ dependencies = [
  "http 1.3.1",
  "indexmap 2.11.4",
  "jsonwebtoken",
- "locktick",
+ "locktick 0.3.0",
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
@@ -4084,7 +4083,7 @@ dependencies = [
  "futures",
  "futures-util",
  "linked-hash-map",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "peak_alloc",
  "rand 0.8.5",
@@ -4130,7 +4129,7 @@ dependencies = [
  "futures",
  "indexmap 2.11.4",
  "itertools 0.14.0",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "rand 0.8.5",
  "serde",
@@ -4172,7 +4171,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "locktick",
+ "locktick 0.3.0",
  "once_cell",
  "parking_lot",
  "snarkos-node-metrics",
@@ -4663,7 +4662,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
@@ -4832,7 +4831,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
@@ -4852,7 +4851,7 @@ dependencies = [
  "anyhow",
  "colored 3.0.0",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
@@ -4892,7 +4891,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "rayon",
  "rocksdb",
@@ -4949,7 +4948,7 @@ dependencies = [
  "curl",
  "hex",
  "lazy_static",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "paste",
  "rand 0.8.5",
@@ -4969,7 +4968,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.11.4",
  "itertools 0.14.0",
- "locktick",
+ "locktick 0.3.0",
  "lru 0.16.1",
  "parking_lot",
  "rand 0.8.5",
@@ -5001,7 +5000,7 @@ dependencies = [
  "aleo-std",
  "colored 3.0.0",
  "indexmap 2.11.4",
- "locktick",
+ "locktick 0.3.0",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5504,29 +5503,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.41",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ version = "2"
 version = "0.3"
 
 [workspace.dependencies.tokio]
-version = "1.28"
+version = "1.48"
 
 [workspace.dependencies.tokio-util]
 version = "0.7"
@@ -279,7 +279,7 @@ workspace = true
 features = [ "derive" ]
 
 [dependencies.locktick]
-version = "0.3"
+version = "0.4"
 optional = true
 
 [dependencies.snarkos-account]


### PR DESCRIPTION
It's been a while since our last `tokio` update, and while some of the dependencies seem to be bumping it for us significantly, we shouldn't rely on it.

As a drive-by, update `locktick` as well, granting the `LockGuard` reexport.