### PR TITLE
[Logs] Don't return an error when the Aleo address is already connecte…

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1455,7 +1455,12 @@ impl<N: Network> Gateway<N> {
         // Verify the challenge request. If a disconnect reason was returned, send the disconnect message and abort.
         if let Some(reason) = self.verify_challenge_request(peer_addr, &peer_request) {
             send_event(&mut framed, peer_addr, reason.into()).await?;
-            return Err(error(format!("Dropped '{peer_addr}' for reason: {reason:?}")));
+            if reason == DisconnectReason::NoReasonGiven {
+                // The Aleo address is already connected; no reason to return an error.
+                return Ok(None);
+            } else {
+                return Err(error(format!("Dropped '{peer_addr}' for reason: {reason:?}")));
+            }
         }
 
         /* Step 2: Send the challenge response followed by own challenge request. */


### PR DESCRIPTION
A tiny follow-up to https://github.com/ProvableHQ/snarkOS/pull/3948, which only affects the logs (as the root issue is already fixed) and makes the validator handshake behavior more coherent; there is an additional spot where `verify_challenge_request` is called (the responder handshake side), which got lost in the linked PR by accident.