### PR TITLE
Disallow unknown peers as validator

### DIFF
--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -53,6 +53,15 @@ common_flags=(
   "--dev-num-validators=$total_validators"
 )
 
+# Set the trusted peers for the validators
+trusted_peers=()
+for ((client_index = 0; client_index < total_clients; client_index++)); do
+  node_index=$((client_index + total_validators))
+  trusted_peers+=("localhost:$((4130 + $node_index)),")
+done
+# Trim the last comma
+trusted_peers=${trusted_peers%,}
+
 # Start all validator nodes in the background
 for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
   snarkos clean "--dev=$validator_index" "--network=$network_id"
@@ -60,10 +69,10 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
   log_file="$log_dir/validator-$validator_index.log"
   if [ $validator_index -eq 0 ]; then
     snarkos start "${common_flags[@]}" "--dev=$validator_index" \
-      --validator "--logfile=$log_file" --metrics --no-dev-txs &
+      --validator "--logfile=$log_file" --metrics --no-dev-txs --peers "$trusted_peers" &
   else
     snarkos start "${common_flags[@]}" "--dev=$validator_index" \
-      --validator "--logfile=$log_file" &
+      --validator "--logfile=$log_file" --peers "$trusted_peers" &
   fi
   PIDS[validator_index]=$!
   echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -167,7 +167,7 @@ echo "{
 " > program/program.json
 
 # Deploy the test program and wait for the deployment to be processed.
-_deploy_result=$(cd program && snarkos developer deploy --dev-key 0 --network "$network_id" --endpoint=localhost:3030 --broadcast --wait --timeout 10 "$program_name")
+_deploy_result=$(cd program && snarkos developer deploy --dev-key 0 --network "$network_id" --endpoint=localhost:3030 --broadcast --wait --timeout 20 "$program_name")
 
 # Ensure we are able to fetch the program fromn the node.
 status_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v2/$network_name/program/${program_name}/0")
@@ -208,7 +208,7 @@ fi
 # Execute a function in the deployed program and wait for the execution to be processed.
 # Use the old flags here `--query` and `--broadcast=URL` to test they still work.
 # Also, use the v1 API to test it still works.
-execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --query=localhost:3030 "--broadcast=http://localhost:3030/v1/$network_name/transaction/broadcast" "$program_name" main 1u32 1u32 --wait --timeout 10)
+execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --query=localhost:3030 "--broadcast=http://localhost:3030/v1/$network_name/transaction/broadcast" "$program_name" main 1u32 1u32 --wait --timeout 20)
 
 # Fail if the execution transaction does not exist.
 tx=$(echo "$execute_result" | tail -n 1)

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -339,7 +339,14 @@ impl<N: Network> Router<N> {
         if self.is_local_ip(listener_addr) {
             bail!("Dropping connection request from '{listener_addr}' (attempted to self-connect)");
         }
-        // Unknown peers are untrusted, so check if `trusted_peers_only` is true.
+        // As a validator, only accept connections from trusted peers and bootstrap nodes.
+        if self.node_type() == NodeType::Validator
+            && !self.is_trusted(listener_addr)
+            && !crate::bootstrap_peers::<N>(self.is_dev()).contains(&listener_addr)
+        {
+            bail!("Dropping connection request from '{listener_addr}' (untrusted)");
+        }
+        // If the node is in trusted peers only mode, ensure the peer is explicitly trusted.
         if self.trusted_peers_only() && !self.is_trusted(listener_addr) {
             bail!("Dropping connection request from '{listener_addr}' (untrusted)");
         }

--- a/node/router/tests/connect.rs
+++ b/node/router/tests/connect.rs
@@ -224,20 +224,19 @@ async fn test_validator_connection() {
             !node1_.is_connected(node0_.local_ip()) && !node0_.is_connected(node1_.local_ip())
         });
 
-        // TODO(vicsn) uncomment this when applying https://github.com/ProvableHQ/snarkOS/pull/3989
-        // // Connect node1 to node0.
-        // let Ok(res) = node1.connect(node0.local_ip()).unwrap().await else {
-        //     panic!("Connection failed for the wrong reasons.");
-        // };
-        // assert!(!res, "Connection was accepted when it should not have been.");
+        // Connect node1 to node0.
+        let Ok(res) = node1.connect(node0.local_ip()).unwrap().await else {
+            panic!("Connection failed for the wrong reasons.");
+        };
+        assert!(!res, "Connection was accepted when it should not have been.");
 
-        // // Check the TCP level - connection was not accepted.
-        // assert_eq!(node0.tcp().num_connected(), 0);
-        // assert_eq!(node1.tcp().num_connected(), 0);
+        // Check the TCP level - connection was not accepted.
+        assert_eq!(node0.tcp().num_connected(), 0);
+        assert_eq!(node1.tcp().num_connected(), 0);
 
-        // // Check the router level - connection was not accepted.
-        // assert_eq!(node0.number_of_connected_peers(), 0);
-        // assert_eq!(node1.number_of_connected_peers(), 0);
+        // Check the router level - connection was not accepted.
+        assert_eq!(node0.number_of_connected_peers(), 0);
+        assert_eq!(node1.number_of_connected_peers(), 0);
     }
 }
 

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -88,6 +88,9 @@ async fn connect_to(router: &TestRouter<Network>, other: &TestRouter<Network>) {
     while !router.is_connected(other.local_ip()) {
         sleep(Duration::from_millis(10)).await;
     }
+    while !other.is_connected(router.local_ip()) {
+        sleep(Duration::from_millis(10)).await;
+    }
 }
 
 /// Checks that clients are ordered before nodes and that ordering is based on when a peer was last seen.
@@ -100,11 +103,11 @@ async fn peer_priority_ordering() {
     router.enable_handshake().await;
     router.enable_on_connect().await;
 
-    let validator_peer1 = validator(0, 5, &[], false, &mut rng).await;
+    let validator_peer1 = validator(0, 5, &[router.local_ip()], false, &mut rng).await;
     validator_peer1.enable_listener().await;
     validator_peer1.enable_handshake().await;
 
-    let validator_peer2 = validator(0, 5, &[], false, &mut rng).await;
+    let validator_peer2 = validator(0, 5, &[router.local_ip()], false, &mut rng).await;
     validator_peer2.enable_listener().await;
     validator_peer2.enable_handshake().await;
 
@@ -165,15 +168,15 @@ async fn peer_priority_trusted_peers() {
     client_peer.enable_listener().await;
     client_peer.enable_handshake().await;
 
-    let router = validator(0, 5, &[validator_peer.local_ip(), client_peer.local_ip()], false, &mut rng).await;
-    router.enable_listener().await;
-    router.enable_handshake().await;
-    router.enable_on_connect().await;
+    let validator_peer_2 = validator(0, 5, &[validator_peer.local_ip(), client_peer.local_ip()], false, &mut rng).await;
+    validator_peer_2.enable_listener().await;
+    validator_peer_2.enable_handshake().await;
+    validator_peer_2.enable_on_connect().await;
 
-    connect_to(&router, &client_peer).await;
-    connect_to(&router, &validator_peer).await;
+    connect_to(&client_peer, &validator_peer_2).await;
+    connect_to(&validator_peer, &validator_peer_2).await;
 
-    let heartbeat = HeartbeatTest { router };
+    let heartbeat = HeartbeatTest { router: validator_peer_2 };
 
     let removable_peers = heartbeat.get_removable_peers();
 

--- a/node/tests/disconnect.rs
+++ b/node/tests/disconnect.rs
@@ -150,8 +150,8 @@ async fn duplicate_disconnect_attempts() {
     // common::initialise_logger(3);
 
     // Spin up 2 full nodes.
-    let node1 = validator().await;
-    let node2 = validator().await;
+    let node1 = client().await;
+    let node2 = client().await;
     let addr2 = node2.tcp().listening_addr().unwrap();
 
     // Connect node1 to node2.

--- a/node/tests/handshake.rs
+++ b/node/tests/handshake.rs
@@ -139,14 +139,14 @@ mod client {
     // Initiator side (full node connects to synthetic peer).
     test_handshake! {
         client -> client,
-        client -> validator,
+        // client -> validator, // router connections to untrusted peers are not allowed
         client -> prover
     }
 
     // Responder side (synthetic peer connects to full node).
     test_handshake! {
         client <- client,
-        client <- validator,
+        // client <- validator, // router connections to untrusted peers are not allowed
         client <- prover
     }
 }
@@ -155,33 +155,34 @@ mod prover {
     // Initiator side (full node connects to synthetic peer).
     test_handshake! {
         prover -> client,
-        prover -> validator,
+        // prover -> validator, // router connections to untrusted peers are not allowed
         prover -> prover
     }
 
     // Responder side (synthetic peer connects to full node).
     test_handshake! {
         prover <- client,
-        prover <- validator,
+        // prover <- validator, // router connections to untrusted peers are not allowed
         prover <- prover
     }
 }
 
-mod validator {
-    // Initiator side (full node connects to synthetic peer).
-    test_handshake! {
-        validator -> client,
-        validator -> validator,
-        validator -> prover
-    }
+// router connections to untrusted peers are not allowed
+// mod validator {
+//     // Initiator side (full node connects to synthetic peer).
+//     test_handshake! {
+//         validator -> client,
+//         validator -> validator,
+//         validator -> prover
+//     }
 
-    // Responder side (synthetic peer connects to full node).
-    test_handshake! {
-        validator <- client,
-        validator <- validator,
-        validator <- prover
-    }
-}
+//     // Responder side (synthetic peer connects to full node).
+//     test_handshake! {
+//         validator <- client,
+//         validator <- validator,
+//         validator <- prover
+//     }
+// }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn simultaneous_connection_attempt() {
@@ -247,8 +248,8 @@ async fn duplicate_connection_attempts() {
     // common::initialise_logger(3);
 
     // Spin up 2 full nodes.
-    let node1 = validator().await;
-    let node2 = validator().await;
+    let node1 = client().await;
+    let node2 = client().await;
     let addr2 = node2.listening_addr();
 
     // Prepare connection attempts.


### PR DESCRIPTION
## Motivation

Extension to https://github.com/ProvableHQ/snarkOS/issues/3888

Validator gateways will already only connect to other validators in the current committee. We didn't extend this logic to the Router because the Router messages aren't signed. However we can at least stick to trusted connections only.

Notes:
- this will be a pain for validators who have some managed nodes which frequently rotate, but if anyone complains we can tackle https://github.com/ProvableHQ/snarkOS/issues/3899
- even though gateways also broadcast transmissions via the `WorkerPing`, this PR may reduce validator transmission propagation overall and increase transmission inclusion latency, reducing the chance that transmissions land in a proposal. However, the validator onboarding guide _already_ implies not to connect to other validator's clients.


## Test Plan

- [x] CI passes
