### PR TITLE
[Fix] Restore Pending Blocks

### DIFF
--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -47,7 +47,7 @@ trap child_exit_handler CHLD
 # Define a trap handler that prints a message when an error occurs 
 trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
-# Flags used by all ndoes
+# Flags used by all nodes.
 common_flags=(
   --nodisplay --nobanner --noupdater "--network=$network_id" --verbosity=1
   "--dev-num-validators=$total_validators"
@@ -81,11 +81,12 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
   sleep 1
 done
 
-# Start all client nodes in the background
+# Start all client nodes in the background.
 for ((client_index = 0; client_index < total_clients; client_index++)); do
+  # compute the absolute index for this node.
   node_index=$((client_index + total_validators))
 
-  snarkos clean --dev $node_index
+  snarkos clean "--dev=$node_index" "--network=$network_id"
 
   log_file="$log_dir/client-$client_index.log"
   snarkos start "${common_flags[@]}" "--dev=$node_index" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,22 +153,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -297,7 +297,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -393,7 +393,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -556,9 +556,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2-sys"
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -627,7 +627,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1423,9 +1423,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1974,7 +1974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1990,7 +1990,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2018,7 +2018,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2028,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2039,7 +2039,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2392,7 +2392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2910,7 +2910,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3476,7 +3476,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -3787,7 +3787,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
 dependencies = [
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "indicatif",
  "log",
  "quick-xml",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "blst",
  "cc",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "indexmap 2.12.0",
  "itertools 0.14.0",
@@ -4630,12 +4630,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4842,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4907,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4940,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5012,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5024,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5091,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5115,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5143,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5195,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5212,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "metrics",
 ]
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5323,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "enum-iterator",
  "indexmap 2.12.0",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=6bec0e0e#6bec0e0e165f7604afa69bce0fc383d50bed9577"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5980,7 +5980,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6529,9 +6529,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6558,34 +6558,19 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6594,16 +6579,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6612,7 +6588,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6648,7 +6624,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6673,7 +6649,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,9 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "6bec0e0e"
+#rev = "6bec0e0e"
 #version = "=4.3.0"
+branch="fix/restore-pending-blocks"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -107,7 +107,9 @@ fn parse_log_filter(filter_str: &str) -> Result<EnvFilter> {
 }
 
 /// Sets the log filter based on the given verbosity level.
+/// Initializes the logger with the specified verbosity level, where 0 is the lowest verbosity and 6 the highest.
 ///
+/// The following shows what messages are enabled at each level.
 /// ```ignore
 /// 0 => info
 /// 1 => info, debug

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -16,8 +16,10 @@
 use crate::{LedgerService, fmt_id, spawn_blocking};
 use snarkvm::{
     ledger::{
+        Block,
         Ledger,
-        block::{Block, Transaction},
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -353,6 +355,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         // Check the transaction is well-formed.
         let ledger = self.ledger.clone();
         spawn_blocking!(ledger.check_transaction_basic(&transaction, None, &mut rand::thread_rng()))
+    }
+
+    fn check_block_subdag(&self, block: Block<N>, prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        self.ledger.check_block_subdag(block, prefix)
+    }
+
+    fn check_block_content(&self, block: PendingBlock<N>) -> Result<Block<N>> {
+        self.ledger.check_block_content(block, &mut rand::thread_rng())
     }
 
     /// Checks the given block is valid next block.

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -16,7 +16,9 @@
 use crate::{LedgerService, fmt_id};
 use snarkvm::{
     ledger::{
-        block::{Block, Transaction},
+        Block,
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -209,6 +211,14 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     ) -> Result<()> {
         trace!("[MockLedgerService] Check transaction basic {:?} - Ok", fmt_id(transaction_id));
         Ok(())
+    }
+
+    fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        unimplemented!();
+    }
+
+    fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>> {
+        unimplemented!();
     }
 
     /// Checks the given block is valid next block.

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -16,7 +16,9 @@
 use crate::LedgerService;
 use snarkvm::{
     ledger::{
-        block::{Block, Transaction},
+        Block,
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -164,6 +166,14 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         _transaction: Transaction<N>,
     ) -> Result<()> {
         Ok(())
+    }
+
+    fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        bail!("Cannot check block subDAG in prover")
+    }
+
+    fn check_block_content(&self, _pending_block: PendingBlock<N>) -> Result<Block<N>> {
+        bail!("Cannot check block content in prover")
     }
 
     /// Checks the given block is valid next block.

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -15,7 +15,9 @@
 
 use snarkvm::{
     ledger::{
-        block::{Block, Transaction},
+        Block,
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -105,6 +107,12 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
         transaction_id: N::TransactionID,
         transaction: Transaction<N>,
     ) -> Result<()>;
+
+    /// Checks that the subDAG in a given block is valid, but does not fully verify the block.
+    fn check_block_subdag(&self, block: Block<N>, prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>>;
+
+    /// Takes a pending block and performs the remaining checks to full verify it.
+    fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>>;
 
     /// Checks the given block is valid next block.
     fn check_next_block(&self, block: &Block<N>) -> Result<()>;

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -18,8 +18,10 @@ use async_trait::async_trait;
 use indexmap::IndexMap;
 use snarkvm::{
     ledger::{
+        Block,
         Ledger,
-        block::{Block, Transaction},
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -175,6 +177,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         _transaction: Transaction<N>,
     ) -> Result<()> {
         Ok(())
+    }
+
+    fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        unimplemented!();
+    }
+
+    fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>> {
+        unimplemented!();
     }
 
     /// Always succeeds.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1192,12 +1192,15 @@ mod tests {
                 subdag_map.insert(leader_round - 2, previous_commit_cert_map);
             }
 
-            let subdag = Subdag::from(subdag_map.clone())?;
-            let block = core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?;
-
             previous_leader_cert = Some(leader_certificate);
 
-            core_ledger.advance_to_next_block(&block)?;
+            let core_ledger = core_ledger.clone();
+            let block = spawn_blocking!({
+                let subdag = Subdag::from(subdag_map.clone())?;
+                let block = core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?;
+                core_ledger.advance_to_next_block(&block)?;
+                Ok(block)
+            })?;
             blocks.push(block);
         }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use crate::{
-    Gateway, MAX_FETCH_TIMEOUT_IN_MS, Transport,
+    Gateway,
+    MAX_FETCH_TIMEOUT_IN_MS,
+    Transport,
     events::{CertificateRequest, CertificateResponse, DataBlocks, Event},
     helpers::{BFTSender, Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
     ledger_service::LedgerService,
@@ -860,15 +862,21 @@ impl<N: Network> Sync<N> {
             }
 
             for pending_block in pending_blocks.drain(0..num_blocks) {
+                let ledger = self.ledger.clone();
                 let hash = pending_block.hash();
                 let height = pending_block.height();
-                match self.ledger.check_block_content(pending_block) {
-                    Ok(block) => {
-                        trace!("Adding pending block {hash} at height {height} to the ledger");
-                        self.ledger.advance_to_next_block(&block)?;
+
+                spawn_blocking!({
+                    match ledger.check_block_content(pending_block) {
+                        Ok(block) => {
+                            trace!("Adding pending block {hash} at height {height} to the ledger");
+                            ledger.advance_to_next_block(&block)?;
+                        }
+                        Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
                     }
-                    Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
-                }
+
+                    Ok(())
+                })?
             }
         }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -14,15 +14,12 @@
 // limitations under the License.
 
 use crate::{
-    Gateway,
-    MAX_FETCH_TIMEOUT_IN_MS,
-    Transport,
-    events::DataBlocks,
+    Gateway, MAX_FETCH_TIMEOUT_IN_MS, Transport,
+    events::{CertificateRequest, CertificateResponse, DataBlocks, Event},
     helpers::{BFTSender, Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
+    ledger_service::LedgerService,
     spawn_blocking,
 };
-use snarkos_node_bft_events::{CertificateRequest, CertificateResponse, Event};
-use snarkos_node_bft_ledger_service::LedgerService;
 use snarkos_node_network::PeerPoolHandling;
 use snarkos_node_sync::{BLOCK_REQUEST_BATCH_DELAY, BlockSync, Ping, PrepareSyncRequest, locators::BlockLocators};
 
@@ -31,12 +28,12 @@ use snarkvm::{
         network::{ConsensusVersion, Network},
         types::Field,
     },
-    ledger::{authority::Authority, block::Block, narwhal::BatchCertificate},
+    ledger::{PendingBlock, authority::Authority, block::Block, narwhal::BatchCertificate},
     prelude::{cfg_into_iter, cfg_iter},
-    utilities::flatten_error,
+    utilities::{ensure_equals, flatten_error},
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
 use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
@@ -45,7 +42,7 @@ use parking_lot::Mutex;
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{HashMap, VecDeque},
     future::Future,
     net::SocketAddr,
     sync::Arc,
@@ -92,12 +89,12 @@ pub struct Sync<N: Network> {
     sync_lock: Arc<TMutex<()>>,
     /// The latest block responses.
     ///
-    /// This is used in [`Sync::sync_storage_with_block()`] to accumulate blocks  whose addition to the ledger is
-    /// deferred until certain checks pass.
+    /// This is used in [`Sync::sync_storage_with_block()`] to accumulate blocks
+    /// whose addition to the ledger is deferred until certain checks pass.
     /// Blocks need to be processed in order, hence a BTree map.
     ///
     /// Whenever a new block is added to this map, BlockSync::set_sync_height needs to be called.
-    latest_block_responses: Arc<TMutex<BTreeMap<u32, Block<N>>>>,
+    pending_blocks: Arc<TMutex<VecDeque<PendingBlock<N>>>>,
 }
 
 impl<N: Network> Sync<N> {
@@ -123,7 +120,7 @@ impl<N: Network> Sync<N> {
             handles: Default::default(),
             response_lock: Default::default(),
             sync_lock: Default::default(),
-            latest_block_responses: Default::default(),
+            pending_blocks: Default::default(),
         }
     }
 
@@ -488,13 +485,17 @@ impl<N: Network> Sync<N> {
     /// If there are queued block responses, this might be higher than the latest block in the ledger.
     async fn compute_sync_height(&self) -> u32 {
         let ledger_height = self.ledger.latest_block_height();
-        let mut responses = self.latest_block_responses.lock().await;
+        let mut pending_blocks = self.pending_blocks.lock().await;
 
         // Remove any old responses.
-        responses.retain(|height, _| *height > ledger_height);
+        while let Some(b) = pending_blocks.front()
+            && b.height() <= ledger_height
+        {
+            pending_blocks.pop_front();
+        }
 
         // Ensure the returned value is always greater or equal than ledger height.
-        responses.last_key_value().map(|(height, _)| *height).unwrap_or(0).max(ledger_height)
+        pending_blocks.back().map(|b| b.height()).unwrap_or(0).max(ledger_height)
     }
 
     /// BFT-version of [`snarkos_node_client::Client::try_advancing_block_synchronization`].
@@ -526,7 +527,7 @@ impl<N: Network> Sync<N> {
     /// This returns Ok(true) if we successfully advanced the ledger by at least one new block.
     ///
     /// A key difference to `BlockSync`'s versions is that it will only add blocks to the ledger once they have been confirmed by the network.
-    /// If blocks are not confirmed yet, they will be kept in [`Self::latest_block_responses`].
+    /// If blocks are not confirmed yet, they will be kept in [`Self::pending_blocks`].
     /// It will also pass certificates from synced blocks to the BFT module so that consensus can progress as expected
     /// (see [`Self::sync_storage_with_block`] for more details).
     ///
@@ -668,7 +669,7 @@ impl<N: Network> Sync<N> {
         let _lock = self.sync_lock.lock().await;
 
         let self_ = self.clone();
-        tokio::task::spawn_blocking(move || {
+        spawn_blocking!({
             // Check the next block.
             self_.ledger.check_next_block(&block)?;
             // Attempt to advance to the next block.
@@ -683,7 +684,88 @@ impl<N: Network> Sync<N> {
 
             Ok(())
         })
-        .await?
+    }
+
+    /// Helper function for [`Self::sync_storage_with_block`].
+    /// It syncs the batch certificates with the BFT, if the block's authority is a sub-DAG.
+    ///
+    /// Note that the block authority is always a sub-DAG in production; beacon signatures are only used for testing,
+    /// and as placeholder (irrelevant) block authority in the genesis block.i
+    async fn add_block_subdag_to_bft(&self, block: &Block<N>) -> Result<()> {
+        // Nothing to do if this is a beacon block
+        let Authority::Quorum(subdag) = block.authority() else {
+            return Ok(());
+        };
+
+        // Reconstruct the unconfirmed transactions.
+        let unconfirmed_transactions = cfg_iter!(block.transactions())
+            .filter_map(|tx| tx.to_unconfirmed_transaction().map(|unconfirmed| (unconfirmed.id(), unconfirmed)).ok())
+            .collect::<HashMap<_, _>>();
+
+        // Iterate over the certificates.
+        for certificates in subdag.values().cloned() {
+            cfg_into_iter!(certificates.clone()).for_each(|certificate| {
+                // Sync the batch certificate with the block.
+                self.storage.sync_certificate_with_block(block, certificate.clone(), &unconfirmed_transactions);
+            });
+
+            // Sync the BFT DAG with the certificates.
+            for certificate in certificates {
+                // If a BFT sender was provided, send the certificate to the BFT.
+                // For validators, BFT spawns a receiver task in `BFT::start_handlers`.
+                if let Some(bft_sender) = self.bft_sender.get() {
+                    let (callback_tx, callback_rx) = oneshot::channel();
+                    bft_sender
+                        .tx_sync_bft
+                        .send((certificate, callback_tx))
+                        .await
+                        .with_context(|| "Failed to sync certificate")?;
+                    callback_rx.await?.with_context(|| "Failed to sync certificate")?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Helper function for [`Self::sync_storage_with_block`].
+    ///
+    /// It checks that successor of a given block contains enough votes to commit it.
+    /// This can only return `Ok(true)` if the certificates of the block's successor were added to the storage.
+    fn is_block_availability_threshold_reached(&self, block: &PendingBlock<N>) -> Result<bool> {
+        // Fetch the leader certificate and the relevant rounds.
+        let leader_certificate = match block.authority() {
+            Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
+            _ => bail!("Received a block with an unexpected authority type."),
+        };
+        let commit_round = leader_certificate.round();
+        let certificate_round =
+            commit_round.checked_add(1).ok_or_else(|| anyhow!("Integer overflow on round number"))?;
+
+        // Get the committee lookback for the round just after the leader.
+        let certificate_committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
+        // Retrieve all of the certificates for the round just after the leader.
+        let certificates = self.storage.get_certificates_for_round(certificate_round);
+        // Construct a set over the authors, at the round just after the leader,
+        // who included the leader's certificate in their previous certificate IDs.
+        let authors = certificates
+            .iter()
+            .filter_map(|c| match c.previous_certificate_ids().contains(&leader_certificate.id()) {
+                true => Some(c.author()),
+                false => None,
+            })
+            .collect();
+
+        // Check if the leader is ready to be committed.
+        if certificate_committee_lookback.is_availability_threshold_reached(&authors) {
+            trace!(
+                "Block {hash} at height {height} has reached availability threshold",
+                hash = block.hash(),
+                height = block.height()
+            );
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     /// Advances the ledger by the given block and updates the storage accordingly.
@@ -692,209 +774,105 @@ impl<N: Network> Sync<N> {
     /// meets the voter availability threshold (i.e. > f voting stake)
     /// or is reachable via a DAG path from a later leader certificate that does.
     /// Since performing this check requires DAG certificates from later blocks,
-    /// the block is stored in `Sync::latest_block_responses`,
+    /// the block is stored in `Sync::pending_blocks`,
     /// and its addition to the ledger is deferred until the check passes.
-    /// Several blocks may be stored in `Sync::latest_block_responses`
+    /// Several blocks may be stored in `Sync::pending_blocks`
     /// before they can be all checked and added to the ledger.
-    async fn sync_storage_with_block(&self, block: Block<N>) -> Result<()> {
+    ///
+    /// # Usage
+    /// This function assumes that blocks are passed in order, i.e.,
+    /// that the given block is a direct successor of the block that was last passed to this function.
+    async fn sync_storage_with_block(&self, new_block: Block<N>) -> Result<()> {
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
 
         // If this block has already been processed, return early.
         // TODO(kaimast): Should we remove the response here?
-        if self.ledger.contains_block_height(block.height()) {
-            debug!("Ledger is already synced with block at height {}. Will not sync.", block.height());
+        if self.ledger.contains_block_height(new_block.height()) {
+            debug!(
+                "Ledger is already synced with block at height {height}. Will not sync.",
+                height = new_block.height()
+            );
             return Ok(());
         }
 
-        // Acquire the latest block responses lock.
-        let mut latest_block_responses = self.latest_block_responses.lock().await;
+        // Append the certificates to the storage.
+        self.add_block_subdag_to_bft(&new_block).await?;
 
-        if latest_block_responses.contains_key(&block.height()) {
-            debug!("An unconfirmed block is queued already for height {}. Will not sync.", block.height());
-            return Ok(());
-        }
+        // Acquire the pending blocks lock.
+        let mut pending_blocks = self.pending_blocks.lock().await;
 
-        // If the block authority is a sub-DAG, then sync the batch certificates with the block.
-        // Note that the block authority is always a sub-DAG in production;
-        // beacon signatures are only used for testing,
-        // and as placeholder (irrelevant) block authority in the genesis block.
-        if let Authority::Quorum(subdag) = block.authority() {
-            // Reconstruct the unconfirmed transactions.
-            let unconfirmed_transactions = cfg_iter!(block.transactions())
-                .filter_map(|tx| {
-                    tx.to_unconfirmed_transaction().map(|unconfirmed| (unconfirmed.id(), unconfirmed)).ok()
-                })
-                .collect::<HashMap<_, _>>();
-
-            // Iterate over the certificates.
-            for certificates in subdag.values().cloned() {
-                cfg_into_iter!(certificates.clone()).for_each(|certificate| {
-                    // Sync the batch certificate with the block.
-                    self.storage.sync_certificate_with_block(&block, certificate.clone(), &unconfirmed_transactions);
-                });
-
-                // Sync the BFT DAG with the certificates.
-                for certificate in certificates {
-                    // If a BFT sender was provided, send the certificate to the BFT.
-                    // For validators, BFT spawns a receiver task in `BFT::start_handlers`.
-                    if let Some(bft_sender) = self.bft_sender.get() {
-                        // Await the callback to continue.
-                        if let Err(err) = bft_sender.send_sync_bft(certificate).await {
-                            bail!("Failed to sync certificate - {err}");
-                        };
-                    }
-                }
+        if let Some(tail) = pending_blocks.back() {
+            if tail.height() >= new_block.height() {
+                debug!(
+                    "A unconfirmed block is queued already for height {height}. \
+                    Will not sync.",
+                    height = new_block.height()
+                );
+                return Ok(());
             }
+
+            ensure_equals!(tail.height() + 1, new_block.height(), "Got an out-of-order block");
         }
 
         // Fetch the latest block height.
         let ledger_block_height = self.ledger.latest_block_height();
 
-        // Insert the latest block response.
-        latest_block_responses.insert(block.height(), block);
-        // Clear the latest block responses of older blocks.
-        latest_block_responses.retain(|height, _| *height > ledger_block_height);
+        // Clear any older pending blocks.
+        // TODO(kaimast): ensure there are no dangling block requests
+        while let Some(pending_block) = pending_blocks.front() {
+            if pending_block.height() > ledger_block_height {
+                break;
+            }
 
-        // Get a list of contiguous blocks from the latest block responses.
-        let contiguous_blocks: Vec<Block<N>> = (ledger_block_height.saturating_add(1)..)
-            .take_while(|&k| latest_block_responses.contains_key(&k))
-            .filter_map(|k| latest_block_responses.get(&k).cloned())
-            .collect();
+            pending_blocks.pop_front();
+        }
 
-        // Check if each block response, from the contiguous sequence just constructed,
-        // is ready to be added to the ledger.
-        // Ensure that the block's leader certificate meets the availability threshold
-        // based on the certificates in the DAG just after the block's round.
-        // If the availability threshold is not met,
-        // process the next block and check if it is linked to the current block,
-        // in the sense that there is a path in the DAG
-        // from the next block's leader certificate
-        // to the current block's leader certificate.
-        // Note: We do not advance to the most recent block response because we would be unable to
-        // validate if the leader certificate in the block has been certified properly.
-        for next_block in contiguous_blocks.into_iter() {
-            // Retrieve the height of the next block.
-            let next_block_height = next_block.height();
+        // Check the block against the chain of pending blocks and append it on success.
+        let new_block = self.ledger.check_block_subdag(new_block, pending_blocks.make_contiguous())?;
+        pending_blocks.push_back(new_block);
 
-            // Fetch the leader certificate and the relevant rounds.
-            let leader_certificate = match next_block.authority() {
-                Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
-                _ => bail!("Received a block with an unexpected authority type."),
-            };
-            let commit_round = leader_certificate.round();
-            let certificate_round =
-                commit_round.checked_add(1).ok_or_else(|| anyhow!("Integer overflow on round number"))?;
+        // Now, figure out if and which pending block we can commit.
+        // To do this effectively and because commits are transitive,
+        // we iterate in reverse so that we can stop at the first successful check.
+        //
+        // Note, that if the storage already contains certificates for the round after new block,
+        // the availability threshold for the new block could also be reached.
+        let mut commit_height = None;
+        for block in pending_blocks.iter().rev() {
+            if self.is_block_availability_threshold_reached(block)? {
+                commit_height = Some(block.height());
+                break;
+            }
+        }
 
-            // Get the committee lookback for the round just after the leader.
-            let certificate_committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
-            // Retrieve all of the certificates for the round just after the leader.
-            let certificates = self.storage.get_certificates_for_round(certificate_round);
-            // Construct a set over the authors, at the round just after the leader,
-            // who included the leader's certificate in their previous certificate IDs.
-            let authors = certificates
-                .iter()
-                .filter_map(|c| match c.previous_certificate_ids().contains(&leader_certificate.id()) {
-                    true => Some(c.author()),
-                    false => None,
-                })
-                .collect();
+        if let Some(commit_height) = commit_height {
+            let start_height = ledger_block_height + 1;
+            ensure!(commit_height >= start_height, "Invalid commit height");
+            let num_blocks = (commit_height - start_height + 1) as usize;
 
-            debug!("Validating sync block {next_block_height} at round {commit_round}...");
-            // Check if the leader is ready to be committed.
-            if certificate_committee_lookback.is_availability_threshold_reached(&authors) {
-                // Initialize the current certificate.
-                let mut current_certificate = leader_certificate;
-                // Check if there are any linked blocks that need to be added.
-                let mut blocks_to_add = vec![next_block];
-
-                // Check if there are other blocks to process based on `is_linked`.
-                for height in (self.ledger.latest_block_height().saturating_add(1)..next_block_height).rev() {
-                    // Retrieve the previous block.
-                    let Some(previous_block) = latest_block_responses.get(&height) else {
-                        bail!("Block {height} is missing from the latest block responses.");
-                    };
-                    // Retrieve the previous block's leader certificate.
-                    let previous_certificate = match previous_block.authority() {
-                        Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
-                        _ => bail!("Received a block with an unexpected authority type."),
-                    };
-                    // Determine if there is a path between the previous certificate and the current certificate.
-                    if self.is_linked(previous_certificate.clone(), current_certificate.clone())? {
-                        debug!("Previous sync block {height} is linked to the current block {next_block_height}");
-                        // Add the previous leader certificate to the list of certificates to commit.
-                        blocks_to_add.insert(0, previous_block.clone());
-                        // Update the current certificate to the previous leader certificate.
-                        current_certificate = previous_certificate;
-                    }
-                }
-
-                // Add the blocks to the ledger.
-                for block in blocks_to_add {
-                    // Check that the blocks are sequential and can be added to the ledger.
-                    let block_height = block.height();
-                    if block_height != self.ledger.latest_block_height().saturating_add(1) {
-                        warn!("Skipping block {block_height} from the latest block responses - not sequential.");
-                        continue;
-                    }
-                    #[cfg(feature = "telemetry")]
-                    let block_authority = block.authority().clone();
-
-                    let self_ = self.clone();
-                    tokio::task::spawn_blocking(move || {
-                        // Check the next block.
-                        self_.ledger.check_next_block(&block)?;
-                        // Attempt to advance to the next block.
-                        self_.ledger.advance_to_next_block(&block)?;
-
-                        // Sync the height with the block.
-                        self_.storage.sync_height_with_block(block.height());
-                        // Sync the round with the block.
-                        self_.storage.sync_round_with_block(block.round());
-
-                        Ok::<(), anyhow::Error>(())
-                    })
-                    .await??;
-                    // Remove the block height from the latest block responses.
-                    latest_block_responses.remove(&block_height);
-
-                    // Update the validator telemetry.
-                    #[cfg(feature = "telemetry")]
-                    if let Authority::Quorum(subdag) = block_authority {
-                        self_.gateway.validator_telemetry().insert_subdag(&subdag);
-                    }
-                }
-            } else {
-                debug!(
-                    "Availability threshold was not reached for block {next_block_height} at round {commit_round}. Checking next block..."
+            // Create a more detailed log message if we are committing more than one block at a time.
+            if num_blocks > 1 {
+                trace!(
+                    "Attempting to commit {chain_length} pending block(s) starting at height {start_height}.",
+                    chain_length = pending_blocks.len(),
                 );
             }
 
-            // Don't remove the response from BlockSync yet as we might fall back to non-BFT sync.
+            for pending_block in pending_blocks.drain(0..num_blocks) {
+                let hash = pending_block.hash();
+                let height = pending_block.height();
+                match self.ledger.check_block_content(pending_block) {
+                    Ok(block) => {
+                        trace!("Adding pending block {hash} at height {height} to the ledger");
+                        self.ledger.advance_to_next_block(&block)?;
+                    }
+                    Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
+                }
+            }
         }
 
         Ok(())
-    }
-
-    /// Returns `true` if there is a path from the previous certificate to the current certificate.
-    fn is_linked(
-        &self,
-        previous_certificate: BatchCertificate<N>,
-        current_certificate: BatchCertificate<N>,
-    ) -> Result<bool> {
-        // Initialize the list containing the traversal.
-        let mut traversal = vec![current_certificate.clone()];
-        // Iterate over the rounds from the current certificate to the previous certificate.
-        for round in (previous_certificate.round()..current_certificate.round()).rev() {
-            // Retrieve all of the certificates for this past round.
-            let certificates = self.storage.get_certificates_for_round(round);
-            // Filter the certificates to only include those that are in the traversal.
-            traversal = certificates
-                .into_iter()
-                .filter(|p| traversal.iter().any(|c| c.previous_certificate_ids().contains(&p.id())))
-                .collect();
-        }
-        Ok(traversal.contains(&previous_certificate))
     }
 }
 
@@ -1042,12 +1020,23 @@ mod tests {
     type CurrentLedger = Ledger<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
     type CurrentConsensusStore = ConsensusStore<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
 
+    /// Tests that commits work as expected when some anchors are not committed immediately.
     #[tokio::test]
-    async fn test_commit_via_is_linked() -> anyhow::Result<()> {
+    async fn test_commit_chain() -> anyhow::Result<()> {
         let rng = &mut TestRng::default();
         // Initialize the round parameters.
         let max_gc_rounds = BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64;
-        let commit_round = 2;
+
+        // The first round of the first block.
+        let first_round = 1;
+        // The total number of blocks we test
+        let num_blocks = 3;
+        // The number of certificate rounds needed.
+        // There is one additional round to provide availability for the inal block.
+        let num_rounds = first_round + num_blocks * 2 + 1;
+        // The first round that has at least N-f certificates referencing the anchor from the previous round.
+        // This is also the last round we use in the test.
+        let first_committed_round = num_rounds - 1;
 
         // Initialize the store.
         let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
@@ -1090,77 +1079,70 @@ mod tests {
                 HashMap::new();
             let mut previous_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::with_capacity(4);
 
-            for round in 0..=commit_round + 8 {
+            for round in first_round..=first_committed_round {
                 let mut current_certificates = IndexSet::new();
                 let previous_certificate_ids: IndexSet<_> = if round == 0 || round == 1 {
                     IndexSet::new()
                 } else {
                     previous_certificates.iter().map(|c| c.id()).collect()
                 };
+
                 let committee_id = committee.id();
+                let prev_leader = committee.get_leader(round - 1).unwrap();
 
-                // Create a certificate for the leader.
-                if round <= 5 {
-                    let leader = committee.get_leader(round).unwrap();
-                    let leader_index = addresses.iter().position(|&address| address == leader).unwrap();
-                    let non_leader_index = addresses.iter().position(|&address| address != leader).unwrap();
-                    for i in [leader_index, non_leader_index].into_iter() {
-                        let batch_header = BatchHeader::new(
-                            &private_keys[i],
-                            round,
-                            now(),
-                            committee_id,
-                            Default::default(),
-                            previous_certificate_ids.clone(),
-                            rng,
-                        )
-                        .unwrap();
-                        // Sign the batch header.
-                        let mut signatures = IndexSet::with_capacity(4);
-                        for (j, private_key_2) in private_keys.iter().enumerate() {
-                            if i != j {
-                                signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
-                            }
+                // For the first two blocks non-leaders will not reference the leader certificate.
+                // This means, while there is an anchor, it is isn't committed
+                // until later.
+                for (i, private_key) in private_keys.iter().enumerate() {
+                    let leader_index = addresses.iter().position(|&address| address == prev_leader).unwrap();
+                    let is_certificate_round = round % 2 == 1;
+                    let is_leader = i == leader_index;
+
+                    let previous_certs = if round < first_committed_round && is_certificate_round && !is_leader {
+                        previous_certificate_ids
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .filter(|(idx, _)| *idx != leader_index)
+                            .map(|(_, id)| id)
+                            .collect()
+                    } else {
+                        previous_certificate_ids.clone()
+                    };
+
+                    let batch_header = BatchHeader::new(
+                        private_key,
+                        round,
+                        now(),
+                        committee_id,
+                        Default::default(),
+                        previous_certs,
+                        rng,
+                    )
+                    .unwrap();
+
+                    // Sign the batch header.
+                    let mut signatures = IndexSet::with_capacity(4);
+                    for (j, private_key_2) in private_keys.iter().enumerate() {
+                        if i != j {
+                            signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
                         }
-                        current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
                     }
+                    current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
                 }
 
-                // Create a certificate for each validator.
-                if round > 5 {
-                    for (i, private_key_1) in private_keys.iter().enumerate() {
-                        let batch_header = BatchHeader::new(
-                            private_key_1,
-                            round,
-                            now(),
-                            committee_id,
-                            Default::default(),
-                            previous_certificate_ids.clone(),
-                            rng,
-                        )
-                        .unwrap();
-                        // Sign the batch header.
-                        let mut signatures = IndexSet::with_capacity(4);
-                        for (j, private_key_2) in private_keys.iter().enumerate() {
-                            if i != j {
-                                signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
-                            }
-                        }
-                        current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
-                    }
-                }
                 // Update the map of certificates.
                 round_to_certificates_map.insert(round, current_certificates.clone());
-                previous_certificates = current_certificates.clone();
+                previous_certificates = current_certificates;
             }
             (round_to_certificates_map, committee)
         };
 
         // Initialize the storage.
         let storage = Storage::new(core_ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
-        // Insert certificates into storage.
+        // Insert all certificates into storage.
         let mut certificates: Vec<BatchCertificate<CurrentNetwork>> = Vec::new();
-        for i in 1..=commit_round + 8 {
+        for i in first_round..=first_committed_round {
             let c = (*round_to_certificates_map.get(&i).unwrap()).clone();
             certificates.extend(c);
         }
@@ -1168,94 +1150,61 @@ mod tests {
             storage.testing_only_insert_certificate_testing_only(certificate.clone());
         }
 
-        // Create block 1.
-        let leader_round_1 = commit_round;
-        let leader_1 = committee.get_leader(leader_round_1).unwrap();
-        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader_1).unwrap();
-        let block_1 = {
+        // Create the blocks
+        let mut previous_leader_cert = None;
+        let mut blocks = vec![];
+
+        for block_height in 1..=num_blocks {
+            let leader_round = block_height * 2;
+
+            let leader = committee.get_leader(leader_round).unwrap();
+            let leader_certificate = storage.get_certificate_for_round_with_author(leader_round, leader).unwrap();
+
             let mut subdag_map: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
             let mut leader_cert_map = IndexSet::new();
             leader_cert_map.insert(leader_certificate.clone());
-            let mut previous_cert_map = IndexSet::new();
-            for cert in storage.get_certificates_for_round(commit_round - 1) {
-                previous_cert_map.insert(cert);
+
+            let previous_cert_map = storage.get_certificates_for_round(leader_round - 1);
+
+            subdag_map.insert(leader_round, leader_cert_map.clone());
+            subdag_map.insert(leader_round - 1, previous_cert_map.clone());
+
+            if leader_round > 2 {
+                let previous_commit_cert_map: IndexSet<_> = storage
+                    .get_certificates_for_round(leader_round - 2)
+                    .into_iter()
+                    .filter(|cert| {
+                        if let Some(previous_leader_cert) = &previous_leader_cert {
+                            cert != previous_leader_cert
+                        } else {
+                            true
+                        }
+                    })
+                    .collect();
+                subdag_map.insert(leader_round - 2, previous_commit_cert_map);
             }
-            subdag_map.insert(commit_round, leader_cert_map.clone());
-            subdag_map.insert(commit_round - 1, previous_cert_map.clone());
+
             let subdag = Subdag::from(subdag_map.clone())?;
-            let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag, Default::default()))?
-        };
-        // Insert block 1.
-        let ledger = core_ledger.clone();
-        let block = block_1.clone();
-        spawn_blocking!(ledger.advance_to_next_block(&block))?;
+            let block = core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?;
 
-        // Create block 2.
-        let leader_round_2 = commit_round + 2;
-        let leader_2 = committee.get_leader(leader_round_2).unwrap();
-        let leader_certificate_2 = storage.get_certificate_for_round_with_author(leader_round_2, leader_2).unwrap();
-        let block_2 = {
-            let mut subdag_map_2: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
-            let mut leader_cert_map_2 = IndexSet::new();
-            leader_cert_map_2.insert(leader_certificate_2.clone());
-            let mut previous_cert_map_2 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_2 - 1) {
-                previous_cert_map_2.insert(cert);
-            }
-            let mut prev_commit_cert_map_2 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_2 - 2) {
-                if cert != leader_certificate {
-                    prev_commit_cert_map_2.insert(cert);
-                }
-            }
-            subdag_map_2.insert(leader_round_2, leader_cert_map_2.clone());
-            subdag_map_2.insert(leader_round_2 - 1, previous_cert_map_2.clone());
-            subdag_map_2.insert(leader_round_2 - 2, prev_commit_cert_map_2.clone());
-            let subdag_2 = Subdag::from(subdag_map_2.clone())?;
-            let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default()))?
-        };
-        // Insert block 2.
-        let ledger = core_ledger.clone();
-        let block = block_2.clone();
-        spawn_blocking!(ledger.advance_to_next_block(&block))?;
+            previous_leader_cert = Some(leader_certificate);
 
-        // Create block 3
-        let leader_round_3 = commit_round + 4;
-        let leader_3 = committee.get_leader(leader_round_3).unwrap();
-        let leader_certificate_3 = storage.get_certificate_for_round_with_author(leader_round_3, leader_3).unwrap();
-        let block_3 = {
-            let mut subdag_map_3: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
-            let mut leader_cert_map_3 = IndexSet::new();
-            leader_cert_map_3.insert(leader_certificate_3.clone());
-            let mut previous_cert_map_3 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_3 - 1) {
-                previous_cert_map_3.insert(cert);
-            }
-            let mut prev_commit_cert_map_3 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_3 - 2) {
-                if cert != leader_certificate_2 {
-                    prev_commit_cert_map_3.insert(cert);
-                }
-            }
-            subdag_map_3.insert(leader_round_3, leader_cert_map_3.clone());
-            subdag_map_3.insert(leader_round_3 - 1, previous_cert_map_3.clone());
-            subdag_map_3.insert(leader_round_3 - 2, prev_commit_cert_map_3.clone());
-            let subdag_3 = Subdag::from(subdag_map_3.clone())?;
-            let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default()))?
-        };
-        // Insert block 3.
-        let ledger = core_ledger.clone();
-        let block = block_3.clone();
-        spawn_blocking!(ledger.advance_to_next_block(&block))?;
+            core_ledger.advance_to_next_block(&block)?;
+            blocks.push(block);
+        }
 
-        // Initialize the syncing ledger.
-        let syncing_ledger = spawn_blocking!(CurrentLedger::load(genesis, StorageMode::new_test(None))).unwrap();
-        let syncing_ledger = Arc::new(CoreLedgerService::new(syncing_ledger, Default::default()));
-        // Initialize the gateway.
-        let storage_mode = StorageMode::new_test(None);
+        // ### Test that sync works as expected ###
+        let storage_mode = StorageMode::Test(None);
+
+        // Create a new ledger to test with, but use the existing storage
+        // so that the certificates exist.
+        let syncing_ledger = {
+            let storage_mode = storage_mode.clone();
+            let syncing_ledger = spawn_blocking!(CurrentLedger::load(genesis, storage_mode)).unwrap();
+            Arc::new(CoreLedgerService::new(syncing_ledger, Default::default()))
+        };
+
+        // Set up sync and its dependencies.
         let gateway = Gateway::new(
             account.clone(),
             storage.clone(),
@@ -1266,19 +1215,25 @@ mod tests {
             storage_mode,
             None,
         )?;
-        // Initialize the block synchronization logic.
         let block_sync = Arc::new(BlockSync::new(syncing_ledger.clone()));
-        // Initialize the sync module.
-        let sync = Sync::new(gateway, storage, syncing_ledger.clone(), block_sync);
-        // Try to sync block 1.
-        sync.sync_storage_with_block(block_1).await?;
-        assert_eq!(syncing_ledger.latest_block_height(), 1);
-        // Try to sync block 2.
-        sync.sync_storage_with_block(block_2).await?;
-        assert_eq!(syncing_ledger.latest_block_height(), 2);
-        // Try to sync block 3.
-        sync.sync_storage_with_block(block_3).await?;
+        let sync = Sync::new(gateway.clone(), storage.clone(), syncing_ledger.clone(), block_sync);
+
+        let mut block_iter = blocks.into_iter();
+
+        // Insert the blocks into the new sync module
+        for _ in 0..num_blocks - 1 {
+            let block = block_iter.next().unwrap();
+            sync.sync_storage_with_block(block).await?;
+
+            // Availability threshold is not met, so we should not advance yet.
+            assert_eq!(syncing_ledger.latest_block_height(), 0);
+        }
+
+        // Only for the final block, the availability threshold is met,
+        // because certificates for the subsequent round are already in storage.
+        sync.sync_storage_with_block(block_iter.next().unwrap()).await?;
         assert_eq!(syncing_ledger.latest_block_height(), 3);
+
         // Ensure blocks 1 and 2 were added to the ledger.
         assert!(syncing_ledger.contains_block_height(1));
         assert!(syncing_ledger.contains_block_height(2));
@@ -1287,7 +1242,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[tracing_test::traced_test]
     async fn test_pending_certificates() -> anyhow::Result<()> {
         let rng = &mut TestRng::default();
         // Initialize the round parameters.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -26,7 +26,7 @@ use snarkos_node_bft_ledger_service::LedgerService;
 use snarkvm::{
     console::prelude::*,
     ledger::{
-        block::Transaction,
+        Transaction,
         narwhal::{BatchHeader, Data, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
@@ -560,7 +560,8 @@ mod tests {
     use snarkvm::{
         console::{network::Network, types::Field},
         ledger::{
-            block::Block,
+            Block,
+            PendingBlock,
             committee::Committee,
             narwhal::{BatchCertificate, Subdag, Transmission, TransmissionID},
             test_helpers::sample_execution_transaction_with_fee,
@@ -626,6 +627,8 @@ mod tests {
                 transaction_id: N::TransactionID,
                 transaction: Transaction<N>,
             ) -> Result<()>;
+            fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>>;
+            fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>>;
             fn check_next_block(&self, block: &Block<N>) -> Result<()>;
             fn prepare_advance_to_next_quorum_block(
                 &self,

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -146,7 +146,7 @@ impl<N: Network> Router<N> {
     /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
     #[cfg(not(feature = "test"))]
     const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
-    /// The maximum amount of connection attempts within a 10 second threshold
+    /// The maximum amount of connection attempts within a 10 second threshold.
     #[cfg(not(feature = "test"))]
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The duration after which a connected peer is considered inactive or


### PR DESCRIPTION
https://github.com/ProvableHQ/snarkVM/pull/3019 needs to be merged first, but it is ready to be reviewed otherwise.

This PR restores the `PendingBlock` changes and makes a small adjustment ([05d93a9](https://github.com/ProvableHQ/snarkOS/pull/3983/commits/05d93a97a8d8caeba506ecd86827d64a7d103e04)) so it works with the new sequential ops in snarkVM.