### PR TITLE
[Feat] Tighten BootstrapClient validator sharing

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -50,6 +50,7 @@ cuda = [
   "snarkos-node-sync/cuda"
 ]
 serial = [ "snarkos-node-bft/serial" ]
+test = []
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -43,7 +43,7 @@ use snarkos_node_bft_events::{
     ValidatorsResponse,
 };
 use snarkos_node_bft_ledger_service::LedgerService;
-use snarkos_node_router::{NodeType, Peer, PeerPoolHandling, Resolver, bootstrap_peers};
+use snarkos_node_router::{ConnectionMode, NodeType, Peer, PeerPoolHandling, Resolver, bootstrap_peers};
 use snarkos_node_sync::{MAX_BLOCKS_BEHIND, communication_service::CommunicationService};
 use snarkos_node_tcp::{
     Config,
@@ -178,6 +178,10 @@ impl<N: Network> PeerPoolHandling<N> for Gateway<N> {
 
     fn is_dev(&self) -> bool {
         self.dev.is_some()
+    }
+
+    fn node_type(&self) -> NodeType {
+        NodeType::Validator
     }
 }
 
@@ -460,7 +464,14 @@ impl<N: Network> Gateway<N> {
         // Add a transmission for this peer in the connected peers.
         self.peer_pool.write().insert(peer_ip, Peer::new_connecting(peer_ip, false));
         if let Some(peer) = self.peer_pool.write().get_mut(&peer_ip) {
-            peer.upgrade_to_connected(peer_addr, peer_ip.port(), address, NodeType::Validator, 0);
+            peer.upgrade_to_connected(
+                peer_addr,
+                peer_ip.port(),
+                address,
+                NodeType::Validator,
+                0,
+                ConnectionMode::Gateway,
+            );
         }
     }
 
@@ -1257,14 +1268,21 @@ impl<N: Network> Handshake for Gateway<N> {
         if let Some(addr) = listener_addr {
             match handshake_result {
                 Ok(Some(ref cr)) => {
-                    let (node_type, aleo_address) = if bootstrap_peers::<N>(self.is_dev()).contains(&addr) {
-                        (NodeType::BootstrapClient, None)
+                    let node_type = if bootstrap_peers::<N>(self.is_dev()).contains(&addr) {
+                        NodeType::BootstrapClient
                     } else {
-                        (NodeType::Validator, Some(cr.address))
+                        NodeType::Validator
                     };
                     if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                        self.resolver.write().insert_peer(addr, peer_addr, aleo_address);
-                        peer.upgrade_to_connected(peer_addr, cr.listener_port, cr.address, node_type, cr.version);
+                        self.resolver.write().insert_peer(addr, peer_addr, Some(cr.address));
+                        peer.upgrade_to_connected(
+                            peer_addr,
+                            cr.listener_port,
+                            cr.address,
+                            node_type,
+                            cr.version,
+                            ConnectionMode::Gateway,
+                        );
                     }
                     #[cfg(feature = "metrics")]
                     self.update_metrics();

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use crate::{
+    ConnectionMode,
     NodeType,
     PeerPoolHandling,
     Router,
@@ -135,8 +136,15 @@ impl<N: Network> Router<N> {
             match handshake_result {
                 Ok(Some(ref cr)) => {
                     if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                        self.resolver.write().insert_peer(peer.listener_addr(), peer_addr, None);
-                        peer.upgrade_to_connected(peer_addr, cr.listener_port, cr.address, cr.node_type, cr.version);
+                        self.resolver.write().insert_peer(peer.listener_addr(), peer_addr, Some(cr.address));
+                        peer.upgrade_to_connected(
+                            peer_addr,
+                            cr.listener_port,
+                            cr.address,
+                            cr.node_type,
+                            cr.version,
+                            ConnectionMode::Router,
+                        );
                     }
                     #[cfg(feature = "metrics")]
                     self.update_metrics();

--- a/node/router/src/helpers/peer.rs
+++ b/node/router/src/helpers/peer.rs
@@ -19,7 +19,7 @@ use snarkvm::prelude::{Address, Network};
 use std::{net::SocketAddr, time::Instant};
 
 /// A peer of any connection status.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Peer<N: Network> {
     /// A candidate peer that's currently not connected to.
     Candidate(CandidatePeer),
@@ -30,7 +30,7 @@ pub enum Peer<N: Network> {
 }
 
 /// A connecting peer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ConnectingPeer {
     /// The listening address of a connecting peer.
     pub listener_addr: SocketAddr,
@@ -39,7 +39,7 @@ pub struct ConnectingPeer {
 }
 
 /// A candidate peer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CandidatePeer {
     /// The listening address of a candidate peer.
     pub listener_addr: SocketAddr,
@@ -50,12 +50,14 @@ pub struct CandidatePeer {
 }
 
 /// A fully connected peer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ConnectedPeer<N: Network> {
     /// The listener address of the peer.
     pub listener_addr: SocketAddr,
     /// The connected address of the peer.
     pub connected_addr: SocketAddr,
+    /// Indicates whether this is a Router or a Gateway connection for the peer.
+    pub connection_mode: ConnectionMode,
     /// Indicates whether the peer is considered trusted.
     pub trusted: bool,
     /// The Aleo address of the peer.
@@ -70,6 +72,13 @@ pub struct ConnectedPeer<N: Network> {
     pub first_seen: Instant,
     /// The timestamp of the last message received from this peer.
     pub last_seen: Instant,
+}
+
+/// Indicates whether a peer is connected via the Gateway or the Router.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConnectionMode {
+    Gateway,
+    Router,
 }
 
 impl<N: Network> Peer<N> {
@@ -91,6 +100,7 @@ impl<N: Network> Peer<N> {
         aleo_address: Address<N>,
         node_type: NodeType,
         node_version: u32,
+        connection_mode: ConnectionMode,
     ) {
         let timestamp = Instant::now();
         let listener_addr = SocketAddr::from((connected_addr.ip(), listener_port));
@@ -104,6 +114,7 @@ impl<N: Network> Peer<N> {
         *self = Self::Connected(ConnectedPeer {
             listener_addr,
             connected_addr,
+            connection_mode,
             aleo_addr: aleo_address,
             node_type,
             trusted: self.is_trusted(),

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -97,6 +97,9 @@ pub trait PeerPoolHandling<N: Network>: P2P {
     /// Returns `true` if the owning node is in development mode.
     fn is_dev(&self) -> bool;
 
+    /// Returns the node type.
+    fn node_type(&self) -> NodeType;
+
     /// Returns the listener address of this node.
     fn local_ip(&self) -> SocketAddr {
         self.tcp().listening_addr().expect("The TCP listener is not enabled")
@@ -203,8 +206,17 @@ pub trait PeerPoolHandling<N: Network>: P2P {
     fn downgrade_peer_to_candidate(&self, listener_addr: SocketAddr) {
         if let Some(peer) = self.peer_pool().write().get_mut(&listener_addr) {
             if let Peer::Connected(peer) = peer {
-                // Only validators get their aleo address registered with the resolver.
-                let aleo_addr = if peer.node_type == NodeType::Validator { Some(peer.aleo_addr) } else { None };
+                // Exception: the BootstrapClient only has a single Resolver,
+                // so it may only map a validator's Aleo address once, for its
+                // Gateway-mode connection. This also means that the Router-mode
+                // connection may not remove that mapping.
+                let aleo_addr = if self.node_type() == NodeType::BootstrapClient
+                    && peer.connection_mode == ConnectionMode::Router
+                {
+                    None
+                } else {
+                    Some(peer.aleo_addr)
+                };
                 self.resolver().write().remove_peer(peer.connected_addr, aleo_addr);
             }
             peer.downgrade_to_candidate(listener_addr);
@@ -596,6 +608,10 @@ impl<N: Network> PeerPoolHandling<N> for Router<N> {
     fn is_dev(&self) -> bool {
         self.is_dev
     }
+
+    fn node_type(&self) -> NodeType {
+        self.node_type
+    }
 }
 
 pub struct InnerRouter<N: Network> {
@@ -704,11 +720,6 @@ impl<N: Network> Router<N> {
 
         // Check if the incoming message version is valid.
         message_version >= lowest_accepted_message_version
-    }
-
-    /// Returns the node type.
-    pub fn node_type(&self) -> NodeType {
-        self.node_type
     }
 
     /// Returns the account private key of the node.

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -171,7 +171,7 @@ pub trait PeerPoolHandling<N: Network>: P2P {
         // Determine whether the peer is trusted or a bootstrap node in order to decide
         // how problematic any potential connection issues are.
         let is_trusted_or_bootstrap =
-            self.is_trusted(listener_addr) || bootstrap_peers::<N>(false).contains(&listener_addr);
+            self.is_trusted(listener_addr) || bootstrap_peers::<N>(self.is_dev()).contains(&listener_addr);
 
         let tcp = self.tcp().clone();
         Some(tokio::spawn(async move {

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -17,6 +17,7 @@ use crate::common::sample_genesis_block;
 use snarkos_node_router::{
     Heartbeat,
     Inbound,
+    NodeType,
     Outbound,
     Peer,
     PeerPoolHandling,
@@ -95,6 +96,10 @@ impl<N: Network> PeerPoolHandling<N> for TestRouter<N> {
 
     fn is_dev(&self) -> bool {
         true
+    }
+
+    fn node_type(&self) -> NodeType {
+        self.router().node_type()
     }
 }
 

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -273,12 +273,38 @@ impl<N: Network> BootstrapClient<N> {
                     send_msg!(msg, framed, peer_addr)?;
                     return Ok(false);
                 }
+
+                // Reject validators that aren't members of the committee.
+                if msg.node_type == NodeType::Validator {
+                    // This check is skipped in dev mode (the None scenario).
+                    if let Some(current_committee) =
+                        self.get_or_update_committee().await.map_err(|_| error("Couldn't load the committee"))?
+                    {
+                        if !current_committee.contains(&msg.address) {
+                            let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
+                            send_msg!(msg, framed, peer_addr)?;
+                            return Ok(false);
+                        }
+                    }
+                }
             }
             MessageOrEvent::Event(Event::ChallengeRequest(msg)) => {
                 if msg.version < Event::<N>::VERSION {
                     let msg = Event::Disconnect::<N>(events::DisconnectReason::OutdatedClientVersion.into());
                     send_msg!(msg, framed, peer_addr)?;
                     return Ok(false);
+                }
+
+                // Reject validators that aren't members of the committee.
+                // This check is skipped in dev mode (the None scenario).
+                if let Some(current_committee) =
+                    self.get_or_update_committee().await.map_err(|_| error("Couldn't load the committee"))?
+                {
+                    if !current_committee.contains(&msg.address) {
+                        let msg = Event::Disconnect::<N>(events::DisconnectReason::ProtocolViolation.into());
+                        send_msg!(msg, framed, peer_addr)?;
+                        return Ok(false);
+                    }
                 }
             }
             _ => unreachable!(),

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -18,6 +18,7 @@ use crate::{
     bft::events::{self, Event},
     bootstrap_client::{codec::BootstrapClientCodec, network::MessageOrEvent},
     router::{
+        ConnectionMode,
         NodeType,
         PeerPoolHandling,
         messages::{self, Message},
@@ -121,15 +122,23 @@ impl<N: Network> Handshake for BootstrapClient<N> {
 
         if let Some(addr) = listener_addr {
             match handshake_result {
-                Ok(Some((peer_port, peer_aleo_addr, peer_node_type, peer_version, validator_mode))) => {
+                Ok(Some((peer_port, peer_aleo_addr, peer_node_type, peer_version, connection_mode))) => {
                     if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                        self.resolver.write().insert_peer(
-                            peer.listener_addr(),
+                        // Due to only having a single Resolver, the BootstrapClient only adds an Aleo
+                        // address mapping for Gateway-mode connections, as it is only used there, and
+                        // it could otherwise clash with the Router-mode mapping for validators, which
+                        // may connect in both modes at the same time.
+                        let aleo_addr =
+                            if connection_mode == ConnectionMode::Gateway { Some(peer_aleo_addr) } else { None };
+                        self.resolver.write().insert_peer(peer.listener_addr(), peer_addr, aleo_addr);
+                        peer.upgrade_to_connected(
                             peer_addr,
-                            // Only resolve aleo addresses for Gateway connections.
-                            if validator_mode { Some(peer_aleo_addr) } else { None },
+                            peer_port,
+                            peer_aleo_addr,
+                            peer_node_type,
+                            peer_version,
+                            connection_mode,
                         );
-                        peer.upgrade_to_connected(peer_addr, peer_port, peer_aleo_addr, peer_node_type, peer_version);
                     }
                     debug!("Completed the handshake with '{peer_addr}'");
                 }
@@ -157,7 +166,7 @@ impl<N: Network> BootstrapClient<N> {
         peer_addr: SocketAddr,
         listener_addr: &mut Option<SocketAddr>,
         stream: &'a mut TcpStream,
-    ) -> io::Result<Option<(u16, Address<N>, NodeType, u32, bool)>> {
+    ) -> io::Result<Option<(u16, Address<N>, NodeType, u32, ConnectionMode)>> {
         // Construct the stream.
         let mut framed = Framed::new(stream, BootstrapClientCodec::<N>::handshake());
 
@@ -165,16 +174,17 @@ impl<N: Network> BootstrapClient<N> {
 
         // Listen for the challenge request message, which can be either from a regular peer, or a validator.
         let peer_request = expect_handshake_msg!(HandshakeMessageKind::ChallengeRequest, framed, peer_addr);
-        let (peer_port, peer_nonce, peer_aleo_addr, peer_node_type, peer_version, validator_mode) = match peer_request {
+        let (peer_port, peer_nonce, peer_aleo_addr, peer_node_type, peer_version, connection_mode) = match peer_request
+        {
             MessageOrEvent::Message(Message::ChallengeRequest(ref msg)) => {
-                (msg.listener_port, msg.nonce, msg.address, msg.node_type, msg.version, false)
+                (msg.listener_port, msg.nonce, msg.address, msg.node_type, msg.version, ConnectionMode::Router)
             }
             MessageOrEvent::Event(Event::ChallengeRequest(ref msg)) => {
-                (msg.listener_port, msg.nonce, msg.address, NodeType::Validator, msg.version, true)
+                (msg.listener_port, msg.nonce, msg.address, NodeType::Validator, msg.version, ConnectionMode::Gateway)
             }
             _ => unreachable!(),
         };
-        debug!("Handshake mode: {}validator", if validator_mode { "" } else { "non-" });
+        debug!("Handshake mode: {connection_mode:?}");
 
         // Obtain the peer's listening address.
         *listener_addr = Some(SocketAddr::new(peer_addr.ip(), peer_port));
@@ -204,7 +214,7 @@ impl<N: Network> BootstrapClient<N> {
         };
 
         // Send the challenge response.
-        if !validator_mode {
+        if connection_mode == ConnectionMode::Router {
             let our_response = messages::ChallengeResponse {
                 genesis_header: self.genesis_header,
                 restrictions_id: self.restrictions_id,
@@ -226,7 +236,7 @@ impl<N: Network> BootstrapClient<N> {
         // Sample a random nonce.
         let our_nonce: u64 = rng.r#gen();
         // Send the challenge request.
-        if !validator_mode {
+        if connection_mode == ConnectionMode::Router {
             let our_request = messages::ChallengeRequest::new(
                 self.local_ip().port(),
                 NodeType::BootstrapClient,
@@ -247,7 +257,7 @@ impl<N: Network> BootstrapClient<N> {
         let peer_response = expect_handshake_msg!(HandshakeMessageKind::ChallengeResponse, framed, peer_addr);
         // Verify the challenge response.
         if !self.verify_challenge_response(peer_addr, peer_aleo_addr, our_nonce, &peer_response).await {
-            if !validator_mode {
+            if connection_mode == ConnectionMode::Router {
                 let msg = Message::Disconnect::<N>(messages::DisconnectReason::InvalidChallengeResponse.into());
                 send_msg!(msg, framed, peer_addr)?;
             } else {
@@ -257,7 +267,7 @@ impl<N: Network> BootstrapClient<N> {
             return Err(error(format!("Handshake with '{peer_addr}' failed: invalid challenge response")));
         }
 
-        Ok(Some((peer_port, peer_aleo_addr, peer_node_type, peer_version, validator_mode)))
+        Ok(Some((peer_port, peer_aleo_addr, peer_node_type, peer_version, connection_mode)))
     }
 
     async fn verify_challenge_request(

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -286,7 +286,6 @@ impl<N: Network> BootstrapClient<N> {
 
                 // Reject validators that aren't members of the committee.
                 if msg.node_type == NodeType::Validator {
-                    // This check is skipped in dev mode (the None scenario).
                     if let Some(current_committee) =
                         self.get_or_update_committee().await.map_err(|_| error("Couldn't load the committee"))?
                     {
@@ -306,7 +305,6 @@ impl<N: Network> BootstrapClient<N> {
                 }
 
                 // Reject validators that aren't members of the committee.
-                // This check is skipped in dev mode (the None scenario).
                 if let Some(current_committee) =
                     self.get_or_update_committee().await.map_err(|_| error("Couldn't load the committee"))?
                 {

--- a/node/src/bootstrap_client/mod.rs
+++ b/node/src/bootstrap_client/mod.rs
@@ -169,9 +169,19 @@ impl<N: Network> BootstrapClient<N> {
     /// Returns the current validator committee or updates it from the explorer, if
     /// we are capable of obtaining it from the network.
     pub async fn get_or_update_committee(&self) -> anyhow::Result<Option<HashSet<Address<N>>>> {
-        // The current committee can't be looked up in dev mode.
-        if self.is_dev() {
-            return Ok(None);
+        // Development testing may include a list of committee Aleo addresses loaded from the environment.
+        if cfg!(feature = "test") || self.is_dev() {
+            match std::env::var("TEST_COMMITTEE_ADDRS") {
+                Ok(aleo_addrs) => {
+                    let dev_committee =
+                        aleo_addrs.split(',').map(|addr| Address::<N>::from_str(addr).unwrap()).collect();
+                    return Ok(Some(dev_committee));
+                }
+                Err(err) => {
+                    warn!("Failed to load committee peers from environment: {err}");
+                    return Ok(None);
+                }
+            }
         }
 
         let now = Instant::now();

--- a/node/src/bootstrap_client/mod.rs
+++ b/node/src/bootstrap_client/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     tcp::{self, Tcp},
 };
 use snarkos_account::Account;
+use snarkos_node_router::ConnectionMode;
 use snarkos_node_tcp::{P2P, protocols::*};
 use snarkvm::{
     ledger::committee::Committee,
@@ -59,8 +60,8 @@ impl<N: Network> Deref for BootstrapClient<N> {
     }
 }
 
-// A tuple holding the validator's Aleo address, and a bool indicating if it's in Gateway mode.
-type KnownValidatorInfo<N> = (Address<N>, bool);
+// A tuple holding the validator's Aleo address, and its connection mode.
+type KnownValidatorInfo<N> = (Address<N>, ConnectionMode);
 
 pub struct InnerBootstrapClient<N: Network> {
     tcp: Tcp,
@@ -94,7 +95,7 @@ impl<N: Network> BootstrapClient<N> {
         let tcp = Tcp::new(tcp::Config::new(listener_addr, Self::MAX_PEERS));
         // Initialize the peer pool.
         let peer_pool = Default::default();
-        // Initialize a collection of validators that had connected in Gateway mode.
+        // Initialize a collection of validators.
         let known_validators = Default::default();
         // Load the restrictions ID.
         let restrictions_id = Restrictions::load()?.restrictions_id();

--- a/node/src/bootstrap_client/mod.rs
+++ b/node/src/bootstrap_client/mod.rs
@@ -59,10 +59,13 @@ impl<N: Network> Deref for BootstrapClient<N> {
     }
 }
 
+// A tuple holding the validator's Aleo address, and a bool indicating if it's in Gateway mode.
+type KnownValidatorInfo<N> = (Address<N>, bool);
+
 pub struct InnerBootstrapClient<N: Network> {
     tcp: Tcp,
     peer_pool: RwLock<HashMap<SocketAddr, Peer<N>>>,
-    known_validators: RwLock<HashMap<SocketAddr, Address<N>>>,
+    known_validators: RwLock<HashMap<SocketAddr, KnownValidatorInfo<N>>>,
     resolver: RwLock<Resolver<N>>,
     account: Account<N>,
     genesis_header: Header<N>,
@@ -188,9 +191,23 @@ impl<N: Network> BootstrapClient<N> {
         }
     }
 
-    /// Returns the list of known validators connected in Gateway mode.
-    pub fn get_known_validators(&self) -> HashMap<SocketAddr, Address<N>> {
-        self.known_validators.read().clone()
+    // Return the known addresses of current committee members, or all known
+    // validators if the committee info is unavailable.
+    pub async fn get_validator_addrs(&self) -> HashMap<SocketAddr, KnownValidatorInfo<N>> {
+        // First, collect info on all the validators we had connected to before.
+        let mut known_validators = self.known_validators.read().clone();
+        // If the committee info is available, prune non-committee members.
+        match self.get_or_update_committee().await {
+            Ok(Some(committee)) => {
+                known_validators.retain(|_, (aleo_addr, _)| committee.contains(aleo_addr));
+                known_validators
+            }
+            Ok(None) => known_validators,
+            Err(error) => {
+                error!("Couldn't update the validator committee: {error}");
+                known_validators
+            }
+        }
     }
 
     /// Shuts down the bootstrap client.

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     bootstrap_client::codec::BootstrapClientCodec,
     router::{
+        ConnectionMode,
         MAX_PEERS_TO_SEND,
         NodeType,
         Peer,
@@ -56,6 +57,10 @@ impl<N: Network> PeerPoolHandling<N> for BootstrapClient<N> {
         self.dev.is_some()
     }
 
+    fn node_type(&self) -> NodeType {
+        NodeType::BootstrapClient
+    }
+
     fn peer_pool(&self) -> &RwLock<HashMap<SocketAddr, Peer<N>>> {
         &self.peer_pool
     }
@@ -80,9 +85,7 @@ impl<N: Network> OnConnect for BootstrapClient<N> {
         if let Some(listener_addr) = self.resolve_to_listener(peer_addr) {
             if let Some(peer) = self.get_connected_peer(listener_addr) {
                 if peer.node_type == NodeType::Validator {
-                    // Having the Aleo address in the resolver indicates Gateway mode.
-                    let gateway_mode = self.resolver().read().get_peer_ip_for_address(peer.aleo_addr).is_some();
-                    self.known_validators.write().insert(listener_addr, (peer.aleo_addr, gateway_mode));
+                    self.known_validators.write().insert(listener_addr, (peer.aleo_addr, peer.connection_mode));
                 }
             }
         }
@@ -141,7 +144,10 @@ impl<N: Network> Reading for BootstrapClient<N> {
                 if peer.node_type == NodeType::Validator {
                     // Filter out Gateway addresses.
                     peers.retain(|peer| {
-                        validators.get(&peer.listener_addr).map(|(_, gateway_mode)| !gateway_mode).unwrap_or(true)
+                        validators
+                            .get(&peer.listener_addr)
+                            .map(|(_, connection_mode)| *connection_mode != ConnectionMode::Gateway)
+                            .unwrap_or(true)
                     });
                 } else {
                     // Filter out all validator addresses.
@@ -167,9 +173,9 @@ impl<N: Network> Reading for BootstrapClient<N> {
                 let validators = self.get_validator_addrs().await;
                 let validators = validators
                     .into_iter()
-                    .filter_map(|(listener_addr, (aleo_addr, gateway_mode))| {
+                    .filter_map(|(listener_addr, (aleo_addr, connection_mode))| {
                         // Only pick addresses connected in Gateway mode.
-                        gateway_mode.then_some((listener_addr, aleo_addr))
+                        (connection_mode == ConnectionMode::Gateway).then_some((listener_addr, aleo_addr))
                     })
                     .take(MAX_VALIDATORS_TO_SEND)
                     .collect::<IndexMap<_, _>>();

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -22,6 +22,7 @@ use crate::{
     bootstrap_client::codec::BootstrapClientCodec,
     router::{
         MAX_PEERS_TO_SEND,
+        NodeType,
         Peer,
         PeerPoolHandling,
         Resolver,
@@ -78,8 +79,10 @@ impl<N: Network> OnConnect for BootstrapClient<N> {
         // of known validators.
         if let Some(listener_addr) = self.resolve_to_listener(peer_addr) {
             if let Some(peer) = self.get_connected_peer(listener_addr) {
-                if self.resolver().read().get_peer_ip_for_address(peer.aleo_addr).is_some() {
-                    self.known_validators.write().insert(listener_addr, peer.aleo_addr);
+                if peer.node_type == NodeType::Validator {
+                    // Having the Aleo address in the resolver indicates Gateway mode.
+                    let gateway_mode = self.resolver().read().get_peer_ip_for_address(peer.aleo_addr).is_some();
+                    self.known_validators.write().insert(listener_addr, (peer.aleo_addr, gateway_mode));
                 }
             }
         }
@@ -128,9 +131,22 @@ impl<N: Network> Reading for BootstrapClient<N> {
                 debug!("Received a PeerRequest from '{listener_addr}'");
                 let mut peers = self.get_candidate_peers();
 
-                // Filter out peers who had been connected via the Gateway.
-                let known_validators = self.get_known_validators();
-                peers.retain(|peer| !known_validators.contains_key(&peer.listener_addr));
+                // In order to filter out validators properly, we'll need the
+                // peer's node type and the list of validators.
+                let Some(peer) = self.get_connected_peer(listener_addr) else {
+                    return Ok(());
+                };
+                let validators = self.get_validator_addrs().await;
+
+                if peer.node_type == NodeType::Validator {
+                    // Filter out Gateway addresses.
+                    peers.retain(|peer| {
+                        validators.get(&peer.listener_addr).map(|(_, gateway_mode)| !gateway_mode).unwrap_or(true)
+                    });
+                } else {
+                    // Filter out all validator addresses.
+                    peers.retain(|peer| !validators.contains_key(&peer.listener_addr));
+                }
                 peers.truncate(MAX_PEERS_TO_SEND);
                 let peers = peers.into_iter().map(|peer| (peer.listener_addr, None)).collect::<Vec<_>>();
 
@@ -146,21 +162,17 @@ impl<N: Network> Reading for BootstrapClient<N> {
             }
             MessageOrEvent::Event(Event::ValidatorsRequest(_)) => {
                 debug!("Received a ValidatorsRequest from '{listener_addr}'");
-                let current_committee = match self.get_or_update_committee().await {
-                    Ok(new_committee) => new_committee,
-                    Err(error) => {
-                        error!("Couldn't update the validator committee: {error}");
-                        None
-                    }
-                };
 
-                // Return the known addresses of current committee members, or all known
-                // validators if the committee info is unavailable.
-                let mut known_validators = self.get_known_validators();
-                if let Some(committee) = &current_committee {
-                    known_validators.retain(|_, aleo_addr| committee.contains(aleo_addr));
-                }
-                let validators = known_validators.into_iter().take(MAX_VALIDATORS_TO_SEND).collect::<IndexMap<_, _>>();
+                // Procure a list of applicable validator addresses.
+                let validators = self.get_validator_addrs().await;
+                let validators = validators
+                    .into_iter()
+                    .filter_map(|(listener_addr, (aleo_addr, gateway_mode))| {
+                        // Only pick addresses connected in Gateway mode.
+                        gateway_mode.then_some((listener_addr, aleo_addr))
+                    })
+                    .take(MAX_VALIDATORS_TO_SEND)
+                    .collect::<IndexMap<_, _>>();
 
                 debug!("Sending {} validator address(es) to '{listener_addr}'", validators.len());
                 let msg = MessageOrEvent::Event(Event::ValidatorsResponse(events::ValidatorsResponse { validators }));

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1307,7 +1307,7 @@ mod tests {
     };
 
     use snarkos_node_bft_ledger_service::MockLedgerService;
-    use snarkos_node_router::{Peer, Resolver};
+    use snarkos_node_router::{NodeType, Peer, Resolver};
     use snarkos_node_tcp::{P2P, Tcp};
     use snarkvm::{
         ledger::committee::Committee,
@@ -1350,6 +1350,10 @@ mod tests {
 
         fn is_dev(&self) -> bool {
             true
+        }
+
+        fn node_type(&self) -> NodeType {
+            NodeType::Client
         }
 
         fn ip_ban_peer(&self, listener_addr: SocketAddr, _reason: Option<&str>) {


### PR DESCRIPTION
This PR addresses https://github.com/ProvableHQ/snarkOS/issues/3926, though I'm not 100% sure that's the end of it.

First, it verifies whether the connecting validator belongs to the committee at the handshake stage, potentially rejecting both `Router` (if the peer's node type is the validator) and `Gateway` connections based on the Aleo address of the peer.

Second, it enhances the peer list filtering:
- non-validator peers receive no validator addresses at all
- validator peers connected in `Router` mode may receive `Router` validator addresses (among other peer addresses)
- validator peers connected in `Gateway` mode receive only `Gateway` validator addresses

Closes https://github.com/ProvableHQ/snarkOS/issues/3945.
Closes https://github.com/ProvableHQ/snarkOS/issues/3949.