### PR TITLE
[Tweak] Validators shouldn't accept duplicate validator connections in router mode

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -371,12 +371,6 @@ impl<N: Network> Gateway<N> {
         self.worker_senders.get().and_then(|senders| senders.get(&worker_id))
     }
 
-    /// Returns `true` if the node is connected to the given Aleo address.
-    pub fn is_connected_address(&self, address: Address<N>) -> bool {
-        // The resolver only contains data on connected peers.
-        self.resolver.read().get_peer_ip_for_address(address).is_some()
-    }
-
     /// Returns `true` if the given peer IP is an authorized validator.
     pub fn is_authorized_validator_ip(&self, ip: SocketAddr) -> bool {
         // If the peer IP is in the trusted validators, return early.

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -352,13 +352,23 @@ impl<N: Network> Router<N> {
         message: &ChallengeRequest<N>,
     ) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge request.
-        let &ChallengeRequest { version, listener_port: _, node_type: _, address: _, nonce: _ } = message;
+        let &ChallengeRequest { version, listener_port: _, node_type, address, nonce: _ } = message;
 
         // Ensure the message protocol version is not outdated.
         if !self.is_valid_message_version(version) {
             warn!("Dropping '{peer_addr}' on version {version} (outdated)");
             return Some(DisconnectReason::OutdatedClientVersion);
         }
+
+        // Ensure there are no validators connected with the given Aleo address.
+        if self.node_type() == NodeType::Validator
+            && node_type == NodeType::Validator
+            && self.is_connected_address(address)
+        {
+            warn!("Dropping '{peer_addr}' for being already connected ({address})");
+            return Some(DisconnectReason::NoReasonGiven);
+        }
+
         None
     }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -341,6 +341,12 @@ pub trait PeerPoolHandling<N: Network>: P2P {
         self.peer_pool().read().get(&listener_addr).is_some_and(|peer| peer.is_connected())
     }
 
+    /// Returns `true` if the node is connected to the given Aleo address.
+    fn is_connected_address(&self, aleo_address: Address<N>) -> bool {
+        // The resolver only contains data on connected peers.
+        self.resolver().read().get_peer_ip_for_address(aleo_address).is_some()
+    }
+
     /// Returns `true` if the given listener address is trusted.
     fn is_trusted(&self, listener_addr: SocketAddr) -> bool {
         self.peer_pool().read().get(&listener_addr).is_some_and(|peer| peer.is_trusted())

--- a/node/router/tests/banning.rs
+++ b/node/router/tests/banning.rs
@@ -21,14 +21,17 @@ use snarkos_node_tcp::{
     P2P,
     protocols::{Disconnect, Handshake},
 };
+use snarkvm::prelude::TestRng;
 
 use std::time::Duration;
 
 #[tokio::test]
 async fn ban_connection_responder() {
+    let mut rng = TestRng::default();
+
     // Create 2 client routers.
-    let node0 = client(0, 1).await;
-    let node1 = client(0, 1).await;
+    let node0 = client(0, 1, &mut rng).await;
+    let node1 = client(0, 1, &mut rng).await;
 
     // Start listening on both sides.
     node0.tcp().enable_listener().await.unwrap();
@@ -65,9 +68,11 @@ async fn ban_connection_responder() {
 
 #[tokio::test]
 async fn ban_connection_initiator() {
+    let mut rng = TestRng::default();
+
     // Create 2 client routers.
-    let node0 = client(0, 1).await;
-    let node1 = client(0, 1).await;
+    let node0 = client(0, 1, &mut rng).await;
+    let node1 = client(0, 1, &mut rng).await;
 
     // Start listening on both sides.
     node0.tcp().enable_listener().await.unwrap();

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -39,9 +39,9 @@ async fn test_connection_cleanups() {
     let mut nodes = Vec::with_capacity(2);
     for _ in 0..2 {
         let node = match rng.gen_range(0..3) % 3 {
-            0 => client(0, 1).await,
-            1 => prover(0, 1).await,
-            2 => validator(0, 1, &[], true).await,
+            0 => client(0, 1, &mut rng).await,
+            1 => prover(0, 1, &mut rng).await,
+            2 => validator(0, 1, &[], true, &mut rng).await,
             _ => unreachable!(),
         };
 

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -19,7 +19,6 @@ pub use router::*;
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    str::FromStr,
     sync::Arc,
 };
 
@@ -28,7 +27,7 @@ use snarkos_account::Account;
 use snarkos_node_bft_ledger_service::MockLedgerService;
 use snarkos_node_router::{Router, messages::NodeType};
 use snarkvm::{
-    prelude::{FromBytes, MainnetV0 as CurrentNetwork, Network, block::Block},
+    prelude::{FromBytes, MainnetV0 as CurrentNetwork, Network, PrivateKey, block::Block},
     utilities::TestRng,
 };
 
@@ -46,8 +45,9 @@ macro_rules! print_tcp {
 }
 
 /// Returns a fixed account.
-pub fn sample_account() -> Account<CurrentNetwork> {
-    Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap()
+pub fn sample_account(rng: &mut TestRng) -> Account<CurrentNetwork> {
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    Account::<CurrentNetwork>::try_from(&private_key).unwrap()
 }
 
 /// Loads the current network's genesis block.
@@ -56,13 +56,13 @@ pub fn sample_genesis_block<N: Network>() -> Block<N> {
 }
 
 /// Initializes a client router. Setting the `listening_port = 0` will result in a random port being assigned.
-pub async fn client(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
-    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(&mut TestRng::default());
+pub async fn client(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> TestRouter<CurrentNetwork> {
+    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
     let ledger_service = Arc::new(MockLedgerService::new(committee));
     Router::new(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
         NodeType::Client,
-        sample_account(),
+        sample_account(rng),
         ledger_service,
         &[],
         max_peers,
@@ -78,13 +78,13 @@ pub async fn client(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNe
 
 /// Initializes a prover router. Setting the `listening_port = 0` will result in a random port being assigned.
 #[allow(dead_code)]
-pub async fn prover(listening_port: u16, max_peers: u16) -> TestRouter<CurrentNetwork> {
-    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(&mut TestRng::default());
+pub async fn prover(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> TestRouter<CurrentNetwork> {
+    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
     let ledger_service = Arc::new(MockLedgerService::new(committee));
     Router::new(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
         NodeType::Prover,
-        sample_account(),
+        sample_account(rng),
         ledger_service,
         &[],
         max_peers,
@@ -105,13 +105,14 @@ pub async fn validator(
     max_peers: u16,
     trusted_peers: &[SocketAddr],
     allow_external_peers: bool,
+    rng: &mut TestRng,
 ) -> TestRouter<CurrentNetwork> {
-    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(&mut TestRng::default());
+    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
     let ledger_service = Arc::new(MockLedgerService::new(committee));
     Router::new(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
         NodeType::Validator,
-        sample_account(),
+        sample_account(rng),
         ledger_service,
         trusted_peers,
         max_peers,

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -21,15 +21,18 @@ use snarkos_node_tcp::{
     P2P,
     protocols::{Disconnect, Handshake, OnConnect},
 };
+use snarkvm::prelude::TestRng;
 
 use core::time::Duration;
 use deadline::deadline;
 
 #[tokio::test]
 async fn test_connect_without_handshake() {
+    let mut rng = TestRng::default();
+
     // Create 2 routers.
-    let node0 = validator(0, 2, &[], true).await;
-    let node1 = client(0, 2).await;
+    let node0 = validator(0, 2, &[], true, &mut rng).await;
+    let node1 = client(0, 2, &mut rng).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 
@@ -83,9 +86,11 @@ async fn test_connect_without_handshake() {
 
 #[tokio::test]
 async fn test_connect_with_handshake() {
+    let mut rng = TestRng::default();
+
     // Create 2 routers.
-    let node0 = validator(0, 2, &[], true).await;
-    let node1 = client(0, 2).await;
+    let node0 = validator(0, 2, &[], true, &mut rng).await;
+    let node1 = client(0, 2, &mut rng).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 
@@ -168,8 +173,10 @@ async fn test_connect_with_handshake() {
 
 #[tokio::test]
 async fn test_validator_connection() {
+    let mut rng = TestRng::default();
+
     // Create first router and start listening.
-    let node0 = validator(0, 2, &[], false).await;
+    let node0 = validator(0, 2, &[], false, &mut rng).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     node0.enable_handshake().await;
     node0.enable_on_connect().await;
@@ -180,7 +187,7 @@ async fn test_validator_connection() {
     let addr0 = node0.local_ip();
 
     // Create second router, trusting the first router, and start listening.
-    let node1 = validator(0, 2, &[addr0], false).await;
+    let node1 = validator(0, 2, &[addr0], false, &mut rng).await;
     assert_eq!(node1.number_of_connected_peers(), 0);
     node1.enable_handshake().await;
     node1.enable_on_connect().await;
@@ -236,9 +243,11 @@ async fn test_validator_connection() {
 #[ignore]
 #[tokio::test]
 async fn test_connect_simultaneously_with_handshake() {
+    let mut rng = TestRng::default();
+
     // Create 2 routers.
-    let node0 = validator(0, 2, &[], true).await;
-    let node1 = client(0, 2).await;
+    let node0 = validator(0, 2, &[], true, &mut rng).await;
+    let node1 = client(0, 2, &mut rng).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 

--- a/node/router/tests/disconnect.rs
+++ b/node/router/tests/disconnect.rs
@@ -21,15 +21,18 @@ use snarkos_node_tcp::{
     P2P,
     protocols::{Handshake, OnConnect},
 };
+use snarkvm::prelude::TestRng;
 
 use core::time::Duration;
 use deadline::deadline;
 
 #[tokio::test]
 async fn test_disconnect_without_handshake() {
+    let mut rng = TestRng::default();
+
     // Create 2 routers.
-    let node0 = validator(0, 1, &[], true).await;
-    let node1 = client(0, 1).await;
+    let node0 = validator(0, 1, &[], true, &mut rng).await;
+    let node1 = client(0, 1, &mut rng).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 
@@ -74,9 +77,11 @@ async fn test_disconnect_without_handshake() {
 
 #[tokio::test]
 async fn test_disconnect_with_handshake() {
+    let mut rng = TestRng::default();
+
     // Create 2 routers.
-    let node0 = validator(0, 1, &[], true).await;
-    let node1 = client(0, 1).await;
+    let node0 = validator(0, 1, &[], true, &mut rng).await;
+    let node1 = client(0, 1, &mut rng).await;
     assert_eq!(node0.number_of_connected_peers(), 0);
     assert_eq!(node1.number_of_connected_peers(), 0);
 

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -29,7 +29,7 @@ use snarkos_node_tcp::{
     P2P,
     protocols::{Handshake, OnConnect, Writing},
 };
-use snarkvm::prelude::MainnetV0 as Network;
+use snarkvm::prelude::{MainnetV0 as Network, TestRng};
 
 use async_trait::async_trait;
 use std::{net::SocketAddr, time::Duration};
@@ -93,20 +93,22 @@ async fn connect_to(router: &TestRouter<Network>, other: &TestRouter<Network>) {
 /// Checks that clients are ordered before nodes and that ordering is based on when a peer was last seen.
 #[tokio::test]
 async fn peer_priority_ordering() {
-    let router = client(0, 10).await;
+    let mut rng = TestRng::default();
+
+    let router = client(0, 10, &mut rng).await;
     router.enable_listener().await;
     router.enable_handshake().await;
     router.enable_on_connect().await;
 
-    let validator_peer1 = validator(0, 5, &[], true).await;
+    let validator_peer1 = validator(0, 5, &[], true, &mut rng).await;
     validator_peer1.enable_listener().await;
     validator_peer1.enable_handshake().await;
 
-    let validator_peer2 = validator(0, 5, &[], true).await;
+    let validator_peer2 = validator(0, 5, &[], true, &mut rng).await;
     validator_peer2.enable_listener().await;
     validator_peer2.enable_handshake().await;
 
-    let client_peer = client(0, 5).await;
+    let client_peer = client(0, 5, &mut rng).await;
     client_peer.enable_listener().await;
     client_peer.enable_handshake().await;
 
@@ -153,15 +155,17 @@ async fn peer_priority_ordering() {
 /// Checks that trusted peers are never marked as removable.
 #[tokio::test]
 async fn peer_priority_trusted_peers() {
-    let validator_peer = validator(0, 5, &[], true).await;
+    let mut rng = TestRng::default();
+
+    let validator_peer = validator(0, 5, &[], true, &mut rng).await;
     validator_peer.enable_listener().await;
     validator_peer.enable_handshake().await;
 
-    let client_peer = client(0, 5).await;
+    let client_peer = client(0, 5, &mut rng).await;
     client_peer.enable_listener().await;
     client_peer.enable_handshake().await;
 
-    let router = validator(0, 5, &[validator_peer.local_ip(), client_peer.local_ip()], false).await;
+    let router = validator(0, 5, &[validator_peer.local_ip(), client_peer.local_ip()], false, &mut rng).await;
     router.enable_listener().await;
     router.enable_handshake().await;
     router.enable_on_connect().await;

--- a/node/tests/common/mod.rs
+++ b/node/tests/common/mod.rs
@@ -19,11 +19,12 @@ pub mod test_peer;
 use std::str::FromStr;
 
 use snarkos_account::Account;
-use snarkvm::prelude::{FromBytes, MainnetV0 as CurrentNetwork, Network, block::Block};
+use snarkvm::prelude::{FromBytes, MainnetV0 as CurrentNetwork, Network, PrivateKey, TestRng, block::Block};
 
 /// Returns a fixed account.
-pub fn sample_account() -> Account<CurrentNetwork> {
-    Account::<CurrentNetwork>::from_str("APrivateKey1zkp2oVPTci9kKcUprnbzMwq95Di1MQERpYBhEeqvkrDirK1").unwrap()
+pub fn sample_account(rng: &mut TestRng) -> Account<CurrentNetwork> {
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    Account::<CurrentNetwork>::try_from(&private_key).unwrap()
 }
 
 /// Loads the current network's genesis block.


### PR DESCRIPTION
This PR resolves the following point from https://github.com/ProvableHQ/snarkOS/issues/3926:
> validator routers should store just a single router peer per validator address in the current committee.

The related method is moved from `Gateway` to `PeerPoolHandling`, as it is now applicable to the `Router` as well.