### PR TITLE
[Fix] Do not tack transmissions that are added to the mempool

### DIFF
--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -372,6 +372,10 @@ impl<N: Network> Consensus<N> {
             if self.ledger.contains_transmission(&TransmissionID::Transaction(transaction_id, checksum))? {
                 bail!("Transaction '{}' exists in the ledger {}", fmt_id(transaction_id), "(skipping)".dimmed());
             }
+            // Check that the transaction is not in the mempool.
+            if self.contains_transaction(&transaction_id) {
+                bail!("Transaction '{}' exists in the memory pool", fmt_id(transaction_id));
+            }
             #[cfg(feature = "metrics")]
             {
                 metrics::increment_gauge(metrics::consensus::UNCONFIRMED_TRANSACTIONS, 1f64);
@@ -379,10 +383,6 @@ impl<N: Network> Consensus<N> {
                 self.transmissions_tracker
                     .lock()
                     .insert(TransmissionID::Transaction(transaction.id(), checksum), timestamp);
-            }
-            // Check that the transaction is not in the mempool.
-            if self.contains_transaction(&transaction_id) {
-                bail!("Transaction '{}' exists in the memory pool", fmt_id(transaction_id));
             }
             // Add the transaction to the memory pool.
             trace!("Received unconfirmed transaction '{}' in the queue", fmt_id(transaction_id));
@@ -565,6 +565,7 @@ impl<N: Network> Consensus<N> {
             let coinbase_target = next_block.header().coinbase_target();
             let cumulative_proof_target = next_block.header().cumulative_proof_target();
 
+            // Calculate latency for all transmissions included in this block.
             metrics::add_transmission_latency_metric(&self.transmissions_tracker, &next_block);
 
             metrics::gauge(metrics::consensus::COMMITTED_CERTIFICATES, num_committed_certificates as f64);

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -103,13 +103,14 @@ pub fn add_transmission_latency_metric<N: Network>(
     transmissions_tracker: &Arc<Mutex<HashMap<TransmissionID<N>, i64>>>,
     block: &Block<N>,
 ) {
-    const AGE_THRESHOLD_SECONDS: i32 = 30 * 60; // 30 minutes set as stale transmission threshold
+    // The age at which we consider a transmission "stale".
+    const AGE_THRESHOLD_SECONDS: i32 = 30 * 60; // 30 minutes
 
-    // Retrieve the solution IDs.
+    // Retrieve all solution IDs (including aborted).
     let solution_ids: std::collections::HashSet<_> =
         block.solutions().solution_ids().chain(block.aborted_solution_ids()).collect();
 
-    // Retrieve the transaction IDs.
+    // Retrieve all transaction IDs (including aborted).
     let transaction_ids: std::collections::HashSet<_> =
         block.transaction_ids().chain(block.aborted_transaction_ids()).collect();
 
@@ -126,7 +127,7 @@ pub fn add_transmission_latency_metric<N: Network>(
                 match transmission_id {
                     TransmissionID::Solution(..) => increment_counter(consensus::STALE_UNCONFIRMED_SOLUTIONS),
                     TransmissionID::Transaction(..) => increment_counter(consensus::STALE_UNCONFIRMED_TRANSACTIONS),
-                    _ => {}
+                    TransmissionID::Ratification => {}
                 }
                 Some(*transmission_id)
             } else {
@@ -135,6 +136,7 @@ pub fn add_transmission_latency_metric<N: Network>(
                     TransmissionID::Transaction(transaction_id, _) if transaction_ids.contains(transaction_id) => {
                         Some("transaction")
                     }
+                    // Either a ratification, or the transmission was not included in the block
                     _ => None,
                 };
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -380,7 +380,9 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
     //     Ok(())
     // }
 
-    /// Initialize the transaction pool.
+    /// Initializes the transaction pool (if in development mode).
+    ///
+    /// Spawns a background task that periodically issues transactions to the network.
     fn initialize_transaction_pool(&self, dev: Option<u16>, dev_txs: bool) -> Result<()> {
         use snarkvm::console::{
             program::{Identifier, Literal, ProgramID, Value},


### PR DESCRIPTION
I found one instance in the code where a transaction can be added to the `transmissions_tracker` (when metrics are enabled) but will not be added to the mempool.

This might fix #3907. The PR also adds a few more comments to the code that should help the next person looking into this.