### PR TITLE
[Fix] Inherit the locktick feature in snarkos-node-network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,8 @@ locktick = [
   "snarkos-node-rest/locktick",
   "snarkos-node-router/locktick",
   "snarkos-node-sync/locktick",
-  "snarkos-node-tcp/locktick"
+  "snarkos-node-tcp/locktick",
+  "snarkvm/locktick"
 ]
 serial = [ "snarkos-cli/serial" ]
 test_targets = [ "snarkos-cli/test_targets" ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -25,6 +25,7 @@ locktick = [
   "snarkos-node-bft/locktick",
   "snarkos-node-cdn/locktick",
   "snarkos-node-consensus/locktick",
+  "snarkos-node-network/locktick",
   "snarkos-node-rest/locktick",
   "snarkos-node-router/locktick",
   "snarkos-node-sync/locktick",

--- a/node/network/Cargo.toml
+++ b/node/network/Cargo.toml
@@ -17,6 +17,7 @@ license = "Apache-2.0"
 edition = "2024"
 
 [features]
+locktick = [ "dep:locktick", "snarkos-node-tcp/locktick" ]
 test = [ ]
 
 [dependencies.aleo-std]


### PR DESCRIPTION
Also do so for `snarkVM`.

I tested it locally, and now `cargo check --features=locktick` works fine.