### PR TITLE
[Tweak] Place per-connection tasks in the heap

### DIFF
--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -138,7 +138,7 @@ impl<R: Reading> ReadingInternal for R {
 
         // the task for processing parsed messages
         let self_clone = self.clone();
-        let inbound_processing_task = tokio::spawn(async move {
+        let inbound_processing_task = tokio::spawn(Box::pin(async move {
             let node = self_clone.tcp();
             trace!(parent: node.span(), "spawned a task for processing messages from {addr}");
             tx_processing.send(()).unwrap(); // safe; the channel was just opened
@@ -151,7 +151,7 @@ impl<R: Reading> ReadingInternal for R {
                 #[cfg(feature = "metrics")]
                 metrics::decrement_gauge(metrics::tcp::TCP_TASKS, 1f64);
             }
-        });
+        }));
         let _ = rx_processing.await;
         conn.tasks.push(inbound_processing_task);
 
@@ -160,7 +160,7 @@ impl<R: Reading> ReadingInternal for R {
 
         // the task for reading messages from a stream
         let node = self.tcp().clone();
-        let reader_task = tokio::spawn(async move {
+        let reader_task = tokio::spawn(Box::pin(async move {
             trace!(parent: node.span(), "spawned a task for reading messages from {addr}");
             tx_reader.send(()).unwrap(); // safe; the channel was just opened
 
@@ -190,7 +190,7 @@ impl<R: Reading> ReadingInternal for R {
             }
 
             let _ = node.disconnect(addr).await;
-        });
+        }));
         let _ = rx_reader.await;
         conn.tasks.push(reader_task);
 

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -211,7 +211,7 @@ impl<W: Writing> WritingInternal for W {
 
         // the task for writing outbound messages
         let self_clone = self.clone();
-        let writer_task = tokio::spawn(async move {
+        let writer_task = tokio::spawn(Box::pin(async move {
             let node = self_clone.tcp();
             trace!(parent: node.span(), "spawned a task for writing messages to {}", addr);
             tx_writer.send(()).unwrap(); // safe; the channel was just opened
@@ -242,7 +242,7 @@ impl<W: Writing> WritingInternal for W {
             }
 
             node.disconnect(addr).await;
-        });
+        }));
         let _ = rx_writer.await;
         conn.tasks.push(writer_task);
 


### PR DESCRIPTION
While `tokio` automatically places tasks with a future larger than 16KiB (in `release` mode, 2KiB in `debug`) on the heap via boxing, our tasks are typically smaller than that, but they can easily reach ~10KiB. Despite having relatively large stacks (8MiB) for both our `rayon` and `tokio` threads, they could still technically blow up under sufficient stress, especially if we scale up the number of connections in the future (for example for the `BootstrapperClient`s).

In order to avoid this, we can manually box the tasks that increase in numbers when the node scales up its operations, and the most obvious candidates for this treatment are long-running tasks that are spawned per each connection; in our case these are 2 `Reading` tasks and 1 `Writing` task, which this PR boxes unconditionally.

This was discovered with the aid of `tokio-console`.