### PR TITLE
Reduce excessive logging in block sync

### DIFF
--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -561,7 +561,10 @@ impl<N: Network> Sync<N> {
 
             // The height is incremented as blocks are added.
             let mut current_height = start_height;
-            trace!("Try advancing with block responses (at block {current_height})");
+            trace!(
+                "Try advancing blocks responses with BFT (starting at block {current_height}, current sync speed is {})",
+                self.block_sync.get_sync_speed()
+            );
 
             // If we already were within GC or successfully caught up with GC, try to advance BFT normally again.
             loop {
@@ -586,12 +589,12 @@ impl<N: Network> Sync<N> {
 
             cleanup(start_height, current_height, None)
         } else {
-            info!("Block sync is too far behind other validators. Syncing without BFT.");
-
             // For non-BFT sync we need to start at the current height of the ledger,as blocks are immediately
             // added to it and not queue up in `latest_block_responses`.
             let start_height = ledger_height;
             let mut current_height = start_height;
+
+            trace!("Try advancing block responses without BFT (starting at block {current_height})");
 
             // For sanity, update the sync height before starting.
             // (if this is lower or equal to the current sync height, this is a noop)

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -29,6 +29,7 @@ use snarkvm::{
     console::{network::Network, types::Field},
     ledger::{authority::Authority, block::Block, narwhal::BatchCertificate},
     prelude::{cfg_into_iter, cfg_iter},
+    utilities::log_error,
 };
 
 use anyhow::{Result, anyhow, bail};
@@ -295,18 +296,26 @@ impl<N: Network> Sync<N> {
     /// This method handles timeout removal, checks if block sync is possible,
     /// and issues block requests to peers.
     async fn try_issuing_block_requests(&self) {
-        // Check if any existing requests can be removed.
-        // We should do this even if we cannot block sync, to ensure
-        // there are no dangling block requests.
-        let timeout_requests = self.block_sync.handle_block_request_timeouts(&self.gateway);
-        if let Some((requests, sync_peers)) = timeout_requests {
-            self.send_block_requests(requests, sync_peers).await;
-            return;
-        }
-
         // Update the sync height to the latest ledger height.
         // (if the ledger height is lower or equal to the current sync height, this is a noop)
         self.block_sync.set_sync_height(self.ledger.latest_block_height());
+
+        // Check if any existing requests can be removed.
+        // We should do this even if we cannot block sync, to ensure
+        // there are no dangling block requests.
+        match self.block_sync.handle_block_request_timeouts(&self.gateway) {
+            Ok(Some((requests, sync_peers))) => {
+                // Re-request blocks instead of performing regular block sync.
+                self.send_block_requests(requests, sync_peers).await;
+                return;
+            }
+            Ok(None) => {}
+            Err(err) => {
+                // Abort and retry later.
+                log_error(&err);
+                return;
+            }
+        }
 
         // Do not attempt to sync if there are no blocks to sync.
         // This prevents redundant log messages and performing unnecessary computation.

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -43,6 +43,7 @@ use snarkvm::{
         store::ConsensusStorage,
     },
     prelude::{VM, block::Transaction},
+    utilities::log_error,
 };
 
 use aleo_std::StorageMode;
@@ -311,17 +312,26 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
     /// Client-side version of `snarkvm_node_bft::Sync::try_block_sync()`.
     async fn try_issuing_block_requests(&self) {
-        let new_requests = self.sync.handle_block_request_timeouts(&self.router);
-        if let Some((block_requests, sync_peers)) = new_requests {
-            self.send_block_requests(block_requests, sync_peers).await;
-        }
-
         // Wait for peer updates or timeout
         let _ = timeout(Self::MAX_SYNC_INTERVAL, self.sync.wait_for_peer_update()).await;
 
         // For sanity, check that sync height is never below ledger height.
         // (if the ledger height is lower or equal to the current sync height, this is a noop)
         self.sync.set_sync_height(self.ledger.latest_height());
+
+        match self.sync.handle_block_request_timeouts(&self.router) {
+            Ok(Some((requests, sync_peers))) => {
+                // Re-request blocks instead of performing regular block sync.
+                self.send_block_requests(requests, sync_peers).await;
+                return;
+            }
+            Ok(None) => {}
+            Err(err) => {
+                // Abort and retry later.
+                log_error(&err);
+                return;
+            }
+        }
 
         // Do not attempt to sync if there are not blocks to sync.
         // This prevents redundant log messages and performing unnecessary computation.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -966,12 +966,16 @@ impl<N: Network> BlockSync<N> {
     /// This removes the corresponding block responses and returns the set of peers/addresses that timed out.
     /// It will ask the peer pool handling service to ban any timed-out peers.
     ///
-    /// Finally, it will return a set of new of block requests that replaced the timed-out requests (if needed).
+    /// # Return Value
+    /// On success it will return an empty set, if there is nothing to re-request, or a set of new of block requests that replaced the timed-out requests.
     /// This set of new requests can also replace requests that timed out earlier, and which we were not able to re-request yet.
+    ///
+    /// This function will return an error if it cannot re-request blocks due to a lack of peers.
+    /// In this case, the current iteration of block synchronization should not continue and the node should re-try later instead.
     pub fn handle_block_request_timeouts<P: PeerPoolHandling<N>>(
         &self,
         peer_pool_handler: &P,
-    ) -> Option<BlockRequestBatch<N>> {
+    ) -> Result<Option<BlockRequestBatch<N>>> {
         // Acquire the write lock on the requests map.
         let mut requests = self.requests.write();
 
@@ -1053,7 +1057,7 @@ impl<N: Network> BlockSync<N> {
         } else {
             // Nothing to do.
             // Do not log here as this check happens frequently.
-            return None;
+            return Ok(None);
         };
 
         // Set the maximum number of blocks, so that they do not exceed the end height.
@@ -1061,15 +1065,13 @@ impl<N: Network> BlockSync<N> {
 
         let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(start_height) else {
             // This generally shouldn't happen, because there cannot be outstanding requests when no peers are connected.
-            error!("Cannot re-request blocks because no or not enough peers are connected");
-            return None;
+            bail!("Cannot re-request blocks because no or not enough peers are connected");
         };
 
         // Retrieve the greatest block height of any connected peer.
         let Some(greatest_peer_height) = sync_peers.values().map(|l| l.latest_locator_height()).max() else {
             // This should never happen because `sync_peers` is guaranteed to be non-empty.
-            error!("Cannot re-request blocks because no or not enough peers are connected");
-            return None;
+            bail!("Cannot re-request blocks because no or not enough peers are connected");
         };
 
         // (Try to) construct the requests.
@@ -1085,10 +1087,10 @@ impl<N: Network> BlockSync<N> {
         // The given height may also be greater `start_height` due to concurerent block advancement.
         if let Some((height, _)) = requests.as_slice().first() {
             debug!("Re-requesting blocks starting at height {height}");
-            Some((requests, sync_peers))
+            Ok(Some((requests, sync_peers)))
         } else {
             // Do not log here as this constitutes a benign race condition.
-            None
+            Ok(None)
         }
     }
 
@@ -1904,7 +1906,7 @@ mod tests {
 
         // Remove timed out block requests.
         let c = DummyPeerPoolHandler::default();
-        new_sync.handle_block_request_timeouts(&c);
+        new_sync.handle_block_request_timeouts(&c).unwrap();
 
         // Check that the number of requests is reduced based on the ledger height.
         assert_eq!(new_sync.requests.read().len(), (locator_height - ledger_height) as usize);
@@ -1933,7 +1935,7 @@ mod tests {
 
         // Remove timed out block requests.
         let c = DummyPeerPoolHandler::default();
-        sync.handle_block_request_timeouts(&c);
+        sync.handle_block_request_timeouts(&c).unwrap();
 
         let ban_list = c.peers_to_ban.write();
         assert_eq!(ban_list.len(), 1);
@@ -1981,7 +1983,7 @@ mod tests {
         // Remove timed out block requests.
         let c = DummyPeerPoolHandler::default();
 
-        let re_requests = sync.handle_block_request_timeouts(&c);
+        let re_requests = sync.handle_block_request_timeouts(&c).unwrap();
 
         let ban_list = c.peers_to_ban.write();
         assert_eq!(ban_list.len(), 1);

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1183,10 +1183,13 @@ impl<N: Network> BlockSync<N> {
         // Compute the start height for the block requests.
         let start_height = {
             let requests = self.requests.read();
-            let mut start_height = sync_height + 1;
+            let ledger_height = self.ledger.latest_block_height();
 
-            // Do not issue requests that already exist or would be obsolete.
-            while requests.contains_key(&start_height) || self.ledger.latest_block_height() >= start_height {
+            // Do not issue requests for blocks already contained in the ledger.
+            let mut start_height = ledger_height.max(sync_height + 1);
+
+            // Do not issue requests that already exist.
+            while requests.contains_key(&start_height) {
                 start_height += 1;
             }
 

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -967,7 +967,7 @@ impl<N: Network> BlockSync<N> {
     /// It will ask the peer pool handling service to ban any timed-out peers.
     ///
     /// # Return Value
-    /// On success it will return an empty set, if there is nothing to re-request, or a set of new of block requests that replaced the timed-out requests.
+    /// On success it will return `None` if there is nothing to re-request, or a set of new of block requests that replaced the timed-out requests.
     /// This set of new requests can also replace requests that timed out earlier, and which we were not able to re-request yet.
     ///
     /// This function will return an error if it cannot re-request blocks due to a lack of peers.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -367,7 +367,7 @@ impl<N: Network> BlockSync<N> {
             }
         };
 
-        debug!("Sending {len} block requests to peers {peers:?}", len = requests.len(), peers = sync_peers.keys());
+        debug!("Sending {len} block requests to peer(s) at {peers:?}", len = requests.len(), peers = sync_peers.keys());
 
         // Use a randomly sampled subset of the sync IPs.
         let sync_ips: IndexSet<_> =
@@ -967,6 +967,7 @@ impl<N: Network> BlockSync<N> {
     /// It will ask the peer pool handling service to ban any timed-out peers.
     ///
     /// Finally, it will return a set of new of block requests that replaced the timed-out requests (if needed).
+    /// This set of new requests can also replace requests that timed out earlier, and which we were not able to re-request yet.
     pub fn handle_block_request_timeouts<P: PeerPoolHandling<N>>(
         &self,
         peer_pool_handler: &P,
@@ -1034,48 +1035,61 @@ impl<N: Network> BlockSync<N> {
             peer_pool_handler.ip_ban_peer(peer_ip, Some("timed out on block requests"));
         }
 
-        // Re-issue any timed-out requests.
+        // Determine if we need to re-issue any timed-out requests.
+        // If there are no requests remaining or no gap at the beginning,
+        // we do not need to re-issue requests and will just issue them regularly.
         //
-        // Do this even if timed_out_requests is empty, because we might not be able to re-issue
+        // This needs to be checked even if timed_out_requests is empty, because we might not be able to re-issue
         // requests immediately if there are no other peers at a given time.
         // Further, this only closes the first gap. So multiple calls to this might be needed.
         let sync_height = self.get_sync_height();
-        if let Some(next_height) = next_request_height {
-            let start = sync_height + 1;
+        let start_height = sync_height + 1;
 
-            // Is there a gap?
-            if next_height > start {
-                // Only request the given range, so there are no overlaps with other requests.
-                let end = next_height; // exclusive
-                let max_new_blocks_to_request = end - start;
+        let end_height = if let Some(next_height) = next_request_height
+            && next_height > start_height
+        {
+            // The end height is exclusive, so use the height of the first existing block requests as the end
+            next_height
+        } else {
+            // Nothing to do.
+            // Do not log here as this check happens frequently.
+            return None;
+        };
 
-                let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(start) else {
-                    warn!("Block requests timed out, but found no other peers to re-request from");
-                    return None;
-                };
+        // Set the maximum number of blocks, so that they do not exceed the end height.
+        let max_new_blocks_to_request = end_height - start_height;
 
-                // Retrieve the greatest block height of any connected peer.
-                let Some(greatest_peer_height) = sync_peers.values().map(|l| l.latest_locator_height()).max() else {
-                    warn!("Cannot re-request blocks because no peers are connected");
-                    return None;
-                };
+        let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(start_height) else {
+            // This generally shouldn't happen, because there cannot be outstanding requests when no peers are connected.
+            error!("Cannot re-request blocks because no or not enough peers are connected");
+            return None;
+        };
 
-                debug!("Re-requesting blocks starting at height {start}");
+        // Retrieve the greatest block height of any connected peer.
+        let Some(greatest_peer_height) = sync_peers.values().map(|l| l.latest_locator_height()).max() else {
+            // This should never happen because `sync_peers` is guaranteed to be non-empty.
+            error!("Cannot re-request blocks because no or not enough peers are connected");
+            return None;
+        };
 
-                return Some((
-                    self.construct_requests(
-                        &sync_peers,
-                        sync_height,
-                        min_common_ancestor,
-                        max_new_blocks_to_request,
-                        greatest_peer_height,
-                    ),
-                    sync_peers,
-                ));
-            }
+        // (Try to) construct the requests.
+        let requests = self.construct_requests(
+            &sync_peers,
+            sync_height,
+            min_common_ancestor,
+            max_new_blocks_to_request,
+            greatest_peer_height,
+        );
+
+        // If the ledger advanced concurrenctly, there may be no requests to issue after all.
+        // The given height may also be greater `start_height` due to concurerent block advancement.
+        if let Some((height, _)) = requests.as_slice().first() {
+            debug!("Re-requesting blocks starting at height {height}");
+            Some((requests, sync_peers))
+        } else {
+            // Do not log here as this constitutes a benign race condition.
+            None
         }
-
-        None
     }
 
     /// Finds the peers to sync from and the shared common ancestor, starting at the give height.
@@ -1169,12 +1183,9 @@ impl<N: Network> BlockSync<N> {
             let requests = self.requests.read();
             let mut start_height = sync_height + 1;
 
-            loop {
-                if requests.contains_key(&start_height) {
-                    start_height += 1;
-                } else {
-                    break;
-                }
+            // Do not issue requests that already exist or would be obsolete.
+            while requests.contains_key(&start_height) || self.ledger.latest_block_height() >= start_height {
+                start_height += 1;
             }
 
             start_height
@@ -1201,7 +1212,7 @@ impl<N: Network> BlockSync<N> {
         for height in start_height..end_height {
             // Ensure the current height is not in the ledger or already requested.
             if let Err(err) = self.check_block_request(height) {
-                trace!("Failed to issue new request for height {height}: {err}");
+                trace!("{err}");
 
                 // If the sequence of block requests is interrupted, then return early.
                 // Otherwise, continue until the first start height that is new.


### PR DESCRIPTION
This PR reduces log verbosity, and adds more documentation to the fairly convoluted `BlockSync::handle_block_request_timeouts`.

Concrete issues with block sync logging were the following:
* There were cases with excessive `Failed to issue new request for height` messages, which usually just means that the ledger advanced while the node was attempting to re-issue requests. This happened when we receive block responses around the same time the associated request times out.
* Validators that were too far behind would frequently print `Block sync is too far behind other validators. Syncing without BFT` at the INFO level. Now, validators will log `Try advancing block responses without BFT` at the TRACE level instead.
* Nodes sometimes logged `Re-requesting blocks starting at height` even if they did *not* re-request any blocks. 

[a811bf71](https://github.com/ProvableHQ/snarkOS/commit/a811bf71fce363405c7752baca7224cb5d9479e2) includes these log improvements and adds more documentation to the re-requesting logic. [a3a08d4](https://github.com/ProvableHQ/snarkOS/commit/a3a08d4b1c0a23c920e1566b736d50e911e0f5d9) additionally ensures that nodes do not attempt regular block sync if re-requesting blocks fails. I am unsure if this ever happened in practice, but I added it just to be safe.