### PR TITLE
Fix DEFAULT_ENDPOINT in snarkos developer

### DIFF
--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -68,8 +68,7 @@ pub enum DeveloperCommand {
 }
 
 /// Use the Provable explorer's API by default.
-/// Note, the `v1` here is not the API version, but the explorer's version.
-const DEFAULT_ENDPOINT: &str = "https://api.explorer.provable.com/v1";
+const DEFAULT_ENDPOINT: &str = "https://api.explorer.provable.com";
 
 #[derive(Debug, Parser)]
 pub struct Developer {


### PR DESCRIPTION
## Motivation

Closes https://github.com/ProvableHQ/snarkOS/issues/3992 CC @AleoAlexander

## Test Plan

Tested the command from the issue manually.

Our CI also contains a few calls using `snarkos developer` but didn't catch this because we override the --query.