### PR TITLE
[Tweak] Slash KnownPeers together with candidate peers

### DIFF
--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -268,6 +268,9 @@ pub trait PeerPoolHandling<N: Network>: P2P {
 
             // Remove the peers to slash from the pool.
             peer_pool.retain(|addr, _| !peers_to_slash.contains(addr));
+
+            // Remove the peers to slash from the low-level list of known peers.
+            self.tcp().known_peers().batch_remove(peers_to_slash.iter().map(|addr| addr.ip()));
         }
 
         // Make sure that we won't breach the pool size limit in case the slashing didn't suffice.

--- a/node/tcp/src/helpers/known_peers.rs
+++ b/node/tcp/src/helpers/known_peers.rs
@@ -55,6 +55,14 @@ impl KnownPeers {
         self.0.write().remove(&addr)
     }
 
+    /// Removes a batch of addresses all at once.
+    pub fn batch_remove<I: Iterator<Item = IpAddr>>(&self, addrs: I) {
+        let mut peers = self.0.write();
+        for addr in addrs {
+            peers.remove(&addr);
+        }
+    }
+
     /// Returns the list of all known peers and their stats.
     pub fn snapshot(&self) -> HashMap<IpAddr, Arc<Stats>> {
         self.0.read().clone()


### PR DESCRIPTION
I've given it some thought, and it seems to me that since now our high- and low-level collections of peers are often used in tandem (when adding candidate peers, selecting the best peers to persist beyond shutdown, etc), we might as well perform maintenance on both collections at the same time. While inserting new candidate peers and detecting the need to slash their numbers, slash the lower-level collection of addresses at the same time, for coherence, performance, and simplicity.

Closes https://github.com/ProvableHQ/snarkOS/issues/3904.