### PR TITLE
Add trusted_peers_only flag, deprecate allow_external_peers and rotate_external_peers

### DIFF
--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -50,7 +50,7 @@ trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" fail
 # Flags used by all ndoes
 common_flags=(
   --nodisplay --nobanner --noupdater "--network=$network_id" --verbosity=1
-  --allow-external-peers "--dev-num-validators=$total_validators"
+  "--dev-num-validators=$total_validators"
 )
 
 # Start all validator nodes in the background

--- a/.ci/generate_ledger.sh
+++ b/.ci/generate_ledger.sh
@@ -50,7 +50,7 @@ trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" fail
 
 # Flags used by all ndoes
 common_flags=(--nodisplay --nobanner --noupdater "--network=$network_id"
-  "--log-filter=$log_filter" --allow-external-peers "--dev-num-validators=$total_validators")
+  "--log-filter=$log_filter" "--dev-num-validators=$total_validators")
 
 # Start all validator nodes in the background
 for ((validator_index = 0; validator_index < total_validators; validator_index++)); do

--- a/.devnet/start.sh
+++ b/.devnet/start.sh
@@ -43,7 +43,7 @@ start_snarkos_in_tmux() {
     tmux new-session -d -s snarkos-session
 
     # Send the snarkOS start command to the tmux session with the NODE_ID
-    tmux send-keys -t "snarkos-session" "snarkos start --nodisplay --bft 0.0.0.0:5000 --rest 0.0.0.0:3030 --allow-external-peers --peers $NODE_IP:4130 --validators $NODE_IP:5000 --rest-rps 1000 --verbosity $VERBOSITY --network $NETWORK_ID --dev $NODE_ID --dev-num-validators $NUM_INSTANCES --validator --metrics" C-m
+    tmux send-keys -t "snarkos-session" "snarkos start --nodisplay --bft 0.0.0.0:5000 --rest 0.0.0.0:3030 --peers $NODE_IP:4130 --validators $NODE_IP:5000 --rest-rps 1000 --verbosity $VERBOSITY --network $NETWORK_ID --dev $NODE_ID --dev-num-validators $NUM_INSTANCES --validator --metrics" C-m
 
     exit  # Exit root user
 EOF

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -155,13 +155,13 @@ pub struct Start {
     #[clap(long)]
     pub validators: Option<String>,
 
-    /// Allow untrusted peers (not listed in `--peers`) to connect.
+    /// [DEPRECATED] [NO-OP] Allow untrusted peers (not listed in `--peers`) to connect.
     ///
-    /// The flag will be ignored by client and prover nodes, as tis behavior is always enabled for these types of nodes.
+    /// The flag will be ignored by client and prover nodes, as this behavior is always enabled for these types of nodes.
     #[clap(long, verbatim_doc_comment)]
     pub allow_external_peers: bool,
 
-    /// If the flag is set, a client will periodically evict more external peers
+    /// [DEPRECATED] [NO-OP] If the flag is set, a client will periodically evict more external peers
     #[clap(long)]
     pub rotate_external_peers: bool,
 
@@ -188,6 +188,10 @@ pub struct Start {
     /// If the flag is set, the node will not require JWT authentication for the REST server.
     #[clap(long, group = "rest_flags")]
     pub nojwt: bool,
+
+    /// If the flag is set, the node will only connect to trusted peers and validators.
+    #[clap(long)]
+    pub trusted_peers_only: bool,
 
     /// Write log message to stdout instead of showing a terminal UI.
     ///
@@ -725,9 +729,9 @@ impl Start {
 
         // Initialize the node.
         match node_type {
-            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, self.allow_external_peers, dev_txs, self.dev, shutdown.clone()).await,
-            NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, storage_mode, self.dev, shutdown.clone()).await,
-            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.rotate_external_peers, self.dev, shutdown).await,
+            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, self.trusted_peers_only, dev_txs, self.dev, shutdown.clone()).await,
+            NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, storage_mode, self.trusted_peers_only, self.dev, shutdown.clone()).await,
+            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, self.trusted_peers_only, self.dev, shutdown).await,
             NodeType::BootstrapClient => Node::new_bootstrap_client(node_ip, account, *genesis.header(), self.dev).await,
         }
     }

--- a/node/bft/examples/simple_node.rs
+++ b/node/bft/examples/simple_node.rs
@@ -141,14 +141,24 @@ pub async fn start_bft(
     let storage_mode = StorageMode::new_test(None);
     // Initialize the trusted validators.
     let trusted_validators = trusted_validators(node_id, num_nodes, peers);
+    let trusted_peers_only = false;
     // Initialize the consensus channels.
     let (consensus_sender, consensus_receiver) = init_consensus_channels::<CurrentNetwork>();
     // Initialize the consensus receiver handler.
     consensus_handler(consensus_receiver);
     // Initialize the BFT instance.
     let block_sync = Arc::new(BlockSync::new(ledger.clone()));
-    let mut bft =
-        BFT::<CurrentNetwork>::new(account, storage, ledger, block_sync, ip, &trusted_validators, storage_mode, None)?;
+    let mut bft = BFT::<CurrentNetwork>::new(
+        account,
+        storage,
+        ledger,
+        block_sync,
+        ip,
+        &trusted_validators,
+        trusted_peers_only,
+        storage_mode,
+        None,
+    )?;
     // Run the BFT instance.
     bft.run(None, Some(consensus_sender), sender.clone(), receiver).await?;
     // Retrieve the BFT's primary.
@@ -185,6 +195,7 @@ pub async fn start_primary(
     let storage_mode = StorageMode::new_test(None);
     // Initialize the trusted validators.
     let trusted_validators = trusted_validators(node_id, num_nodes, peers);
+    let trusted_peers_only = false;
     // Initialize the primary instance.
     let block_sync = Arc::new(BlockSync::new(ledger.clone()));
     let mut primary = Primary::<CurrentNetwork>::new(
@@ -194,6 +205,7 @@ pub async fn start_primary(
         block_sync,
         ip,
         &trusted_validators,
+        trusted_peers_only,
         storage_mode,
         None,
     )?;

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -96,11 +96,22 @@ impl<N: Network> BFT<N> {
         block_sync: Arc<BlockSync<N>>,
         ip: Option<SocketAddr>,
         trusted_validators: &[SocketAddr],
+        trusted_peers_only: bool,
         storage_mode: StorageMode,
         dev: Option<u16>,
     ) -> Result<Self> {
         Ok(Self {
-            primary: Primary::new(account, storage, ledger, block_sync, ip, trusted_validators, storage_mode, dev)?,
+            primary: Primary::new(
+                account,
+                storage,
+                ledger,
+                block_sync,
+                ip,
+                trusted_validators,
+                trusted_peers_only,
+                storage_mode,
+                dev,
+            )?,
             dag: Default::default(),
             leader_certificate: Default::default(),
             leader_certificate_timer: Default::default(),
@@ -1000,6 +1011,7 @@ mod tests {
             block_sync,
             None,
             &[],
+            false,
             StorageMode::new_test(None),
             None,
         )

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -167,6 +167,8 @@ pub struct InnerGateway<N: Network> {
     handles: Mutex<Vec<JoinHandle<()>>>,
     /// The storage mode.
     storage_mode: StorageMode,
+    /// If the flag is set, the node will only connect to trusted peers.
+    trusted_peers_only: bool,
     /// The development mode.
     dev: Option<u16>,
 }
@@ -195,12 +197,14 @@ impl<N: Network> PeerPoolHandling<N> for Gateway<N> {
 
 impl<N: Network> Gateway<N> {
     /// Initializes a new gateway.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         account: Account<N>,
         storage: Storage<N>,
         ledger: Arc<dyn LedgerService<N>>,
         ip: Option<SocketAddr>,
         trusted_validators: &[SocketAddr],
+        trusted_peers_only: bool,
         storage_mode: StorageMode,
         dev: Option<u16>,
     ) -> Result<Self> {
@@ -216,10 +220,12 @@ impl<N: Network> Gateway<N> {
         // Prepare the collection of the initial peers.
         let mut initial_peers = HashMap::new();
 
-        // Load entries from the validator cache (if present).
-        let cached_peers = Self::load_cached_peers(&storage_mode, VALIDATOR_CACHE_FILENAME)?;
-        for addr in cached_peers {
-            initial_peers.insert(addr, Peer::new_candidate(addr, false));
+        // Load entries from the validator cache (if present and if we are not in trusted peers only mode).
+        if !trusted_peers_only {
+            let cached_peers = Self::load_cached_peers(&storage_mode, VALIDATOR_CACHE_FILENAME)?;
+            for addr in cached_peers {
+                initial_peers.insert(addr, Peer::new_candidate(addr, false));
+            }
         }
 
         // Add the trusted peers to the list of the initial peers; this may promote
@@ -242,6 +248,7 @@ impl<N: Network> Gateway<N> {
             sync_sender: Default::default(),
             handles: Default::default(),
             storage_mode,
+            trusted_peers_only,
             dev,
         })))
     }
@@ -937,6 +944,10 @@ impl<N: Network> Gateway<N> {
 
     /// This function keeps the number of bootstrap peers within the allowed range.
     async fn handle_bootstrap_peers(&self) {
+        // Return early if we are in trusted peers only mode.
+        if self.trusted_peers_only {
+            return;
+        }
         // Split the bootstrap peers into connected and candidate lists.
         let mut candidate_bootstrap = Vec::new();
         let connected_bootstrap = self.filter_connected_peers(|peer| peer.node_type == NodeType::BootstrapClient);
@@ -1666,6 +1677,7 @@ mod prop_tests {
                         storage.ledger().clone(),
                         address.ip(),
                         &[],
+                        false,
                         StorageMode::new_test(None),
                         address.port(),
                     )
@@ -1718,6 +1730,7 @@ mod prop_tests {
             storage.ledger().clone(),
             dev.ip(),
             &[],
+            false,
             StorageMode::new_test(None),
             dev.port(),
         )
@@ -1742,6 +1755,7 @@ mod prop_tests {
             storage.ledger().clone(),
             dev.ip(),
             &[],
+            false,
             StorageMode::new_test(None),
             dev.port(),
         )
@@ -1776,6 +1790,7 @@ mod prop_tests {
             storage.ledger().clone(),
             dev.ip(),
             &[],
+            false,
             StorageMode::new_test(None),
             dev.port(),
         )
@@ -1849,6 +1864,7 @@ mod prop_tests {
             ledger.clone(),
             dev.ip(),
             &[],
+            false,
             StorageMode::new_test(None),
             dev.port(),
         )

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -190,6 +190,10 @@ impl<N: Network> PeerPoolHandling<N> for Gateway<N> {
         self.dev.is_some()
     }
 
+    fn trusted_peers_only(&self) -> bool {
+        self.trusted_peers_only
+    }
+
     fn node_type(&self) -> NodeType {
         NodeType::Validator
     }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1557,7 +1557,7 @@ impl<N: Network> Gateway<N> {
         }
         // If the node is in trusted peers only mode, ensure the peer is trusted.
         if self.trusted_peers_only && !self.is_trusted(listener_addr) {
-            warn!("{CONTEXT} Dropping '{peer_addr}' for being an unauthorized validator ({address})");
+            warn!("{CONTEXT} Dropping '{peer_addr}' for being an untrusted validator ({address})");
             return Some(DisconnectReason::ProtocolViolation);
         }
         if !bootstrap_peers::<N>(self.dev().is_some()).contains(&listener_addr) {

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -751,6 +751,9 @@ impl<N: Network> Gateway<N> {
                 Ok(true)
             }
             Event::ValidatorsResponse(response) => {
+                if self.trusted_peers_only {
+                    bail!("{CONTEXT} Not accepting validators response from '{peer_ip}' (trusted peers only)");
+                }
                 let ValidatorsResponse { validators } = response;
                 // Ensure the number of validators is not too large.
                 ensure!(validators.len() <= MAX_VALIDATORS_TO_SEND, "{CONTEXT} Received too many validators");
@@ -1545,6 +1548,11 @@ impl<N: Network> Gateway<N> {
         if version < Event::<N>::VERSION {
             warn!("{CONTEXT} Dropping '{peer_addr}' on version {version} (outdated)");
             return Some(DisconnectReason::OutdatedClientVersion);
+        }
+        // If the node is in trusted peers only mode, ensure the peer is trusted.
+        if self.trusted_peers_only && !self.is_trusted(peer_addr) {
+            warn!("{CONTEXT} Dropping '{peer_addr}' for being an unauthorized validator ({address})");
+            return Some(DisconnectReason::ProtocolViolation);
         }
         if !bootstrap_peers::<N>(self.dev().is_some()).contains(&peer_addr) {
             // Ensure the address is a current committee member.

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1541,8 +1541,10 @@ impl<N: Network> Gateway<N> {
     /// Verifies the given challenge request. Returns a disconnect reason if the request is invalid.
     fn verify_challenge_request(&self, peer_addr: SocketAddr, event: &ChallengeRequest<N>) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge request.
-        let &ChallengeRequest { version, listener_port: _, address, nonce: _, ref snarkos_sha } = event;
+        let &ChallengeRequest { version, listener_port, address, nonce: _, ref snarkos_sha } = event;
         log_repo_sha_comparison(peer_addr, snarkos_sha, CONTEXT);
+
+        let listener_addr = SocketAddr::new(peer_addr.ip(), listener_port);
 
         // Ensure the event protocol version is not outdated.
         if version < Event::<N>::VERSION {
@@ -1550,11 +1552,11 @@ impl<N: Network> Gateway<N> {
             return Some(DisconnectReason::OutdatedClientVersion);
         }
         // If the node is in trusted peers only mode, ensure the peer is trusted.
-        if self.trusted_peers_only && !self.is_trusted(peer_addr) {
+        if self.trusted_peers_only && !self.is_trusted(listener_addr) {
             warn!("{CONTEXT} Dropping '{peer_addr}' for being an unauthorized validator ({address})");
             return Some(DisconnectReason::ProtocolViolation);
         }
-        if !bootstrap_peers::<N>(self.dev().is_some()).contains(&peer_addr) {
+        if !bootstrap_peers::<N>(self.dev().is_some()).contains(&listener_addr) {
             // Ensure the address is a current committee member.
             if !self.is_authorized_validator_address(address) {
                 warn!("{CONTEXT} Dropping '{peer_addr}' for being an unauthorized validator ({address})");

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -129,12 +129,21 @@ impl<N: Network> Primary<N> {
         block_sync: Arc<BlockSync<N>>,
         ip: Option<SocketAddr>,
         trusted_validators: &[SocketAddr],
+        trusted_peers_only: bool,
         storage_mode: StorageMode,
         dev: Option<u16>,
     ) -> Result<Self> {
         // Initialize the gateway.
-        let gateway =
-            Gateway::new(account, storage.clone(), ledger.clone(), ip, trusted_validators, storage_mode.clone(), dev)?;
+        let gateway = Gateway::new(
+            account,
+            storage.clone(),
+            ledger.clone(),
+            ip,
+            trusted_validators,
+            trusted_peers_only,
+            storage_mode.clone(),
+            dev,
+        )?;
         // Initialize the sync module.
         let sync = Sync::new(gateway.clone(), storage.clone(), ledger.clone(), block_sync);
 
@@ -2003,7 +2012,8 @@ mod tests {
         let account = accounts[account_index].1.clone();
         let block_sync = Arc::new(BlockSync::new(ledger.clone()));
         let mut primary =
-            Primary::new(account, storage, ledger, block_sync, None, &[], StorageMode::new_test(None), None).unwrap();
+            Primary::new(account, storage, ledger, block_sync, None, &[], false, StorageMode::new_test(None), None)
+                .unwrap();
 
         // Construct a worker instance.
         primary.workers = Arc::from([Worker::new(

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1246,8 +1246,16 @@ mod tests {
             Default::default(),
         ));
         // Initialize the gateway.
-        let gateway =
-            Gateway::new(account.clone(), storage.clone(), syncing_ledger.clone(), None, &[], storage_mode, None)?;
+        let gateway = Gateway::new(
+            account.clone(),
+            storage.clone(),
+            syncing_ledger.clone(),
+            None,
+            &[],
+            false,
+            storage_mode,
+            None,
+        )?;
         // Initialize the block synchronization logic.
         let block_sync = Arc::new(BlockSync::new(syncing_ledger.clone()));
         // Initialize the sync module.

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -176,6 +176,7 @@ impl TestNetwork {
                     block_sync,
                     Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), MEMORY_POOL_PORT + id as u16)),
                     &[],
+                    false,
                     StorageMode::new_test(None),
                     None,
                 )
@@ -189,6 +190,7 @@ impl TestNetwork {
                     block_sync,
                     Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), MEMORY_POOL_PORT + id as u16)),
                     &[],
+                    false,
                     StorageMode::new_test(None),
                     None,
                 )

--- a/node/bft/tests/common/utils.rs
+++ b/node/bft/tests/common/utils.rs
@@ -217,7 +217,7 @@ pub fn sample_gateway<N: Network>(
     ledger: Arc<TranslucentLedgerService<N, ConsensusMemory<N>>>,
 ) -> Gateway<N> {
     // Initialize the gateway.
-    Gateway::new(account, storage, ledger, None, &[], StorageMode::new_test(None), None).unwrap()
+    Gateway::new(account, storage, ledger, None, &[], false, StorageMode::new_test(None), None).unwrap()
 }
 
 /// Samples a new worker with the given ledger.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -121,6 +121,7 @@ impl<N: Network> Consensus<N> {
         block_sync: Arc<BlockSync<N>>,
         ip: Option<SocketAddr>,
         trusted_validators: &[SocketAddr],
+        trusted_peers_only: bool,
         storage_mode: StorageMode,
         ping: Arc<Ping<N>>,
         dev: Option<u16>,
@@ -132,8 +133,17 @@ impl<N: Network> Consensus<N> {
         // Initialize the Narwhal storage.
         let storage = NarwhalStorage::new(ledger.clone(), transmissions, BatchHeader::<N>::MAX_GC_ROUNDS as u64);
         // Initialize the BFT.
-        let bft =
-            BFT::new(account, storage, ledger.clone(), block_sync.clone(), ip, trusted_validators, storage_mode, dev)?;
+        let bft = BFT::new(
+            account,
+            storage,
+            ledger.clone(),
+            block_sync.clone(),
+            ip,
+            trusted_validators,
+            trusted_peers_only,
+            storage_mode,
+            dev,
+        )?;
         // Create a new instance of Consensus.
         let mut _self = Self {
             ledger,

--- a/node/network/src/peering.rs
+++ b/node/network/src/peering.rs
@@ -56,6 +56,9 @@ pub trait PeerPoolHandling<N: Network>: P2P {
     /// Returns `true` if the owning node is in development mode.
     fn is_dev(&self) -> bool;
 
+    /// Returns `true` if the node is in trusted peers only mode.
+    fn trusted_peers_only(&self) -> bool;
+
     /// Returns the node type.
     fn node_type(&self) -> NodeType;
 
@@ -108,6 +111,10 @@ pub trait PeerPoolHandling<N: Network>: P2P {
         // If the IP is already banned, reject the attempt.
         if self.is_ip_banned(listener_addr.ip()) {
             bail!("{} Rejected a connection attempt to a banned IP '{}'", Self::OWNER, listener_addr.ip());
+        }
+        // If the node is in trusted peers only mode, ensure the peer is trusted.
+        if self.trusted_peers_only() && !self.is_trusted(listener_addr) {
+            bail!("{} Dropping connection attempt to '{listener_addr}' (untrusted)", Self::OWNER);
         }
         Ok(false)
     }

--- a/node/network/src/peering.rs
+++ b/node/network/src/peering.rs
@@ -193,6 +193,8 @@ pub trait PeerPoolHandling<N: Network>: P2P {
     /// limit on the number of peers in the pool. The listener addresses may be paired with
     /// the last known block height of the associated peer.
     fn insert_candidate_peers(&self, mut listener_addrs: Vec<(SocketAddr, Option<u32>)>) {
+        let trusted_peers = self.trusted_peers();
+
         // Hold a write guard from now on, so as not to accidentally slash multiple times
         // based on multiple batches of candidate peers, and to not overwrite any entries.
         let mut peer_pool = self.peer_pool().write();
@@ -225,7 +227,9 @@ pub trait PeerPoolHandling<N: Network>: P2P {
             // Collect the addresses of prospect peers.
             let mut peers_to_slash = peer_pool
                 .iter()
-                .filter_map(|(addr, peer)| (matches!(peer, Peer::Candidate(_))).then_some(*addr))
+                .filter_map(|(addr, peer)| {
+                    (matches!(peer, Peer::Candidate(_)) && !trusted_peers.contains(addr)).then_some(*addr)
+                })
                 .collect::<Vec<_>>();
 
             // Get the low-level peer stats.

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -339,8 +339,8 @@ impl<N: Network> Router<N> {
         if self.is_local_ip(listener_addr) {
             bail!("Dropping connection request from '{listener_addr}' (attempted to self-connect)");
         }
-        // Unknown peers are untrusted, so check if `allow_external_peers` is true.
-        if !self.allow_external_peers() && !self.is_trusted(listener_addr) {
+        // Unknown peers are untrusted, so check if `trusted_peers_only` is true.
+        if self.trusted_peers_only() && !self.is_trusted(listener_addr) {
             bail!("Dropping connection request from '{listener_addr}' (untrusted)");
         }
         Ok(())

--- a/node/router/src/heartbeat.rs
+++ b/node/router/src/heartbeat.rs
@@ -27,7 +27,7 @@ use snarkvm::prelude::Network;
 use snarkos_node_tcp::P2P;
 
 use colored::Colorize;
-use rand::{Rng, prelude::IteratorRandom, rngs::OsRng};
+use rand::{prelude::IteratorRandom, rngs::OsRng};
 
 /// A helper function to compute the maximum of two numbers.
 /// See Rust issue 92391: https://github.com/rust-lang/rust/issues/92391.
@@ -142,7 +142,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
     /// It only triggers if the router is above the minimum number of connected peers.
     fn remove_oldest_connected_peer(&self) {
         // Skip if the node is not requesting peers.
-        if !self.router().allow_external_peers() {
+        if self.router().trusted_peers_only() {
             return;
         }
 
@@ -171,14 +171,8 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
         // Obtain the number of connected provers.
         let num_connected_provers = self.router().filter_connected_peers(|peer| peer.node_type.is_prover()).len();
 
-        // Consider rotating more external peers every ~10 heartbeats.
-        let reduce_peers = self.router().rotate_external_peers() && rng.gen_range(0..10) == 0;
         // Determine the maximum number of peers and provers to keep.
-        let (max_peers, max_provers) = if reduce_peers {
-            (Self::MEDIAN_NUMBER_OF_PEERS, 0)
-        } else {
-            (Self::MAXIMUM_NUMBER_OF_PEERS, Self::MAXIMUM_NUMBER_OF_PROVERS)
-        };
+        let (max_peers, max_provers) = (Self::MAXIMUM_NUMBER_OF_PEERS, Self::MAXIMUM_NUMBER_OF_PROVERS);
 
         // Compute the number of surplus peers.
         let num_surplus_peers = num_connected.saturating_sub(max_peers);
@@ -249,7 +243,7 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
                 self.router().connect(peer.listener_addr);
             }
 
-            if self.router().allow_external_peers() {
+            if !self.router().trusted_peers_only() {
                 // Request more peers from the connected peers.
                 for peer_ip in self.router().connected_peers().into_iter().choose_multiple(rng, 3) {
                     self.router().send(peer_ip, Message::PeerRequest(PeerRequest));
@@ -260,6 +254,10 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
 
     /// This function keeps the number of bootstrap peers within the allowed range.
     async fn handle_bootstrap_peers(&self) {
+        // Return early if we are in trusted peers only mode.
+        if self.router().trusted_peers_only() {
+            return;
+        }
         // Split the bootstrap peers into connected and candidate lists.
         let mut candidate_bootstrap = Vec::new();
         let connected_bootstrap =

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -174,8 +174,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                     bail!("Peer '{peer_ip}' is not following the protocol (unexpected peer response)")
                 }
                 self.router().cache.decrement_outbound_peer_requests(peer_ip);
-                if !self.router().allow_external_peers() {
-                    bail!("Not accepting peer response from '{peer_ip}' (validator gossip is disabled)");
+                if self.router().trusted_peers_only() {
+                    bail!("Not accepting peer response from '{peer_ip}' (trusted peers only)");
                 }
 
                 match self.peer_response(peer_ip, message.peers) {

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -108,6 +108,10 @@ impl<N: Network> PeerPoolHandling<N> for Router<N> {
         self.is_dev
     }
 
+    fn trusted_peers_only(&self) -> bool {
+        self.trusted_peers_only
+    }
+
     fn node_type(&self) -> NodeType {
         self.node_type
     }

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -130,10 +130,8 @@ pub struct InnerRouter<N: Network> {
     peer_pool: RwLock<HashMap<SocketAddr, Peer<N>>>,
     /// The spawned handles.
     handles: Mutex<Vec<JoinHandle<()>>>,
-    /// If the flag is set, the node will periodically evict more external peers.
-    rotate_external_peers: bool,
-    /// If the flag is set, the node will engage in P2P gossip to request more peers.
-    allow_external_peers: bool,
+    /// If the flag is set, the node will only connect to trusted peers.
+    trusted_peers_only: bool,
     /// The storage mode.
     storage_mode: StorageMode,
     /// The boolean flag for the development mode.
@@ -162,8 +160,7 @@ impl<N: Network> Router<N> {
         ledger: Arc<dyn LedgerService<N>>,
         trusted_peers: &[SocketAddr],
         max_peers: u16,
-        rotate_external_peers: bool,
-        allow_external_peers: bool,
+        trusted_peers_only: bool,
         storage_mode: StorageMode,
         is_dev: bool,
     ) -> Result<Self> {
@@ -173,10 +170,12 @@ impl<N: Network> Router<N> {
         // Prepare the collection of the initial peers.
         let mut initial_peers = HashMap::new();
 
-        // Load entries from the peer cache (if present).
-        let cached_peers = Self::load_cached_peers(&storage_mode, PEER_CACHE_FILENAME)?;
-        for addr in cached_peers {
-            initial_peers.insert(addr, Peer::new_candidate(addr, false));
+        // Load entries from the peer cache (if present and if we are not in trusted peers only mode).
+        if !trusted_peers_only {
+            let cached_peers = Self::load_cached_peers(&storage_mode, PEER_CACHE_FILENAME)?;
+            for addr in cached_peers {
+                initial_peers.insert(addr, Peer::new_candidate(addr, false));
+            }
         }
 
         // Add the trusted peers to the list of the initial peers; this may promote
@@ -193,8 +192,7 @@ impl<N: Network> Router<N> {
             resolver: Default::default(),
             peer_pool: RwLock::new(initial_peers),
             handles: Default::default(),
-            rotate_external_peers,
-            allow_external_peers,
+            trusted_peers_only,
             storage_mode,
             is_dev,
         })))
@@ -241,14 +239,9 @@ impl<N: Network> Router<N> {
         &self.cache
     }
 
-    /// Returns `true` if the node is periodically evicting more external peers.
-    pub fn rotate_external_peers(&self) -> bool {
-        self.rotate_external_peers
-    }
-
-    /// Returns `true` if the node is engaging in P2P gossip to request more peers.
-    pub fn allow_external_peers(&self) -> bool {
-        self.allow_external_peers
+    /// Returns `true` if the node is only engaging with trusted peers.
+    pub fn trusted_peers_only(&self) -> bool {
+        self.trusted_peers_only
     }
 
     /// Returns the listener IP address from the (ambiguous) peer address.

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -42,7 +42,7 @@ async fn test_connection_cleanups() {
         let node = match rng.gen_range(0..3) % 3 {
             0 => client(0, 1, &mut rng).await,
             1 => prover(0, 1, &mut rng).await,
-            2 => validator(0, 1, &[], true, &mut rng).await,
+            2 => validator(0, 1, &[], false, &mut rng).await,
             _ => unreachable!(),
         };
 

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -68,7 +68,6 @@ pub async fn client(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> T
         &[],
         max_peers,
         false,
-        true,
         StorageMode::new_test(None),
         true,
     )
@@ -90,7 +89,6 @@ pub async fn prover(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> T
         &[],
         max_peers,
         false,
-        true,
         StorageMode::new_test(None),
         true,
     )
@@ -105,7 +103,7 @@ pub async fn validator(
     listening_port: u16,
     max_peers: u16,
     trusted_peers: &[SocketAddr],
-    allow_external_peers: bool,
+    trusted_peers_only: bool,
     rng: &mut TestRng,
 ) -> TestRouter<CurrentNetwork> {
     let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
@@ -117,8 +115,7 @@ pub async fn validator(
         ledger_service,
         trusted_peers,
         max_peers,
-        false,
-        allow_external_peers,
+        trusted_peers_only,
         StorageMode::new_test(None),
         true,
     )

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -96,6 +96,10 @@ impl<N: Network> PeerPoolHandling<N> for TestRouter<N> {
         true
     }
 
+    fn trusted_peers_only(&self) -> bool {
+        false
+    }
+
     fn node_type(&self) -> NodeType {
         self.router().node_type()
     }

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -224,19 +224,20 @@ async fn test_validator_connection() {
             !node1_.is_connected(node0_.local_ip()) && !node0_.is_connected(node1_.local_ip())
         });
 
-        // Connect node1 to node0.
-        let Ok(res) = node1.connect(node0.local_ip()).unwrap().await else {
-            panic!("Connection failed for the wrong reasons.");
-        };
-        assert!(!res, "Connection was accepted when it should not have been.");
+        // TODO(vicsn) uncomment this when applying https://github.com/ProvableHQ/snarkOS/pull/3989
+        // // Connect node1 to node0.
+        // let Ok(res) = node1.connect(node0.local_ip()).unwrap().await else {
+        //     panic!("Connection failed for the wrong reasons.");
+        // };
+        // assert!(!res, "Connection was accepted when it should not have been.");
 
-        // Check the TCP level - connection was not accepted.
-        assert_eq!(node0.tcp().num_connected(), 0);
-        assert_eq!(node1.tcp().num_connected(), 0);
+        // // Check the TCP level - connection was not accepted.
+        // assert_eq!(node0.tcp().num_connected(), 0);
+        // assert_eq!(node1.tcp().num_connected(), 0);
 
-        // Check the router level - connection was not accepted.
-        assert_eq!(node0.number_of_connected_peers(), 0);
-        assert_eq!(node1.number_of_connected_peers(), 0);
+        // // Check the router level - connection was not accepted.
+        // assert_eq!(node0.number_of_connected_peers(), 0);
+        // assert_eq!(node1.number_of_connected_peers(), 0);
     }
 }
 

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -100,11 +100,11 @@ async fn peer_priority_ordering() {
     router.enable_handshake().await;
     router.enable_on_connect().await;
 
-    let validator_peer1 = validator(0, 5, &[], true, &mut rng).await;
+    let validator_peer1 = validator(0, 5, &[], false, &mut rng).await;
     validator_peer1.enable_listener().await;
     validator_peer1.enable_handshake().await;
 
-    let validator_peer2 = validator(0, 5, &[], true, &mut rng).await;
+    let validator_peer2 = validator(0, 5, &[], false, &mut rng).await;
     validator_peer2.enable_listener().await;
     validator_peer2.enable_handshake().await;
 
@@ -157,7 +157,7 @@ async fn peer_priority_ordering() {
 async fn peer_priority_trusted_peers() {
     let mut rng = TestRng::default();
 
-    let validator_peer = validator(0, 5, &[], true, &mut rng).await;
+    let validator_peer = validator(0, 5, &[], false, &mut rng).await;
     validator_peer.enable_listener().await;
     validator_peer.enable_handshake().await;
 

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -53,6 +53,10 @@ impl<N: Network> PeerPoolHandling<N> for BootstrapClient<N> {
         self.dev.is_some()
     }
 
+    fn trusted_peers_only(&self) -> bool {
+        false
+    }
+
     fn node_type(&self) -> NodeType {
         NodeType::BootstrapClient
     }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -140,7 +140,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         genesis: Block<N>,
         cdn: Option<http::Uri>,
         storage_mode: StorageMode,
-        rotate_external_peers: bool,
+        trusted_peers_only: bool,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
     ) -> Result<Self> {
@@ -152,8 +152,6 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone(), shutdown.clone()));
-        // Determine if the client should allow external peers.
-        let allow_external_peers = true;
 
         // Initialize the node router.
         let router = Router::new(
@@ -163,8 +161,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             ledger_service.clone(),
             trusted_peers,
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
-            rotate_external_peers,
-            allow_external_peers,
+            trusted_peers_only,
             storage_mode.clone(),
             dev.is_some(),
         )

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -65,7 +65,7 @@ impl<N: Network> Node<N> {
         genesis: Block<N>,
         cdn: Option<http::Uri>,
         storage_mode: StorageMode,
-        allow_external_peers: bool,
+        trusted_peers_only: bool,
         dev_txs: bool,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
@@ -82,7 +82,7 @@ impl<N: Network> Node<N> {
                 genesis,
                 cdn,
                 storage_mode,
-                allow_external_peers,
+                trusted_peers_only,
                 dev_txs,
                 dev,
                 shutdown,
@@ -98,11 +98,13 @@ impl<N: Network> Node<N> {
         trusted_peers: &[SocketAddr],
         genesis: Block<N>,
         storage_mode: StorageMode,
+        trusted_peers_only: bool,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
     ) -> Result<Self> {
         Ok(Self::Prover(Arc::new(
-            Prover::new(node_ip, account, trusted_peers, genesis, storage_mode, dev, shutdown).await?,
+            Prover::new(node_ip, account, trusted_peers, genesis, storage_mode, trusted_peers_only, dev, shutdown)
+                .await?,
         )))
     }
 
@@ -116,7 +118,7 @@ impl<N: Network> Node<N> {
         genesis: Block<N>,
         cdn: Option<http::Uri>,
         storage_mode: StorageMode,
-        rotate_external_peers: bool,
+        trusted_peers_only: bool,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
     ) -> Result<Self> {
@@ -130,7 +132,7 @@ impl<N: Network> Node<N> {
                 genesis,
                 cdn,
                 storage_mode,
-                rotate_external_peers,
+                trusted_peers_only,
                 dev,
                 shutdown,
             )

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -99,6 +99,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
         trusted_peers: &[SocketAddr],
         genesis: Block<N>,
         storage_mode: StorageMode,
+        trusted_peers_only: bool,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
     ) -> Result<Self> {
@@ -107,10 +108,6 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(ProverLedgerService::new());
-        // Determine if the prover should allow external peers.
-        let allow_external_peers = true;
-        // Determine if the prover should rotate external peers.
-        let rotate_external_peers = false;
 
         // Initialize the node router.
         let router = Router::new(
@@ -120,8 +117,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
             ledger_service.clone(),
             trusted_peers,
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
-            rotate_external_peers,
-            allow_external_peers,
+            trusted_peers_only,
             storage_mode,
             dev.is_some(),
         )

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -92,7 +92,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         genesis: Block<N>,
         cdn: Option<http::Uri>,
         storage_mode: StorageMode,
-        allow_external_peers: bool,
+        trusted_peers_only: bool,
         dev_txs: bool,
         dev: Option<u16>,
         shutdown: Arc<AtomicBool>,
@@ -106,9 +106,6 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), shutdown.clone()));
 
-        // Determine if the validator should rotate external peers.
-        let rotate_external_peers = false;
-
         // Initialize the node router.
         let router = Router::new(
             node_ip,
@@ -117,8 +114,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             ledger_service.clone(),
             trusted_peers,
             Self::MAXIMUM_NUMBER_OF_PEERS as u16,
-            rotate_external_peers,
-            allow_external_peers,
+            trusted_peers_only,
             storage_mode.clone(),
             dev.is_some(),
         )
@@ -136,6 +132,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             sync.clone(),
             bft_ip,
             trusted_validators,
+            trusted_peers_only,
             storage_mode.clone(),
             ping.clone(),
             dev,

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1413,6 +1413,10 @@ mod tests {
             true
         }
 
+        fn trusted_peers_only(&self) -> bool {
+            false
+        }
+
         fn node_type(&self) -> NodeType {
             NodeType::Client
         }

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -46,6 +46,7 @@ pub async fn prover() -> Prover<CurrentNetwork, ConsensusMemory<CurrentNetwork>>
         &[],
         sample_genesis_block(),
         StorageMode::new_test(None),
+        false,
         None,
         Default::default(),
     )

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -31,7 +31,7 @@ pub async fn client() -> Client<CurrentNetwork, ConsensusMemory<CurrentNetwork>>
         sample_genesis_block(),
         None, // No CDN.
         StorageMode::new_test(None),
-        false, // No extra peer rotation.
+        false, // Connect to untrusted peers.
         None,
         Default::default(),
     )
@@ -66,7 +66,7 @@ pub async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNet
         sample_genesis_block(), // Should load the current network's genesis block.
         None,                   // No CDN.
         StorageMode::new_test(None),
-        true,  // This test requires validators to connect to peers.
+        false, // This test requires validators to connect to peers.
         false, // No dev traffic in production mode.
         None,
         Default::default(),

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -121,7 +121,7 @@ for validator_index in "${validator_indices[@]}"; do
   fi
 
   # Send the command to start the validator to the new window and capture output to the log file
-  tmux send-keys -t "devnet:$window_index" "${binary_path}snarkos start --nodisplay --network $network_id --dev $validator_index --allow-external-peers --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity --metrics --metrics-ip=0.0.0.0:$metrics_port --no-dev-txs" C-m
+  tmux send-keys -t "devnet:$window_index" "${binary_path}snarkos start --nodisplay --network $network_id --dev $validator_index --dev-num-validators $total_validators --validator --logfile $log_file --verbosity $verbosity --metrics --metrics-ip=0.0.0.0:$metrics_port --no-dev-txs" C-m
 done
 
 if [ "$total_clients" -ne 0 ]; then


### PR DESCRIPTION
## Motivation

Closes https://github.com/ProvableHQ/snarkOS/issues/3984
Closes https://github.com/ProvableHQ/snarkOS/issues/3985
Deprecates rotate_external_peers which is no longer needed now that we have custom bootstrap peers.

Tackled them together in order to reduce the aggregate diff.

## Test Plan

- [x] Letting a local devnet produce a few blocks, turning off a validator, revive it as a client with --trusted-peers-only to see if it connects and syncs from just a single validator.

## Documentation

Validator onboarding docs will be adjusted accordingly.

## Backwards compatibility

The deprecated flags are still present to ensure nodes can still start with them, so as not to break any existing workflows.