### PR TITLE
Reduce spurious ERROR logs

### DIFF
--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -91,7 +91,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         let connected_peers = self.router().connected_peers();
         let connected_peers_fmt = format!("{connected_peers:?}").dimmed();
         match connected_peers.len() {
-            0 => debug!("No connected peers"),
+            0 => warn!("No connected peers"),
             1 => debug!("Connected to 1 peer: {connected_peers_fmt}"),
             num_connected => debug!("Connected to {num_connected} peers {connected_peers_fmt}"),
         }

--- a/node/tcp/src/protocols/handshake.rs
+++ b/node/tcp/src/protocols/handshake.rs
@@ -69,7 +69,7 @@ where
                             Ok(conn)
                         }
                         Ok(Err(e)) => {
-                            debug!(parent: node.tcp().span(), "handshake with {} failed: {}", addr, e);
+                            debug!(parent: node.tcp().span(), "handshake with {addr} failed: {e}");
                             Err(e)
                         }
                         Err(_) => {

--- a/node/tcp/src/protocols/handshake.rs
+++ b/node/tcp/src/protocols/handshake.rs
@@ -69,11 +69,11 @@ where
                             Ok(conn)
                         }
                         Ok(Err(e)) => {
-                            error!(parent: node.tcp().span(), "handshake with {} failed: {}", addr, e);
+                            debug!(parent: node.tcp().span(), "handshake with {} failed: {}", addr, e);
                             Err(e)
                         }
                         Err(_) => {
-                            error!(parent: node.tcp().span(), "handshake with {} timed out", addr);
+                            debug!(parent: node.tcp().span(), "handshake with {} timed out", addr);
                             Err(io::ErrorKind::TimedOut.into())
                         }
                     };


### PR DESCRIPTION
## Motivation

Closes https://github.com/ProvableHQ/snarkOS/issues/3716

Some of the consensus-related logs are tricky to extract and don't happen that frequently anyway, so only changes some P2P log levels.