### PR TITLE
[Logs] Don't show duplicate signatures as warnings

### DIFF
--- a/node/bft/src/helpers/proposal.rs
+++ b/node/bft/src/helpers/proposal.rs
@@ -149,28 +149,34 @@ impl<N: Network> Proposal<N> {
     /// Adds an endorsing signature to the proposal, if the signature is valid
     /// and the signer is a committee member that has not already signed the proposal
     /// (this implicitly checks that the signature is not from the author).
+    ///
+    /// # Returns
+    ///  - `Ok(true)` for a new and valid signature.
+    ///  - `Ok(false)` for a valid but already existing signature.
+    ///  - `Err(err)` for invalid signatures and other errors.
     pub fn add_signature(
         &mut self,
         signer: Address<N>,
         signature: Signature<N>,
         committee: &Committee<N>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         // Ensure the signer is in the committee.
         if !committee.is_committee_member(signer) {
             bail!("Signature from a non-committee member - '{signer}'")
         }
         // Ensure the signer is new.
         if self.signers().contains(&signer) {
-            bail!("Duplicate signature from '{signer}'")
+            return Ok(false);
         }
         // Verify the signature. If the signature is not valid, return an error.
         // Note: This check ensures the peer's address matches the address of the signature.
         if !signature.verify(&signer, &[self.batch_id()]) {
             bail!("Signature verification failed")
         }
-        // Insert the signature.
+
+        // Insert the new signature and return success.
         self.signatures.insert(signature);
-        Ok(())
+        Ok(true)
     }
 
     /// Returns the batch certificate and transmissions.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -424,12 +424,17 @@ impl<N: Network> Storage<N> {
     /// - All previous certificates are for the previous round (i.e. round - 1).
     /// - All previous certificates contain a unique author.
     /// - The previous certificates reached the quorum threshold (N - f).
+    ///
+    /// # Returns
+    /// - `Ok(Some(txns))` for a valid new batch, where `txns` is the set of missing transactions in the batch
+    ///   that need to be fetched from peers.
+    /// - `Ok(None)` if the batch already exists in storage
     pub fn check_batch_header(
         &self,
         batch_header: &BatchHeader<N>,
         transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
         aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
+    ) -> Result<Option<HashMap<TransmissionID<N>, Transmission<N>>>> {
         // Retrieve the round.
         let round = batch_header.round();
         // Retrieve the GC round.
@@ -439,7 +444,8 @@ impl<N: Network> Storage<N> {
 
         // Ensure the batch ID does not already exist in storage.
         if self.contains_batch(batch_header.batch_id()) {
-            bail!("Batch for round {round} already exists in storage {gc_log}")
+            debug!("Batch for round {round} already exists in storage {gc_log}");
+            return Ok(None);
         }
 
         // Retrieve the committee lookback for the batch round.
@@ -503,7 +509,8 @@ impl<N: Network> Storage<N> {
                 bail!("Previous certificates for a batch in round {round} did not reach quorum threshold {gc_log}")
             }
         }
-        Ok(missing_transmissions)
+
+        Ok(Some(missing_transmissions))
     }
 
     /// Check the validity of a certificate coming from another validator.
@@ -588,8 +595,11 @@ impl<N: Network> Storage<N> {
         }
 
         // Ensure the batch header is well-formed.
-        let missing_transmissions =
-            self.check_batch_header(certificate.batch_header(), transmissions, aborted_transmissions)?;
+        let Some(missing_transmissions) =
+            self.check_batch_header(certificate.batch_header(), transmissions, aborted_transmissions)?
+        else {
+            bail!("Certificate for round {round} already exists in storage {gc_log}")
+        };
 
         // Check the timestamp for liveness.
         check_timestamp_for_liveness(certificate.timestamp())?;
@@ -620,6 +630,7 @@ impl<N: Network> Storage<N> {
         if !committee_lookback.is_quorum_threshold_reached(&signers) {
             bail!("Signatures for a batch in round {round} did not reach quorum threshold {gc_log}")
         }
+
         Ok(missing_transmissions)
     }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -57,6 +57,7 @@ use snarkvm::{
         puzzle::{Solution, SolutionID},
     },
     prelude::{ConsensusVersion, committee::Committee},
+    utilities::flatten_error,
 };
 
 use aleo_std::StorageMode;
@@ -190,14 +191,18 @@ impl<N: Network> Primary<N> {
                         // skip the certificate.
                         if let Err(err) = self.sync_with_certificate_from_peer::<true>(DUMMY_SELF_IP, certificate).await
                         {
-                            warn!("Failed to load stored certificate {} from proposal cache - {err}", fmt_id(batch_id));
+                            warn!(
+                                "{}",
+                                &flatten_error(err.context(format!(
+                                    "Failed to load stored certificate {} from proposal cache",
+                                    fmt_id(batch_id)
+                                )))
+                            );
                         }
                     }
                     Ok(())
                 }
-                Err(err) => {
-                    bail!("Failed to read the signed proposals from the file system - {err}.");
-                }
+                Err(err) => Err(err.context("Failed to read the signed proposals from the file system")),
             },
             // If the proposal cache does not exist, then return early.
             false => Ok(()),
@@ -368,8 +373,8 @@ impl<N: Network> Primary<N> {
         let mut lock_guard = self.propose_lock.lock().await;
 
         // Check if the proposed batch has expired, and clear it if it has expired.
-        if let Err(e) = self.check_proposed_batch_for_expiration().await {
-            warn!("Failed to check the proposed batch for expiration - {e}");
+        if let Err(err) = self.check_proposed_batch_for_expiration().await {
+            warn!("{}", &flatten_error(err.context("Failed to check the proposed batch for expiration")));
             return Ok(());
         }
 
@@ -435,8 +440,11 @@ impl<N: Network> Primary<N> {
         metrics::gauge(metrics::bft::PROPOSAL_ROUND, round as f64);
 
         // Ensure that the primary does not create a new proposal too quickly.
-        if let Err(e) = self.check_proposal_timestamp(previous_round, self.gateway.account().address(), now()) {
-            debug!("Primary is safely skipping a batch proposal for round {round} - {}", format!("{e}").dimmed());
+        if let Err(err) = self.check_proposal_timestamp(previous_round, self.gateway.account().address(), now()) {
+            debug!(
+                "{}",
+                flatten_error(err.context(format!("Primary is safely skipping a batch proposal for round {round}")))
+            );
             return Ok(());
         }
 
@@ -450,9 +458,10 @@ impl<N: Network> Primary<N> {
                     // 'is_ready' is false if the primary is not ready to propose a batch for the next round.
                     Ok(false) => return Ok(()),
                     // An error occurred while attempting to advance the current round.
-                    Err(e) => {
-                        warn!("Failed to update the BFT to the next round - {e}");
-                        return Err(e);
+                    Err(err) => {
+                        let err = err.context("Failed to update the BFT to the next round");
+                        warn!("{}", &flatten_error(&err));
+                        return Err(err);
                     }
                 }
             }
@@ -466,7 +475,7 @@ impl<N: Network> Primary<N> {
         // If a certificate already exists for the current round, an attempt should be made to advance the
         // round as early as possible.
         if round == *lock_guard {
-            warn!("Primary is safely skipping a batch proposal - round {round} already proposed");
+            debug!("Primary is safely skipping a batch proposal - round {round} already proposed");
             return Ok(());
         }
 
@@ -699,8 +708,8 @@ impl<N: Network> Primary<N> {
         })
         .inspect_err(|_| {
             // On error, reinsert the transmissions and then propagate the error.
-            if let Err(e) = self.reinsert_transmissions_into_workers(transmissions) {
-                error!("Failed to reinsert transmissions: {e:?}");
+            if let Err(err) = self.reinsert_transmissions_into_workers(transmissions) {
+                error!("{}", flatten_error(err.context("Failed to reinsert transmissions")));
             }
         })?;
         // Broadcast the batch to all validators for signing.
@@ -817,10 +826,10 @@ impl<N: Network> Primary<N> {
         // Compute the previous round.
         let previous_round = batch_round.saturating_sub(1);
         // Ensure that the peer did not propose a batch too quickly.
-        if let Err(e) = self.check_proposal_timestamp(previous_round, batch_author, batch_header.timestamp()) {
+        if let Err(err) = self.check_proposal_timestamp(previous_round, batch_author, batch_header.timestamp()) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
-            bail!("Malicious peer - {e} from '{peer_ip}'");
+            return Err(err.context(format!("Malicious behavior of peer '{peer_ip}'")));
         }
 
         // Ensure the batch header does not contain any ratifications.
@@ -840,7 +849,12 @@ impl<N: Network> Primary<N> {
             // If the transmission is not well-formed, then return early.
             self.ledger.ensure_transmission_is_well_formed(*transmission_id, transmission)
         }) {
-            debug!("Batch propose at round {batch_round} from '{peer_ip}' contains an invalid transmission - {err}",);
+            debug!(
+                "{}",
+                &flatten_error(err.context(format!(
+                    "Batch propose at round {batch_round} from '{peer_ip}' contains an invalid transmission"
+                )))
+            );
             return Ok(());
         }
 
@@ -1051,11 +1065,20 @@ impl<N: Network> Primary<N> {
                         bail!("Signature is from a disconnected validator");
                     };
                     // Add the signature to the batch.
-                    proposal.add_signature(signer, signature, &committee_lookback)?;
-                    info!("Received a batch signature for round {} from '{peer_ip}'", proposal.round());
-                    // Check if the batch is ready to be certified.
-                    if !proposal.is_quorum_threshold_reached(&committee_lookback) {
-                        // If the batch is not ready to be certified, return early.
+                    let new_signature = proposal.add_signature(signer, signature, &committee_lookback)?;
+
+                    if new_signature {
+                        info!("Received a batch signature for round {} from '{peer_ip}'", proposal.round());
+                        // Check if the batch is ready to be certified.
+                        if !proposal.is_quorum_threshold_reached(&committee_lookback) {
+                            // If the batch is not ready to be certified, return early.
+                            return Ok(None);
+                        }
+                    } else {
+                        debug!(
+                            "Received duplicated signature from '{peer_ip}' for batch {batch_id} in round {round}",
+                            round = proposal.round()
+                        );
                         return Ok(None);
                     }
                 }
@@ -1376,8 +1399,13 @@ impl<N: Network> Primary<N> {
                 // In addition, spawning a task can cause concurrent processing of signatures (even with a lock),
                 // which means the RwLock for the proposed batch must become a 'tokio::sync' to be safe.
                 let id = fmt_id(batch_signature.batch_id);
-                if let Err(e) = self_.process_batch_signature_from_peer(peer_ip, batch_signature).await {
-                    warn!("Cannot store a signature for batch '{id}' from '{peer_ip}' - {e}");
+                if let Err(err) = self_.process_batch_signature_from_peer(peer_ip, batch_signature).await {
+                    warn!(
+                        "{}",
+                        &flatten_error(
+                            err.context(format!("Cannot store a signature for batch '{id}' from '{peer_ip}'"))
+                        )
+                    );
                 }
             }
         });
@@ -1402,8 +1430,13 @@ impl<N: Network> Primary<N> {
                     // Process the batch certificate.
                     let id = fmt_id(batch_certificate.id());
                     let round = batch_certificate.round();
-                    if let Err(e) = self_.process_batch_certificate_from_peer(peer_ip, batch_certificate).await {
-                        warn!("Cannot store a certificate '{id}' for round {round} from '{peer_ip}' - {e}");
+                    if let Err(err) = self_.process_batch_certificate_from_peer(peer_ip, batch_certificate).await {
+                        warn!(
+                            "{}",
+                            &flatten_error(err.context(format!(
+                                "Cannot store a certificate '{id}' for round {round} from '{peer_ip}'"
+                            )))
+                        )
                     }
                 });
             }
@@ -1445,8 +1478,8 @@ impl<N: Network> Primary<N> {
                 // Attempt to increment to the next round if the quorum threshold is reached.
                 if is_quorum_threshold_reached {
                     debug!("Quorum threshold reached for round {}", current_round);
-                    if let Err(e) = self_.try_increment_to_the_next_round(next_round).await {
-                        warn!("Failed to increment to the next round - {e}");
+                    if let Err(err) = self_.try_increment_to_the_next_round(next_round).await {
+                        warn!("{}", &flatten_error(err.context("Failed to increment to the next round")));
                     }
                 }
             }
@@ -1547,9 +1580,10 @@ impl<N: Network> Primary<N> {
             let is_ready = if let Some(bft_sender) = self.bft_sender.get() {
                 match bft_sender.send_primary_round_to_bft(current_round).await {
                     Ok(is_ready) => is_ready,
-                    Err(e) => {
-                        warn!("Failed to update the BFT to the next round - {e}");
-                        return Err(e);
+                    Err(err) => {
+                        let err = err.context("Failed to update the BFT to the next round");
+                        warn!("{}", &flatten_error(&err));
+                        return Err(err);
                     }
                 }
             }
@@ -1640,9 +1674,10 @@ impl<N: Network> Primary<N> {
         // If a BFT sender was provided, send the certificate to the BFT.
         if let Some(bft_sender) = self.bft_sender.get() {
             // Await the callback to continue.
-            if let Err(e) = bft_sender.send_primary_certificate_to_bft(certificate.clone()).await {
-                warn!("Failed to update the BFT DAG from primary - {e}");
-                return Err(e);
+            if let Err(err) = bft_sender.send_primary_certificate_to_bft(certificate.clone()).await {
+                let err = err.context("Failed to update the BFT DAG from primary");
+                warn!("{}", flatten_error(&err));
+                return Err(err);
             };
         }
         // Broadcast the certified batch to all validators.
@@ -1727,9 +1762,10 @@ impl<N: Network> Primary<N> {
             // If a BFT sender was provided, send the round and certificate to the BFT.
             if let Some(bft_sender) = self.bft_sender.get() {
                 // Send the certificate to the BFT.
-                if let Err(e) = bft_sender.send_primary_certificate_to_bft(certificate).await {
-                    warn!("Failed to update the BFT DAG from sync: {e}");
-                    return Err(e);
+                if let Err(err) = bft_sender.send_primary_certificate_to_bft(certificate).await {
+                    let err = err.context("Failed to update the BFT DAG from sync");
+                    warn!("{}", &flatten_error(&err));
+                    return Err(err);
                 };
             }
         }
@@ -1954,7 +1990,7 @@ impl<N: Network> Primary<N> {
             ProposalCache::new(latest_round, proposal, signed_proposals, pending_certificates)
         };
         if let Err(err) = proposal_cache.store(&self.storage_mode) {
-            error!("Failed to store the current proposal cache: {err}");
+            error!("{}", flatten_error(err.context("Failed to store the current proposal cache")));
         }
         // Close the gateway.
         self.gateway.shut_down().await;

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -61,6 +61,7 @@ use snarkvm::{
 };
 
 use aleo_std::StorageMode;
+use anyhow::Context;
 use colored::Colorize;
 use futures::stream::{FuturesUnordered, StreamExt};
 use indexmap::{IndexMap, IndexSet};
@@ -191,13 +192,11 @@ impl<N: Network> Primary<N> {
                         // skip the certificate.
                         if let Err(err) = self.sync_with_certificate_from_peer::<true>(DUMMY_SELF_IP, certificate).await
                         {
-                            warn!(
-                                "{}",
-                                &flatten_error(err.context(format!(
-                                    "Failed to load stored certificate {} from proposal cache",
-                                    fmt_id(batch_id)
-                                )))
-                            );
+                            let err = err.context(format!(
+                                "Failed to load stored certificate {} from proposal cache",
+                                fmt_id(batch_id)
+                            ));
+                            warn!("{}", &flatten_error(err));
                         }
                     }
                     Ok(())
@@ -373,8 +372,12 @@ impl<N: Network> Primary<N> {
         let mut lock_guard = self.propose_lock.lock().await;
 
         // Check if the proposed batch has expired, and clear it if it has expired.
-        if let Err(err) = self.check_proposed_batch_for_expiration().await {
-            warn!("{}", &flatten_error(err.context("Failed to check the proposed batch for expiration")));
+        if let Err(err) = self
+            .check_proposed_batch_for_expiration()
+            .await
+            .with_context(|| "Failed to check the proposed batch for expiration")
+        {
+            warn!("{}", flatten_error(&err));
             return Ok(());
         }
 
@@ -849,12 +852,10 @@ impl<N: Network> Primary<N> {
             // If the transmission is not well-formed, then return early.
             self.ledger.ensure_transmission_is_well_formed(*transmission_id, transmission)
         }) {
-            debug!(
-                "{}",
-                &flatten_error(err.context(format!(
-                    "Batch propose at round {batch_round} from '{peer_ip}' contains an invalid transmission"
-                )))
-            );
+            let err = err.context(format!(
+                "Batch propose at round {batch_round} from '{peer_ip}' contains an invalid transmission"
+            ));
+            debug!("{}", flatten_error(err));
             return Ok(());
         }
 
@@ -869,8 +870,14 @@ impl<N: Network> Primary<N> {
 
         // Ensure the batch header from the peer is valid.
         let (storage, header) = (self.storage.clone(), batch_header.clone());
-        let missing_transmissions =
-            spawn_blocking!(storage.check_batch_header(&header, missing_transmissions, Default::default()))?;
+
+        // Check the batch header, and return early if it already exists in storage.
+        let Some(missing_transmissions) =
+            spawn_blocking!(storage.check_batch_header(&header, missing_transmissions, Default::default()))?
+        else {
+            return Ok(());
+        };
+
         // Inserts the missing transmissions into the workers.
         self.insert_missing_transmissions_into_workers(peer_ip, missing_transmissions.into_iter())?;
 
@@ -1400,12 +1407,8 @@ impl<N: Network> Primary<N> {
                 // which means the RwLock for the proposed batch must become a 'tokio::sync' to be safe.
                 let id = fmt_id(batch_signature.batch_id);
                 if let Err(err) = self_.process_batch_signature_from_peer(peer_ip, batch_signature).await {
-                    warn!(
-                        "{}",
-                        &flatten_error(
-                            err.context(format!("Cannot store a signature for batch '{id}' from '{peer_ip}'"))
-                        )
-                    );
+                    let err = err.context(format!("Cannot store a signature for batch '{id}' from '{peer_ip}'"));
+                    warn!("{}", flatten_error(err));
                 }
             }
         });
@@ -1433,10 +1436,10 @@ impl<N: Network> Primary<N> {
                     if let Err(err) = self_.process_batch_certificate_from_peer(peer_ip, batch_certificate).await {
                         warn!(
                             "{}",
-                            &flatten_error(err.context(format!(
+                            flatten_error(err.context(format!(
                                 "Cannot store a certificate '{id}' for round {round} from '{peer_ip}'"
                             )))
-                        )
+                        );
                     }
                 });
             }
@@ -1477,9 +1480,9 @@ impl<N: Network> Primary<N> {
                 };
                 // Attempt to increment to the next round if the quorum threshold is reached.
                 if is_quorum_threshold_reached {
-                    debug!("Quorum threshold reached for round {}", current_round);
+                    debug!("Quorum threshold reached for round {current_round}");
                     if let Err(err) = self_.try_increment_to_the_next_round(next_round).await {
-                        warn!("{}", &flatten_error(err.context("Failed to increment to the next round")));
+                        warn!("{}", flatten_error(err.context("Failed to increment to the next round")));
                     }
                 }
             }
@@ -1582,7 +1585,7 @@ impl<N: Network> Primary<N> {
                     Ok(is_ready) => is_ready,
                     Err(err) => {
                         let err = err.context("Failed to update the BFT to the next round");
-                        warn!("{}", &flatten_error(&err));
+                        warn!("{}", flatten_error(&err));
                         return Err(err);
                     }
                 }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -36,7 +36,7 @@ use snarkvm::{
     utilities::flatten_error,
 };
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
 use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
@@ -472,9 +472,11 @@ impl<N: Network> Sync<N> {
         // If a BFT sender was provided, send the certificates to the BFT.
         if let Some(bft_sender) = self.bft_sender.get() {
             // Await the callback to continue.
-            if let Err(e) = bft_sender.tx_sync_bft_dag_at_bootup.send(certificates).await {
-                bail!("Failed to update the BFT DAG from sync: {e}");
-            }
+            bft_sender
+                .tx_sync_bft_dag_at_bootup
+                .send(certificates)
+                .await
+                .with_context(|| "Failed to update the BFT DAG from sync")?;
         }
 
         self.block_sync.set_sync_height(block_height);


### PR DESCRIPTION
This PR differentiates between duplicate signatures or certificates, and more serious errors. The former are logged as debug messages, while the latter are logged as error messages, like before.