### PR TITLE
[Metrics] Add BLOCK_LAG histogram

### DIFF
--- a/node/bft/src/helpers/timestamp.rs
+++ b/node/bft/src/helpers/timestamp.rs
@@ -23,6 +23,16 @@ pub fn now() -> i64 {
     OffsetDateTime::now_utc().unix_timestamp()
 }
 
+/// Returns the current UTC epoch time.
+pub fn now_utc() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}
+
+/// Converts the given timestamp to an `OffsetDateTime`, defaulting to the current UTC time if invalid.
+pub fn to_utc_datetime(timestamp: i64) -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp(timestamp).unwrap_or_else(|_| OffsetDateTime::now_utc())
+}
+
 /// Sanity checks the timestamp for liveness.
 pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
     // Ensure the timestamp is within range.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -554,9 +554,13 @@ impl<N: Network> Consensus<N> {
 
         #[cfg(feature = "metrics")]
         {
-            let elapsed = std::time::Duration::from_secs((snarkos_node_bft::helpers::now() - start) as u64);
+            let now_utc = snarkos_node_bft::helpers::now_utc();
+            let elapsed = std::time::Duration::from_secs((now_utc.unix_timestamp() - start) as u64);
             let next_block_timestamp = next_block.header().metadata().timestamp();
+            let next_block_utc = snarkos_node_bft::helpers::to_utc_datetime(next_block_timestamp);
             let block_latency = next_block_timestamp - current_block_timestamp;
+            let block_lag = (now_utc - next_block_utc).whole_milliseconds();
+
             let proof_target = next_block.header().proof_target();
             let coinbase_target = next_block.header().coinbase_target();
             let cumulative_proof_target = next_block.header().cumulative_proof_target();
@@ -566,6 +570,7 @@ impl<N: Network> Consensus<N> {
             metrics::gauge(metrics::consensus::COMMITTED_CERTIFICATES, num_committed_certificates as f64);
             metrics::histogram(metrics::consensus::CERTIFICATE_COMMIT_LATENCY, elapsed.as_secs_f64());
             metrics::histogram(metrics::consensus::BLOCK_LATENCY, block_latency as f64);
+            metrics::histogram(metrics::consensus::BLOCK_LAG, block_lag as f64);
             metrics::gauge(metrics::blocks::PROOF_TARGET, proof_target as f64);
             metrics::gauge(metrics::blocks::COINBASE_TARGET, coinbase_target as f64);
             metrics::gauge(metrics::blocks::CUMULATIVE_PROOF_TARGET, cumulative_proof_target as f64);

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -45,8 +45,8 @@ pub(super) const GAUGE_NAMES: [&str; 26] = [
     tcp::TCP_TASKS,
 ];
 
-pub(super) const HISTOGRAM_NAMES: [&str; 3] =
-    [bft::COMMIT_ROUNDS_LATENCY, consensus::CERTIFICATE_COMMIT_LATENCY, consensus::BLOCK_LATENCY];
+pub(super) const HISTOGRAM_NAMES: [&str; 4] =
+    [bft::COMMIT_ROUNDS_LATENCY, consensus::CERTIFICATE_COMMIT_LATENCY, consensus::BLOCK_LATENCY, consensus::BLOCK_LAG];
 
 pub mod bft {
     pub const COMMIT_ROUNDS_LATENCY: &str = "snarkos_bft_commit_rounds_latency_secs"; // <-- This one doesn't even make sense.
@@ -79,6 +79,7 @@ pub mod consensus {
     pub const CERTIFICATE_COMMIT_LATENCY: &str = "snarkos_consensus_certificate_commit_latency_secs";
     pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
     pub const BLOCK_LATENCY: &str = "snarkos_consensus_block_latency_secs";
+    pub const BLOCK_LAG: &str = "snarkos_consensus_block_lag_ms";
     pub const UNCONFIRMED_TRANSACTIONS: &str = "snarkos_consensus_unconfirmed_transactions_total";
     pub const UNCONFIRMED_SOLUTIONS: &str = "snarkos_consensus_unconfirmed_solutions_total";
     pub const TRANSMISSION_LATENCY: &str = "snarkos_consensus_transmission_latency";


### PR DESCRIPTION
## Motivation

Adds a new `BLOCK_LAG` histogram metric to track the validator's system time with the block timestamp of the latest processed block. This is tracked in milliseconds.
