### PR TITLE
[Fix] Correct downgrade_peer_to_candidate for non-Gateway use

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1275,7 +1275,10 @@ impl<N: Network> Handshake for Gateway<N> {
                 }
                 Err(error) => {
                     if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                        peer.downgrade_to_candidate(addr);
+                        // The peer may only be downgraded if it's a ConnectingPeer.
+                        if peer.is_connecting() {
+                            peer.downgrade_to_candidate(addr);
+                        }
                     }
                     // This error needs to be "repackaged" in order to conform to the return type.
                     return Err(error);
@@ -1375,7 +1378,12 @@ impl<N: Network> Gateway<N> {
         // Verify the challenge request. If a disconnect reason was returned, send the disconnect message and abort.
         if let Some(reason) = self.verify_challenge_request(peer_addr, &peer_request) {
             send_event(&mut framed, peer_addr, reason.into()).await?;
-            return Err(error(format!("Dropped '{peer_addr}' for reason: {reason:?}")));
+            if reason == DisconnectReason::NoReasonGiven {
+                // The Aleo address is already connected; no reason to return an error.
+                return Ok(None);
+            } else {
+                return Err(error(format!("Dropped '{peer_addr}' for reason: {reason:?}")));
+            }
         }
 
         /* Step 3: Send the challenge response. */
@@ -1492,7 +1500,7 @@ impl<N: Network> Gateway<N> {
         // Ensure the address is not already connected.
         if self.is_connected_address(address) {
             warn!("{CONTEXT} Dropping '{peer_addr}' for being already connected ({address})");
-            return Some(DisconnectReason::ProtocolViolation);
+            return Some(DisconnectReason::NoReasonGiven);
         }
         None
     }

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -147,7 +147,10 @@ impl<N: Network> Router<N> {
                 }
                 Err(_) => {
                     if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                        peer.downgrade_to_candidate(addr);
+                        // The peer may only be downgraded if it's a ConnectingPeer.
+                        if peer.is_connecting() {
+                            peer.downgrade_to_candidate(addr);
+                        }
                     }
                 }
             }

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -139,7 +139,10 @@ impl<N: Network> Handshake for BootstrapClient<N> {
                 Err(error) => {
                     debug!("Handshake with '{peer_addr}' failed: {error}");
                     if let Some(peer) = self.peer_pool.write().get_mut(&addr) {
-                        peer.downgrade_to_candidate(addr);
+                        // The peer may only be downgraded if it's a ConnectingPeer.
+                        if peer.is_connecting() {
+                            peer.downgrade_to_candidate(addr);
+                        }
                     }
                     return Err(error);
                 }


### PR DESCRIPTION
When we abort a validator handshake attempt due to already being connected to the given Aleo address, we should neither error out (because it's not an error), nor we should downgrade any peer that's not a `ConnectingPeer` (which is the intended downgrade target) on a broken handshake. This could only happen to a validator due to that extra handshake condition, but we should apply this to other nodes too as a means of future-proofing.

Fixes https://github.com/ProvableHQ/snarkOS/issues/3944.