### PR TITLE
[Logs] Print detailed errors in `bft.rs`

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -40,9 +40,11 @@ use snarkvm::{
         puzzle::{Solution, SolutionID},
     },
     prelude::{Field, Network, Result, bail, ensure},
+    utilities::LoggableError,
 };
 
 use aleo_std::StorageMode;
+use anyhow::Context;
 use colored::Colorize;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
@@ -269,8 +271,8 @@ impl<N: Network> BFT<N> {
         // If the BFT is ready, then update to the next round.
         if is_ready {
             // Update to the next round in storage.
-            if let Err(e) = self.storage().increment_to_next_round(current_round) {
-                warn!("BFT failed to increment to the next round from round {current_round} - {e}");
+            if let Err(err) = self.storage().increment_to_next_round(current_round) {
+                err.log_warning(format!("BFT failed to increment to the next round from round {current_round}"));
                 return false;
             }
             // Update the timer for the leader certificate.
@@ -312,8 +314,10 @@ impl<N: Network> BFT<N> {
         // Retrieve the committee lookback of the current round.
         let committee_lookback = match self.ledger().get_committee_lookback_for_round(current_round) {
             Ok(committee) => committee,
-            Err(e) => {
-                error!("BFT failed to retrieve the committee lookback for the even round {current_round} - {e}");
+            Err(err) => {
+                err.log_warning(format!(
+                    "BFT failed to retrieve the committee lookback for the even round {current_round}"
+                ));
                 return false;
             }
         };
@@ -324,8 +328,8 @@ impl<N: Network> BFT<N> {
                 // Compute the leader for the current round.
                 let computed_leader = match committee_lookback.get_leader(current_round) {
                     Ok(leader) => leader,
-                    Err(e) => {
-                        error!("BFT failed to compute the leader for the even round {current_round} - {e}");
+                    Err(err) => {
+                        err.log_error(format!("BFT failed to compute the leader for the even round {current_round}"));
                         return false;
                     }
                 };
@@ -403,8 +407,10 @@ impl<N: Network> BFT<N> {
         // Retrieve the committee lookback for the current round.
         let committee_lookback = match self.ledger().get_committee_lookback_for_round(current_round) {
             Ok(committee) => committee,
-            Err(e) => {
-                error!("BFT failed to retrieve the committee lookback for the odd round {current_round} - {e}");
+            Err(err) => {
+                err.log_error(format!(
+                    "BFT failed to retrieve the committee lookback for the odd round {current_round}"
+                ));
                 return false;
             }
         };
@@ -412,7 +418,7 @@ impl<N: Network> BFT<N> {
         let authors = current_certificates.clone().into_iter().map(|c| c.author()).collect();
         // Check if quorum threshold is reached.
         if !committee_lookback.is_quorum_threshold_reached(&authors) {
-            trace!("BFT failed reach quorum threshold in odd round {current_round}. ");
+            trace!("BFT failed reach quorum threshold in odd round {current_round}.");
             return false;
         }
         // Retrieve the leader certificate.
@@ -573,23 +579,19 @@ impl<N: Network> BFT<N> {
             for round in (self.dag.read().last_committed_round() + 2..=leader_round.saturating_sub(2)).rev().step_by(2)
             {
                 // Retrieve the previous committee for the leader round.
-                let previous_committee_lookback = match self.ledger().get_committee_lookback_for_round(round) {
-                    Ok(committee) => committee,
-                    Err(e) => {
-                        bail!("BFT failed to retrieve a previous committee lookback for the even round {round} - {e}");
-                    }
-                };
+                let previous_committee_lookback =
+                    self.ledger().get_committee_lookback_for_round(round).with_context(|| {
+                        format!("BFT failed to retrieve a previous committee lookback for the even round {round}")
+                    })?;
+
                 // Either retrieve the cached leader or compute it.
                 let leader = match self.ledger().latest_leader() {
                     Some((cached_round, cached_leader)) if cached_round == round => cached_leader,
                     _ => {
                         // Compute the leader for the commit round.
-                        let computed_leader = match previous_committee_lookback.get_leader(round) {
-                            Ok(leader) => leader,
-                            Err(e) => {
-                                bail!("BFT failed to compute the leader for the even round {round} - {e}");
-                            }
-                        };
+                        let computed_leader = previous_committee_lookback
+                            .get_leader(round)
+                            .with_context(|| format!("BFT failed to compute the leader for the even round {round}"))?;
 
                         // Cache the computed leader.
                         self.ledger().update_latest_leader(round, computed_leader);
@@ -710,12 +712,12 @@ impl<N: Network> BFT<N> {
                     // Await the callback to continue.
                     match callback_receiver.await {
                         Ok(Ok(())) => (), // continue
-                        Ok(Err(e)) => {
-                            error!("BFT failed to advance the subdag for round {anchor_round} - {e}");
+                        Ok(Err(err)) => {
+                            err.log_error(format!("BFT failed to advance the subdag for round {anchor_round}"));
                             return Ok(());
                         }
-                        Err(e) => {
-                            error!("BFT failed to receive the callback for round {anchor_round} - {e}");
+                        Err(err) => {
+                            err.log_error(format!("BFT failed to receive the callback for round {anchor_round}"));
                             return Ok(());
                         }
                     }


### PR DESCRIPTION
This PR does not change any functionality, but simply improves how errors in `bft.rs` are printed.

The change will be helpful to debug #3636. Merging it into staging will allow us to collect better logs from validators.