### PR TITLE
[CI] Set correct sccache folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,11 @@ commands:
       - setup_environment:
           cache_key: v4.2.0-rust-1.88.0-<< parameters.cache_key >>-cache
       - run:
+          name: "Build tests"
+          no_output_timeout: 30m
+          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >> --no-run
+      - run:
+          name: "Run tests"
           no_output_timeout: 30m
           command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
       - clear_environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,25 +77,24 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v3.3.1-rust-1.88.0-snarkos-stable-cache
+        default: v4.2.0-rust-1.88.0-snarkos-stable-cache
     steps:
       - run: set -e
       - run:
           name: Install sccache
           command: |
-            export WORK_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"
-            export SCCACHE_DIR="$CIRCLE_WORKING_DIRECTORY/.cache/sccache"
+            export SCCACHE_DIR="$HOME/.cache/sccache"
             export SCCACHE_VERSION=v0.10.0
             export SCCACHE_PKG="sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl"
 
-            mkdir -p "$CIRCLE_WORKING_DIRECTORY/.bin"
+            mkdir -p "$HOME/.bin"
             wget "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/$SCCACHE_PKG.tar.gz"
-            tar -C "$CIRCLE_WORKING_DIRECTORY/.bin" -xvf "$SCCACHE_PKG.tar.gz"
-            chmod +x "$CIRCLE_WORKING_DIRECTORY/.bin/$SCCACHE_PKG/sccache"
-            mv "$CIRCLE_WORKING_DIRECTORY/.bin/$SCCACHE_PKG/sccache" "$CIRCLE_WORKING_DIRECTORY/.bin/sccache"
-            rm -rf "$CIRCLE_WORKING_DIRECTORY/.cargo/registry"
+            tar -C "$HOME/.bin" -xvf "$SCCACHE_PKG.tar.gz"
+            chmod +x "$HOME/.bin/$SCCACHE_PKG/sccache"
+            mv "$HOME/.bin/$SCCACHE_PKG/sccache" "$HOME/.bin/sccache"
+            rm -rf "$HOME/.cargo/registry"
 
-            export PATH="$PATH:$CIRCLE_WORKING_DIRECTORY/.bin"
+            export PATH="$PATH:$HOME/.bin"
             export RUSTC_WRAPPER="sccache"
       - run:
           name: Install Debian packages
@@ -111,15 +110,17 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v3.3.1-rust-1.88.0-snarkos-stable-cache
+        default: v4.2.0-rust-1.88.0-snarkos-stable-cache
     steps:
       - run: (sccache -s||true)
       - run: set +e
       - save_cache:
           key: << parameters.cache_key >>
           paths:
-            - .cache/sccache
-            - .cargo
+            # Store the sccache files
+            - ~/.cache/sccache
+            # Store the cargo registry
+            - ~/.cargo
 
   run_serial:
     description: "Build and run tests"
@@ -134,12 +135,12 @@ commands:
     steps:
       - checkout
       - setup_environment:
-          cache_key:  v3.3.1-rust-1.88.0-<< parameters.cache_key >>-cache
+          cache_key: v4.2.0-rust-1.88.0-<< parameters.cache_key >>-cache
       - run:
           no_output_timeout: 30m
           command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-<< parameters.cache_key >>-cache
+          cache_key: v4.2.0-rust-1.88.0-<< parameters.cache_key >>-cache
 
   run_serial_long:
     description: "Build and run long running tests"
@@ -349,7 +350,7 @@ jobs:
     steps:
       - run_devnet:
           workspace_member: .
-          cache_key: v3.3.1-rust-1.88.0-devnet-test-cache
+          cache_key: v4.2.0-rust-1.88.0-devnet-test-cache
 
   # Check crates that do not have any tests individually
   check-other-crates:
@@ -358,7 +359,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-check-other-crates-cache
+          cache_key: v4.2.0-rust-1.88.0-check-other-crates-cache
       - run:
           name: Check snarkos-node-metrics crate
           no_output_timeout: 10m
@@ -368,7 +369,7 @@ jobs:
           no_output_timeout: 10m
           command: cargo check --package=snarkos-node-metrics --all-features
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-check-other-crates-cache
+          cache_key: v4.2.0-rust-1.88.0-check-other-crates-cache
 
   check-fmt:
     executor: rust-docker
@@ -377,13 +378,13 @@ jobs:
       - checkout
       - install_rust_nightly
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-fmt-cache
+          cache_key: v4.2.0-rust-1.88.0-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-fmt-cache
+          cache_key: v4.2.0-rust-1.88.0-fmt-cache
 
   check-unused-dependencies:
     executor: rust-docker
@@ -391,7 +392,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-machete-cache
+          cache_key: v4.2.0-rust-1.88.0-machete-cache
       - run:
           name: Check for unused dependencies
           no_output_timeout: 10m
@@ -399,7 +400,7 @@ jobs:
             cargo install cargo-machete@0.7.0
             cargo machete
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-machete-cache
+          cache_key: v4.2.0-rust-1.88.0-machete-cache
 
   check-cargo-audit:
     executor: rust-docker
@@ -407,7 +408,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.2.0-rust-1.88.0-cargo-audit-cache
       - run:
           name: Check for security vulnerabilities
           no_output_timeout: 10m
@@ -415,7 +416,7 @@ jobs:
             cargo install cargo-audit@0.21.2 --locked
             cargo audit -D warnings
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.2.0-rust-1.88.0-cargo-audit-cache
 
   check-clippy:
     executor: rust-docker
@@ -423,7 +424,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v3.3.1-rust-1.88.0-clippy-cache
+          cache_key: v4.2.0-rust-1.88.0-clippy-cache
       - run:
           name: Check lint
           no_output_timeout: 35m
@@ -431,7 +432,7 @@ jobs:
             cargo clippy --workspace --all-targets -- -D warnings
             cargo clippy --workspace --all-targets --all-features -- -D warnings
       - clear_environment:
-          cache_key: v3.3.1-rust-1.88.0-clippy-cache
+          cache_key: v4.2.0-rust-1.88.0-clippy-cache
 
   verify-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,14 @@ commands:
     steps:
       - run: set -e
       - run:
+          name: Prepare environment variables
+          command: |
+            echo 'export "RUSTC_WRAPPER"="$HOME/.bin/sccache"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="20000M"' >> $BASH_ENV
+
+            # Disable incremental builds so that sccache works as expected
+            echo 'export CARGO_INCREMENTAL=0' >> "$BASH_ENV"
+      - run:
           name: Install sccache
           command: |
             export SCCACHE_DIR="$HOME/.cache/sccache"
@@ -93,9 +101,6 @@ commands:
             chmod +x "$HOME/.bin/$SCCACHE_PKG/sccache"
             mv "$HOME/.bin/$SCCACHE_PKG/sccache" "$HOME/.bin/sccache"
             rm -rf "$HOME/.cargo/registry"
-
-            export PATH="$PATH:$HOME/.bin"
-            export RUSTC_WRAPPER="sccache"
       - run:
           name: Install Debian packages
           command: |
@@ -112,8 +117,10 @@ commands:
         type: string
         default: v4.2.0-rust-1.88.0-snarkos-stable-cache
     steps:
-      - run: (sccache -s||true)
       - run: set +e
+      - run:
+          name: "Show sccache statistics"
+          command: $HOME/.bin/sccache -s
       - save_cache:
           key: << parameters.cache_key >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
           name: Prepare environment variables
           command: |
             echo 'export "RUSTC_WRAPPER"="$HOME/.bin/sccache"' >> $BASH_ENV
-            echo 'export "SCCACHE_CACHE_SIZE"="20000M"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="5000M"' >> $BASH_ENV
 
             # Disable incremental builds so that sccache works as expected
             echo 'export CARGO_INCREMENTAL=0' >> "$BASH_ENV"
@@ -139,6 +139,9 @@ commands:
       flags:
         type: string
         default: ""
+      env_vars:
+        type: string
+        default: ""
     steps:
       - checkout
       - setup_environment:
@@ -146,11 +149,11 @@ commands:
       - run:
           name: "Build tests"
           no_output_timeout: 30m
-          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >> --no-run
+          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 << parameters.env_vars >> cargo test << parameters.flags >> --no-run
       - run:
           name: "Run tests"
           no_output_timeout: 30m
-          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 cargo test << parameters.flags >>
+          command: cd << parameters.workspace_member >> && RUST_MIN_STACK=67108864 << parameters.env_vars >> cargo test << parameters.flags >>
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-<< parameters.cache_key >>-cache
 
@@ -251,7 +254,10 @@ jobs:
       - run_serial:
           workspace_member: node
           cache_key: node
-
+          # reduce concurrency
+          flags: -j12
+          # disable sccache for this workflow
+          env_vars: RUSTC_WRAPPER="" CARGO_INCREMENTAL=1
   node-bft:
     executor: rust-docker
     resource_class: << pipeline.parameters.twoxlarge >>
@@ -259,6 +265,10 @@ jobs:
       - run_serial:
           workspace_member: node/bft
           cache_key: node-bft
+          # reduce concurrency
+          flags: -j12
+           # disable sccache for this workflow
+          env_vars: RUSTC_WRAPPER="" CARGO_INCREMENTAL=1
 
   node-bft-events:
     executor: rust-docker


### PR DESCRIPTION
The `cargo-audit` workflow has been failing. I realized it is because we cache `.cargo` instead of `~./cargo`, which means the workflow overwrites our `audit.toml` file.

This PR bumps the cache prefix so that we generated new caches. I also included the sccache fixes from snarkVM, so it is used correctly in snarkOS as well.