### PR TITLE
Specify ConsensusVersion relevant to the task at hand

### DIFF
--- a/node/bft/events/src/block_response.rs
+++ b/node/bft/events/src/block_response.rs
@@ -64,7 +64,7 @@ impl<N: Network> ToBytes for BlockResponse<N> {
         };
 
         // Send the consensus version starting with V12.
-        if latest_consensus_version > ConsensusVersion::V11 {
+        if latest_consensus_version >= ConsensusVersion::V12 {
             // Currently, we simply write four zero bytes as the version number,
             // because we know a valid request start height is always non-zero.
             // In the future we can encode the real version here.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -467,7 +467,7 @@ impl<N: Network> BlockSync<N> {
 
         // Perform consensus version check, if possible.
         // This check is only enabled after nodes have reached V12.
-        if expected_consensus_version > ConsensusVersion::V11 {
+        if expected_consensus_version >= ConsensusVersion::V12 {
             if let Some(latest_consensus_version) = latest_consensus_version {
                 ensure_equals!(
                     expected_consensus_version,


### PR DESCRIPTION
## Motivation

A small codestyle nit, this makes it easier to grep through the codebase to see the influence of a ConsensusVersion.
