### PR TITLE
[Fix] Correct tests for new BlockResponse

### DIFF
--- a/node/bft/events/src/block_response.rs
+++ b/node/bft/events/src/block_response.rs
@@ -216,7 +216,16 @@ pub mod prop_tests {
         let decoded = BlockResponse::<CurrentNetwork>::read_le(&mut bytes.into_inner().reader()).unwrap();
 
         assert_eq!(block_response.request, decoded.request);
-        assert_eq!(block_response.latest_consensus_version, decoded.latest_consensus_version);
+
+        // A block response will never contain a version below 12.
+        if let Some(vno) = block_response.latest_consensus_version
+            && vno < ConsensusVersion::V12
+        {
+            assert_eq!(decoded.latest_consensus_version, None)
+        } else {
+            assert_eq!(decoded.latest_consensus_version, block_response.latest_consensus_version);
+        }
+
         assert_eq!(
             block_response.blocks.deserialize_blocking().unwrap(),
             decoded.blocks.deserialize_blocking().unwrap(),


### PR DESCRIPTION
This PR fixes the tests for `BlockReponse` to work with both message versions (before V12 and after V12).

I am unclear why this did not fail for the PR that we merged, but it does not seem worth it to investigate that.